### PR TITLE
Modified plugin documentation by clarifying valid plugin ID inputs

### DIFF
--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -27,9 +27,16 @@ The install command takes a plugin id, which may be any of the following:
 - Maven coordinates to a plugin zip file
 - A URL to a plugin zip file
 
+If you're installing an official OpenSearch plugin, use:
+```
+bin/opensearch-plugin install <plugin-name>
+```
+
+For a plugin installed via zip, use:
 ```
 bin/opensearch-plugin install <name|Zip File|Url>
 ```
+
 Restart your OpenSearch node after installing a plugin.
 
 ## Remove a plugin

--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -21,8 +21,14 @@ You can install individual plugins on an OpenSearch cluster.
 
 ## Install a plugin
 
+The install command takes a plugin id, which may be any of the following:
+
+- An official OpenSearch plugin name
+- Maven coordinates to a plugin zip file
+- A URL to a plugin zip file
+
 ```
-bin/opensearch-plugin install <plugin-name>
+bin/opensearch-plugin install <name|Zip File|Url>
 ```
 Restart your OpenSearch node after installing a plugin.
 


### PR DESCRIPTION
As per issue https://github.com/opensearch-project/OpenSearch/issues/2041, plugin documentation lacks clarification on what are valid plugin IDs

Signed-off-by: Joshua Palis <jpalis@amazon.com>