### PR TITLE
Fixed the data-prepper URI

### DIFF
--- a/_clients/data-prepper/get-started.md
+++ b/_clients/data-prepper/get-started.md
@@ -38,7 +38,7 @@ Run the following command with your pipeline configuration YAML.
 ```bash
 docker run --name data-prepper \
     -v /full/path/to/pipelines.yaml:/usr/share/data-prepper/pipelines.yaml \
-    opensearchproject/opensearch-data-prepper:latest
+    opensearchproject/data-prepper:latest
 ```
 
 This sample pipeline configuration above demonstrates a simple pipeline with a source (`random`) sending data to a sink (`stdout`). For more examples and details on more advanced pipeline configurations, see [Pipelines]({{site.url}}{{site.baseurl}}/clients/data-prepper/pipelines).

--- a/_clients/data-prepper/pipelines.md
+++ b/_clients/data-prepper/pipelines.md
@@ -122,7 +122,7 @@ Data Prepper supports Logstash configuration files for a limited set of plugins.
 ```bash
 docker run --name data-prepper \
     -v /full/path/to/logstash.conf:/usr/share/data-prepper/pipelines.conf \
-    opensearchproject/opensearch-data-prepper:latest
+    opensearchproject/data-prepper:latest
 ```
 
 This feature is limited by feature parity of Data Prepper. As of Data Prepper 1.2 release, the following plugins from the Logstash configuration are supported:
@@ -149,5 +149,5 @@ To configure the Data Prepper server, run Data Prepper with the additional yaml 
 ```bash
 docker run --name data-prepper -v /full/path/to/pipelines.yaml:/usr/share/data-prepper/pipelines.yaml \
     /full/path/to/data-prepper-config.yaml:/usr/share/data-prepper/data-prepper-config.yaml \
-    opensearchproject/opensearch-data-prepper:latest
+    opensearchproject/data-prepper:latest
 ````


### PR DESCRIPTION
Signed-off-by: Victor Nilsson <victor@viclab.se>

### Description
There is an error on the documentation for data-prepper which tries to pull images from opensearchproject/opensearch-data-prepper when in fact the correct path is opensearchproject/data-prepper.

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
