### PR TITLE
Use same attribute name as cluster page

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -347,7 +347,7 @@ Parameter | Description | Type | Required | Default
 
 ### allocation
 
-Allocate the index to a node with a specific attribute.
+Allocate the index to a node with a specific attribute set like this {{site.url}}{{site.baseurl}}/opensearch/cluster/#advanced-step-7-set-up-a-hot-warm-architecture
 For example, setting `require` to `warm` moves your data only to "warm" nodes.
 
 The `allocation` operation has the following parameters:
@@ -363,7 +363,7 @@ Parameter | Description | Type | Required
 "actions": [
   {
     "allocation": {
-      "require": { "box_type": "warm" }
+      "require": { "temp": "warm" }
     }
   }
 ]


### PR DESCRIPTION
Simple fix, but because https://opensearch.org/docs/opensearch/cluster/ uses the node.attr.temp setting and this page uses the box_type setting a less experienced user like me easily makes a mistake (not comprehending the exact workings). Using the temp attribute here as well would have saved me a couple of hours and some grey hairs.

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
