### PR TITLE
Fix names of entries to delete from opensearch.yml when uninstalling the security plugin.

### DIFF
--- a/docs/security/configuration/disable.md
+++ b/docs/security/configuration/disable.md
@@ -14,7 +14,7 @@ You might want to temporarily disable the security plugin to make testing or int
 plugins.security.disabled: true
 ```
 
-A more permanent option is to remove the security plugin entirely. Delete the `plugins/opensearch-security` folder on all nodes, and delete the `opensearch_security` configuration entries from `opensearch.yml`.
+A more permanent option is to remove the security plugin entirely. Delete the `plugins/opensearch-security` folder on all nodes, and delete the `plugins.security.*` configuration entries from `opensearch.yml`.
 
 To perform these steps on the Docker image, see [Customize the Docker image](../../../opensearch/install/docker/#customize-the-docker-image).
 


### PR DESCRIPTION
Coming from https://github.com/opensearch-project/security/issues/1249#issuecomment-857306457

Signed-off-by: dblock <dblock@amazon.com>

### Description

Fix names of entries to delete from opensearch.yml when uninstalling the security plugin.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
