### PR TITLE
Add Basic Documentation for Terms Lookup Query

### DIFF
--- a/_opensearch/query-dsl/term.md
+++ b/_opensearch/query-dsl/term.md
@@ -271,6 +271,33 @@ GET shakespeare/_search
 
 You get back documents that match any of the terms.
 
+### Terms Lookup
+
+You can use a `terms` query with a `lookup` to match values based on a field in a document in another index.
+
+Parameter | Behavior
+:--- | :---
+`index` | The index from which the document is read.
+`id` | The id of the documented.
+`path` | Path to the field from which the values are used in the terms query.
+
+E.g. to get all lines from the shakespeare play for a role (or roles) specified in the index `play-assignments` for the entry `42`:
+
+```json
+GET shakespeare/_search
+{
+  "query": {
+    "terms": {
+      "speaker": {
+        "index": "play-assignments",
+        "id": "42",
+        "path": "role"
+      }
+    }
+  }
+}
+```
+
 ## IDs
 
 Use the `ids` query to search for one or more document ID values.


### PR DESCRIPTION
### Description
this adds very rudimentary documentation for TLQ so that it at least
doesn't go unmentioned. however, there are many more details which
should be mentioned. this should then be done with #430.

more information can be found in the [Elasticsearch TLQ
Documentation][ESTLQ]. i'm not 100% sure whether this was under the
Apache 2.0 license in 7.10 (the repo states that everything is Apache
2.0 unless explicitly stated otherwise in the file and the documentation
files don't seem to include any other license?) and thus didn't simply
take over the documentation from there (which would of course be the
easiest and most complete way of doing it).

also i'm not sure (and didn't find this information anywhere) whether
the test data actually exists and the queries can be run against the
test data? in that case the provided example either needs to be adapted
to the existing test data or the test data needs to be extended
accordingly (i doubt that an index `play-assignments` already exists?).
due to this the example has also not been tested.

Signed-off-by: Ralph Ursprung <Ralph.Ursprung@avaloq.com>

[ESTLQ]: https://www.elastic.co/guide/en/elasticsearch/reference/7.10/query-dsl-terms-query.html#query-dsl-terms-lookup
 
### Issues Resolved
partially resolves #430 (but more will be required to fully resolve it, but i'll leave that to someone else with better knowledge about TLQ as the ES docs show that it has some details to be aware of)
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
