### PR TITLE
Match `basedir` build config with actual destination of CI

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,7 @@
 title: OpenSearch documentation
 description: >- # this means to ignore newlines until "baseurl:"
   Documentation for OpenSearch, the Apache 2.0 search, analytics, and visualization suite with advanced security, alerting, SQL support, automated index management, deep performance analysis, and more.
-baseurl: "/docs" # the subpath of your site, e.g. /blog
+baseurl: "/docs/latest" # the subpath of your site, e.g. /blog
 url: "https://opensearch.org" # the base hostname & protocol for your site, e.g. http://example.com
 permalink: /:path/
 


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
With versioned documentation, the base of the documentation is `/docs/latest` or `/docs/<version number>`. This commit changed the configuration to use `/docs/latest`.

This value is overwritten during CI/CD to match the deployment needs and is only meaningful during local development and testing.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
