### PR TITLE
Fix version-selector in Safari 15.x

### DIFF
--- a/assets/js/_version-selector.js
+++ b/assets/js/_version-selector.js
@@ -39,6 +39,11 @@ const tpl = `
         background-image: var(--hover-bg);
     }
     
+    #root:focus {
+        outline: none;
+    }
+    
+    :host(:not([aria-expanded="true"])) #root:focus,
     #root:focus:hover {
         box-shadow: 0 0 0 3px rgba(0, 0, 255, 0.25);
     }
@@ -136,7 +141,7 @@ class VersionSelector extends HTMLElement {
 
     constructor() {
         super();
-        this.attachShadow({mode: 'open'});
+        this.attachShadow({mode: 'open', delegatesFocus: true});
         this._onBlur = (e => {
             this._expand(false);
             this.removeEventListener('blur', this._onBlur);


### PR DESCRIPTION
Signed-off-by: Miki <mehranb@amazon.com>

### Description
Some browser+OS combinations trigger `blur` on the version-selector before a click within the component. To mitigate this, an extra `pointerup` listener was attached but that didn't solve the problem for Safari 15.x. However, `delegatesFocus: true` makes the shadow host focusable and that helps work around this problem.
 
### Issues Resolved
#307
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
