### PR TITLE
Updated so snapshots now include Mustache templates as names

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -314,13 +314,13 @@ The `snapshot` operation has the following parameters:
 Parameter | Description | Type | Required | Default
 :--- | :--- |:--- |:--- |
 `repository` | The repository name that you register through the native snapshot API operations.  | `string` | Yes | -
-`snapshot` | The name of the snapshot. | `string` | Yes | -
+`snapshot` | The name of the snapshot. Accepts strings and the Mustache variables `{{ctx.IndexName}}` and `{{ctx.IndexUuid}}`. If the Mustache variables are invalid, then the snapshot name is defaulted to the index's name. | `string` or Mustache template | Yes | -
 
 ```json
 {
   "snapshot": {
     "repository": "my_backup",
-    "snapshot": "my_snapshot"
+    "snapshot": "{{ctx.IndexUuid}}"
   }
 }
 ```

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -314,7 +314,7 @@ The `snapshot` operation has the following parameters:
 Parameter | Description | Type | Required | Default
 :--- | :--- |:--- |:--- |
 `repository` | The repository name that you register through the native snapshot API operations.  | `string` | Yes | -
-`snapshot` | The name of the snapshot. Accepts strings and the Mustache variables `{{ctx.IndexName}}` and `{{ctx.IndexUuid}}`. If the Mustache variables are invalid, then the snapshot name is defaulted to the index's name. | `string` or Mustache template | Yes | -
+`snapshot` | The name of the snapshot. Accepts strings and the Mustache variables `{{ctx.index}}` and `{{ctx.indexUuid}}`. If the Mustache variables are invalid, then the snapshot name defaults to the index's name. | `string` or Mustache template | Yes | -
 
 ```json
 {

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -320,7 +320,7 @@ Parameter | Description | Type | Required | Default
 {
   "snapshot": {
     "repository": "my_backup",
-    "snapshot": "{{ctx.IndexUuid}}"
+    "snapshot": "{{ctx.indexUuid}}"
   }
 }
 ```


### PR DESCRIPTION
### Description

Updated snapshot policy to include Mustache templates as possible snapshot names

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
