### PR TITLE
Fix paths in `redirect_from` data

### DIFF
--- a/_clients/cli.md
+++ b/_clients/cli.md
@@ -4,8 +4,8 @@ title: OpenSearch CLI
 nav_order: 52
 has_children: false
 redirect_from:
-  - /docs/odfe-cli/
-  - /docs/cli/
+  - /odfe-cli/
+  - /cli/
 ---
 
 # OpenSearch CLI

--- a/_dashboards/index.md
+++ b/_dashboards/index.md
@@ -5,7 +5,6 @@ nav_order: 1
 has_children: false
 has_toc: false
 redirect_from:
-  - /docs/opensearch-dashboards/
   - /opensearch-dashboards/
   - /dashboards/
 ---

--- a/_dashboards/notebooks.md
+++ b/_dashboards/notebooks.md
@@ -2,7 +2,7 @@
 layout: default
 title: Notebooks
 nav_order: 50
-redirect_from: /docs/notebooks/
+redirect_from: /notebooks/
 has_children: false
 ---
 

--- a/_im-plugin/index-rollups/index.md
+++ b/_im-plugin/index-rollups/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Index rollups
 nav_order: 35
 has_children: true
-redirect_from: /docs/ism/index-rollups/
+redirect_from: /ism/index-rollups/
 has_toc: false
 ---
 

--- a/_im-plugin/index-rollups/rollup-api.md
+++ b/_im-plugin/index-rollups/rollup-api.md
@@ -2,7 +2,7 @@
 layout: default
 title: Index rollups API
 parent: Index rollups
-redirect_from: /docs/ism/rollup-api/
+redirect_from: /ism/rollup-api/
 nav_order: 9
 ---
 

--- a/_im-plugin/index-transforms/index.md
+++ b/_im-plugin/index-transforms/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Index transforms
 nav_order: 20
 has_children: true
-redirect_from: /docs/im/index-transforms/
+redirect_from: /im/index-transforms/
 has_toc: false
 ---
 

--- a/_im-plugin/ism/api.md
+++ b/_im-plugin/ism/api.md
@@ -2,7 +2,7 @@
 layout: default
 title: ISM API
 parent: Index State Management
-redirect_from: /docs/ism/api/
+redirect_from: /ism/api/
 nav_order: 5
 ---
 

--- a/_im-plugin/ism/index.md
+++ b/_im-plugin/ism/index.md
@@ -4,8 +4,8 @@ title: Index State Management
 nav_order: 3
 has_children: true
 redirect_from:
-  - /docs/im/ism/
-  - /docs/ism/
+  - /im/ism/
+  - /ism/
 has_toc: false
 ---
 

--- a/_im-plugin/ism/managedindices.md
+++ b/_im-plugin/ism/managedindices.md
@@ -3,7 +3,7 @@ layout: default
 title: Managed Indices
 nav_order: 3
 parent: Index State Management
-redirect_from: /docs/ism/managedindices/
+redirect_from: /ism/managedindices/
 has_children: false
 ---
 

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -3,7 +3,7 @@ layout: default
 title: Policies
 nav_order: 1
 parent: Index State Management
-redirect_from: /docs/ism/policies/
+redirect_from: /ism/policies/
 has_children: false
 ---
 

--- a/_im-plugin/ism/settings.md
+++ b/_im-plugin/ism/settings.md
@@ -2,7 +2,7 @@
 layout: default
 title: Settings
 parent: Index State Management
-redirect_from: /docs/ism/settings/
+redirect_from: /ism/settings/
 nav_order: 4
 ---
 

--- a/_im-plugin/refresh-analyzer/index.md
+++ b/_im-plugin/refresh-analyzer/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Refresh search analyzer
 nav_order: 40
 has_children: false
-redirect_from: /docs/ism/refresh-analyzer/
+redirect_from: /ism/refresh-analyzer/
 has_toc: false
 ---
 

