### PR TITLE
update compatibility matrix and remove setting [issue 517]

### DIFF
--- a/_clients/agents-and-ingestion-tools/index.md
+++ b/_clients/agents-and-ingestion-tools/index.md
@@ -26,6 +26,8 @@ PUT _cluster/settings
   }
 }
 ```
+{: .note}
+The Override main response setting `compatibility.override_main_response_version` is removed from OpenSearch 2.0.0. This setting is no longer supported for compatibility with legacy clients.
 <!-- This setting is deprecated in 1.0 and removed from 2.0
 [Just like any other setting]({{site.url}}{{site.baseurl}}/opensearch/configuration/), the alternative is to add the following line to `opensearch.yml` on each node and then restart the node:
 

--- a/_clients/agents-and-ingestion-tools/index.md
+++ b/_clients/agents-and-ingestion-tools/index.md
@@ -17,9 +17,10 @@ Previously, an intermediate compatibility solution was available. OpenSearch had
 The Override main response setting `compatibility.override_main_response_version` is deprecated from OpenSearch version 1.x and removed from OpenSearch 2.0.0. This setting is no longer supported for compatibility with legacy clients.
 {: .note}
 
+<!--
 {: .note}
 
-<!--
+
 If you use clients that include a version check, such as versions of Logstash OSS or Filebeat OSS between 7.x - 7.12.x, enable the setting:
 
 ```json

--- a/_clients/agents-and-ingestion-tools/index.md
+++ b/_clients/agents-and-ingestion-tools/index.md
@@ -12,8 +12,14 @@ redirect_from:
 
 Historically, many multiple popular agents and ingestion tools have worked with Elasticsearch OSS, such as Beats, Logstash, Fluentd, FluentBit, and OpenTelemetry. OpenSearch aims to continue to support a broad set of agents and ingestion tools, but not all have been tested or have explicitly added OpenSearch compatibility.
 
-As an intermediate compatibility solution, OpenSearch has a setting that instructs the cluster to return version 7.10.2 rather than its actual version.
+Previously, an intermediate compatibility solution was available. OpenSearch had a setting that instructs the cluster to return version 7.10.2 rather than its actual version.
 
+The Override main response setting `compatibility.override_main_response_version` is deprecated from OpenSearch version 1.x and removed from OpenSearch 2.0.0. This setting is no longer supported for compatibility with legacy clients.
+{: .note}
+
+{: .note}
+
+<!--
 If you use clients that include a version check, such as versions of Logstash OSS or Filebeat OSS between 7.x - 7.12.x, enable the setting:
 
 ```json
@@ -26,9 +32,7 @@ PUT _cluster/settings
   }
 }
 ```
-{: .note}
-The Override main response setting `compatibility.override_main_response_version` is removed from OpenSearch 2.0.0. This setting is no longer supported for compatibility with legacy clients.
-<!-- This setting is deprecated in 1.0 and removed from 2.0
+
 [Just like any other setting]({{site.url}}{{site.baseurl}}/opensearch/configuration/), the alternative is to add the following line to `opensearch.yml` on each node and then restart the node:
 
 ```yml

--- a/_clients/agents-and-ingestion-tools/index.md
+++ b/_clients/agents-and-ingestion-tools/index.md
@@ -26,13 +26,13 @@ PUT _cluster/settings
   }
 }
 ```
-
+<!-- This setting is deprecated in 1.0 and removed from 2.0
 [Just like any other setting]({{site.url}}{{site.baseurl}}/opensearch/configuration/), the alternative is to add the following line to `opensearch.yml` on each node and then restart the node:
 
 ```yml
 compatibility.override_main_response_version: true
 ```
