### PR TITLE
Add `.x` suffix to versions selector

### DIFF
--- a/assets/js/_version-selector.js
+++ b/assets/js/_version-selector.js
@@ -143,10 +143,10 @@ class VersionSelector extends HTMLElement {
         const {shadowRoot} = this;
         const frag = this._makeFragment(tpl);
 
-        frag.querySelector('#selected').textContent = `${PREFIX}${this.getAttribute('selected')}`;
+        frag.querySelector('#selected').textContent = `${PREFIX}${this.getAttribute('selected')}.x`;
 
         const pathName = location.pathname.replace(/\/docs(\/((latest|\d+\.\d+)\/?)?)?/, '');
-        const versionsDOMText = DOC_VERSIONS.map((v, idx) => `<a href="/docs/${v}/${pathName}"${idx === 0 ? ' class="latest"' : ''}>${PREFIX}${v}</a>`)
+        const versionsDOMText = DOC_VERSIONS.map((v, idx) => `<a href="/docs/${v}/${pathName}"${idx === 0 ? ' class="latest"' : ''}>${PREFIX}${v}.x</a>`)
             .join('');
 
         frag.querySelector('#dropdown').appendChild(this._makeFragment(versionsDOMText));


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
Changes the displayed versions in the selector to have a `.x` suffix. `1.1` -> `1.1.x`.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
