### PR TITLE
Add doc on action rollover min_primary_shard_size

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -200,7 +200,7 @@ Deletes a managed index.
 
 Rolls an alias over to a new index when the managed index meets one of the rollover conditions.
 
-**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. The rollover will not be performed before the value is **above** the configured limit **when the check is performed**. For example for `min_size`, with a value of 100GiB, ISM might check the index at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation.
+**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. The rollover will not be performed before the value **has reached** or exceeded the configured limit **when the check is performed**. For example for `min_size`, with a value of 100GiB, ISM might check the index at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation.
 
 The index format must match the pattern: `^.*-\d+$`. For example, `(logs-000001)`.
 Set `index.plugins.index_state_management.rollover_alias` as the alias to rollover.

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -200,7 +200,7 @@ Deletes a managed index.
 
 Rolls an alias over to a new index when the managed index meets one of the rollover conditions.
 
-**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. The rollover will not be performed before the value **has reached** or exceeded the configured limit **when the check is performed**. For example for `min_size`, with a value of 100GiB, ISM might check the index at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation.
+**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. The rollover will not be performed before the value **has reached** or exceeded the configured limit **when the check is performed**. For example with `min_size` configured to a value of 100GiB, ISM might check the index at 99 GiB and not perform the rollover. At the next check the index can have grown to i.e. 105 GiB, and the operation is performed.
 
 The index format must match the pattern: `^.*-\d+$`. For example, `(logs-000001)`.
 Set `index.plugins.index_state_management.rollover_alias` as the alias to rollover.

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -200,15 +200,17 @@ Deletes a managed index.
 
 Rolls an alias over to a new index when the managed index meets one of the rollover conditions.
 
+**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. If the condition is checked and the value is **close to but not above** the configured value the rollover will not be performed before the value is above the configured limit. For example for `min_size`, with a value of 100GiB, ISM might check the index at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation.
+
 The index format must match the pattern: `^.*-\d+$`. For example, `(logs-000001)`.
 Set `index.plugins.index_state_management.rollover_alias` as the alias to rollover.
 
 Parameter | Description | Type | Example | Required
 :--- | :--- |:--- |:--- |