--- a/_monitoring-plugins/alerting/cron.md
+++ b/_monitoring-plugins/alerting/cron.md
@@ -6,7 +6,6 @@ parent: Alerting
 has_children: false
 redirect_from:
   - /alerting/cron/
-  - /docs/alerting/cron/
 ---
 
 # Cron expression reference

--- a/_opensearch/install/index.md
+++ b/_opensearch/install/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Install OpenSearch
 nav_order: 2
 redirect_from:
-  - /docs/install/
+  - /install/
   - /opensearch/install/
 has_children: true
 ---

--- a/_opensearch/query-dsl/bool.md
+++ b/_opensearch/query-dsl/bool.md
@@ -3,7 +3,7 @@ layout: default
 title: Boolean queries
 parent: Query DSL
 nav_order: 45
-redirect_from: /docs/opensearch/bool/
+redirect_from: /opensearch/bool/
 ---
 
 # Boolean queries

--- a/_opensearch/query-dsl/full-text.md
+++ b/_opensearch/query-dsl/full-text.md
@@ -3,9 +3,7 @@ layout: default
 title: Full-text queries
 parent: Query DSL
 nav_order: 40
-redirect_from:
-  - /docs/opensearch/full-text/
-  - /opensearch/full-text/
+redirect_from: /opensearch/full-text/
 ---
 
 # Full-text queries

--- a/_opensearch/query-dsl/term.md
+++ b/_opensearch/query-dsl/term.md
@@ -3,7 +3,7 @@ layout: default
 title: Term-level queries
 parent: Query DSL
 nav_order: 30
-redirect_from: /docs/opensearch/term/
+redirect_from: /opensearch/term/
 ---
 
 # Term-level queries

--- a/_search-plugins/async/index.md
+++ b/_search-plugins/async/index.md
@@ -4,7 +4,7 @@ title: Asynchronous search
 nav_order: 51
 has_children: true
 redirect_from:
-  - /docs/async/
+  - /async/
   - /search-plugins/async/
 ---
 

--- a/_search-plugins/async/security.md
+++ b/_search-plugins/async/security.md
@@ -4,7 +4,7 @@ title: Asynchronous search security
 nav_order: 2
 parent: Asynchronous search
 has_children: false
-redirect_from: /docs/async/security/
+redirect_from: /async/security/
 ---
 
 # Asynchronous search security

--- a/_search-plugins/async/settings.md
+++ b/_search-plugins/async/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: Asynchronous search
 nav_order: 4
-redirect_from: /docs/async/settings/
+redirect_from: /async/settings/
 ---
 
 # Settings

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -4,7 +4,7 @@ title: k-NN API
 nav_order: 5
 parent: k-NN
 has_children: false
-redirect_from: /docs/knn/api/
+redirect_from: /knn/api/
 ---
 
 # k-NN plugin API

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -5,7 +5,7 @@ nav_order: 2
 parent: k-NN
 has_children: false
 has_math: true
-redirect_from: /docs/knn/approximate-knn/
+redirect_from: /knn/approximate-knn/
 ---
 
 # Approximate k-NN search

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -5,7 +5,7 @@ nav_order: 50
 has_children: true
 has_toc: false
 redirect_from:
-  - /docs/knn/
+  - /knn/
   - /search-plugins/knn/
 ---
 

--- a/_search-plugins/knn/jni-library.md
+++ b/_search-plugins/knn/jni-library.md
@@ -4,7 +4,7 @@ title: JNI library
 nav_order: 6
 parent: k-NN
 has_children: false
-redirect_from: /docs/knn/jni-library/
+redirect_from: /knn/jni-library/
 ---
 
 # JNI library

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -4,7 +4,7 @@ title: k-NN Index
 nav_order: 1
 parent: k-NN
 has_children: false
-redirect_from: /docs/knn/knn-index/
+redirect_from: /knn/knn-index/
 ---
 
 # k-NN Index

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -5,7 +5,7 @@ nav_order: 3
 parent: k-NN
 has_children: false
 has_math: true
