### PR TITLE
[Documentation FIXED] fixed the wrong upgrade command on "Documentation/InstallOpenSearch/RPM"

### DIFF
--- a/_opensearch/install/rpm.md
+++ b/_opensearch/install/rpm.md
@@ -150,7 +150,7 @@ You can upgrade your RPM OpenSearch instance both manually and through YUM.
 
 ### Manual 
 
-Download the new version of OpenSearch you want to use, and then use `rmp -Uvh` to upgrade.
+Download the new version of OpenSearch you want to use, and then use `rpm -Uvh` to upgrade.
 
 ### YUM
 


### PR DESCRIPTION

### Description
the Documentation page "Documentation/InstallOpenSearch/RPM" have mistake with commands.
fixed the mistake about rpm.md ,the upgrade command was wrong , but the correct command is `rpm -Uvh` .


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
