### PR TITLE
Updated usage of ISM's rollover_skip

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -521,7 +521,7 @@ You can use the same options for `ctx` variables as the [notification](#notifica
 
 The following sample template policy is for a rollover use case.
 
-If you want to skip rollovers for an index, use the [update cluster settings API]({{site.url}}{{site.baseurl}}/opensearch/configuration/#update-cluster-settings-using-the-api) to set `index.plugins.index_state_management.rollover_skip` to true.
+If you want to skip rollovers for an index, set `index.plugins.index_state_management.rollover_skip` to `true` in the settings of that index.
 
 1. Create a policy with an `ism_template` field:
 


### PR DESCRIPTION
### Description
Cluster Update Settings API complains that `index.plugins.index_state_management.rollover_skip` is an invalid setting. Index Update Settings API seems to work, though. And it's backed up by the definition here: https://github.com/opensearch-project/index-management/blob/6141c3c6fec9fe4c0c7bf733877660e78ed2b1b1/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/settings/ManagedIndexSettings.kt#L78

This PR updates the doc according to the above.
 
### Issues Resolved
N/A
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
