### PR TITLE
Add default o11y roles

### DIFF
--- a/_security-plugin/access-control/users-roles.md
+++ b/_security-plugin/access-control/users-roles.md
@@ -111,6 +111,8 @@ Role | Description
 `all_access` | Grants full access to the cluster: all cluster-wide operations, write to all indices, write to all tenants.
 `cross_cluster_replication_follower_full_access` | Grants full access to perform cross-cluster replication actions on the follower cluster.
 `cross_cluster_replication_leader_full_access` | Grants full access to perform cross-cluster replication actions on the leader cluster.
+`observability_full_access` | Grants full access to perform actions on Observability objects such as visualizations, notebooks, and operational panels.
+`observability_read_access` | Grants permission to view Observability objects such as visualizations, notebooks, and operational panels, but not create, modify, or delete them.
 `opensearch_dashboards_read_only` | A special role that prevents users from making changes to visualizations, dashboards, and other OpenSearch Dashboards objects. See `opensearch_security.readonly_mode.roles` in `opensearch_dashboards.yml`. Pair with the `opensearch_dashboards_user` role.
 `opensearch_dashboards_user` | Grants permissions to use OpenSearch Dashboards: cluster-wide searches, index monitoring, and write to various OpenSearch Dashboards indices.
 `logstash` | Grants permissions for Logstash to interact with the cluster: cluster-wide searches, cluster monitoring, and write to the various Logstash indices.


### PR DESCRIPTION
Signed-off-by: Liz Snyder <elizabsn@amazon.com>

### Description
Per https://github.com/opensearch-project/security/pull/1484/files, we added two default roles for Observability. They are currently not showing up in OpenSearch Dashboards (filed https://github.com/opensearch-project/security/issues/1759 to address). We still need to add them to the docs to keep engineering team accountable, as this is expected behavior.
 
### Check List
- [X] Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
