### PR TITLE
update sample names to 'opensearch' instead of 'odfe'

### DIFF
--- a/_opensearch/rest-api/cat/cat-allocation.md
+++ b/_opensearch/rest-api/cat/cat-allocation.md
@@ -58,6 +58,6 @@ The following response shows that 8 shards are allocated to each the two nodes a
 
 ```json
 shards | disk.indices | disk.used | disk.avail | disk.total | disk.percent host | ip          | node
-  8    |   989.4kb    |   25.9gb  |   32.4gb   |   58.4gb   |   44 172.18.0.4   | 172.18.0.4  | odfe-node1
-  8    |   962.4kb    |   25.9gb  |   32.4gb   |   58.4gb   |   44 172.18.0.3   | 172.18.0.3  | odfe-node2
+  8    |   989.4kb    |   25.9gb  |   32.4gb   |   58.4gb   |   44 172.18.0.4   | 172.18.0.4  | opensearch-node1
+  8    |   962.4kb    |   25.9gb  |   32.4gb   |   58.4gb   |   44 172.18.0.3   | 172.18.0.3  | opensearch-node2
 ```

--- a/_opensearch/rest-api/cat/cat-field-data.md
+++ b/_opensearch/rest-api/cat/cat-field-data.md
@@ -54,6 +54,6 @@ The following response shows the memory size for all fields as 284 bytes:
 
 ```json
 id                     host       ip         node       field size
-1vo54NuxSxOrbPEYdkSF0w 172.18.0.4 172.18.0.4 odfe-node1 _id   284b
-ZaIkkUd4TEiAihqJGkp5CA 172.18.0.3 172.18.0.3 odfe-node2 _id   284b
+1vo54NuxSxOrbPEYdkSF0w 172.18.0.4 172.18.0.4 opensearch-node1 _id   284b
+ZaIkkUd4TEiAihqJGkp5CA 172.18.0.3 172.18.0.3 opensearch-node2 _id   284b
 ```

--- a/_opensearch/rest-api/cat/cat-health.md
+++ b/_opensearch/rest-api/cat/cat-health.md
@@ -40,5 +40,5 @@ ts | Boolean | If true, returns HH:MM:SS and Unix epoch timestamps. Default is t
 GET _cat/health?v&time=5d
 
 epoch | timestamp | cluster | status | node.total | node.data | shards | pri | relo | init | unassign | pending_tasks | max_task_wait_time | active_shards_percent
-1624248112 | 04:01:52 | odfe-cluster | green | 2 | 2 | 16 | 8 | 0 | 0 | 0 | 0 | - | 100.0%
+1624248112 | 04:01:52 | opensearch-cluster | green | 2 | 2 | 16 | 8 | 0 | 0 | 0 | 0 | - | 100.0%
 ```

--- a/_opensearch/rest-api/cat/cat-master.md
+++ b/_opensearch/rest-api/cat/cat-master.md
@@ -40,5 +40,5 @@ master_timeout | Time | The amount of time to wait for a connection to the maste
 
 ```json
 id                     |   host     |     ip     |   node
-ZaIkkUd4TEiAihqJGkp5CA | 172.18.0.3 | 172.18.0.3 | odfe-node2
+ZaIkkUd4TEiAihqJGkp5CA | 172.18.0.3 | 172.18.0.3 | opensearch-node2
 ```

--- a/_opensearch/rest-api/cat/cat-nodeattrs.md
+++ b/_opensearch/rest-api/cat/cat-nodeattrs.md
@@ -41,5 +41,5 @@ master_timeout | Time | The amount of time to wait for a connection to the maste
 
 ```json
 node | host | ip | attr | value
-odfe-node2 | 172.18.0.3 | 172.18.0.3 | testattr | test
+opensearch-node2 | 172.18.0.3 | 172.18.0.3 | testattr | test
 ```

--- a/_opensearch/rest-api/cat/cat-nodes.md
+++ b/_opensearch/rest-api/cat/cat-nodes.md
@@ -47,6 +47,6 @@ include_unloaded_segments | Boolean | Whether to include information from segmen
 
 ```json
 ip         | heap.percent | ram.percent | cpu load_1m | load_5m | load_15m | node.role | master | name