-redirect_from: /docs/knn/knn-score-script/
+redirect_from: /knn/knn-score-script/
 ---
 
 # Exact k-NN with scoring script

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -5,7 +5,7 @@ nav_order: 4
 parent: k-NN
 has_children: false
 has_math: true
-redirect_from: /docs/knn/painless-functions/
+redirect_from: /knn/painless-functions/
 ---
 
 # k-NN Painless Scripting extensions

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -3,7 +3,7 @@ layout: default
 title: Performance tuning
 parent: k-NN
 nav_order: 8
-redirect_from: /docs/knn/performance-tuning/
+redirect_from: /knn/performance-tuning/
 ---
 
 # Performance tuning

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: k-NN
 nav_order: 7
-redirect_from: /docs/knn/settings/
+redirect_from: /knn/settings/
 ---
 
 # k-NN settings

--- a/_search-plugins/ppl/commands.md
+++ b/_search-plugins/ppl/commands.md
@@ -3,7 +3,7 @@ layout: default
 title: Commands
 parent: Piped processing language
 nav_order: 4
-redirect_from: /docs/ppl/commands/
+redirect_from: /ppl/commands/
 ---
 
 

--- a/_search-plugins/ppl/datatypes.md
+++ b/_search-plugins/ppl/datatypes.md
@@ -3,7 +3,7 @@ layout: default
 title: Data Types
 parent: Piped processing language
 nav_order: 6
-redirect_from: /docs/ppl/datatypes/
+redirect_from: /ppl/datatypes/
 ---
 
 

--- a/_search-plugins/ppl/endpoint.md
+++ b/_search-plugins/ppl/endpoint.md
@@ -3,7 +3,7 @@ layout: default
 title: Endpoint
 parent: Piped processing language
 nav_order: 1
-redirect_from: /docs/ppl/endpoint/
+redirect_from: /ppl/endpoint/
 ---
 
 # Endpoint

--- a/_search-plugins/ppl/functions.md
+++ b/_search-plugins/ppl/functions.md
@@ -3,7 +3,7 @@ layout: default
 title: Functions
 parent: Piped processing language
 nav_order: 10
-redirect_from: /docs/ppl/functions/
+redirect_from: /ppl/functions/
 ---
 
 # Functions

--- a/_search-plugins/ppl/identifiers.md
+++ b/_search-plugins/ppl/identifiers.md
@@ -3,7 +3,7 @@ layout: default
 title: Identifiers
 parent: Piped processing language
 nav_order: 7
-redirect_from: /docs/ppl/identifiers/
+redirect_from: /ppl/identifiers/
 ---
 
 

--- a/_search-plugins/ppl/index.md
+++ b/_search-plugins/ppl/index.md
@@ -5,7 +5,7 @@ nav_order: 42
 has_children: true
 has_toc: false
 redirect_from:
-  - /docs/ppl/
+  - /ppl/
   - /search-plugins/ppl/
 ---
 

--- a/_search-plugins/ppl/protocol.md
+++ b/_search-plugins/ppl/protocol.md
@@ -3,7 +3,7 @@ layout: default
 title: Protocol
 parent: Piped processing language
 nav_order: 2
-redirect_from: /docs/ppl/protocol/
+redirect_from: /ppl/protocol/
 ---
 
 # Protocol

--- a/_search-plugins/ppl/settings.md
+++ b/_search-plugins/ppl/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: Piped processing language
 nav_order: 3
-redirect_from: /docs/ppl/settings/
+redirect_from: /ppl/settings/
 ---
 
 # Settings

--- a/_search-plugins/sql/aggregations.md
+++ b/_search-plugins/sql/aggregations.md
@@ -3,7 +3,7 @@ layout: default
 title: Aggregation Functions
 parent: SQL
 nav_order: 11
-redirect_from: /docs/sql/aggregations/
+redirect_from: /sql/aggregations/
 ---
 
 # Aggregation functions

