### PR TITLE
Update snapshot-restore.md

### DIFF
--- a/_opensearch/snapshot-restore.md
+++ b/_opensearch/snapshot-restore.md
@@ -146,7 +146,6 @@ Setting | Description
 1. (Optional) Add other settings to `opensearch.yml`:
 
    ```yml
-   s3.client.default.disable_chunked_encoding: false # Disables chunked encoding for compatibility with some storage services, but you probably don't need to change this value.
    s3.client.default.endpoint: s3.amazonaws.com # S3 has alternate endpoints, but you probably don't need to change this value.
    s3.client.default.max_retries: 3 # number of retries if a request fails
    s3.client.default.path_style_access: false # whether to use the deprecated path-style bucket URLs.


### PR DESCRIPTION
disable_chunked_encoding option gives runtime error: unknown configuration option.

### Description
Opensearch starts
 
### Issues Resolved
-
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