-`min_size` | The minimum size of the total primary shard storage (not counting replicas) required to roll over the index. For example, if you set `min_size` to 100 GiB and your index has 5 primary shards and 5 replica shards of 20 GiB each, the total size of all primary shards is 100 GiB, so the rollover occurs. ISM doesn't check indexes continually, so it doesn't roll over indexes at exactly 100 GiB. Instead, if an index is continuously growing, ISM might check it at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation. | `string` | `20gb` or `5mb` | No
-`min_primary_shard_size` | The minimum size of a *single primary shard* storage (not counting replicas) required to roll over the index. For example, if you set `min_primary_shard_size` to 30 GiB and there is a *single primary shard* that has a size greater than the condition, the rollover occurs. ISM doesn't check indexes continually, so it doesn't roll over indexes at exactly 30 GiB. Instead, if an index shard is continuously growing, ISM might check it at 29 GiB, not perform the rollover, check again when the shards reach 32 GiB, and then perform the operation. | `string` | `20gb` or `5mb` | No
-`min_doc_count` |  The minimum number of documents required to roll over the index. | `number` | `2000000` | No
-`min_index_age` |  The minimum age required to roll over the index. Index age is the time between its creation and the present. | `string` | `5d` or `7h` | No
+`min_size` | The minimum size of the total primary shard storage (not counting replicas) required to roll over the index. For example, if you set `min_size` to 100 GiB and your index has 5 primary shards and 5 replica shards of 20 GiB each, the total size of all primary shards is 100 GiB, so the rollover occurs. See **Important** note above. | `string` | `20gb` or `5mb` | No
+`min_primary_shard_size` | The minimum storage size of a **single primary shard** required to roll over the index. For example, if you set `min_primary_shard_size` to 30 GiB and **one of** the primary shards in the index has a size greater than the condition, the rollover occurs. See **Important** note above. | `string` | `20gb` or `5mb` | No
+`min_doc_count` |  The minimum number of documents required to roll over the index. See **Important** note above. | `number` | `2000000` | No
+`min_index_age` |  The minimum age required to roll over the index. Index age is the time between its creation and the present. See **Important** note above. | `string` | `5d` or `7h` | No
 
 ```json
 {

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -200,7 +200,7 @@ Deletes a managed index.
 
 Rolls an alias over to a new index when the managed index meets one of the rollover conditions.
 
-**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. If the condition is checked and the value is **close to but not above** the configured value the rollover will not be performed before the value is above the configured limit. For example for `min_size`, with a value of 100GiB, ISM might check the index at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation.
+**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. The rollover will not be performed before the value is **above** the configured limit **when the check is performed**. For example for `min_size`, with a value of 100GiB, ISM might check the index at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation.
 
 The index format must match the pattern: `^.*-\d+$`. For example, `(logs-000001)`.
 Set `index.plugins.index_state_management.rollover_alias` as the alias to rollover.

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -200,7 +200,7 @@ Deletes a managed index.
 
 Rolls an alias over to a new index when the managed index meets one of the rollover conditions.
 
-**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. The rollover will not be performed before the value **has reached** or exceeded the configured limit **when the check is performed**. For example with `min_size` configured to a value of 100GiB, ISM might check the index at 99 GiB and not perform the rollover. At the next check the index can have grown to i.e. 105 GiB, and the operation is performed.
+**Important**: ISM checks the conditions for operations on **every execution of the policy** based on the **set interval**, _not_ continuously. The rollover will be performed if the value **has reached** or _exceeded_ the configured limit **when the check is performed**. For example with `min_size` configured to a value of 100GiB, ISM might check the index at 99 GiB and not perform the rollover. However, if the index has grown past the limit (e.g. 105GiB) by the next check, the operation is performed.
 
 The index format must match the pattern: `^.*-\d+$`. For example, `(logs-000001)`.
 Set `index.plugins.index_state_management.rollover_alias` as the alias to rollover.

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -206,6 +206,7 @@ Set `index.plugins.index_state_management.rollover_alias` as the alias to rollov
 Parameter | Description | Type | Example | Required
 :--- | :--- |:--- |:--- |
 `min_size` | The minimum size of the total primary shard storage (not counting replicas) required to roll over the index. For example, if you set `min_size` to 100 GiB and your index has 5 primary shards and 5 replica shards of 20 GiB each, the total size of all primary shards is 100 GiB, so the rollover occurs. ISM doesn't check indexes continually, so it doesn't roll over indexes at exactly 100 GiB. Instead, if an index is continuously growing, ISM might check it at 99 GiB, not perform the rollover, check again when the shards reach 105 GiB, and then perform the operation. | `string` | `20gb` or `5mb` | No
+`min_primary_shard_size` | The minimum size of a *single primary shard* storage (not counting replicas) required to roll over the index. For example, if you set `min_primary_shard_size` to 30 GiB and there is a *single primary shard* that has a size greater than the condition, the rollover occurs. ISM doesn't check indexes continually, so it doesn't roll over indexes at exactly 30 GiB. Instead, if an index shard is continuously growing, ISM might check it at 29 GiB, not perform the rollover, check again when the shards reach 32 GiB, and then perform the operation. | `string` | `20gb` or `5mb` | No
 `min_doc_count` |  The minimum number of documents required to roll over the index. | `number` | `2000000` | No
 `min_index_age` |  The minimum age required to roll over the index. Index age is the time between its creation and the present. | `string` | `5d` or `7h` | No
 
@@ -213,6 +214,14 @@ Parameter | Description | Type | Example | Required
 {
   "rollover": {
     "min_size": "50gb"
+  }
+}
+```
+
+```json
+{
+  "rollover": {
+    "min_primary_shard_size": "30gb"
   }
 }
 ```
@@ -618,7 +627,8 @@ After 30 days, the policy moves this index into a `delete` state. The service se
         "actions": [
           {
             "rollover": {
-              "min_index_age": "1d"
+              "min_index_age": "1d",
+              "min_primary_shard_size": "30gb"
             }
           }
         ],
@@ -666,7 +676,11 @@ After 30 days, the policy moves this index into a `delete` state. The service se
           }
         ]
       }
-    ]
+    ],
+    "ism_template": {
+      "index_patterns": ["log*"],
+      "priority": 100
+    }
   }
 }
 ```


### PR DESCRIPTION
### Description
Adds documentation to the Index State Management / ISM policy action `rollover` parameter `min_primary_shard_size` which was added in opensearch-project/index-management#220

### Issues Resolved
Closes #541

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).