--- a/_search-plugins/sql/basic.md
+++ b/_search-plugins/sql/basic.md
@@ -3,7 +3,7 @@ layout: default
 title: Basic Queries
 parent: SQL
 nav_order: 5
-redirect_from: /docs/sql/basic/
+redirect_from: /sql/basic/
 ---
 
 

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -3,7 +3,7 @@ layout: default
 title: SQL CLI
 parent: SQL
 nav_order: 2
-redirect_from: /docs/sql/cli/
+redirect_from: /sql/cli/
 ---
 
 # SQL CLI

--- a/_search-plugins/sql/complex.md
+++ b/_search-plugins/sql/complex.md
@@ -3,7 +3,7 @@ layout: default
 title: Complex Queries
 parent: SQL
 nav_order: 6
-redirect_from: /docs/sql/complex/
+redirect_from: /sql/complex/
 ---
 
 # Complex queries

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -3,7 +3,7 @@ layout: default
 title: Data Types
 parent: SQL
 nav_order: 73
-redirect_from: /docs/sql/datatypes/
+redirect_from: /sql/datatypes/
 ---
 
 # Data types

--- a/_search-plugins/sql/delete.md
+++ b/_search-plugins/sql/delete.md
@@ -3,7 +3,7 @@ layout: default
 title: Delete
 parent: SQL
 nav_order: 12
-redirect_from: /docs/sql/delete/
+redirect_from: /sql/delete/
 ---
 
 

--- a/_search-plugins/sql/endpoints.md
+++ b/_search-plugins/sql/endpoints.md
@@ -3,7 +3,7 @@ layout: default
 title: Endpoint
 parent: SQL
 nav_order: 13
-redirect_from: /docs/sql/endpoints/
+redirect_from: /sql/endpoints/
 ---
 
 

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -3,7 +3,7 @@ layout: default
 title: Functions
 parent: SQL
 nav_order: 10
-redirect_from: /docs/sql/functions/
+redirect_from: /sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -5,7 +5,7 @@ nav_order: 38
 has_children: true
 has_toc: false
 redirect_from:
-  - /docs/sql/
+  - /sql/
   - /search-plugins/sql/
 ---
 

--- a/_search-plugins/sql/jdbc.md
+++ b/_search-plugins/sql/jdbc.md
@@ -3,7 +3,7 @@ layout: default
 title: JDBC Driver
 parent: SQL
 nav_order: 71
-redirect_from: /docs/sql/jdbc/
+redirect_from: /sql/jdbc/
 ---
 
 # JDBC driver

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -3,7 +3,7 @@ layout: default
 title: Limitations
 parent: SQL
 nav_order: 18
-redirect_from: /docs/sql/limitation/
+redirect_from: /sql/limitation/
 ---
 
 # Limitations

--- a/_search-plugins/sql/metadata.md
+++ b/_search-plugins/sql/metadata.md
@@ -3,7 +3,7 @@ layout: default
 title: Metadata Queries
 parent: SQL
 nav_order: 9
-redirect_from: /docs/sql/metadata/
+redirect_from: /sql/metadata/
 ---
 
 # Metadata queries

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -3,7 +3,7 @@ layout: default
 title: Monitoring
 parent: SQL
 nav_order: 15
-redirect_from: /docs/sql/monitoring/
+redirect_from: /sql/monitoring/
 ---
 
 # Monitoring

--- a/_search-plugins/sql/odbc.md
+++ b/_search-plugins/sql/odbc.md
@@ -3,7 +3,7 @@ layout: default
 title: ODBC Driver
 parent: SQL
 nav_order: 72
-redirect_from: /docs/sql/obdc/
+redirect_from: /sql/obdc/
 ---
 
 # ODBC driver

--- a/_search-plugins/sql/partiql.md
+++ b/_search-plugins/sql/partiql.md
@@ -3,7 +3,7 @@ layout: default
 title: JSON Support
 parent: SQL
 nav_order: 7
-redirect_from: /docs/sql/partiql/
+redirect_from: /sql/partiql/
 ---
 
 # JSON Support

