### PR TITLE
Separate OpenSearch Dashboards version from that of OpenSearch

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,6 +6,7 @@ url: "https://opensearch.org" # the base hostname & protocol for your site, e.g.
 permalink: /:path/
 
 opensearch_version: 1.2.3
+opensearch_dashboards_version: 1.2.0
 opensearch_major_minor_version: 1.2
 lucene_version: 8_9_0
 

--- a/_dashboards/install/docker.md
+++ b/_dashboards/install/docker.md
@@ -9,7 +9,7 @@ nav_order: 1
 
 You *can* start OpenSearch Dashboards using `docker run` after [creating a Docker network](https://docs.docker.com/engine/reference/commandline/network_create/) and starting OpenSearch, but the process of connecting OpenSearch Dashboards to OpenSearch is significantly easier with a Docker Compose file.
 
-1. Run `docker pull opensearchproject/opensearch-dashboards:{{site.opensearch_version}}`.
+1. Run `docker pull opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}`.
 
 1. Create a [`docker-compose.yml`](https://docs.docker.com/compose/compose-file/) file appropriate for your environment. A sample file that includes OpenSearch Dashboards is available on the OpenSearch [Docker installation page]({{site.url}}{{site.baseurl}}/opensearch/install/docker#sample-docker-compose-file).
 

--- a/_opensearch/install/docker-security.md
+++ b/_opensearch/install/docker-security.md
@@ -87,7 +87,7 @@ services:
     networks:
       - opensearch-net
   opensearch-dashboards
-    image: opensearchproject/opensearch-dashboards:{{site.opensearch_version}}
+    image: opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}
     container_name: opensearch-dashboards
     ports:
       - 5601:5601

--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -11,7 +11,7 @@ You can pull the OpenSearch Docker image just like any other image:
 
 ```bash
 docker pull opensearchproject/opensearch:{{site.opensearch_version}}
-docker pull opensearchproject/opensearch-dashboards:{{site.opensearch_version}}
+docker pull opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}
 ```
 
 To check available versions, see [Docker Hub](https://hub.docker.com/u/opensearchproject).
@@ -131,7 +131,7 @@ services:
     networks:
       - opensearch-net
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:{{site.opensearch_version}}
+    image: opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}
     container_name: opensearch-dashboards
     ports:
       - 5601:5601
@@ -359,7 +359,7 @@ services:
       - opensearch-net
 
   opensearch-dashboards:
-    image: opensearchproject/opensearch-dashboards:{{site.opensearch_version}}
+    image: opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}
     container_name: opensearch-dashboards
     ports:
       - 5601:5601

--- a/_security-plugin/configuration/disable.md
+++ b/_security-plugin/configuration/disable.md
@@ -36,7 +36,7 @@ If you disable the security plugin in `opensearch.yml` (or delete the plugin ent
 1. Create a new `Dockerfile`:
 
    ```
-   FROM opensearchproject/opensearch-dashboards:{{site.opensearch_version}}
+   FROM opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}
    RUN /usr/share/opensearch-dashboards/bin/opensearch-dashboards-plugin remove securityDashboards
    COPY --chown=opensearch-dashboards:opensearch-dashboards opensearch_dashboards.yml /usr/share/opensearch-dashboards/config/
    ```
@@ -57,6 +57,6 @@ If you disable the security plugin in `opensearch.yml` (or delete the plugin ent
    docker build --tag=opensearch-dashboards-no-security .
    ```
 
-1. In `docker-compose.yml`, change `opensearchproject/opensearch-dashboards:{{site.opensearch_version}}` to `opensearch-dashboards-no-security`.
+1. In `docker-compose.yml`, change `opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}` to `opensearch-dashboards-no-security`.
 1. Change `OPENSEARCH_HOSTS` or `opensearch.hosts` to `http://` rather than `https://`.
 1. Enter `docker-compose up`.


### PR DESCRIPTION
Signed-off-by: Miki <miki@amazon.com>

### Description
Until now, all references to OpenSearch and OpenSearch dashboards were using `opensearch_version` which are not always the same. This change, introduces a separate variable, `opensearch_dashboards_version`, for referencing OpenSearch Dashboards version.

 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
