### PR TITLE
Correct log4j2 syntax in the example

### DIFF
--- a/_troubleshoot/openid-connect.md
+++ b/_troubleshoot/openid-connect.md
@@ -23,8 +23,8 @@ This page includes troubleshooting steps for using OpenID Connect with the secur
 To help troubleshoot OpenID Connect, set the log level to `debug` on OpenSearch. Add the following lines in `config/log4j2.properties` and restart the node:
 
 ```
-logger.plugins.security.name = com.amazon.dlic.auth.http.jwt
-logger.plugins.security.level = trace
+logger.securityjwt.name = com.amazon.dlic.auth.http.jwt
+logger.securityjwt.level = trace
 ```
 
 This setting prints a lot of helpful information to your log file. If this information isn't sufficient, you can also set the log level to `trace`.


### PR DESCRIPTION
### Description

In the [yml format](https://logging.apache.org/log4j/2.x/manual/configuration.html#Configuration_with_Properties) in of the log4j properties file, a logger is declared with `logger.LOGGER_NAME.name`, the value of LOGGER_NAME can be set as desired by the user.  When the example included the `.` operator it was treated as another object and 'security' was referenced as a key which didn't resolve to anything.

### Issues Resolved
* Resolves https://github.com/opensearch-project/security/issues/1689
* Resolves https://github.com/opensearch-project/security/issues/1452
* Also reported in https://github.com/opensearch-project/helm-charts/issues/208
* Also reported in https://github.com/opensearch-project/OpenSearch/issues/1579
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
