### PR TITLE
fix bash export command syntax

### DIFF
--- a/_upgrade-to/upgrade-to.md
+++ b/_upgrade-to/upgrade-to.md
@@ -223,25 +223,25 @@ Check [Upgrade paths]({{site.url}}{{site.baseurl}}/upgrade-to/upgrade-to/#upgrad
     - `ES_HOME` - Path to the existing Elasticsearch installation home.
 
       ```bash
-      export ES_HOME = /home/workspace/upgrade-demo/node1/elasticsearch-7.10.2
+      export ES_HOME=/home/workspace/upgrade-demo/node1/elasticsearch-7.10.2
       ```
 
     - `ES_PATH_CONF` - Path to the existing Elasticsearch config directory.
 
       ```bash
-      export ES_PATH_CONF = /home/workspace/upgrade-demo/node1/os-config
+      export ES_PATH_CONF=/home/workspace/upgrade-demo/node1/os-config
       ```
 
     - `OPENSEARCH_HOME` - Path to the OpenSearch installation home.
 
       ```bash
-      export OPENSEARCH_HOME = /home/workspace/upgrade-demo/node1/opensearch-1.0.0
+      export OPENSEARCH_HOME=/home/workspace/upgrade-demo/node1/opensearch-1.0.0
       ```
 
     - `OPENSEARCH_PATH_CONF` - Path to the OpenSearch config directory.
 
       ```bash
-      export OPENSEARCH_PATH_CONF = /home/workspace/upgrade-demo/node1/opensearch-config
+      export OPENSEARCH_PATH_CONF=/home/workspace/upgrade-demo/node1/opensearch-config
       ```
 
 1. The `opensearch-upgrade` tool is in the `bin` directory of the distribution. Run the following command from the distribution home:


### PR DESCRIPTION
### Description
Removed unnecessary spaces surrounding = symbol to make the command snippet copy paste friendly
 
### Issues Resolved
None.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
