### PR TITLE
correct javadoc url

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -98,6 +98,6 @@
     {%- endif -%}
   {%- endfor -%}
   <li class="nav-list-item">
-    <a href="https://opensearch.org/javadoc/" target="_blank" class="nav-list-link">Javadoc <svg class="external-arrow" width="16" height="16" fill="#002A3A"><use xlink:href="#external-arrow"></use></svg></a>
+    <a href="https://opensearch.org/docs/javadocs/" target="_blank" class="nav-list-link">Javadoc <svg class="external-arrow" width="16" height="16" fill="#002A3A"><use xlink:href="#external-arrow"></use></svg></a>
   </li>
 </ul>

--- a/index.md
+++ b/index.md
@@ -69,7 +69,7 @@ To learn more, see [Install OpenSearch](docs/opensearch/install/).
 
 ## Looking for the Javadoc?
 
-See [opensearch.org/javadoc](https://opensearch.org/javadoc/).
+See [opensearch.org/docs/javadocs/](https://opensearch.org/docs/javadocs/).
 
 
 ## Get involved


### PR DESCRIPTION
Signed-off-by: Kyle Davis <kyledvs@amazon.com>

### Description
Fixed issue incorrect link to javadocs

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
