### PR TITLE
Document OpenSearch 2.0 Java compatibility.

### DIFF
--- a/_opensearch/install/compatibility.md
+++ b/_opensearch/install/compatibility.md
@@ -11,14 +11,12 @@ We recommend installing OpenSearch on RHEL- or Debian-based Linux distributions 
 
 # Java Compatibility
 
-The OpenSearch ditribution for Linux ships with a compatible [Adoptium JDK](https://adoptium.net/) version of Java in the `jdk` directory. To find its version, run `./jdk/bin/java -version`. For example, the OpenSearch 1.0.0 tarball ships with Java 15.0.1+9 (non-LTS), OpenSearch 1.3.0 includes Java 11.0.14.1+1 (LTS), and OpenSearch 2.0.0 includes Java 17.0.2+8 (LTS).
-
-OpenSearch 1.0 to 1.2.4 is built and tested with Java 15, OpenSearch 1.3.0 is built and tested with Java 8, 11 and 14, and OpenSearch 2.0.0 is built and tested with Java 11 and 17.
-
-To use a different Java installation, set the `OPENSEARCH_JAVA_HOME` or `JAVA_HOME` environment variable to the Java install location.
+The OpenSearch distribution for Linux ships with a compatible [Adoptium JDK](https://adoptium.net/) version of Java in the `jdk` directory. To find the JDK version, run `./jdk/bin/java -version`. For example, the OpenSearch 1.0.0 tarball ships with Java 15.0.1+9 (non-LTS), OpenSearch 1.3.0 ships with Java 11.0.14.1+1 (LTS), and OpenSearch 2.0.0 ships with Java 17.0.2+8 (LTS). OpenSearch is tested with all compatible Java versions.
 
 OpenSearch Version | Compatible Java Versions | Bundled Java Version
 :---------- | :-------- | :-----------
 1.0 - 1.2.x | 11, 15    | 15.0.1+9
 1.3.x       | 8, 11, 14 | 11.0.14.1+1
 2.0.0       | 11, 17    | 17.0.2+8
+
+To use a different Java installation, set the `OPENSEARCH_JAVA_HOME` or `JAVA_HOME` environment variable to the Java install location.

--- a/_opensearch/install/compatibility.md
+++ b/_opensearch/install/compatibility.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Operating System Compatibility
 
-We recommend installing OpenSearch on RHEL- or Debian-based Linux distributions that use [systemd](https://en.wikipedia.org/wiki/Systemd), such as CentOS, Amazon Linux 2, and Ubuntu (LTS). OpenSearch should work on many Linux distributions, but we only test a handful. We recommend Red Hat Enterprise Linux 7 or 8, CentOS 7 or 8, Amazon Linux 2, Ubuntu 16.04, 18.04, or 20.04 for any version of OpenSearch.
+We recommend installing OpenSearch on RHEL or Debian-based Linux distributions that use [systemd](https://en.wikipedia.org/wiki/Systemd), such as CentOS, Amazon Linux 2, and Ubuntu (LTS). OpenSearch should work on many Linux distributions, but we only test a handful. We recommend Red Hat Enterprise Linux 7 or 8, CentOS 7 or 8, Amazon Linux 2, Ubuntu 16.04, 18.04, or 20.04 for any version of OpenSearch.
 
 # Java Compatibility
 

--- a/_opensearch/install/compatibility.md
+++ b/_opensearch/install/compatibility.md
@@ -5,15 +5,20 @@ parent: Install OpenSearch
 nav_order: 2
 ---
 
-# Operating system and JVM compatibility
+# Operating System Compatibility
 
-- We recommend installing OpenSearch on RHEL- or Debian-based Linux distributions that use [systemd](https://en.wikipedia.org/wiki/Systemd), such as CentOS, Amazon Linux 2, and Ubuntu (LTS). OpenSearch should work on many Linux distributions, but we only test a handful.
-- The OpenSearch tarball ships with a compatible version of Java in the `jdk` directory. To find its version, run `./jdk/bin/java -version`. For example, the OpenSearch 1.0.0 tarball ships with Java 15.0.1+9 (non-LTS), while OpenSearch 1.3.0 includes Java 11.0.14.1+1 (LTS).
-- OpenSearch 1.0 to 1.2.4 is built and tested with Java 15, while OpenSearch 1.3.0 is built and tested with Java 8, 11 and 14.
+We recommend installing OpenSearch on RHEL- or Debian-based Linux distributions that use [systemd](https://en.wikipedia.org/wiki/Systemd), such as CentOS, Amazon Linux 2, and Ubuntu (LTS). OpenSearch should work on many Linux distributions, but we only test a handful. We recommend Red Hat Enterprise Linux 7 or 8, CentOS 7 or 8, Amazon Linux 2, Ubuntu 16.04, 18.04, or 20.04 for any version of OpenSearch.
 
-  To use a different Java installation, set the `OPENSEARCH_JAVA_HOME` or `JAVA_HOME` environment variable to the Java install location. We recommend Java 11 (LTS), but OpenSearch also works with Java 8.
+# Java Compatibility
 
-OpenSearch version | Compatible Java versions | Recommended operating systems
-:--- | :--- | :---
-1.0 - 1.2.x | 11, 15 | Red Hat Enterprise Linux 7, 8; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04
-1.3.x | 8, 11, 14 | Red Hat Enterprise Linux 7, 8; CentOS 7, 8; Amazon Linux 2; Ubuntu 16.04, 18.04, 20.04
+The OpenSearch ditribution for Linux ships with a compatible [Adoptium JDK](https://adoptium.net/) version of Java in the `jdk` directory. To find its version, run `./jdk/bin/java -version`. For example, the OpenSearch 1.0.0 tarball ships with Java 15.0.1+9 (non-LTS), OpenSearch 1.3.0 includes Java 11.0.14.1+1 (LTS), and OpenSearch 2.0.0 includes Java 17.0.2+8 (LTS).
+
+OpenSearch 1.0 to 1.2.4 is built and tested with Java 15, OpenSearch 1.3.0 is built and tested with Java 8, 11 and 14, and OpenSearch 2.0.0 is built and tested with Java 11 and 17.
+
+To use a different Java installation, set the `OPENSEARCH_JAVA_HOME` or `JAVA_HOME` environment variable to the Java install location.
+
+OpenSearch Version | Compatible Java Versions | Bundled Java Version
+:---------- | :-------- | :-----------
+1.0 - 1.2.x | 11, 15    | 15.0.1+9
+1.3.x       | 8, 11, 14 | 11.0.14.1+1
+2.0.0       | 11, 17    | 17.0.2+8


### PR DESCRIPTION
Signed-off-by: dblock <dblock@amazon.com>

### Description

Took a stab at cleaning up the compatibility page and documenting 2.0 as part of https://github.com/opensearch-project/opensearch-plugins/issues/132.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
