### PR TITLE
Update GitHub links in documentation to correct new branch names

### DIFF
--- a/_clients/logstash/common-filters.md
+++ b/_clients/logstash/common-filters.md
@@ -154,4 +154,4 @@ http_status: 200
 num_bytes: 12798
 ```
 
-For common log formats, you use the predefined patterns defined here⁠---[Logstash patterns](https://github.com/logstash-plugins/logstash-patterns-core/blob/master/patterns/ecs-v1). You can make any adjustments to the results with the `mutate` filter.
+For common log formats, you use the predefined patterns defined here⁠---[Logstash patterns](https://github.com/logstash-plugins/logstash-patterns-core/blob/main/patterns/ecs-v1). You can make any adjustments to the results with the `mutate` filter.

--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -24,7 +24,7 @@ opensearch_security:
       ...
 ```
 
-For a more complete example, see the [sample file on GitHub](https://github.com/opensearch-project/security/blob/master/securityconfig/config.yml).
+For a more complete example, see the [sample file on GitHub](https://github.com/opensearch-project/security/blob/main/securityconfig/config.yml).
 
 
 ## HTTP


### PR DESCRIPTION
### Description
Some GitHub links are no longer strictly correct; branches have been renamed from `master` to `main` (woohoo!) but the links haven't been updated.

Even though GitHub automatically redirects to the new default branch, it's better to have it go to the right place from the start 😄 
 
### Check List
- [ ] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
