### PR TITLE
Improve permissions introduction

### DIFF
--- a/_security-plugin/access-control/permissions.md
+++ b/_security-plugin/access-control/permissions.md
@@ -7,58 +7,125 @@ nav_order: 50
 
 # Permissions
 
-This page is a complete list of available permissions in the security plugin. Each permission controls access to a data type or API.
+Each permission in the security plugin controls access to some action that the OpenSearch cluster can perform, such as indexing a document or checking cluster health.
 
-Rather than creating new action groups from individual permissions, you can often achieve your desired security posture using some combination of the default action groups. To learn more, see [Default Action Groups]({{site.url}}{{site.baseurl}}/security-plugin/access-control/default-action-groups/).
+Most permissions are self-describing. For example, `cluster:admin/ingest/pipeline/get` lets you retrieve information about ingest pipelines. _In many cases_, a permission correlates to a specific REST API operation, such as `GET _ingest/pipeline`.
+
+Despite this correlation, permissions do **not** directly map to REST API operations. Operations such as `POST _bulk` and `GET _msearch` can access many indices and perform many actions in a single request. Even a simple request, such as `GET _cat/nodes`, performs several actions in order to generate its response.
+
+In short, controlling access to the REST API is insufficient. Instead, the security plugin controls access to the underlying OpenSearch actions.
+
+For example, consider the following `_bulk` request:
+
+```json
+POST _bulk
+{ "delete": { "_index": "test-index", "_id": "tt2229499" } }
+{ "index": { "_index": "test-index", "_id": "tt1979320" } }
+{ "title": "Rush", "year": 2013 }
+{ "create": { "_index": "test-index", "_id": "tt1392214" } }
+{ "title": "Prisoners", "year": 2013 }
+{ "update": { "_index": "test-index", "_id": "tt0816711" } }
+{ "doc" : { "title": "World War Z" } }
+
+```
+
+For this request to succeed, you must have the following permissions for `test-index`:
+
+- indices:data/write/bulk*
+- indices:data/write/delete
+- indices:data/write/index
+- indices:data/write/update
+
+These permissions also allow you add, update, or delete documents (e.g. `PUT test-index/_doc/tt0816711`), because they govern the underlying OpenSearch actions of indexing and deleting documents rather than a specific API path and HTTP method.
+
+
+## Test permissions
+
+If you want a user to have the absolute minimum set of permissions necessary to perform some function---the [principle of least privilege](https://en.wikipedia.org/wiki/Principle_of_least_privilege)----the best way is to send representative requests to your cluster as a new test user. In the case of a permissions error, the security plugin is very explicit about which permissions are missing. Consider this request and response:
+
+```json
+GET _cat/shards?v
+
+{
+  "error": {
+    "root_cause": [{
+      "type": "security_exception",
+      "reason": "no permissions for [indices:monitor/stats] and User [name=test-user, backend_roles=[], requestedTenant=null]"
+    }]
+  },
+  "status": 403
+}
+```
+
+[Create a user and a role]({{site.url}}{{site.baseurl}}/security-plugin/access-control/users-roles/), map the role to the user, and start sending signed requests using curl, Postman, or any other client. Then gradually add permissions to the role as you encounter errors. Even after you resolve one permissions error, the same request might generate new errors; the plugin only returns the first error it encounters, so keep trying until the request succeeds.
+
+Rather than individual permissions, you can often achieve your desired security posture using a combination of the default action groups. See [Default action groups]({{site.url}}{{site.baseurl}}/security-plugin/access-control/default-action-groups/) for descriptions of the permissions that each group grants.
 {: .tip }
 
 
-## Cluster
+## Cluster permissions
+
+These permissions are for the cluster and can't be applied granularly. For example, you either have permissions to take snapshots (`cluster:admin/snapshot/create`) or you don't. You can't have permissions to take snapshots only for certain indices.
 
 - cluster:admin/ingest/pipeline/delete
 - cluster:admin/ingest/pipeline/get
 - cluster:admin/ingest/pipeline/put
 - cluster:admin/ingest/pipeline/simulate
 - cluster:admin/ingest/processor/grok/get
-- cluster:admin/opensearch/ad/detector/delete
-- cluster:admin/opensearch/ad/detector/jobmanagement
-- cluster:admin/opensearch/ad/detector/run
-- cluster:admin/opensearch/ad/detector/search
-- cluster:admin/opensearch/ad/detector/stats
-- cluster:admin/opensearch/ad/detector/write
-- cluster:admin/opensearch/ad/detectors/get
-- cluster:admin/opensearch/ad/result/search
-- cluster:admin/opensearch/alerting/alerts/ack
-- cluster:admin/opensearch/alerting/alerts/get
-- cluster:admin/opensearch/alerting/destination/delete
-- cluster:admin/opensearch/alerting/destination/email_account/delete
-- cluster:admin/opensearch/alerting/destination/email_account/get
-- cluster:admin/opensearch/alerting/destination/email_account/search
-- cluster:admin/opensearch/alerting/destination/email_account/write
-- cluster:admin/opensearch/alerting/destination/email_group/delete
-- cluster:admin/opensearch/alerting/destination/email_group/get
-- cluster:admin/opensearch/alerting/destination/email_group/search
-- cluster:admin/opensearch/alerting/destination/email_group/write
-- cluster:admin/opensearch/alerting/destination/get
-- cluster:admin/opensearch/alerting/destination/write
-- cluster:admin/opensearch/alerting/monitor/delete
-- cluster:admin/opensearch/alerting/monitor/execute
-- cluster:admin/opensearch/alerting/monitor/get
-- cluster:admin/opensearch/alerting/monitor/search
-- cluster:admin/opensearch/alerting/monitor/write
-- cluster:admin/opensearch/asynchronous_search/stats
-- cluster:admin/opensearch/asynchronous_search/delete
-- cluster:admin/opensearch/asynchronous_search/get
-- cluster:admin/opensearch/asynchronous_search/submit
-- cluster:admin/opensearch/reports/definition/create
-- cluster:admin/opensearch/reports/definition/delete
-- cluster:admin/opensearch/reports/definition/get
-- cluster:admin/opensearch/reports/definition/list
-- cluster:admin/opensearch/reports/definition/on_demand
-- cluster:admin/opensearch/reports/definition/update
-- cluster:admin/opensearch/reports/instance/get
-- cluster:admin/opensearch/reports/instance/list
-- cluster:admin/opensearch/reports/menu/download
+- cluster:admin/opendistro/ad/detector/delete
+- cluster:admin/opendistro/ad/detector/info
+- cluster:admin/opendistro/ad/detector/jobmanagement
+- cluster:admin/opendistro/ad/detector/preview
+- cluster:admin/opendistro/ad/detector/run
+- cluster:admin/opendistro/ad/detector/search
+- cluster:admin/opendistro/ad/detector/stats
+- cluster:admin/opendistro/ad/detector/write
+- cluster:admin/opendistro/ad/detectors/get
+- cluster:admin/opendistro/ad/result/search
+- cluster:admin/opendistro/ad/tasks/search
+- cluster:admin/opendistro/alerting/alerts/ack (acknowledge)
+- cluster:admin/opendistro/alerting/alerts/get
+- cluster:admin/opendistro/alerting/destination/delete
+- cluster:admin/opendistro/alerting/destination/email_account/delete
+- cluster:admin/opendistro/alerting/destination/email_account/get
+- cluster:admin/opendistro/alerting/destination/email_account/search
+- cluster:admin/opendistro/alerting/destination/email_account/write
+- cluster:admin/opendistro/alerting/destination/email_group/delete
+- cluster:admin/opendistro/alerting/destination/email_group/get
+- cluster:admin/opendistro/alerting/destination/email_group/search
+- cluster:admin/opendistro/alerting/destination/email_group/write
+- cluster:admin/opendistro/alerting/destination/get
+- cluster:admin/opendistro/alerting/destination/write
+- cluster:admin/opendistro/alerting/monitor/delete
+- cluster:admin/opendistro/alerting/monitor/execute
+- cluster:admin/opendistro/alerting/monitor/get
+- cluster:admin/opendistro/alerting/monitor/search
+- cluster:admin/opendistro/alerting/monitor/write
+- cluster:admin/opendistro/ism/managedindex/add
+- cluster:admin/opendistro/ism/managedindex/change
+- cluster:admin/opendistro/ism/managedindex/remove
+- cluster:admin/opendistro/ism/managedindex/explain
+- cluster:admin/opendistro/ism/managedindex/retry
+- cluster:admin/opendistro/ism/policy/write
+- cluster:admin/opendistro/ism/policy/get
+- cluster:admin/opendistro/ism/policy/search
+- cluster:admin/opendistro/ism/policy/delete
+- cluster:admin/opendistro/rollup/index
+- cluster:admin/opendistro/rollup/get
+- cluster:admin/opendistro/rollup/search
+- cluster:admin/opendistro/rollup/delete
+- cluster:admin/opendistro/rollup/start
+- cluster:admin/opendistro/rollup/stop
+- cluster:admin/opendistro/rollup/explain
+- cluster:admin/opendistro/reports/definition/create
+- cluster:admin/opendistro/reports/definition/update
+- cluster:admin/opendistro/reports/definition/on_demand
+- cluster:admin/opendistro/reports/definition/delete
+- cluster:admin/opendistro/reports/definition/get
+- cluster:admin/opendistro/reports/definition/list
+- cluster:admin/opendistro/reports/instance/list
+- cluster:admin/opendistro/reports/instance/get
+- cluster:admin/opendistro/reports/menu/download
 - cluster:admin/reindex/rethrottle
 - cluster:admin/repository/delete
 - cluster:admin/repository/get
@@ -94,7 +161,9 @@ Rather than creating new action groups from individual permissions, you can ofte
 - cluster:monitor/tasks/list
 
 
-## Indices
+## Index permissions
+
+These permissions apply to an index or index pattern. You might want a user to have read access to all indices (i.e. `*`), but write access to only a few (e.g. `web-logs` and `product-catalog`).
 
 - indices:admin/aliases
 - indices:admin/aliases/exists
@@ -102,13 +171,22 @@ Rather than creating new action groups from individual permissions, you can ofte
 - indices:admin/analyze
 - indices:admin/cache/clear
 - indices:admin/close
-- indices:admin/create
-- indices:admin/delete
+- indices:admin/close*
+- indices:admin/create (create indices)
+- indices:admin/data_stream/create
+- indices:admin/data_stream/delete
+- indices:admin/data_stream/get
+- indices:admin/delete (delete indices)
 - indices:admin/exists
 - indices:admin/flush
 - indices:admin/flush*
 - indices:admin/forcemerge
-- indices:admin/get
+- indices:admin/get (retrieve index and mapping)
+- indices:admin/index_template/delete
+- indices:admin/index_template/get
+- indices:admin/index_template/put
+- indices:admin/index_template/simulate
+- indices:admin/index_template/simulate_index
 - indices:admin/mapping/put
 - indices:admin/mappings/fields/get
 - indices:admin/mappings/fields/get*
@@ -137,22 +215,23 @@ Rather than creating new action groups from individual permissions, you can ofte
 - indices:data/read/mget*
 - indices:data/read/msearch
 - indices:data/read/msearch/template
-- indices:data/read/mtv
+- indices:data/read/mtv (multi-term vectors)
 - indices:data/read/mtv*
 - indices:data/read/scroll
 - indices:data/read/scroll/clear
 - indices:data/read/search
 - indices:data/read/search*
 - indices:data/read/search/template
-- indices:data/read/tv
+- indices:data/read/tv (term vectors)
 - indices:data/write/bulk
 - indices:data/write/bulk*
-- indices:data/write/delete
+- indices:data/write/delete (delete documents)
 - indices:data/write/delete/byquery
-- indices:data/write/index
+- indices:data/write/index (add documents to existing indices)
 - indices:data/write/reindex
 - indices:data/write/update
 - indices:data/write/update/byquery
+- indices:monitor/data_stream/stats
 - indices:monitor/recovery
 - indices:monitor/segments
 - indices:monitor/settings/get

--- a/_security-plugin/access-control/permissions.md
+++ b/_security-plugin/access-control/permissions.md
@@ -101,6 +101,10 @@ These permissions are for the cluster and can't be applied granularly. For examp
 - cluster:admin/opendistro/alerting/monitor/get
 - cluster:admin/opendistro/alerting/monitor/search
 - cluster:admin/opendistro/alerting/monitor/write
+- cluster:admin/opendistro/asynchronous_search/stats
+- cluster:admin/opendistro/asynchronous_search/delete
+- cluster:admin/opendistro/asynchronous_search/get
+- cluster:admin/opendistro/asynchronous_search/submit
 - cluster:admin/opendistro/ism/managedindex/add
 - cluster:admin/opendistro/ism/managedindex/change
 - cluster:admin/opendistro/ism/managedindex/remove


### PR DESCRIPTION
Also corrects some permissions names that still use `opendistro`, adds missing permissions, adds some short () description to unclear permissions.

### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
