### PR TITLE
Add Sample Docker Compose file for development

### DIFF
--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -376,5 +376,5 @@ networks:
   opensearch-net:
 ```
 
-The `"DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"` disables security dashboards Plugin in OpenSearch Dashboards by removing security dashboards plugin folder, removing all related settings in `opensearch_dashboards.yml`, and sets `opensearch.hosts` entry protocol from HTTPS to HTTP. This step is not reversible as the security dashboards plugin is removed in the process. If you want to re-enable security for OpenSearch Dashboards, you need to start a new container with `DISABLE_SECURITY_DASHBOARDS_PLUGIN` unset, or false.
+The enviroment variable `"DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"` disables security dashboards plugin in OpenSearch Dashboards by removing security dashboards plugin folder, removing all related settings in `opensearch_dashboards.yml`, and sets `opensearch.hosts` entry protocol from HTTPS to HTTP. This step is not reversible as the security dashboards plugin is removed in the process. If you want to re-enable security for OpenSearch Dashboards, you need to start a new container with `DISABLE_SECURITY_DASHBOARDS_PLUGIN` unset, or false.
 {: .note}

--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -325,7 +325,9 @@ network.host: 0.0.0.0
 
 ## Sample Docker Compose file for development
 
-This sample file starts one OpenSearch node and a container for OpenSearch Dashboards for development by disabling security plugin.
+You can use this sample file as a development environment.
+
+This sample file starts one OpenSearch node and a container for OpenSearch Dashboards with the security plugin disabled.
 
 ```yml
 version: '3'
@@ -376,5 +378,7 @@ networks:
   opensearch-net:
 ```
 
-The enviroment variable `"DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"` disables security dashboards plugin in OpenSearch Dashboards by removing security dashboards plugin folder, removing all related settings in `opensearch_dashboards.yml`, and sets `opensearch.hosts` entry protocol from HTTPS to HTTP. This step is not reversible as the security dashboards plugin is removed in the process. If you want to re-enable security for OpenSearch Dashboards, you need to start a new container with `DISABLE_SECURITY_DASHBOARDS_PLUGIN` unset, or false.
+The environment variable `"DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"` disables the security dashboards plugin in OpenSearch Dashboards by removing the security dashboards plugin folder, removing all related settings in the `opensearch_dashboards.yml` file, and setting the `opensearch.hosts` entry protocol from HTTPS to HTTP. 
+You can't reverse this step as the security dashboards plugin is removed in the process. 
+To re-enable security for OpenSearch Dashboards, start a new container and set `DISABLE_SECURITY_DASHBOARDS_PLUGIN` to false or leave it unset.
 {: .note}

--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -322,3 +322,59 @@ In this case, `opensearch.yml` is a "vanilla" version of the file with no plugin
 cluster.name: "docker-cluster"
 network.host: 0.0.0.0
 ```
+
+## Sample Docker Compose file for development
+
+This sample file starts one OpenSearch node and a container for OpenSearch Dashboards for development by disabling security plugin.
+
+```yml
+version: '3'
+services:
+  opensearch-node1:
+    image: opensearchproject/opensearch:{{site.opensearch_version}}
+    container_name: opensearch-node1
+    environment:
+      - cluster.name=opensearch-cluster
+      - node.name=opensearch-node1
+      - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
+      - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
+      - "DISABLE_INSTALL_DEMO_CONFIG=true" # disables execution of install_demo_configuration.sh bundled with security plugin, which installs demo certificates and security configurations to OpenSearch
+      - "DISABLE_SECURITY_PLUGIN=true" # disables security plugin entirely in OpenSearch by setting plugins.security.disabled: true in opensearch.yml
+      - "discovery.type=single-node" # disables bootstrap checks that are enabled when network.host is set to a non-loopback address
+    ulimits:
+      memlock:
+        soft: -1
+        hard: -1
+      nofile:
+        soft: 65536 # maximum number of open files for the OpenSearch user, set to at least 65536 on modern systems
+        hard: 65536
+    volumes:
+      - opensearch-data1:/usr/share/opensearch/data
+    ports:
+      - 9200:9200
+      - 9600:9600 # required for Performance Analyzer
+    networks:
+      - opensearch-net
+
+  opensearch-dashboards:
+    image: opensearchproject/opensearch-dashboards:{{site.opensearch_version}}
+    container_name: opensearch-dashboards
+    ports:
+      - 5601:5601
+    expose:
+      - "5601"
+    environment:
+      - 'OPENSEARCH_HOSTS=["http://opensearch-node1:9200"]'
+      - "DISABLE_SECURITY_DASHBOARDS_PLUGIN=true" # disables security dashboards plugin in OpenSearch Dashboards
+    networks:
+      - opensearch-net
+
+volumes:
+  opensearch-data1:
+
+networks:
+  opensearch-net:
+```
+
+The `"DISABLE_SECURITY_DASHBOARDS_PLUGIN=true"` disables security dashboards Plugin in OpenSearch Dashboards by removing security dashboards plugin folder, removing all related settings in `opensearch_dashboards.yml`, and sets `opensearch.hosts` entry protocol from HTTPS to HTTP. This step is not reversible as the security dashboards plugin is removed in the process. If you want to re-enable security for OpenSearch Dashboards, you need to start a new container with `DISABLE_SECURITY_DASHBOARDS_PLUGIN` unset, or false.
+{: .note}


### PR DESCRIPTION
Signed-off-by: namrataa-p <namrata23x@gmail.com>

### Description
Allows users to setup OpenSearch and OpenSearch Dashboards containers for development environments using plain HTTP.

The environment variables used in the docker-compose file for disabling security plugins are referred from [disable-security-plugin-security-dashboards-plugin-security-demo-configurations-and-related-configurations](https://github.com/opensearch-project/opensearch-build/blob/main/docker/release/README.md#disable-security-plugin-security-dashboards-plugin-security-demo-configurations-and-related-configurations) section.
 
### Issues Resolved
[1598 - Needed: easy way to setup service as plain HTTP (for development)](https://github.com/opensearch-project/OpenSearch/issues/1598)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
