### PR TITLE
add opt-out of search telemetry in OS dashboards

### DIFF
--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -7,35 +7,35 @@ nav_order: 30
 
 # About search telemetry
 
-You can use search telemetry to analyze performance for success or failed search requests in OpenSearch Dashboards. OpenSearch stores telemetry data in the `.kibana_1` index.
+You can use search telemetry to analyze search request performance by success or failure in OpenSearch Dashboards. OpenSearch stores telemetry data in the `.kibana_1` index.
 
-Because there are thousands of concurrent search requests from OpenSearch Dashboards, the large traffic can cause significant load in an OpenSearch cluster.
+Because there are thousands of concurrent search requests from OpenSearch Dashboards, the heavy traffic can cause significant load in an OpenSearch cluster.
 
 OpenSearch clusters perform better with search telemetry turned off.
 {: .tip }
 
-## Enable search telemetry
+## Turn on search telemetry
 
-Search usage telemetry is disabled by default. To enable it, you need to set `data.search.usageTelemetry.enabled` to `true` in the `opensearch_dashboards.yml` file.
+Search usage telemetry is turned off by default. To turn it on, you need to set `data.search.usageTelemetry.enabled` to `true` in the `opensearch_dashboards.yml` file.
 
 You can find the [OpenSearch Dashboards YAML file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/config/opensearch_dashboards.yml) in the opensearch-project repository on GitHub.
 
-Enabling telemetry in the `opensearch_dashboards.yml` file overrides the default search telemetry setting of `false` in the [Data plugin configuration file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/config.ts).
+Turning on telemetry in the `opensearch_dashboards.yml` file overrides the default search telemetry setting of `false` in the [Data plugin configuration file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/config.ts).
 {: .note }
 
-### To opt-in or opt-out of search telemetry data
+### Turn search telemetry on or off
 
-The following table shows the `data.search.usageTelemetry.enabled` values you can set in `opensearch_dashboards.yml` to opt-in or opt-out of search telemetry.
+The following table shows the `data.search.usageTelemetry.enabled` values you can set in `opensearch_dashboards.yml` to turn search telemetry on or off.
 
-OpenSearch Dashboards YAML value  | Opt-in or Opt-out of search telemetry
+OpenSearch Dashboards YAML value  | Search telemetry status: on or off
 :--- |  :---
- `true`  | Opt-in
- `false` | Opt-out
- `none`  | Opt-out
+ `true`  | On
+ `false` | Off
+ `none`  | Off
 
 #### Sample opensearch_dashboards.yml with telemetry enabled
 
- This OpenSearch Dashboards YAML file excerpt shows the telemetry setting set to `true` to opt-in to search telemetry:
+ This OpenSearch Dashboards YAML file excerpt shows the telemetry setting set to `true` to turn on search telemetry:
 
  ```json
 # Set the value of this setting to false to suppress 

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -5,20 +5,25 @@ nav_order: 30
 ---
 
 
-# About Search telemetry
+# About search telemetry
 
-Search Telemetry is used to analyze performance for success or failed search requests in OpenSearch Dashboards. Telemetry data is saved in the `.kibana_1` index.
+You can use search telemetry to analyze performance for success or failed search requests in OpenSearch Dashboards. OpenSearch stores telemetry data in the `.kibana_1` index.
 
 Because there are thousands of concurrent search request from OpenSearch Dashboards, the large traffic causes significant load in an OpenSearch cluster.
 
-To improve performance for your OpenSearch cluster, you can turn off search telemetry.
+By default it is disabled, so you need to do some configuration changes to enable it.
 
-## Disable search telemetry to improve cluster performance
+OpenSearch clusters perform better with search telemetry turned off.
+{: .tip }
 
-You can suppress the search usage telemetry by enabling the `data.search.usageTelemetry.enabled` setting in your `opensearch_dashboard.yml` file.
+To learn more about using telemetry data with OpenSearch Dashboards, see [Trace Analytics OpenSearch Dashboards plugin](docs/2.0/observability-plugin/trace/ta-dashboards/).
 
-{: note}
-You can find the OpenSearch Dashboards YAML file in the opensearch-project GitHub directory: OpenSearch-Dashboards/config/opensearch_dashboards.yml
+## Enable search telemetry
+
+Search usage telemetry is disabled by default. To enable it, you need to set the `data.search.usageTelemetry.enabled` setting to `true` in the `opensearch_dashboard.yml` file.
+
+You can find the OpenSearch Dashboards YAML file in the opensearch-project GitHub directory: `OpenSearch-Dashboards/config/opensearch_dashboards.yml`
+{: .note }
 
 Alternatively, you can modify the Data plugin config file to opt out of search telemetry.
 
@@ -26,23 +31,36 @@ Alternatively, you can modify the Data plugin config file to opt out of search t
 
 You can opt-in or opt-out of using search telemetry in your cluster by changing the configuration values in both the OpenSearch Dashboards YAML and Data plugin configuration files.
 
-The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file setting `search.usageTelemetry.enabled` values that will result in search telemetry opt-in or opt-out.
+The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file src/plugins/data/config.ts setting `search.usageTelemetry.enabled` values that will result in search telemetry opt-in or opt-out.
 
-OpenSearch Dashboards YML value  | Data plugin config value | Opt-in or Opt-out of search telemetry
+In the data configuration file (), 
+
+
+
+OpenSearch Dashboards YAML value  | Data plugin config value | Opt-in or Opt-out of search telemetry
 :--- | :--- | :---
  `true`  |  `false` | Opt-in
  `true`  |  `true`  | Opt-in
  `none`  |  `true`  | Opt-in
- `true`  |  `true`  | Opt-in
  `none`  |  `false` | Opt-out
  `false` |  `true`  | Opt-out
  `false` |  `false` | Opt-out
 
- #### Sample opensearch_dashboards.yml
+#### Sample opensearch_dashboards.yml
 
  This OpenSearch Dashboards YAML file excerpt shows the telemetry setting set to `false` to opt-out:
 
  ```json
