### PR TITLE
Fix authc configuration format.

### DIFF
--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -53,10 +53,10 @@ The `authc` section has the following format:
   http_enabled: <true|false>
   transport_enabled: <true|false>
   order: <integer>
-    http_authenticator:
-      ...
-    authentication_backend:
-      ...
+  http_authenticator:
+    ...
+  authentication_backend:
+    ...
 ```
 
 An entry in the `authc` section is called an *authentication domain*. It specifies where to get the user credentials and against which backend they should be authenticated.


### PR DESCRIPTION
### Description
Fix authc configuration format.
https://opensearch.org/docs/latest/security-plugin/configuration/configuration/#authentication
One indentation level too many I believe, looking at this 
https://github.com/opensearch-project/security/blob/main/securityconfig/config.yml#L84-L98
 
### Issues Resolved
-
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