--- a/_search-plugins/sql/protocol.md
+++ b/_search-plugins/sql/protocol.md
@@ -3,7 +3,7 @@ layout: default
 title: Protocol
 parent: SQL
 nav_order: 14
-redirect_from: /docs/sql/protocol/
+redirect_from: /sql/protocol/
 ---
 
 # Protocol

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: SQL
 nav_order: 16
-redirect_from: /docs/sql/settings/
+redirect_from: /sql/settings/
 ---
 
 # Settings

--- a/_search-plugins/sql/sql-full-text.md
+++ b/_search-plugins/sql/sql-full-text.md
@@ -3,7 +3,7 @@ layout: default
 title: Full-Text Search
 parent: SQL
 nav_order: 8
-redirect_from: /docs/sql/sql-full-text/
+redirect_from: /sql/sql-full-text/
 ---
 
 # Full-text search

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -3,7 +3,7 @@ layout: default
 title: Troubleshooting
 parent: SQL
 nav_order: 17
-redirect_from: /docs/sql/troubleshoot/
+redirect_from: /sql/troubleshoot/
 ---
 
 # Troubleshooting

--- a/_search-plugins/sql/workbench.md
+++ b/_search-plugins/sql/workbench.md
@@ -3,7 +3,7 @@ layout: default
 title: Query Workbench
 parent: SQL
 nav_order: 1
-redirect_from: /docs/sql/workbench/
+redirect_from: /sql/workbench/
 ---
 
 

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -3,7 +3,7 @@ layout: default
 title: API
 parent: Access Control
 nav_order: 90
-redirect_from: /docs/security/access-control/api/
+redirect_from: /security/access-control/api/
 ---
 
 # API

--- a/_security-plugin/access-control/cross-cluster-search.md
+++ b/_security-plugin/access-control/cross-cluster-search.md
@@ -3,7 +3,7 @@ layout: default
 title: Cross-Cluster Search
 parent: Access Control
 nav_order: 40
-redirect_from: /docs/security/access-control/cross-cluster-search/
+redirect_from: /security/access-control/cross-cluster-search/
 ---
 
 # Cross-cluster search

--- a/_security-plugin/access-control/default-action-groups.md
+++ b/_security-plugin/access-control/default-action-groups.md
@@ -3,7 +3,7 @@ layout: default
 title: Default Action Groups
 parent: Access Control
 nav_order: 51
-redirect_from: /docs/security/access-control/default-action-groups/
+redirect_from: /security/access-control/default-action-groups/
 ---
 
 # Default action groups

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -3,7 +3,7 @@ layout: default
 title: Document-Level Security
 parent: Access Control
 nav_order: 10
-redirect_from: /docs/security/access-control/document-level-security/
+redirect_from: /security/access-control/document-level-security/
 ---
 
 # Document-level security

--- a/_security-plugin/access-control/field-level-security.md
+++ b/_security-plugin/access-control/field-level-security.md
@@ -3,7 +3,7 @@ layout: default
 title: Field-Level Security
 parent: Access Control
 nav_order: 11
-redirect_from: /docs/security/access-control/field-level-security/
+redirect_from: /security/access-control/field-level-security/
 ---
 
 # Field-level security

--- a/_security-plugin/access-control/field-masking.md
+++ b/_security-plugin/access-control/field-masking.md
@@ -3,7 +3,7 @@ layout: default
 title: Field Masking
 parent: Access Control
 nav_order: 12
-redirect_from: /docs/security/access-control/field-masking/
+redirect_from: /security/access-control/field-masking/
 ---
 
 # Field masking

--- a/_security-plugin/access-control/impersonation.md
+++ b/_security-plugin/access-control/impersonation.md
@@ -3,7 +3,7 @@ layout: default
 title: User Impersonation
 parent: Access Control
 nav_order: 20
-redirect_from: /docs/security/access-control/impersonation/
+redirect_from: /security/access-control/impersonation/
 ---
 
 # User impersonation