- # Set the value of this setting to false to suppress search usage telemetry to reduce the load of the OpenSearch cluster.
-# data.search.usageTelemetry.enabled: false
+# Set the value of this setting to false to suppress 
+# search usage telemetry to reduce the load of the OpenSearch cluster.
+ data.search.usageTelemetry.enabled: false
+```
+
+#### Sample data configuration file with telemetry enabled
+
+This excerpt shows the `/src/plugins/data/config.ts` file with telemetry set to enabled:
+```json
+. . .
+usageTelemetry: schema.object({
+   enabled: schema.boolean({ defaultValue: false }),
 ```

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -18,10 +18,11 @@ OpenSearch clusters perform better with search telemetry turned off.
 
 Search usage telemetry is disabled by default. To enable it, you need to set `data.search.usageTelemetry.enabled` to `true` in the `opensearch_dashboards.yml` file.
 
-You can find the [OpenSearch Dashboards YAML file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/config/opensearch_dashboards.yml) in the opensearch-project on GitHub.
+You can find the [OpenSearch Dashboards YAML file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/config/opensearch_dashboards.yml) in the opensearch-project repository on GitHub.
 
 Enabling telemetry in the `opensearch_dashboards.yml` file overrides the default search telemetry setting of `false` in the [Data plugin configuration file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/config.ts).
 {: .note }
+
 ### To opt-in or opt-out of search telemetry data
 
 The following table shows the `data.search.usageTelemetry.enabled` values you can set in `opensearch_dashboards.yml` to opt-in or opt-out of search telemetry.

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -16,22 +16,23 @@ By default it is disabled, so you need to do some configuration changes to enabl
 OpenSearch clusters perform better with search telemetry turned off.
 {: .tip }
 
-To learn more about using telemetry data with OpenSearch Dashboards, see [Trace Analytics OpenSearch Dashboards plugin](docs/2.0/observability-plugin/trace/ta-dashboards/).
-
 ## Enable search telemetry
 
-Search usage telemetry is disabled by default. To enable it, you need to set the `data.search.usageTelemetry.enabled` setting to `true` in the `opensearch_dashboard.yml` file.
+Search usage telemetry is disabled by default. To enable it, you need to change the OpenSearch Dashboards YAML file `opensearch_dashboards.yml` setting `data.search.usageTelemetry.enabled` to `true`.
 
-You can find the OpenSearch Dashboards YAML file in the opensearch-project GitHub directory: `OpenSearch-Dashboards/config/opensearch_dashboards.yml`
+You can find the OpenSearch Dashboards YAML file in the opensearch-project GitHub directory: `OpenSearch-Dashboards/config/opensearch_dashboards.yml`.
+
+When you enable telemetry in the OpenSearch Dashboards YAML file, this overrides the default `false` telemetry setting in the [Data plugin configuration file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/config.ts).
 {: .note }
 
-Alternatively, you can modify the Data plugin config file to opt out of search telemetry.
+<!-- they don't need this table after all. the .yml file changed to 'true' will override the detault setting in the data plugin config file. but saving in-case SMEs decide they can change the data plugin config file at a later date.
 
 ### To opt-in or opt-out of search telemetry data
 
 You can opt-in or opt-out of using search telemetry in your cluster by changing the configuration values in both the OpenSearch Dashboards YAML and Data plugin configuration files.
 
-The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file OpenSearch-Dashboards/src/plugins/data/config.ts setting `usageTelemetry` values that will result in search telemetry opt-in or opt-out.
+The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the 
+ values that will result in search telemetry opt-in or opt-out.
 
 OpenSearch Dashboards YAML value  | Data plugin config value | Opt-in or Opt-out of search telemetry
 :--- | :--- | :---
@@ -41,22 +42,14 @@ OpenSearch Dashboards YAML value  | Data plugin config value | Opt-in or Opt-out
  `none`  |  `false` | Opt-out
  `false` |  `true`  | Opt-out
  `false` |  `false` | Opt-out
+ -->
 
-#### Sample opensearch_dashboards.yml
+#### Sample opensearch_dashboards.yml with telemetry enabled
 
- This OpenSearch Dashboards YAML file excerpt shows the telemetry setting set to `false` to opt-out:
+ This OpenSearch Dashboards YAML file excerpt shows the telemetry setting set to `true` to opt-in to search telemetry:
 
  ```json
 # Set the value of this setting to false to suppress 
 # search usage telemetry to reduce the load of the OpenSearch cluster.
- data.search.usageTelemetry.enabled: false
-```
-
-#### Sample data configuration file with telemetry disabled
-
-By default, the data plugin configuration file sets telemetry to `false`. This excerpt shows the OpenSearch-Dashboards/src/plugins/data/config.ts file with telemetry enabled:
-```json
-. . .
-usageTelemetry: schema.object({
-   enabled: schema.boolean({ defaultValue: true }),
+ data.search.usageTelemetry.enabled: true
 ```

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -1,0 +1,40 @@
+---
+layout: default
+title: Search telemetry
+nav_order: 21
+---
+
+
+# About Search telemetry
+
+Search Telemetry is used to analyze performance for success or failed search requests in OpenSearch Dashboards. Telemetry data is saved in the `.kibana_1` index.
+
+Because there are thousands of concurrent search request from OpenSearch Dashboards, the large traffic causes significant load in an OpenSearch cluster.
+
+To improve performance for your OpenSearch cluster, you can turn off search telemetry.
+
+## Disable search telemetry to improve cluster performance
+
+You can suppress the search usage telemetry by enabling the `data.search.usageTelemetry.enabled` setting in your `opensearch_dashboard.yml` file.
+
+Alternatively, you can modify the Data plugin config file to opt out of search telemetry.
+
+### To opt-in or opt-out of search telemetry data
+
+There are several combinations of OpenSearch Dashboards YAML file and Data plugin configuration file values that allow you to either opt-in or opt-out of using search telemetry in your cluster.
+
+The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file values that will result in search telemetry opt-in or opt-out.
+This table refers to these settings:
+
+* OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` value is either `true`, `false` or `none`.
+* Data plugin configuration file value is either `true`, or `false`.
+
+OpenSearch Dashboards YML value | Data plugin config value | Opt-in or Opt-out of search telemetry
+:--- | :--- | :---
+ `true`  |  `false` | Opt-in
+ `true`  |  `true`  | Opt-in
+ `none`  |  `true`  | Opt-in
+ `true`  |  `true`  | Opt-in
+ `none`  |  `false` | Opt-out
+ `false` |  `true`  | Opt-out
+ `false` |  `false` | Opt-out

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -9,22 +9,22 @@ nav_order: 30
 
 You can use search telemetry to analyze performance for success or failed search requests in OpenSearch Dashboards. OpenSearch stores telemetry data in the `.kibana_1` index.
 
-Because there are thousands of concurrent search request from OpenSearch Dashboards, the large traffic causes significant load in an OpenSearch cluster.
+Because there are thousands of concurrent search requests from OpenSearch Dashboards, the large traffic can cause significant load in an OpenSearch cluster.
 
 OpenSearch clusters perform better with search telemetry turned off.
 {: .tip }
 
 ## Enable search telemetry
 
-Search usage telemetry is disabled by default. To enable it, you need to change the OpenSearch Dashboards YAML file `opensearch_dashboards.yml` setting `data.search.usageTelemetry.enabled` to `true`.
+Search usage telemetry is disabled by default. To enable it, you need to set `data.search.usageTelemetry.enabled` to `true` in the `opensearch_dashboards.yml` file.
 
-You can find the OpenSearch Dashboards YAML file in the opensearch-project GitHub directory: `OpenSearch-Dashboards/config/opensearch_dashboards.yml`.
+You can find the [OpenSearch Dashboards YAML file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/config/opensearch_dashboards.yml) in the opensearch-project on GitHub.
 
-When you enable telemetry in the OpenSearch Dashboards YAML file, this overrides the default `false` telemetry setting in the [Data plugin configuration file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/config.ts).
+Enabling telemetry in the `opensearch_dashboards.yml` file overrides the default search telemetry setting of `false` in the [Data plugin configuration file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/config.ts).
 {: .note }
 ### To opt-in or opt-out of search telemetry data
 
-The following table shows the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` values you can choose to opt-in or opt-out of search telemetry.
+The following table shows the `data.search.usageTelemetry.enabled` values you can set in `opensearch_dashboards.yml` to opt-in or opt-out of search telemetry.
 
 OpenSearch Dashboards YAML value  | Opt-in or Opt-out of search telemetry
 :--- |  :---

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -11,8 +11,6 @@ You can use search telemetry to analyze performance for success or failed search
 
 Because there are thousands of concurrent search request from OpenSearch Dashboards, the large traffic causes significant load in an OpenSearch cluster.
 
-By default it is disabled, so you need to do some configuration changes to enable it.
-
 OpenSearch clusters perform better with search telemetry turned off.
 {: .tip }
 
@@ -26,7 +24,7 @@ When you enable telemetry in the OpenSearch Dashboards YAML file, this overrides
 {: .note }
 ### To opt-in or opt-out of search telemetry data
 
-The following table shows the values to opt-in or opt-out of search telemetry data in the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled`.
+The following table shows the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` values you can choose to opt-in or opt-out of search telemetry.
 
 OpenSearch Dashboards YAML value  | Opt-in or Opt-out of search telemetry
 :--- |  :---

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -24,25 +24,15 @@ You can find the OpenSearch Dashboards YAML file in the opensearch-project GitHu
 
 When you enable telemetry in the OpenSearch Dashboards YAML file, this overrides the default `false` telemetry setting in the [Data plugin configuration file](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/data/config.ts).
 {: .note }
-
-<!-- they don't need this table after all. the .yml file changed to 'true' will override the detault setting in the data plugin config file. but saving in-case SMEs decide they can change the data plugin config file at a later date.
-
 ### To opt-in or opt-out of search telemetry data
 
-You can opt-in or opt-out of using search telemetry in your cluster by changing the configuration values in both the OpenSearch Dashboards YAML and Data plugin configuration files.
+The following table shows the values to opt-in or opt-out of search telemetry data in the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled`.
 
-The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the 
- values that will result in search telemetry opt-in or opt-out.
-
-OpenSearch Dashboards YAML value  | Data plugin config value | Opt-in or Opt-out of search telemetry
-:--- | :--- | :---
- `true`  |  `false` | Opt-in
- `true`  |  `true`  | Opt-in
- `none`  |  `true`  | Opt-in
- `none`  |  `false` | Opt-out
- `false` |  `true`  | Opt-out
- `false` |  `false` | Opt-out
- -->
+OpenSearch Dashboards YAML value  | Opt-in or Opt-out of search telemetry
+:--- |  :---
+ `true`  | Opt-in
+ `false` | Opt-out
+ `none`  | Opt-out
 
 #### Sample opensearch_dashboards.yml with telemetry enabled
 

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -17,6 +17,9 @@ To improve performance for your OpenSearch cluster, you can turn off search tele
 
 You can suppress the search usage telemetry by enabling the `data.search.usageTelemetry.enabled` setting in your `opensearch_dashboard.yml` file.
 
+{: note}
+You can find the OpenSearch Dashboards YAML file in the opensearch-project GitHub directory: OpenSearch-Dashboards/config/opensearch_dashboards.yml
+
 Alternatively, you can modify the Data plugin config file to opt out of search telemetry.
 
 ### To opt-in or opt-out of search telemetry data
@@ -27,7 +30,7 @@ The following table shows the combination of values for the OpenSearch Dashboard
 This table refers to these settings:
 
 * OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` value is either `true`, `false` or `none`.
-* Data plugin configuration file value is either `true`, or `false`.
+* Data plugin configuration file setting `search.usageTelemetry.enabled` value is either `true`, or `false`.
 
 OpenSearch Dashboards YML value | Data plugin config value | Opt-in or Opt-out of search telemetry
 :--- | :--- | :---
@@ -38,3 +41,12 @@ OpenSearch Dashboards YML value | Data plugin config value | Opt-in or Opt-out o
  `none`  |  `false` | Opt-out
  `false` |  `true`  | Opt-out
  `false` |  `false` | Opt-out
+
+ #### Sample opensearch_dashboards.yml
+
+ This OpenSearch Dashboards YAML file excerpt shows the telemetry setting set to `false` to opt-out:
+
+ ```json
+ # Set the value of this setting to false to suppress search usage telemetry to reduce the load of the OpenSearch cluster.
+# data.search.usageTelemetry.enabled: false
+```

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -24,15 +24,11 @@ Alternatively, you can modify the Data plugin config file to opt out of search t
 
 ### To opt-in or opt-out of search telemetry data
 
-There are several combinations of OpenSearch Dashboards YAML file and Data plugin configuration file values that allow you to either opt-in or opt-out of using search telemetry in your cluster.
+You can opt-in or opt-out of using search telemetry in your cluster by changing the configuration values in both the OpenSearch Dashboards YAML and Data plugin configuration files.
 
-The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file values that will result in search telemetry opt-in or opt-out.
-This table refers to these settings:
+The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file setting `search.usageTelemetry.enabled` values that will result in search telemetry opt-in or opt-out.
 
-* OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` value is either `true`, `false` or `none`.
-* Data plugin configuration file setting `search.usageTelemetry.enabled` value is either `true`, or `false`.
-
-OpenSearch Dashboards YML value | Data plugin config value | Opt-in or Opt-out of search telemetry
+OpenSearch Dashboards YML value  | Data plugin config value | Opt-in or Opt-out of search telemetry
 :--- | :--- | :---
  `true`  |  `false` | Opt-in
  `true`  |  `true`  | Opt-in

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Search telemetry
-nav_order: 21
+nav_order: 30
 ---
 
 

--- a/_dashboards/search-telemetry.md
+++ b/_dashboards/search-telemetry.md
@@ -31,11 +31,7 @@ Alternatively, you can modify the Data plugin config file to opt out of search t
 
 You can opt-in or opt-out of using search telemetry in your cluster by changing the configuration values in both the OpenSearch Dashboards YAML and Data plugin configuration files.
 
-The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file src/plugins/data/config.ts setting `search.usageTelemetry.enabled` values that will result in search telemetry opt-in or opt-out.
-
-In the data configuration file (), 
-
-
+The following table shows the combination of values for the OpenSearch Dashboards YAML file setting `data.search.usageTelemetry.enabled` and the Data plugin configuration file OpenSearch-Dashboards/src/plugins/data/config.ts setting `usageTelemetry` values that will result in search telemetry opt-in or opt-out.
 
 OpenSearch Dashboards YAML value  | Data plugin config value | Opt-in or Opt-out of search telemetry
 :--- | :--- | :---
@@ -56,11 +52,11 @@ OpenSearch Dashboards YAML value  | Data plugin config value | Opt-in or Opt-out
  data.search.usageTelemetry.enabled: false
 ```
 
-#### Sample data configuration file with telemetry enabled
+#### Sample data configuration file with telemetry disabled
 
-This excerpt shows the `/src/plugins/data/config.ts` file with telemetry set to enabled:
+By default, the data plugin configuration file sets telemetry to `false`. This excerpt shows the OpenSearch-Dashboards/src/plugins/data/config.ts file with telemetry enabled:
 ```json
 . . .
 usageTelemetry: schema.object({
-   enabled: schema.boolean({ defaultValue: false }),
+   enabled: schema.boolean({ defaultValue: true }),
 ```


### PR DESCRIPTION
### Description
Create a Search Telemetry page under OpenSearch Dashboards to explain how to increase performance on an OS cluster by opting out of using search telemetry data.

Site URL: https://opensearch.org/docs/2.0/dashboards/search-telemetry/

### Issues Resolved
[494](https://github.com/opensearch-project/documentation-website/issues/494)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