-172.18.0.3 |     31       |     97      |       3     |  0.03   |   0.10   |  0.14 dimr |  *    |  odfe-node2
-172.18.0.4 |     45       |     97      |       3     |  0.19   |   0.14   |  0.15 dimr |  -    |  odfe-node1
+172.18.0.3 |     31       |     97      |       3     |  0.03   |   0.10   |  0.14 dimr |  *    |  opensearch-node2
+172.18.0.4 |     45       |     97      |       3     |  0.19   |   0.14   |  0.15 dimr |  -    |  opensearch-node1
 ```

--- a/_opensearch/rest-api/cat/cat-plugins.md
+++ b/_opensearch/rest-api/cat/cat-plugins.md
@@ -41,24 +41,24 @@ master_timeout | Time | The amount of time to wait for a connection to the maste
 
 ```json
 name       component                       version
-odfe-node2 opendistro-alerting             1.13.1.0
-odfe-node2 opendistro-anomaly-detection    1.13.0.0
-odfe-node2 opendistro-asynchronous-search  1.13.0.1
-odfe-node2 opendistro-index-management     1.13.2.0
-odfe-node2 opendistro-job-scheduler        1.13.0.0
-odfe-node2 opendistro-knn                  1.13.0.0
-odfe-node2 opendistro-performance-analyzer 1.13.0.0
-odfe-node2 opendistro-reports-scheduler    1.13.0.0
-odfe-node2 opendistro-sql                  1.13.2.0
-odfe-node2 opendistro_security             1.13.1.0
-odfe-node1 opendistro-alerting             1.13.1.0
-odfe-node1 opendistro-anomaly-detection    1.13.0.0
-odfe-node1 opendistro-asynchronous-search  1.13.0.1
-odfe-node1 opendistro-index-management     1.13.2.0
-odfe-node1 opendistro-job-scheduler        1.13.0.0
-odfe-node1 opendistro-knn                  1.13.0.0
-odfe-node1 opendistro-performance-analyzer 1.13.0.0
-odfe-node1 opendistro-reports-scheduler    1.13.0.0
-odfe-node1 opendistro-sql                  1.13.2.0
-odfe-node1 opendistro_security             1.13.1.0
+opensearch-node2 opendistro-alerting             1.13.1.0
+opensearch-node2 opendistro-anomaly-detection    1.13.0.0
+opensearch-node2 opendistro-asynchronous-search  1.13.0.1
+opensearch-node2 opendistro-index-management     1.13.2.0
+opensearch-node2 opendistro-job-scheduler        1.13.0.0
+opensearch-node2 opendistro-knn                  1.13.0.0
+opensearch-node2 opendistro-performance-analyzer 1.13.0.0
+opensearch-node2 opendistro-reports-scheduler    1.13.0.0
+opensearch-node2 opendistro-sql                  1.13.2.0
+opensearch-node2 opendistro_security             1.13.1.0
+opensearch-node1 opendistro-alerting             1.13.1.0
+opensearch-node1 opendistro-anomaly-detection    1.13.0.0
+opensearch-node1 opendistro-asynchronous-search  1.13.0.1
+opensearch-node1 opendistro-index-management     1.13.2.0
+opensearch-node1 opendistro-job-scheduler        1.13.0.0
+opensearch-node1 opendistro-knn                  1.13.0.0
+opensearch-node1 opendistro-performance-analyzer 1.13.0.0
+opensearch-node1 opendistro-reports-scheduler    1.13.0.0
+opensearch-node1 opendistro-sql                  1.13.2.0
+opensearch-node1 opendistro_security             1.13.1.0
 ```

--- a/_opensearch/rest-api/cat/cat-recovery.md
+++ b/_opensearch/rest-api/cat/cat-recovery.md
@@ -54,6 +54,6 @@ time | Time | Specify the units for time. For example, `5d` or `7h`. For more in
 
 ```json
 index | shard | time | type | stage | source_host | source_node | target_host | target_node | repository | snapshot | files | files_recovered | files_percent | files_total | bytes | bytes_recovered | bytes_percent | bytes_total | translog_ops | translog_ops_recovered | translog_ops_percent