--- a/_security-plugin/access-control/index.md
+++ b/_security-plugin/access-control/index.md
@@ -5,7 +5,7 @@ nav_order: 10
 has_children: true
 has_toc: false
 redirect_from:
-  - /docs/security/access-control/
+  - /security/access-control/
   - /security-plugin/access-control/
 ---
 

--- a/_security-plugin/access-control/multi-tenancy.md
+++ b/_security-plugin/access-control/multi-tenancy.md
@@ -3,7 +3,7 @@ layout: default
 title: OpenSearch Dashboards Multi-Tenancy
 parent: Access Control
 nav_order: 30
-redirect_from: /docs/security/access-control/multi-tenancy/
+redirect_from: /security/access-control/multi-tenancy/
 ---
 
 # OpenSearch Dashboards multi-tenancy

--- a/_security-plugin/access-control/permissions.md
+++ b/_security-plugin/access-control/permissions.md
@@ -3,7 +3,7 @@ layout: default
 title: Permissions
 parent: Access Control
 nav_order: 50
-redirect_from: /docs/security/access-control/permissions/
+redirect_from: /security/access-control/permissions/
 ---
 
 # Permissions

--- a/_security-plugin/access-control/users-roles.md
+++ b/_security-plugin/access-control/users-roles.md
@@ -3,7 +3,7 @@ layout: default
 title: Users and Roles
 parent: Access Control
 nav_order: 1
-redirect_from: /docs/security/access-control/users-roles/
+redirect_from: /security/access-control/users-roles/
 ---
 
 # Users and roles

--- a/_security-plugin/audit-logs/field-reference.md
+++ b/_security-plugin/audit-logs/field-reference.md
@@ -3,7 +3,7 @@ layout: default
 title: Audit Log Field Reference
 parent: Audit Logs
 nav_order: 1
-redirect_from: /docs/security/audit-logs/field-reference/
+redirect_from: /security/audit-logs/field-reference/
 ---
 
 # Audit log field reference

--- a/_security-plugin/audit-logs/index.md
+++ b/_security-plugin/audit-logs/index.md
@@ -5,7 +5,7 @@ nav_order: 90
 has_children: true
 has_toc: false
 redirect_from:
-  - /docs/security/audit-logs/
+  - /security/audit-logs/
   - /security-plugin/audit-logs/
 ---
 

--- a/_security-plugin/audit-logs/storage-types.md
+++ b/_security-plugin/audit-logs/storage-types.md
@@ -3,7 +3,7 @@ layout: default
 title: Audit Log Storage Types
 parent: Audit Logs
 nav_order: 10
-redirect_from: /docs/security/audit-logs/storage-types/
+redirect_from: /security/audit-logs/storage-types/
 ---
 
 # Audit log storage types

--- a/_security-plugin/configuration/client-auth.md
+++ b/_security-plugin/configuration/client-auth.md
@@ -3,7 +3,7 @@ layout: default
 title: Client certificate authentication
 parent: Configuration
 nav_order: 50
-redirect_from: /docs/security/configuration/client-auth/
+redirect_from: /security/configuration/client-auth/
 ---
 
 # Client certificate authentication

--- a/_security-plugin/configuration/concepts.md
+++ b/_security-plugin/configuration/concepts.md
@@ -3,7 +3,7 @@ layout: default
 title: Authentication flow
 parent: Configuration
 nav_order: 1
-redirect_from: /docs/security/configuration/concepts/
+redirect_from: /security/configuration/concepts/
 ---
 
 # Authentication flow

--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -3,7 +3,7 @@ layout: default
 title: Backend Configuration
 parent: Configuration
 nav_order: 2
-redirect_from: /docs/security/configuration/configuration/
+redirect_from: /security/configuration/configuration/
 ---
 
 # Backend configuration

--- a/_security-plugin/configuration/disable.md
+++ b/_security-plugin/configuration/disable.md
@@ -3,7 +3,7 @@ layout: default
 title: Disable Security
 parent: Configuration
 nav_order: 99