-
+-->
 Logstash OSS 8.0 introduces a breaking change where all plugins run in ECS compatibility mode by default. If you use a compatible [OSS client](#compatibility-matrices) you must override the default value to maintain legacy behavior:
 
 ```yml

--- a/_clients/agents-and-ingestion-tools/index.md
+++ b/_clients/agents-and-ingestion-tools/index.md
@@ -12,9 +12,9 @@ redirect_from:
 
 Historically, many multiple popular agents and ingestion tools have worked with Elasticsearch OSS, such as Beats, Logstash, Fluentd, FluentBit, and OpenTelemetry. OpenSearch aims to continue to support a broad set of agents and ingestion tools, but not all have been tested or have explicitly added OpenSearch compatibility.
 
-Previously, an intermediate compatibility solution was available. OpenSearch had a setting that instructs the cluster to return version 7.10.2 rather than its actual version.
+Previously, an intermediate compatibility solution was available. OpenSearch had a setting that instructed the cluster to return version 7.10.2 rather than its actual version.
 
-The Override main response setting `compatibility.override_main_response_version` is deprecated from OpenSearch version 1.x and removed from OpenSearch 2.0.0. This setting is no longer supported for compatibility with legacy clients.
+The override main response setting `compatibility.override_main_response_version` is deprecated from OpenSearch version 1.x and removed from OpenSearch 2.0.0. This setting is no longer supported for compatibility with legacy clients.
 {: .note}
 
 <!--

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -27,7 +27,7 @@ For example, a 1.0.0 client works with an OpenSearch 1.1.0 cluster, but might no
 Most clients that work with Elasticsearch OSS 7.10.2 *should* work with OpenSearch, but the latest versions of those clients might include license or version checks that artificially break compatibility. This page includes recommendations around which versions of those clients to use for best compatibility with OpenSearch.
 
 {: .note}
-OpenSearch 2.0.0 no longer supports compatibility with legacy clients. Due to breaking changes with REST APIs, clients using older OpenSearch 1.x versions can't connect with OpenSearch 2.0.
+OpenSearch 2.0.0 no longer supports compatibility with legacy clients. Due to breaking changes with REST APIs, some features are not supported when using OpenSearch 1.x clients to connect with OpenSearch 2.0.
 
 
 Client | Recommended version

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -26,6 +26,10 @@ For example, a 1.0.0 client works with an OpenSearch 1.1.0 cluster, but might no
 
 Most clients that work with Elasticsearch OSS 7.10.2 *should* work with OpenSearch, but the latest versions of those clients might include license or version checks that artificially break compatibility. This page includes recommendations around which versions of those clients to use for best compatibility with OpenSearch.
 
+{: .note}
+OpenSearch 2.0.0 no longer supports HLRC compatibility with legacy clients.
+
+
 Client | Recommended version
 :--- | :---
 [Java low-level REST client](https://search.maven.org/artifact/org.elasticsearch.client/elasticsearch-rest-client/7.13.4/jar) | 7.13.4

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -27,7 +27,7 @@ For example, a 1.0.0 client works with an OpenSearch 1.1.0 cluster, but might no
 Most clients that work with Elasticsearch OSS 7.10.2 *should* work with OpenSearch, but the latest versions of those clients might include license or version checks that artificially break compatibility. This page includes recommendations around which versions of those clients to use for best compatibility with OpenSearch.
 
 {: .note}
-OpenSearch 2.0.0 no longer supports compatibility with legacy clients. Due to breaking changes with REST APIs, some features are not supported when using OpenSearch 1.x clients to connect with OpenSearch 2.0.
+OpenSearch 2.0.0 no longer supports compatibility with legacy clients. Due to breaking changes with REST APIs, some features are not supported when using OpenSearch 1.x clients to connect to OpenSearch 2.0.
 
 
 Client | Recommended version

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -27,7 +27,7 @@ For example, a 1.0.0 client works with an OpenSearch 1.1.0 cluster, but might no
 Most clients that work with Elasticsearch OSS 7.10.2 *should* work with OpenSearch, but the latest versions of those clients might include license or version checks that artificially break compatibility. This page includes recommendations around which versions of those clients to use for best compatibility with OpenSearch.
 
 {: .note}
-OpenSearch 2.0.0 no longer supports HLRC compatibility with legacy clients.
+OpenSearch 2.0.0 no longer supports compatibility with legacy clients. Due to breaking changes with REST APIs, clients using older OpenSearch 1.x versions can't connect with OpenSearch 2.0.
 
 
 Client | Recommended version

--- a/_opensearch/configuration.md
+++ b/_opensearch/configuration.md
@@ -74,7 +74,6 @@ You don't mark settings in `opensearch.yml` as persistent or transient, and sett
 ```yml
 cluster.name: my-application
 action.auto_create_index: true
-compatibility.override_main_response_version: true
 ```
 
 The demo configuration includes a number of settings for the security plugin that you should modify before using OpenSearch for a production workload. To learn more, see [Security]({{site.url}}{{site.baseurl}}/security-plugin/).


### PR DESCRIPTION
Signed-off-by: alicejw <alicejw@amazon.com>

### Description
Remove setting that was removed from OpenSearch 2.0. 
we will not support this anymore for clients working with OpenSearch clusters 2.0 and up.

### Issues Resolved
This PR closes this document issue: 
[517](https://github.com/opensearch-project/documentation-website/issues/517)

**Note:** This other related issue will be handled in separate PR: 
[533](https://github.com/opensearch-project/documentation-website/issues/533)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
