### PR TITLE
Documentation for security roles to be used for DLS parameter substit…

### DIFF
--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -85,7 +85,8 @@ This table lists substitutions.
 Term | Replaced with
 :--- | :---
 `${user.name}` | Username.
-`${user.roles}` | A comma-separated, quoted list of user roles.
+`${user.roles}` | A comma-separated, quoted list of user backend roles.
+`${user.securityRoles}` | A comma-separated, quoted list of user security roles. 
 `${attr.<TYPE>.<NAME>}` | An attribute with name `<NAME>` defined for a user. `<TYPE>` is `internal`, `jwt`, `proxy` or `ldap`
 
 


### PR DESCRIPTION
…ution. Added under opensearch-project/security/#1568

Signed-off-by: Matthew Moreland <matthew.moreland1@defence.gov.au>

### Description
Minor update to add in the parameter substitution implemented under [#1588](https://github.com/opensearch-project/security/pull/1588).
 
### Issues Resolved
Related to [#1568](https://github.com/opensearch-project/security/issues/1568).

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