-redirect_from: /docs/security/configuration/disable/
+redirect_from: /security/configuration/disable/
 ---
 
 # Disable security

--- a/_security-plugin/configuration/generate-certificates.md
+++ b/_security-plugin/configuration/generate-certificates.md
@@ -3,7 +3,7 @@ layout: default
 title: Generate Certificates
 parent: Configuration
 nav_order: 11
-redirect_from: /docs/security/configuration/generate-certificates/
+redirect_from: /security/configuration/generate-certificates/
 ---
 
 # Generate certificates

--- a/_security-plugin/configuration/index.md
+++ b/_security-plugin/configuration/index.md
@@ -5,7 +5,7 @@ nav_order: 5
 has_children: true
 has_toc: false
 redirect_from:
-  - /docs/security/configuration/
+  - /security/configuration/
   - /security-plugin/configuration/
 ---
 

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -3,7 +3,7 @@ layout: default
 title: Active Directory and LDAP
 parent: Configuration
 nav_order: 30
-redirect_from: /docs/security/configuration/ldap/
+redirect_from: /security/configuration/ldap/
 ---
 
 # Active Directory and LDAP

--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -3,7 +3,7 @@ layout: default
 title: OpenID Connect
 parent: Configuration
 nav_order: 32
-redirect_from: /docs/security/configuration/openid-connect/
+redirect_from: /security/configuration/openid-connect/
 ---
 
 # OpenID Connect

--- a/_security-plugin/configuration/proxy.md
+++ b/_security-plugin/configuration/proxy.md
@@ -3,7 +3,7 @@ layout: default
 title: Proxy-based authentication
 parent: Configuration
 nav_order: 40
-redirect_from: /docs/security/configuration/proxy/
+redirect_from: /security/configuration/proxy/
 ---
 
 # Proxy-based authentication

--- a/_security-plugin/configuration/saml.md
+++ b/_security-plugin/configuration/saml.md
@@ -3,7 +3,7 @@ layout: default
 title: SAML
 parent: Configuration
 nav_order: 31
-redirect_from: /docs/security/configuration/saml/
+redirect_from: /security/configuration/saml/
 ---
 
 # SAML

--- a/_security-plugin/configuration/security-admin.md
+++ b/_security-plugin/configuration/security-admin.md
@@ -3,7 +3,7 @@ layout: default
 title: Apply Changes with securityadmin.sh
 parent: Configuration
 nav_order: 20
-redirect_from: /docs/security/configuration/security-admin/
+redirect_from: /security/configuration/security-admin/
 ---
 
 # Apply configuration changes using securityadmin.sh

--- a/_security-plugin/configuration/system-indices.md
+++ b/_security-plugin/configuration/system-indices.md
@@ -3,7 +3,7 @@ layout: default
 title: System Indices
 parent: Configuration
 nav_order: 15
-redirect_from: /docs/security/configuration/system-indices/
+redirect_from: /security/configuration/system-indices/
 ---
 
 # System indices

--- a/_security-plugin/configuration/tls.md
+++ b/_security-plugin/configuration/tls.md
@@ -3,7 +3,7 @@ layout: default
 title: TLS Certificates
 parent: Configuration
 nav_order: 10
-redirect_from: /docs/security/configuration/tls/
+redirect_from: /security/configuration/tls/
 ---
 
 # Configure TLS certificates

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -3,7 +3,7 @@ layout: default
 title: YAML Files
 parent: Configuration
 nav_order: 3
-redirect_from: /docs/security/configuration/yaml/
+redirect_from: /security/configuration/yaml/
 ---
 
 # YAML files

--- a/_security-plugin/index.md
+++ b/_security-plugin/index.md
@@ -5,7 +5,7 @@ nav_order: 1
 has_children: false
 has_toc: false
 redirect_from:
-  - /docs/security/
+  - /security/
   - /security-plugin/
 ---
 


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
These URLs are used to refer to other pages within the documentation and this change fixes some that are miss-mapped.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
