### PR TITLE
Add o11y security

### DIFF
--- a/_observability-plugin/observability-security.md
+++ b/_observability-plugin/observability-security.md
@@ -1,0 +1,56 @@
+---
+layout: default
+title: Observability security
+nav_order: 5
+has_children: false
+---
+
+# Observability security
+
+You can use the security plugin with Observability in OpenSearch to limit non-admin users to specific actions. For example, you might want some users to only view visualizations, notebooks, and other Observability objects, while others can create and modify them.
+
+## Basic permissions
+
+The security plugin has two built-in roles that cover most Observability use cases: `observability_full_access` and `observability_read_access`. For descriptions of each, see [Predefined roles]({{site.url}}{{site.baseurl}}/security-plugin/access-control/users-roles#predefined-roles). If you don't see these predefined roles in OpenSearch Dashboards, you can create them with the following commands:
+
+```json
+PUT _plugins/_security/api/roles/observability_read_access
+{
+  "cluster_permissions": [
+    "cluster:admin/opensearch/observability/get"
+  ]
+}
+```
+
+```json
+PUT _plugins/_security/api/roles/observability_full_access
+{
+  "cluster_permissions": [
+    "cluster:admin/opensearch/observability/*"
+  ]
+}
+```
+
+If these roles don't meet your needs, mix and match individual Observability [permissions]({{site.url}}{{site.baseurl}}/security-plugin/access-control/permissions/) to suit your use case. For example, the `cluster:admin/opensearch/observability/create` permission lets you create Observability objects (visualizations, operational panels, notebooks, etc.)
+
+The following is an example role that that provides access to Observability:
+
+```json
+PUT _plugins/_security/api/roles/observability_permissions
+{
+  "cluster_permissions": [
+    "cluster:admin/opensearch/observability/create",
+    "cluster:admin/opensearch/observability/update",
+    "cluster:admin/opensearch/observability/delete",
+    "cluster:admin/opensearch/observability/get"
+    ],
+  "index_permissions": [{
+    "index_patterns": [".opensearch-observability"],
+    "allowed_actions": ["write", "read", "search"]
+  }],
+  "tenant_permissions": [{
+    "tenant_patterns": ["global_tenant"],
+    "allowed_actions": ["opensearch_dashboards_all_write"]
+  }]
+}
+```

--- a/_replication-plugin/permissions.md
+++ b/_replication-plugin/permissions.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Permissions
+title: Replication security
 nav_order: 30
 ---
 
-# Cross-cluster replication permissions
+# Cross-cluster replication security
 
 You can use the [security plugin]({{site.url}}{{site.baseurl}}/security-plugin/index/) with cross-cluster replication to limit users to certain actions. For example, you might want certain users to only perform replication activity on the leader or follower cluster.
 


### PR DESCRIPTION
Signed-off-by: Liz Snyder <elizabsn@amazon.com>

### Description
Add docs for Observability security integration added in https://github.com/opensearch-project/security/pull/1484.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
