### PR TITLE
Adding Documentation for Creating Email Destinations

### DIFF
--- a/_monitoring-plugins/alerting/api.md
+++ b/_monitoring-plugins/alerting/api.md
@@ -912,6 +912,28 @@ POST _plugins/_alerting/destinations
     "host": "hooks.chime.aws"
   }
 }
+
+POST _plugins/_alerting/destinations
+{
+  "type": "email",
+  "name": "my-email-destination",
+  "email": {
+    "email_account_id": "YjY7mXMBx015759_IcfW",
+    "recipients": [
+      {
+        "type": "email_group",
+        "email_group_id": "YzY-mXMBx015759_dscs"
+      },
+      {
+        "type": "email",
+        "email": "example@email.com"
+      }
+    ]
+  }
+}
+
+// The email_account_id and email_group_id will be the document IDs of the email_account and email_group you have created.
+
 ```
 
 #### Sample response


### PR DESCRIPTION
### Description
This change adds the sample API request for creating the emails as destinations.  
 
### Issues Resolved
We were fixing a bug in alerting for showing alerts in ERROR state when we are unable to resolve the Email Server. (https://github.com/opensearch-project/alerting/issues/94). 

PR: https://github.com/opensearch-project/alerting/pull/113 
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
