### PR TITLE
[issue 486]Adding Request parameter 'master_timeout' is missing in the page of 'CAT Segments' API

### DIFF
--- a/_opensearch/rest-api/cat/cat-segments.md
+++ b/_opensearch/rest-api/cat/cat-segments.md
@@ -46,6 +46,7 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/opensear
 Parameter | Type | Description
 :--- | :--- | :---
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/)..
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 
 ## Response


### PR DESCRIPTION

### Description
Adding Request parameter 'master_timeout' is missing in the page of 'CAT Segments' API
 
### Issues Resolved
[issue 486 Adding Request parameter 'master_timeout' is missing in the page of 'CAT Segments' API](https://github.com/opensearch-project/documentation-website/issues/486)
 
### Check List
- * [x]  Commits are signed per the DCO using --signoff 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
