### PR TITLE
Clarify stop autofollow behavior

### DIFF
--- a/_replication-plugin/api.md
+++ b/_replication-plugin/api.md
@@ -361,7 +361,7 @@ Options | Description | Type | Required
 Introduced 1.1
 {: .label .label-purple }
 
-Deletes the specified replication rule. This operation prevents any new indices from being replicated but does not stop existing replication that the rule has already initiated.
+Deletes the specified replication rule. This operation prevents any new indices from being replicated but does not stop existing replication that the rule has already initiated. Replicated indices remain read-only until you stop replication.
 
 Send this request to the follower cluster.
 

--- a/_replication-plugin/auto-follow.md
+++ b/_replication-plugin/auto-follow.md
@@ -92,7 +92,7 @@ curl -XGET -u 'admin:admin' -k 'https://localhost:9200/_plugins/_replication/aut
 
 ## Delete a replication rule
 
-When you delete a replication rule, OpenSearch stops replicating *new* indices that match the pattern, but existing indices that the rule previously created continue to replicate. If you need to stop existing replication activity, use the [stop replication API operation]({{site.url}}{{site.baseurl}}/replication-plugin/api/#stop-replication).
+To delete a replication rule, send the following request:
 
 ```bash
 curl -XDELETE -k -H 'Content-Type: application/json' -u 'admin:admin' 'https://localhost:9200/_plugins/_replication/_autofollow?pretty' -d '
@@ -101,4 +101,6 @@ curl -XDELETE -k -H 'Content-Type: application/json' -u 'admin:admin' 'https://l
    "name": "my-replication-rule"
 }'
 ```
+
+OpenSearch stops replicating *new* indices that match the pattern, but existing indices that the rule previously created remain read-only and continue to replicate. If you need to stop existing replication activity and open the indices up for writes, use the [stop replication API operation]({{site.url}}{{site.baseurl}}/replication-plugin/api/#stop-replication).
 


### PR DESCRIPTION
Signed-off-by: Liz Snyder <elizabsn@amazon.com>

### Description
Docs are a bit vague on read-only behavior after auto-follow is stopped. Clarified here.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
