### PR TITLE
Fix missing past versions from config

### DIFF
--- a/_data/versions.json
+++ b/_data/versions.json
@@ -1,3 +1,4 @@
 {
-  "current": "1.0"
+  "current": "1.0",
+  "past": []
 }


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
The `past` empty array was missing from the config; this commit adds it.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
