### PR TITLE
[DOCUMENTATION] Support use of IRSA for repository-s3 plugin credentials

### DIFF
--- a/_opensearch/snapshot-restore.md
+++ b/_opensearch/snapshot-restore.md
@@ -159,7 +159,7 @@ Setting | Description
    s3.client.default.region: us-east-2 # AWS region to use
    ```
 
-1. (Optional) If you don't want to use AWS access and secret keys, you could configure S3 plugin to use AWS IAM roles for service accounts:
+1. (Optional) If you don't want to use AWS access and secret keys, you could configure the S3 plugin to use AWS Identity and Access Management (IAM) roles for service accounts:
 
    ```bash
    sudo ./bin/opensearch-keystore add s3.client.default.role_arn
@@ -171,7 +171,7 @@ Setting | Description
    s3.client.default.identity_token_file: /usr/share/opensearch/plugins/repository-s3/token
    ```
 
-   AWS IAM roles require at least one of the above settings. Other settings will be taken from environment variables (if available): `AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_SESSION_NAME`.
+   IAM roles require at least one of the above settings. Other settings will be taken from environment variables (if available): `AWS_ROLE_ARN`, `AWS_WEB_IDENTITY_TOKEN_FILE`, `AWS_ROLE_SESSION_NAME`.
 
 1. If you changed `opensearch.yml`, you must restart each node in the cluster. Otherwise, you only need to reload secure cluster settings:
 


### PR DESCRIPTION
Signed-off-by: Andriy Redko <andriy.redko@aiven.io>

### Description
Add documentation to `repository-s3` plugin related to support  of the AWS IAM roles for service accounts (IRSA) credentials. The feature is targeting `2.1.0` release.

### Issues Resolved
Part of https://github.com/opensearch-project/OpenSearch/issues/2999

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
