### PR TITLE
Updated Data Prepper reference for Data Prepper 1.1.0

### DIFF
--- a/_monitoring-plugins/trace/data-prepper-reference.md
+++ b/_monitoring-plugins/trace/data-prepper-reference.md
@@ -43,7 +43,7 @@ Option | Required | Description
 port | No | Integer, the port OTel trace source is running on. Default is `21890`.
 request_timeout | No | Integer, the request timeout in millis. Default is `10_000`.
 health_check_service | No | Boolean, enables a gRPC health check service under `grpc.health.v1/Health/Check`. Default is `false`.
-proto_reflection_service | No | Boolean, enables a reflection service for Protobuf services (see ProtoReflectionService and gRPC reflection docs). Default is `false`.
+proto_reflection_service | No | Boolean, enables a reflection service for Protobuf services (see [gRPC reflection](https://github.com/grpc/grpc/blob/master/doc/server-reflection.md) and [gRPC Server Reflection Tutorial](https://github.com/grpc/grpc-java/blob/master/documentation/server-reflection-tutorial.md) docs). Default is `false`.
 unframed_requests | No | Boolean, enable requests not framed using the gRPC wire protocol.
 thread_count | No | Integer, the number of threads to keep in the ScheduledThreadPool. Default is `200`.
 max_connection_count | No | Integer, the maximum allowed number of open connections. Default is `500`.

--- a/_monitoring-plugins/trace/data-prepper-reference.md
+++ b/_monitoring-plugins/trace/data-prepper-reference.md
@@ -40,9 +40,19 @@ Source for the OpenTelemetry Collector.
 
 Option | Required | Description
 :--- | :--- | :---
-ssl | No | Boolean, whether to connect to the OpenTelemetry Collector over SSL.
-sslKeyCertChainFile | No | String, path to the security certificate (e.g. `"config/demo-data-prepper.crt"`.
-sslKeyFile | No | String, path to the security certificate key (e.g. `"config/demo-data-prepper.key"`).
+port | No | Integer, the port OTel trace source is running on. Default is `21890`.
+request_timeout | No | Integer, the request timeout in millis. Default is `10_000`.
+health_check_service | No | Boolean, enables a gRPC health check service under `grpc.health.v1/Health/Check`. Default is `false`.
+proto_reflection_service | No | Boolean, enables a reflection service for Protobuf services (see ProtoReflectionService and gRPC reflection docs). Default is `false`.
+unframed_requests | No | Boolean, enable requests not framed using the gRPC wire protocol.
+thread_count | No | Integer, the number of threads to keep in the ScheduledThreadPool. Default is `200`.
+max_connection_count | No | Integer, the maximum allowed number of open connections. Default is `500`.
+ssl | No | Boolean, enables connections to the OTel source port over TLS/SSL. Defaults to `true`.
+sslKeyCertChainFile | Conditionally | String, file-system path or AWS S3 path to the security certificate (e.g. `"config/demo-data-prepper.crt"` or `"s3://my-secrets-bucket/demo-data-prepper.crt"`). Required if ssl is set to `true`.
+sslKeyFile | Conditionally | String, file-system path or AWS S3 path to the security key (e.g. `"config/demo-data-prepper.key"` or `"s3://my-secrets-bucket/demo-data-prepper.key"`). Required if ssl is set to `true`.
+useAcmCertForSSL | No | Boolean, enables TLS/SSL using certificate and private key from AWS Certificate Manager (ACM). Default is `false`.
+acmCertificateArn | Conditionally | String, represents the ACM certificate ARN. ACM certificate take preference over S3 or local file system certificate. Required if `useAcmCertForSSL` is set to `true`.
+awsRegion | Conditionally | String, represents the AWS region to use ACM or S3. Required if `useAcmCertForSSL` is set to `true` or `sslKeyCertChainFile` and `sslKeyFile` are AWS S3 paths.
 
 
 ### file
@@ -114,11 +124,17 @@ Option | Required | Description
 :--- | :--- | :---
 time_out | No | Integer, forwarded request timeout in seconds. Defaults to 3 seconds.
 span_agg_count | No | Integer, batch size for number of spans per request. Defaults to 48.
-discovery_mode | No | String, peer discovery mode to be used. Allowable values are `static` and `dns`. Defaults to `static`.
+target_port | No | Integer, the destination port to forward requests to. Defaults to `21890`.
+discovery_mode | No | String, peer discovery mode to be used. Allowable values are `static`, `dns`, and `aws_cloud_map`. Defaults to `static`.
 static_endpoints | No | List, containing string endpoints of all Data Prepper instances.
 domain_name | No | String, single domain name to query DNS against. Typically used by creating multiple DNS A Records for the same domain.
 ssl | No | Boolean, indicating whether TLS should be used. Default is true.
-sslKeyCertChainFile | No | String, path to the security certificate
+awsCloudMapNamespaceName | Conditionally | String, name of your CloudMap Namespace. Required if `discovery_mode` is set to `aws_cloud_map`.
+awsCloudMapServiceName | Conditionally | String, service name within your CloudMap Namespace. Required if `discovery_mode` is set to `aws_cloud_map`.
+sslKeyCertChainFile | Conditionally | String, represents the SSL certificate chain file path or AWS S3 path. S3 path example `s3://<bucketName>/<path>`. Required if `ssl` is set to `true`.
+useAcmCertForSSL | No | Boolean, enables TLS/SSL using certificate and private key from AWS Certificate Manager (ACM). Default is `false`.
+awsRegion | Conditionally | String, represents the AWS region to use ACM, S3, or CloudMap. Required if `useAcmCertForSSL` is set to `true` or `sslKeyCertChainFile` and `sslKeyFile` are AWS S3 paths.
+acmCertificateArn | Conditionally | String represents the ACM certificate ARN. ACM certificate take preference over S3 or local file system certificate. Required if `useAcmCertForSSL` is set to `true`.
 
 ### string_converter
 
@@ -144,8 +160,9 @@ hosts | Yes | List of OpenSearch hosts to write to (e.g. `["https://localhost:92
 cert | No | String, path to the security certificate (e.g. `"config/root-ca.pem"`) if the cluster uses the OpenSearch security plugin.
 username | No | String, username for HTTP basic authentication.
 password | No | String, password for HTTP basic authentication.
-aws_sigv4 | No | Boolean, whether to use IAM signing to connect to an Amazon ES cluster. For your access key, secret key, and optional session token, Data Prepper uses the default credential chain (environment variables, Java system properties, `~/.aws/credential`, etc.).
-aws_region | No | String, AWS region for the cluster (e.g. `"us-east-1"`) if you are connecting to Amazon ES.
+aws_sigv4 | No | Boolean, whether to use IAM signing to connect to an Amazon OpenSearch Service domain. For your access key, secret key, and optional session token, Data Prepper uses the default credential chain (environment variables, Java system properties, `~/.aws/credential`, etc.).
+aws_region | No | String, AWS region (e.g. `"us-east-1"`) for the domain if you are connecting to Amazon OpenSearch Service.
+aws_sts_role | No | String, IAM role which the sink plugin will assume to sign request to Amazon OpenSearch Service. If not provided the plugin will use the default credentials.
 trace_analytics_raw | No | Boolean, default false. Whether to export as trace data to the `otel-v1-apm-span-*` index pattern (alias `otel-v1-apm-span`) for use with the Trace Analytics OpenSearch Dashboards plugin.
 trace_analytics_service_map | No | Boolean, default false. Whether to export as trace data to the `otel-v1-apm-service-map` index for use with the service map component of the Trace Analytics OpenSearch Dashboards plugin.
 index | No | String, name of the index to export to. Only required if you don't use the `trace_analytics_raw` or `trace_analytics_service_map` presets.


### PR DESCRIPTION
Signed-off-by: David Venable <dlv@amazon.com>

### Description

We are releasing Data Prepper 1.1.0 in the next few days. This PR contains an updated reference page for Data Prepper with some of the new fields.

Note: Please do not merge until Data Prepper 1.1.0 is released. Scheduled for Oct 15, 2021.
 
### Issues Resolved

N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