-movies | 0 | 117ms | empty_store | done | n/a | n/a | 172.18.0.4 | odfe-node1 | n/a | n/a | 0 | 0 | 0.0% | 0 | 0 | 0 | 0.0% | 0 | 0 | 0 | 100.0%
-movies | 0 | 382ms | peer | done | 172.18.0.4 | odfe-node1 | 172.18.0.3 | odfe-node2 | n/a | n/a | 1 | 1 |  100.0% | 1 | 208 | 208 | 100.0% | 208 | 1 | 1 | 100.0%
+movies | 0 | 117ms | empty_store | done | n/a | n/a | 172.18.0.4 | opensearch-node1 | n/a | n/a | 0 | 0 | 0.0% | 0 | 0 | 0 | 0.0% | 0 | 0 | 0 | 100.0%
+movies | 0 | 382ms | peer | done | 172.18.0.4 | opensearch-node1 | 172.18.0.3 | opensearch-node2 | n/a | n/a | 1 | 1 |  100.0% | 1 | 208 | 208 | 100.0% | 208 | 1 | 1 | 100.0%
 ```

--- a/_opensearch/rest-api/cat/cat-shards.md
+++ b/_opensearch/rest-api/cat/cat-shards.md
@@ -55,6 +55,6 @@ time | Time | Specify the units for time. For example, `5d` or `7h`. For more in
 
 ```json
 index | shard | prirep | state   | docs | store | ip |       | node
-plugins | 0   |   p    | STARTED |   0  |  208b | 172.18.0.4 | odfe-node1
-plugins | 0   |   r    | STARTED |   0  |  208b | 172.18.0.3 |  odfe-node2          
+plugins | 0   |   p    | STARTED |   0  |  208b | 172.18.0.4 | opensearch-node1
+plugins | 0   |   r    | STARTED |   0  |  208b | 172.18.0.3 | opensearch-node2          
 ```

--- a/_opensearch/rest-api/cat/cat-snapshots.md
+++ b/_opensearch/rest-api/cat/cat-snapshots.md
@@ -41,6 +41,6 @@ time | Time | Specify the units for time. For example, `5d` or `7h`. For more in
 
 ```json
 index | shard | prirep | state   | docs | store | ip |       | node
-plugins | 0   |   p    | STARTED |   0  |  208b | 172.18.0.4 | odfe-node1
-plugins | 0   |   r    | STARTED |   0  |  208b | 172.18.0.3 |  odfe-node2          
+plugins | 0   |   p    | STARTED |   0  |  208b | 172.18.0.4 | opensearch-node1
+plugins | 0   |   r    | STARTED |   0  |  208b | 172.18.0.3 | opensearch-node2          
 ```

--- a/_opensearch/rest-api/cat/cat-tasks.md
+++ b/_opensearch/rest-api/cat/cat-tasks.md
@@ -43,5 +43,5 @@ time | Time | Specify the units for time. For example, `5d` or `7h`. For more in
 
 ```json
 action | task_id | parent_task_id | type | start_time | timestamp | running_time | ip | node
-cluster:monitor/tasks/lists | 1vo54NuxSxOrbPEYdkSF0w:168062 | - | transport | 1624337809471 | 04:56:49 | 489.5ms | 172.18.0.4 | odfe-node1     
+cluster:monitor/tasks/lists | 1vo54NuxSxOrbPEYdkSF0w:168062 | - | transport | 1624337809471 | 04:56:49 | 489.5ms | 172.18.0.4 | opensearch-node1     
 ```

--- a/_opensearch/rest-api/cat/cat-thread-pool.md
+++ b/_opensearch/rest-api/cat/cat-thread-pool.md
@@ -47,7 +47,7 @@ master_timeout | Time | The amount of time to wait for a connection to the maste
 
 ```json
 node_name  name                      active queue rejected
-odfe-node2 ad-batch-task-threadpool    0     0        0
-odfe-node2 ad-threadpool               0     0        0
-odfe-node2 analyze                     0     0        0s
+opensearch-node2 ad-batch-task-threadpool    0     0        0
+opensearch-node2 ad-threadpool               0     0        0
+opensearch-node2 analyze                     0     0        0s
 ```


### PR DESCRIPTION
Signed-off-by: alicejw <alicejw@amazon.com>

### Description
Need to update examples throughout the docs for the  legacy "odfe" node that stood for (opendistro for elasticsearch) to "opensearch-node." 

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
