### PR TITLE
Fixing Nodes APIs issues

### DIFF
--- a/_opensearch/rest-api/cluster-stats.md
+++ b/_opensearch/rest-api/cluster-stats.md
@@ -31,7 +31,7 @@ All cluster stats parameters are optional.
 
 Parameter | Type | Description
 :--- | :--- | :---
-&lt;node-filters&gt; | List | A comma-separated list of [node filters](../nodes-apis/index/#node-filters) that OpenSearch uses to filter results.
+&lt;node-filters&gt; | List | A comma-separated list of [node filters]({{site.url}}{{site.baseurl}}/opensearch/rest-api/nodes-apis/index/#node-filters) that OpenSearch uses to filter results.
 
 
   Although the `master` node is now called `cluster_manager` for version 2.0, we retained the `master` field for backwards compatibility. If you have a node that has either a `master` role or a `cluster_manager` role, the `count` increases for both fields by 1. To see an example node count increase, see the Response sample.

--- a/_opensearch/rest-api/nodes-apis/index.md
+++ b/_opensearch/rest-api/nodes-apis/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Nodes API
+title: Nodes APIs
 parent: REST API reference
 has_children: true
 nav_order: 5

--- a/_opensearch/rest-api/nodes-apis/nodes-hot-threads.md
+++ b/_opensearch/rest-api/nodes-apis/nodes-hot-threads.md
@@ -29,13 +29,13 @@ You can include the following URL parameters in your request. All parameters are
 
 Parameter | Type     | Description
 :--- |:----------| :---
-nodeId | String  | A comma-separated list of node IDs to filter results. Supports [node filters](../index/#node-filters). Defaults to `_all`.
+nodeId | String  | A comma-separated list of node IDs to filter results. Supports [node filters]({{site.url}}{{site.baseurl}}/opensearch/rest-api/nodes-apis/index/#node-filters). Defaults to `_all`.
 snapshots | Integer  | Number of samples of thread stacktraces. Defaults to `10`.
 interval | TimeValue | Interval between consecutive samples. Defaults to `500ms`.
 threads | Integer   | A number of top busiest threads to return information about. Defaults to `3`.
 ignore_idle_threads | Boolean   | Don’t show threads that are in known-idle states, such as waiting on a socket select or pulling from an empty task queue. Defaults to `true`.
 type | String    | Supported thread types are `cpu`, `wait`, or `block`. Defaults to `cpu`.
-timeout | TimeValue | A request [timeout](../index/#timeout). Defaults to `30s`.
+timeout | TimeValue | A request [timeout]({{site.url}}{{site.baseurl}}/opensearch/rest-api/nodes-apis/index/#timeout). Defaults to `30s`.
 
 ## Response
 

--- a/_opensearch/rest-api/nodes-apis/nodes-info.md
+++ b/_opensearch/rest-api/nodes-apis/nodes-info.md
@@ -48,15 +48,15 @@ You can include the following URL parameters in your request. All parameters are
 
 Parameter | Type   | Description
 :--- |:-------| :---
-nodeId | String | A comma-separated list of nodeIds to filter results. Supports [node filters](../index/#node-filters). Defaults to `_all`.
+nodeId | String | A comma-separated list of nodeIds to filter results. Supports [node filters]({{site.url}}{{site.baseurl}}/opensearch/rest-api/nodes-apis/index/#node-filters). Defaults to `_all`.
 metrics | String | A comma-separated list of metric groups that will be included in the response. For example `jvm,thread_pools`. Defaults to all metrics.
-timeout | TimeValue | A request [timeout](../index/#timeout). Defaults to `30s`.
+timeout | TimeValue | A request [timeout]({{site.url}}{{site.baseurl}}/opensearch/rest-api/nodes-apis/index/#timeout). Defaults to `30s`.
 
 The following are listed for all available metric groups:
 
 Metric | Description
 :--- |:----
-`settings` | A node's settings. This is combination of the default settings, custom settings from [configuration file](../../../configuration/#configuration-file) and dynamically [updated settings](../../../configuration/#update-cluster-settings-using-the-api).
+`settings` | A node's settings. This is combination of the default settings, custom settings from [configuration file]({{site.url}}{{site.baseurl}}/opensearch/configuration/#configuration-file) and dynamically [updated settings]({{site.url}}{{site.baseurl}}/opensearch/configuration/#update-cluster-settings-using-the-api).
 `os` | Static information about the host OS, including version, processor architecture and available/allocated processors.
 `process` | Contains process OD.
 `jvm` | Detailed static information about running JVM, including arguments.
@@ -65,7 +65,7 @@ Metric | Description
 `http` | Mostly static information about the HTTP layer.
 `plugins` | Information about installed plugins and modules.
 `ingest` | Information about ingest pipelines and available ingest processors.
-`aggregations` | Information about available [aggregations](../../../aggregations).
+`aggregations` | Information about available [aggregations]({{site.url}}{{site.baseurl}}/opensearch/aggregations).
 `indices` | Static index settings configured at the node level.
 
 ## Response


### PR DESCRIPTION
### Fixing Nodes APIs issues

1. Fixing all reported dead links.
2. Changing `title` value in index.md back to plural form, i.e. "Nodes APIs".

The second change fixed missing child pages. I am not saying I insist on use of plural form but if we want to change it to a singular form then we also have to change `parent` fields in all child pages to correctly refer to valid parent, otherwise all child pages and content is missing.

As for the debate of use APIs vs API (plural vs singular) I just want to point out that right now there are many other parent pages using plural form. If we want to change that then I suggest doing it in separate PR and include other relevant parent pages too.

### Issues Resolved

Closes: #591

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Lukáš Vlček <lukas.vlcek@aiven.io>
