### PR TITLE
Clarify ISM refresh behavior

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -126,7 +126,7 @@ Parameter | Description | Type | Required
 
 ### read_only
 
-Sets a managed index to be read only.
+Sets a managed index to be read only. When an index is read only it doesn't refresh.
 
 ```json
 {


### PR DESCRIPTION
Signed-off-by: Liz Snyder <elizabsn@amazon.com>

### Description
In our current documentation we don't specifically say that if an index is in read_only mode, it will not refresh.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
