### PR TITLE
Adds both nodes for dashboards to talk to in docker-compose

### DIFF
--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -138,7 +138,7 @@ services:
     expose:
       - "5601"
     environment:
-      OPENSEARCH_HOSTS: https://opensearch-node1:9200
+      OPENSEARCH_HOSTS: '["https://opensearch-node1:9200","https://opensearch-node2:9200"]'
     networks:
       - opensearch-net
 


### PR DESCRIPTION
### Description
Enables OpenSearch Dashboards to talk to both OpenSearch nodes in the event one is down. To reproduce. Run the compose file and terminate node1. Dashboards will still talk to node2 (although the cluster will be yellow).
 
### Related Issues/PRs 
https://github.com/opensearch-project/project-website/pull/137 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
