### PR TITLE
change ES_HOME env variable to OPENSEARCH_HOME

### DIFF
--- a/_opensearch/install/tar.md
+++ b/_opensearch/install/tar.md
@@ -111,7 +111,7 @@ In a tarball installation, Performance Analyzer collects data when it is enabled
 1. Launch the agent CLI:
 
    ```bash
-   ES_HOME="$PWD" ./bin/performance-analyzer-agent-cli
+   OPENSEARCH_HOME="$PWD" ./bin/performance-analyzer-agent-cli
    ```
 
 1. In a separate window, enable the Performance Analyzer plugin:


### PR DESCRIPTION
env variable looks wrong on "Launch the agent CLI"

### Description
[Describe what this change achieves]
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
