### PR TITLE
Documentation for security-dashboards-plugin PR929

### DIFF
--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -281,6 +281,7 @@ Name | Description
 `opensearch_security.openid.header` | HTTP header name of the JWT token. Optional. Default is `Authorization`.
 `opensearch_security.openid.logout_url` | The logout URL of your IdP. Optional. Only necessary if your IdP does not publish the logout URL in its metadata.
 `opensearch_security.openid.base_redirect_url` | The base of the redirect URL that will be sent to your IdP. Optional. Only necessary when OpenSearch Dashboards is behind a reverse proxy, in which case it should be different than `server.host` and `server.port` in `opensearch_dashboards.yml`.
+`opensearch_security.openid.trust_dynamic_headers` | Compute `base_redirect_url` from the reverse proxy HTTP headers (`X-Forwarded-Host` / `X-Forwarded-Proto`). Optional. Default is `false`.
 
 
 ### Configuration example


### PR DESCRIPTION
Signed-off-by: Jean-Christian Simonetti <github@elysiria.fr>

### Description
The OpenID redirectURI can be dynamically computed from proxy HTTP headers (`X-Forwarded-*`) if its new specific parameter is turned on in the configuration file (`opensearch_security.openid.trust_dynamic_headers`).
 
### Issues Resolved
This is documentation for opensearch-project/security-dashboards-plugin#929.

### Additional context
My company hosts one Opensearch Dashboards shared by many users (with tenants). We have a federated IAM based on OpenID configuration. The Opensearch Dashboards is behind a reverse proxy. We have a specific URL for each client that points to the same Opensearch Dashboards, thus we need to set dynamically the redirectURI.

Opensearch Dashboards should have a new option allowing dynamic configuration of the redirectURI, based on information sent by a reverse proxy.
 
### Check List
- [x] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
