### PR TITLE
Redirect javadoc to https://opensearch.org/javadocs/

### DIFF
--- a/_external_links/javadocs.md
+++ b/_external_links/javadocs.md
@@ -1,7 +1,6 @@
 ---
 layout: default
-title: Javadoc
-nav_order: 1
-permalink: /javadoc/
+nav_exclude: true
+permalink: /javadocs/
 redirect_to: https://opensearch.org/javadocs/
 ---

--- a/index.md
+++ b/index.md
@@ -72,7 +72,7 @@ OpenSearch includes a demo configuration so that you can get up and running quic
 
 ## Looking for the Javadoc?
 
-See [opensearch.org/docs/javadocs/](https://opensearch.org/docs/javadocs/).
+See [opensearch.org/javadocs/](https://opensearch.org/javadocs/).
 
 
 ## Get involved


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
With the "website" moving the landing pages of javadoc to https://opensearch.org/javadocs/, this commit changes the nav-menu item to point to that. This commit also adds a redirect from the old location to the new one and adjusts a link.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
