### PR TITLE
Added missed "template" settings

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -560,7 +560,7 @@ The following sample template policy is for a rollover use case.
      "index_patterns": ["log*"],
      "template": {
       "settings": {
-       "opendistro.index_state_management.rollover_alias": "log"
+       "plugins.index_state_management.rollover_alias": "log"
       }
     }
    }
@@ -586,12 +586,6 @@ The following sample template policy is for a rollover use case.
    {
      "message": "dummy"
    }
-   ```
-
-5. Verify if the policy is attached to the `log-000001` index:
-
-   ```json
-   GET _opendistro/_ism/explain/log-000001?pretty
    ```
 
 ## Example policy

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -558,9 +558,11 @@ The following sample template policy is for a rollover use case.
    PUT _index_template/ism_rollover
    {
      "index_patterns": ["log*"],
-     "settings": {
-       "plugins.index_state_management.rollover_alias": "log"
-     }
+     "template": {
+      "settings": {
+       "opendistro.index_state_management.rollover_alias": "log"
+      }
+    }
    }
    ```
 
@@ -584,6 +586,12 @@ The following sample template policy is for a rollover use case.
    {
      "message": "dummy"
    }
+   ```
+
+5. Verify if the policy is attached to the `log-000001` index:
+
+   ```json
+   GET _opendistro/_ism/explain/log-000001?pretty
    ```
 
 ## Example policy

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -588,6 +588,12 @@ The following sample template policy is for a rollover use case.
    }
    ```
 
+5. Verify if the policy is attached to the `log-000001` index:
+
+   ```json
+   GET _plugins/_ism/explain/log-000001?pretty
+   ```
+
 ## Example policy
 
 The following example policy implements a `hot`, `warm`, and `delete` workflow. You can use this policy as a template to prioritize resources to your indices based on their levels of activity.


### PR DESCRIPTION
### Description
[Describe what this change achieves]
This change fixes below error when creating index template shown in step 2.
```
{
  "error" : {
    "root_cause" : [
      {
        "type" : "x_content_parse_exception",
        "reason" : "[3:3] [index_template] unknown field [settings]"
      }
    ],
    "type" : "x_content_parse_exception",
    "reason" : "[3:3] [index_template] unknown field [settings]"
  },
  "status" : 400
}
```

 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
