### PR TITLE
Mistake in memory estimation for IVF k-NN

### DIFF
--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -184,7 +184,7 @@ The memory required for HNSW is estimated to be `1.1 * (4 * dimension + 8 * M)` 
 As an example, assume you have a million vectors with a dimension of 256 and M of 16. The memory requirement can be estimated as follows:
 
 ```
-1.1 * (4 *256 + 8 * 16) * 1,000,000 ~= 1.26 GB
+1.1 * (4 * 256 + 8 * 16) * 1,000,000 ~= 1.267 GB
 ```
 
 #### IVF memory estimation
@@ -194,7 +194,7 @@ The memory required for IVF is estimated to be `1.1 * (((4 * dimension) * num_ve
 As an example, assume you have a million vectors with a dimension of 256 and nlist of 128. The memory requirement can be estimated as follows:
 
 ```
-1.1 * (((4 * 128) * 1000000) + (4 * 128 * 256))  ~= 563 MB
+1.1 * (((4 * 256) * 1,000,000) + (4 * 128 * 256))  ~= 1.126 GB
 
 ```
 


### PR DESCRIPTION
Signed-off-by: John Mazanec <jmazane@amazon.com>

### Description
For k-NN, I made a mistake in documentation for IVF memory estimation. In the example, dimension is 256 but in the calculation, it is 128. This PR fixes that.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
