### PR TITLE
Fix versions selection being blocked on mobile devices

### DIFF
--- a/assets/js/_version-selector.js
+++ b/assets/js/_version-selector.js
@@ -1,3 +1,7 @@
+/* During build, DOC_VERSIONS is prefixed to convey all the versions available, informed by `_data/versions.json`
+ * Example:
+ *    const DOC_VERSIONS = ["1.1","1.0"];
+ */
 const PREFIX = "OpenSearch ";
 const tpl = `
     <style>
@@ -160,6 +164,16 @@ class VersionSelector extends HTMLElement {
     _instrument(shadowRoot) {
         shadowRoot.querySelector('#root').addEventListener('click', e => {
             this._expand(this.getAttribute('aria-expanded') !== 'true');
+        });
+
+        /* On some devices, `blur` is fired on the component before navigation occurs when choosing a version from the
+         * dropdown; this ends up hiding the dropdown and preventing the navigation. The `pointerup` on the anchor
+         * element is always fired before the `blur` is dispatched on the component and that is used here to trigger
+         * the navigation before the dropdown is hidden.
+         */
+        shadowRoot.querySelector('#dropdown').addEventListener('pointerup', e => {
+            const {target} = e;
+            if (target.matches('a[href]') && target.href) document.location.href = target.href;
         });
     }
 


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
On some devices, `blur` is fired on the component before navigation occurs when choosing a version from the version selection dropdown; this ends up hiding the dropdown and preventing the navigation. The `pointerup` on the anchor element of the dropdown is always fired before the `blur` is dispatched on the component. This change uses that to trigger the navigation before the dropdown is hidden.

I also added a line to explain the source of the versions.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
