### PR TITLE
Add Ingest API to reference

### DIFF
--- a/_opensearch/rest-api/ingest-apis/create-update-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/create-update-ingest.md
@@ -13,7 +13,7 @@ The create ingest pipeline API operation creates or updates an ingest pipeline. 
 ## Example
 
 ```
-PUT _ingest/pipeline/{id}
+PUT _ingest/pipeline/12345
 {
   "description" : "A description for your pipeline",
   "processors" : [
@@ -34,10 +34,10 @@ PUT _ingest/pipeline/{id}
 
 ## Request body fields
 
-Field | Type | Description
-:--- | :--- | :---
-`description` (optional) | string | Description of your ingest pipeline. 
-`processors` | processor objects | A processor that transforms documents. Runs in the order specified. Appears in index once ran.
+Field | Required | Type | Description
+:--- | :--- | :--- | :---
+description | Optional | string | Description of your ingest pipeline. 
+processors | **Required** | Array of processor objects | A processor that transforms documents. Runs in the order specified. Appears in index once ran.
 
 ```json
 {
@@ -54,6 +54,8 @@ Field | Type | Description
 ```
 
 ## URL parameters
+
+All URL parameters are optional.
 
 Parameter | Type | Description
 :--- | :--- | :---

--- a/_opensearch/rest-api/ingest-apis/create-update-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/create-update-ingest.md
@@ -1,0 +1,75 @@
+---
+layout: default
+title: Create or update ingest pipeline
+parent: Ingest APIs
+grand_parent: REST API reference
+nav_order: 11
+---
+
+# Create and update a pipeline
+
+The create ingest pipeline API operation creates or updates an ingest pipeline. Each pipeline requires an ingest definition defining how each processor transforms your documents. 
+
+## Example
+
+```
+PUT _ingest/pipeline/{id}
+{
+  "description" : "A description for your pipeline",
+  "processors" : [
+    {
+      "set" : {
+        "field": "field-name",
+        "value": "value"
+      }
+    }
+  ]
+}
+```
+
+## Path and HTTP methods
+```
+PUT _ingest/pipeline/{id}
+```
+
+## Request body fields
+
+Field | Type | Description
+:--- | :--- | :---
+`description` (optional) | string | Description of your ingest pipeline 
+`processors` | processor objects | A processor that transforms documents. Runs in the order specified. Appears in index once ran.
+
+```json
+{
+  "description" : "A description for your pipeline",
+  "processors" : [
+    {
+      "set" : {
+        "field": "field-name",
+        "value": "value"
+      }
+    }
+  ]
+}
+```
+
+## URL parameters
+
+Parameter | Type | Description
+:--- | :--- | :---
+master_timeout | time | Explicit operation timeout for connection to master node
+timeout | time | Explicit operation timeout
+
+## Response
+
+```json
+{
+  "acknowledged" : true
+}
+```
+
+
+
+
+
+

--- a/_opensearch/rest-api/ingest-apis/create-update-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/create-update-ingest.md
@@ -37,7 +37,7 @@ PUT _ingest/pipeline/{id}
 Field | Required | Type | Description
 :--- | :--- | :--- | :---
 description | Optional | string | Description of your ingest pipeline. 
-processors | **Required** | Array of processor objects | A processor that transforms documents. Runs in the order specified. Appears in index once ran.
+processors | Required | Array of processor objects | A processor that transforms documents. Runs in the order specified. Appears in index once ran.
 
 ```json
 {

--- a/_opensearch/rest-api/ingest-apis/create-update-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/create-update-ingest.md
@@ -57,8 +57,8 @@ Field | Type | Description
 
 Parameter | Type | Description
 :--- | :--- | :---
-master_timeout | time | Explicit operation timeout for connection to master node
-timeout | time | Explicit operation timeout
+master_timeout | time | How long to wait for a connection to the master node.
+timeout | time | How long to wait for the request to return. 
 
 ## Response
 

--- a/_opensearch/rest-api/ingest-apis/create-update-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/create-update-ingest.md
@@ -36,7 +36,7 @@ PUT _ingest/pipeline/{id}
 
 Field | Type | Description
 :--- | :--- | :---
-`description` (optional) | string | Description of your ingest pipeline 
+`description` (optional) | string | Description of your ingest pipeline. 
 `processors` | processor objects | A processor that transforms documents. Runs in the order specified. Appears in index once ran.
 
 ```json

--- a/_opensearch/rest-api/ingest-apis/delete-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/delete-ingest.md
@@ -21,8 +21,8 @@ DELETE _ingest/pipeline/{id}
 
 Parameter | Type | Description
 :--- | :--- | :---
-master_timeout | time | Explicit operation timeout for connection to master node
-timeout | time | Explicit operation timeout
+master_timeout | time | How long to wait for a connection to the master node.
+timeout | time | How long to wait for the request to return.
 
 ## Response
 

--- a/_opensearch/rest-api/ingest-apis/delete-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/delete-ingest.md
@@ -13,11 +13,20 @@ If you no longer want to use an ingest pipeline, use the delete ingest pipeline 
 ## Example
 
 ```
-DELETE _ingest/pipeline/{id}
+DELETE _ingest/pipeline/12345
 ```
 
+## Path and HTTP methods
+
+Delete an ingest pipeline based on that pipeline's ID.
+
+```
+DELETE _ingest/pipeline/
+```
 
 ## URL parameters
+
+All URL parameters are optional.
 
 Parameter | Type | Description
 :--- | :--- | :---

--- a/_opensearch/rest-api/ingest-apis/delete-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/delete-ingest.md
@@ -1,0 +1,33 @@
+---
+layout: default
+title: Delete a pipeline
+parent: Ingest APIs
+grand_parent: REST API reference
+nav_order: 14
+---
+
+# Delete a pipeline
+
+If you no longer want to use an ingest pipeline, use the delete ingest pipeline API operation.
+
+## Example
+
+```
+DELETE _ingest/pipeline/{id}
+```
+
+
+## URL parameters
+
+Parameter | Type | Description
+:--- | :--- | :---
+master_timeout | time | Explicit operation timeout for connection to master node
+timeout | time | Explicit operation timeout
+
+## Response
+
+```json
+{
+  "acknowledged" : true
+}
+```

--- a/_opensearch/rest-api/ingest-apis/get-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/get-ingest.md
@@ -13,7 +13,7 @@ After you create a pipeline, use the get ingest pipeline API operation to return
 ## Example
 
 ```
-GET _ingest/pipeline/{id}
+GET _ingest/pipeline/12345
 ```
 
 ## Path and HTTP methods
@@ -23,7 +23,6 @@ Return all ingest pipelines.
 ```
 GET _ingest/pipeline
 ```
-
 
 Returns a single ingest pipeline based on the pipeline's ID.
 

--- a/_opensearch/rest-api/ingest-apis/get-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/get-ingest.md
@@ -37,7 +37,7 @@ All parameters are optional.
 
 Parameter | Type | Description
 :--- | :--- | :---
-master_timeout | time | Explicit operation timeout for connection to master node
+master_timeout | time | How long to wait for a connection to the master node.
 
 ## Response
 

--- a/_opensearch/rest-api/ingest-apis/get-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/get-ingest.md
@@ -1,0 +1,58 @@
+---
+layout: default
+title: Get ingest pipeline
+parent: Ingest APIs
+grand_parent: REST API reference
+nav_order: 10
+---
+
+## Get ingest pipeline
+
+After you create a pipeline, use the get ingest pipeline API operation to return all the information about a specific ingest pipeline.
+
+## Example
+
+```
+GET _ingest/pipeline/{id}
+```
+
+## Path and HTTP methods
+
+Return all ingest pipelines.
+
+```
+GET _ingest/pipeline
+```
+
+
+Returns a single ingest pipeline based on the pipeline's ID.
+
+```
+GET _ingest/pipeline/{id}
+```
+
+## URL parameters
+
+All parameters are optional.
+
+Parameter | Type | Description
+:--- | :--- | :---
+master_timeout | time | Explicit operation timeout for connection to master node
+
+## Response
+
+```json
+{
+  "pipeline-id" : {
+    "description" : "A description for your pipeline",
+    "processors" : [
+      {
+        "set" : {
+          "field" : "field-name",
+          "value" : "value"
+        }
+      }
+    ]
+  }
+}
+```

--- a/_opensearch/rest-api/ingest-apis/index.md
+++ b/_opensearch/rest-api/ingest-apis/index.md
@@ -10,6 +10,6 @@ redirect_from:
 
 # Ingest APIs
 
-Before you index your data, OpenSearch's ingest APIs help transform your data through the creation of ingest pipelines. Pipelines are made up of processors, a customizable task that run in succession. The transformed data appears in your data stream or index after each of the processors completes.
+Before you index your data, OpenSearch's ingest APIs help transform your data through the creation of ingest pipelines. Pipelines are made up of processors, a customizable task that run in the order they appear in the request body. The transformed data appears in your data stream or index after each of the processors completes.
 
 Ingest pipelines in OpenSearch are managed using ingest API operations. In production environments, your cluster should contain at least one node with the `node.roles: [ingest]`. For more information on setting up node roles within a cluster, see [Cluster Formation]({{site.url}}{{site.baseurl}}/cluster/).

--- a/_opensearch/rest-api/ingest-apis/index.md
+++ b/_opensearch/rest-api/ingest-apis/index.md
@@ -12,4 +12,4 @@ redirect_from:
 
 Before you index your data, OpenSearch's ingest APIs help transform your data through the creation of ingest pipelines. Pipelines are made up of processors, a customizable task that run in the order they appear in the request body. The transformed data appears in your data stream or index after each of the processors completes.
 
-Ingest pipelines in OpenSearch are managed using ingest API operations. In production environments, your cluster should contain at least one node with the `node.roles: [ingest]`. For more information on setting up node roles within a cluster, see [Cluster Formation]({{site.url}}{{site.baseurl}}/cluster/).
+Ingest pipelines in OpenSearch are managed using ingest API operations. In production environments, your cluster should contain at least one node with the node roles permission set to `ingest`. For more information on setting up node roles within a cluster, see [Cluster Formation]({{site.url}}{{site.baseurl}}/cluster/).

--- a/_opensearch/rest-api/ingest-apis/index.md
+++ b/_opensearch/rest-api/ingest-apis/index.md
@@ -1,0 +1,15 @@
+---
+layout: default
+title: Ingest APIs
+parent: REST API reference
+has_children: true
+nav_order: 3
+redirect_from:
+  - /opensearch/rest-api/ingest-apis/
+---
+
+# Ingest APIs
+
+Before you index your data, OpenSearch's ingest APIs help transform your data through the creation of ingest pipelines. Pipelines are made up of processors, a customizable task that run in succession. The transformed data appears in your data stream or index after each of the processors completes.
+
+Ingest pipelines in OpenSearch are managed using ingest API operations. In production environments, your cluster should contain at least one node with the `node.roles: [ingest]`. For more information on setting up node roles within a cluster, see [Cluster Formation]({{site.url}}{{site.baseurl}}/cluster/).

--- a/_opensearch/rest-api/ingest-apis/index.md
+++ b/_opensearch/rest-api/ingest-apis/index.md
@@ -10,6 +10,6 @@ redirect_from:
 
 # Ingest APIs
 
-Before you index your data, OpenSearch's ingest APIs help transform your data through the creation of ingest pipelines. Pipelines are made up of processors, a customizable task that run in the order they appear in the request body. The transformed data appears in your data stream or index after each of the processors completes.
+Before you index your data, OpenSearch's ingest APIs help transform your data by creating and managing ingest pipelines. Pipelines consist of **processors**, customizable tasks that run in the order they appear in the request body. The transformed data appears in your index after each of the processor completes.
 
-Ingest pipelines in OpenSearch are managed using ingest API operations. In production environments, your cluster should contain at least one node with the node roles permission set to `ingest`. For more information on setting up node roles within a cluster, see [Cluster Formation]({{site.url}}{{site.baseurl}}/cluster/).
+Ingest pipelines in OpenSearch can only be managed using ingest API operations. When using ingest in production environments, your cluster should contain at least one node with the node roles permission set to `ingest`. For more information on setting up node roles within a cluster, see [Cluster Formation]({{site.url}}{{site.baseurl}}/opensearch/cluster/).

--- a/_opensearch/rest-api/ingest-apis/simulate-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/simulate-ingest.md
@@ -1,0 +1,201 @@
+---
+layout: default
+title: Simulate an ingest pipeline
+parent: Ingest APIs
+grand_parent: REST API reference
+nav_order: 13
+---
+
+# Simulate a pipeline
+
+Simulates an ingest pipeline with any example documents set you specify.
+
+## Example
+
+```
+POST /_ingest/pipeline/{id}/_simulate
+{
+  "docs": [
+    {
+      "_index": "index",
+      "_id": "id",
+      "_source": {
+        "location": "document-name"
+      }
+    },
+    {
+      "_index": "index",
+      "_id": "id",
+      "_source": {
+        "location": "document-name"
+      }
+    }
+  ]
+}
+```
+
+## Path and HTTP methods
+
+Simulate the last ingest pipeline created
+
+```
+GET _ingest/pipeline/_simulate
+POST _ingest/pipeline/_simulate
+```
+
+Simulate a single pipeline based on the pipeline's ID.
+
+```
+GET _ingest/pipeline/{id}/_simulate
+POST _ingest/pipeline/{id}/_simulate
+```
+
+## URL parameters
+
+Parameter | Type | Description
+:--- | :--- | :---
+verbose | boolean | Verbose mode. Display data output for each processor in executed pipeline
+
+## Request body fields
+
+Field | Type | Description
+:--- | :--- | :---
+`pipeline` | object | The pipeline you want to simulate. When included without the pipeline `{id}` inside the request path, the response simulates the last pipeline created
+`docs` | array of objects | The documents you want to use to test the pipeline
+
+The `docs` field can include the following subfields:
+
+Field | Type | Description
+:--- | :--- | :---
+`id` (Optional) | string | An optional identifier for the document. Cannot be used elsewhere in the index
+`index` (Optional) | string |The index where the documents transformed data will be stored
+`source` | object | The documents JSON body
+
+## Response
+
+### Specify pipeline in request body
+
+```json
+{
+  "docs" : [
+    {
+      "doc" : {
+        "_index" : "index",
+        "_type" : "_doc",
+        "_id" : "id",
+        "_source" : {
+          "location" : "new-new",
+          "field2" : "_value"
+        },
+        "_ingest" : {
+          "timestamp" : "2022-02-03T23:12:11.337706671Z"
+        }
+      }
+    },
+    {
+      "doc" : {
+        "_index" : "index",
+        "_type" : "_doc",
+        "_id" : "id",
+        "_source" : {
+          "location" : "new-new",
+          "field2" : "_value"
+        },
+        "_ingest" : {
+          "timestamp" : "2022-02-03T23:12:11.337721296Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Specify pipeline ID inside path
+
+```json
+{
+  "docs" : [
+    {
+      "doc" : {
+        "_index" : "index",
+        "_type" : "_doc",
+        "_id" : "id",
+        "_source" : {
+          "field-name" : "value",
+          "location" : "document-name"
+        },
+        "_ingest" : {
+          "timestamp" : "2022-02-03T21:47:05.382744877Z"
+        }
+      }
+    },
+    {
+      "doc" : {
+        "_index" : "index",
+        "_type" : "_doc",
+        "_id" : "id",
+        "_source" : {
+          "field-name" : "value",
+          "location" : "document-name"
+        },
+        "_ingest" : {
+          "timestamp" : "2022-02-03T21:47:05.382803544Z"
+        }
+      }
+    }
+  ]
+}
+```
+
+### Receive verbose response 
+
+With the `verbose` parameter set to `true`, the response shows how each processor transform the specified document. 
+
+```json
+{
+  "docs" : [
+    {
+      "processor_results" : [
+        {
+          "processor_type" : "set",
+          "status" : "success",
+          "doc" : {
+            "_index" : "index",
+            "_type" : "_doc",
+            "_id" : "id",
+            "_source" : {
+              "field-name" : "value",
+              "location" : "document-name"
+            },
+            "_ingest" : {
+              "pipeline" : "35678",
+              "timestamp" : "2022-02-03T21:45:09.414049004Z"
+            }
+          }
+        }
+      ]
+    },
+    {
+      "processor_results" : [
+        {
+          "processor_type" : "set",
+          "status" : "success",
+          "doc" : {
+            "_index" : "index",
+            "_type" : "_doc",
+            "_id" : "id",
+            "_source" : {
+              "field-name" : "value",
+              "location" : "document-name"
+            },
+            "_ingest" : {
+              "pipeline" : "35678",
+              "timestamp" : "2022-02-03T21:45:09.414093212Z"
+            }
+          }
+        }
+      ]
+    }
+  ]
+}
+```

--- a/_opensearch/rest-api/ingest-apis/simulate-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/simulate-ingest.md
@@ -13,7 +13,7 @@ Simulates an ingest pipeline with any example documents you specify.
 ## Example
 
 ```
-POST /_ingest/pipeline/{id}/_simulate
+POST /_ingest/pipeline/35678/_simulate
 {
   "docs": [
     {
@@ -52,26 +52,30 @@ POST _ingest/pipeline/{id}/_simulate
 
 ## URL parameters
 
+All URL parameters are optional.
+
 Parameter | Type | Description
 :--- | :--- | :---
 verbose | boolean | Verbose mode. Display data output for each processor in executed pipeline.
 
 ## Request body fields
 
-Field | Type | Description
-:--- | :--- | :---
-`pipeline` | object | The pipeline you want to simulate. When included without the pipeline `{id}` inside the request path, the response simulates the last pipeline created.
-`docs` | array of objects | The documents you want to use to test the pipeline.
+Field | Required | Type | Description
+:--- | :--- | :--- | :---
+`pipeline` | Optional | object | The pipeline you want to simulate. When included without the pipeline `{id}` inside the request path, the response simulates the last pipeline created.
+`docs` | Required | array of objects | The documents you want to use to test the pipeline.
 
 The `docs` field can include the following subfields:
 
-Field | Type | Description
+Field | Required | Type | Description
 :--- | :--- | :---
-`id` (Optional) | string | An optional identifier for the document. The identifier cannot be used elsewhere in the index.
-`index` (Optional) | string | The index where the document's transformed data will be stored.
-`source` | object | The document's JSON body.
+`id` | Optional |string | An optional identifier for the document. The identifier cannot be used elsewhere in the index.
+`index` | Optional | string | The index where the document's transformed data appears.
+`source` | Required | object | The document's JSON body.
 
 ## Response
+
+Responses vary based on on which path and HTTP method you choose. 
 
 ### Specify pipeline in request body
 
@@ -88,7 +92,7 @@ Field | Type | Description
           "field2" : "_value"
         },
         "_ingest" : {
-          "timestamp" : "2022-02-03T23:12:11.337706671Z"
+          "timestamp" : "2022-02-07T18:47:57.479230835Z"
         }
       }
     },
@@ -102,15 +106,14 @@ Field | Type | Description
           "field2" : "_value"
         },
         "_ingest" : {
-          "timestamp" : "2022-02-03T23:12:11.337721296Z"
+          "timestamp" : "2022-02-07T18:47:57.47933496Z"
         }
       }
     }
   ]
 }
-```
 
-### Specify pipeline ID inside path
+### Specify pipeline ID inside HTTP path
 
 ```json
 {
@@ -149,7 +152,7 @@ Field | Type | Description
 
 ### Receive verbose response 
 
-With the `verbose` parameter set to `true`, the response shows how each processor transform the specified document. 
+With the `verbose` parameter set to `true`, the response shows how each processor transforms the specified document. 
 
 ```json
 {

--- a/_opensearch/rest-api/ingest-apis/simulate-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/simulate-ingest.md
@@ -60,8 +60,8 @@ verbose | boolean | Verbose mode. Display data output for each processor in exec
 
 Field | Type | Description
 :--- | :--- | :---
-`pipeline` | object | The pipeline you want to simulate. When included without the pipeline `{id}` inside the request path, the response simulates the last pipeline created
-`docs` | array of objects | The documents you want to use to test the pipeline
+`pipeline` | object | The pipeline you want to simulate. When included without the pipeline `{id}` inside the request path, the response simulates the last pipeline created.
+`docs` | array of objects | The documents you want to use to test the pipeline.
 
 The `docs` field can include the following subfields:
 

--- a/_opensearch/rest-api/ingest-apis/simulate-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/simulate-ingest.md
@@ -8,7 +8,7 @@ nav_order: 13
 
 # Simulate a pipeline
 
-Simulates an ingest pipeline with any example documents set you specify.
+Simulates an ingest pipeline with any example documents you specify.
 
 ## Example
 
@@ -54,7 +54,7 @@ POST _ingest/pipeline/{id}/_simulate
 
 Parameter | Type | Description
 :--- | :--- | :---
-verbose | boolean | Verbose mode. Display data output for each processor in executed pipeline
+verbose | boolean | Verbose mode. Display data output for each processor in executed pipeline.
 
 ## Request body fields
 
@@ -67,9 +67,9 @@ The `docs` field can include the following subfields:
 
 Field | Type | Description
 :--- | :--- | :---
-`id` (Optional) | string | An optional identifier for the document. Cannot be used elsewhere in the index
-`index` (Optional) | string |The index where the documents transformed data will be stored
-`source` | object | The documents JSON body
+`id` (Optional) | string | An optional identifier for the document. The identifier cannot be used elsewhere in the index.
+`index` (Optional) | string | The index where the document's transformed data will be stored.
+`source` | object | The document's JSON body.
 
 ## Response
 

--- a/_opensearch/rest-api/ingest-apis/simulate-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/simulate-ingest.md
@@ -36,7 +36,7 @@ POST /_ingest/pipeline/{id}/_simulate
 
 ## Path and HTTP methods
 
-Simulate the last ingest pipeline created
+Simulate the last ingest pipeline created.
 
 ```
 GET _ingest/pipeline/_simulate

--- a/_opensearch/rest-api/ingest-apis/simulate-ingest.md
+++ b/_opensearch/rest-api/ingest-apis/simulate-ingest.md
@@ -75,7 +75,7 @@ Field | Required | Type | Description
 
 ## Response
 
-Responses vary based on on which path and HTTP method you choose. 
+Responses vary based on which path and HTTP method you choose. 
 
 ### Specify pipeline in request body
 
@@ -112,6 +112,7 @@ Responses vary based on on which path and HTTP method you choose.
     }
   ]
 }
+```
 
 ### Specify pipeline ID inside HTTP path
 


### PR DESCRIPTION
Signed-off-by: Naarcha-AWS <naarcha@amazon.com>

### Description
This PR adds back the Ingest API endpoints into the API reference. I plan to add a processor reference for creating ingest pipelines in a different PR.
 
### Issues Resolved
[List any issues this PR will resolve]
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
