### PR TITLE
Add warning about Kerberos support

### DIFF
--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -145,7 +145,7 @@ If `challenge` is set to `false` and no `Authorization` header field is set, the
 
 ## Kerberos
 
-Kerberos authentication will not work with OpenSearch Dashboards. To track OpenSearch's progress adding support for Kerberos in OpenSearch Dashboards, see [issue #907 Kerberos Auth does not exist](https://github.com/opensearch-project/security-dashboards-plugin/issues/907) in the Dashboard's Security Plugin repository. {: .warning }
+Kerberos authentication does not work with OpenSearch Dashboards. To track OpenSearch's progress in adding support for Kerberos in OpenSearch Dashboards, see [issue #907 Kerberos Auth does not exist](https://github.com/opensearch-project/security-dashboards-plugin/issues/907) in the Dashboard's Security Plugin repository. {: .warning }
 
 Due to the nature of Kerberos, you must define some settings in `opensearch.yml` and some in `config.yml`.
 

--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -145,6 +145,9 @@ If `challenge` is set to `false` and no `Authorization` header field is set, the
 
 ## Kerberos
 
+
+Kerberos authentication will not work with OpenSearch Dashboards. To track OpenSearch's progress on adding support for Kerberos in OpenSearch Dashboards, see [issue #907, Kerberos Auth does not exist](https://github.com/opensearch-project/security-dashboards-plugin/issues/907) in the Dashboard's Security Plugin repository. {: .warning }
+
 Due to the nature of Kerberos, you must define some settings in `opensearch.yml` and some in `config.yml`.
 
 In `opensearch.yml`, define the following:

--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -145,8 +145,7 @@ If `challenge` is set to `false` and no `Authorization` header field is set, the
 
 ## Kerberos
 
-
-Kerberos authentication will not work with OpenSearch Dashboards. To track OpenSearch's progress on adding support for Kerberos in OpenSearch Dashboards, see [issue #907, Kerberos Auth does not exist](https://github.com/opensearch-project/security-dashboards-plugin/issues/907) in the Dashboard's Security Plugin repository. {: .warning }
+Kerberos authentication will not work with OpenSearch Dashboards. To track OpenSearch's progress adding support for Kerberos in OpenSearch Dashboards, see [issue #907 Kerberos Auth does not exist](https://github.com/opensearch-project/security-dashboards-plugin/issues/907) in the Dashboard's Security Plugin repository. {: .warning }
 
 Due to the nature of Kerberos, you must define some settings in `opensearch.yml` and some in `config.yml`.
 


### PR DESCRIPTION
### Description
Because Kerberos auth is not supported in Dashboards, add a warning to the security plugin that gives users a heads us. Give users a place to track our progress on settling the issue.
 
### Issues Resolved
Solve issue #398 
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
