### PR TITLE
Generate a sitemap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,11 +21,9 @@ gem "jekyll-redirect-from", "~> 0.16"
 # gem 'github-pages', group: :jekyll_plugins
 
 # If you have any plugins, put them here!
-# group :jekyll_plugins do
-#   # gem "jekyll-feed", "~> 0.6"
-#   gem "jekyll-remote-theme"
-#   gem "jekyll-redirect-from"
-# end
+group :jekyll_plugins do
+  gem "jekyll-sitemap"
+end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]

--- a/_config.yml
+++ b/_config.yml
@@ -137,6 +137,7 @@ footer_content:
 plugins:
   - jekyll-remote-theme
   - jekyll-redirect-from
+  - jekyll-sitemap
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
With this change, builds will also generate a `sitemap.xml` which will get referenced from a sitemap-index on the project-website.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
