### PR TITLE
Documented JDK compatibility for version 1.3.0.

### DIFF
--- a/_opensearch/install/compatibility.md
+++ b/_opensearch/install/compatibility.md
@@ -8,14 +8,12 @@ nav_order: 2
 # Operating system and JVM compatibility
 
 - We recommend installing OpenSearch on RHEL- or Debian-based Linux distributions that use [systemd](https://en.wikipedia.org/wiki/Systemd), such as CentOS, Amazon Linux 2, and Ubuntu (LTS). OpenSearch should work on many Linux distributions, but we only test a handful.
-- The OpenSearch tarball ships with a compatible version of Java in the `jdk` directory. To find its version, run `./jdk/bin/java -version`. For example, the OpenSearch 1.0.0 tarball ships with Java 15 (non-LTS).
+- The OpenSearch tarball ships with a compatible version of Java in the `jdk` directory. To find its version, run `./jdk/bin/java -version`. For example, the OpenSearch 1.0.0 tarball ships with Java 15.0.1+9 (non-LTS), while OpenSearch 1.3.0 includes Java 11.0.14.1+1 (LTS).
+- OpenSearch 1.0 to 1.2.x is built and tested with Java 15, while OpenSearch 1.3.0 is built and tested with Java 8, 11 and 14.
 
-{% comment %}`./jdk/bin/java -version` doesn't work on macOS with zsh at the moment, and I have no idea why. Maybe we need a macOS artifact. Regardless, the command works on Amazon Linux 2 with bash and presumably other distros. - aetter{% endcomment %}
-
-  To use a different Java installation, set the `JAVA_HOME` environment variable to the Java install location. We recommend Java 11 (LTS), but OpenSearch also works with Java 8.
+  To use a different Java installation, set the `OPENSEARCH_JAVA_HOME` or `JAVA_HOME` environment variable to the Java install location. We recommend Java 11 (LTS), but OpenSearch also works with Java 8.
 
 OpenSearch version | Compatible Java versions | Recommended operating systems
 :--- | :--- | :---
-1.x | 8, 11, 15 | Red Hat Enterprise Linux 7, 8; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04
-
-If you plan on running applications besides OpenSearch with different Java requirements, set the `OPENSEARCH_JAVA_HOME` environment variable to the location of the Java installation to be used by OpenSearch. `OPENSEARCH_JAVA_HOME` supersedes the `JAVA_HOME` environment variable.
+1.0 - 1.2.x | 11, 15 | Red Hat Enterprise Linux 7, 8; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04
+1.3.x | 8, 11, 14 | Red Hat Enterprise Linux 7, 8; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04

--- a/_opensearch/install/compatibility.md
+++ b/_opensearch/install/compatibility.md
@@ -9,7 +9,7 @@ nav_order: 2
 
 - We recommend installing OpenSearch on RHEL- or Debian-based Linux distributions that use [systemd](https://en.wikipedia.org/wiki/Systemd), such as CentOS, Amazon Linux 2, and Ubuntu (LTS). OpenSearch should work on many Linux distributions, but we only test a handful.
 - The OpenSearch tarball ships with a compatible version of Java in the `jdk` directory. To find its version, run `./jdk/bin/java -version`. For example, the OpenSearch 1.0.0 tarball ships with Java 15.0.1+9 (non-LTS), while OpenSearch 1.3.0 includes Java 11.0.14.1+1 (LTS).
-- OpenSearch 1.0 to 1.2.x is built and tested with Java 15, while OpenSearch 1.3.0 is built and tested with Java 8, 11 and 14.
+- OpenSearch 1.0 to 1.2.4 is built and tested with Java 15, while OpenSearch 1.3.0 is built and tested with Java 8, 11 and 14.
 
   To use a different Java installation, set the `OPENSEARCH_JAVA_HOME` or `JAVA_HOME` environment variable to the Java install location. We recommend Java 11 (LTS), but OpenSearch also works with Java 8.
 


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

The summary of changes can be found in https://github.com/opensearch-project/project-website/pull/670. In this PR I have corrected our compatibility matrix, removing JDK8 from versions 1.0 - 1.2.x, and only including versions that are built with and tested.
 
I removed the MacOS comment because we bundle a Linux JDK, not a MacOS one, so that's why that doesn't work. If we want to say something about Mac (or Windows), we should link to [opensearch-build#33](https://github.com/opensearch-project/opensearch-build/issues/33), [#37](https://github.com/opensearch-project/opensearch-build/issues/37) and [#38](https://github.com/opensearch-project/opensearch-build/issues/38) for the work remaining on those, but I think it's unnecessary.

Let me know what else needs to change to document the JDK changes, happy to iterate.

### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
