### PR TITLE
Change nlists to nlist for k-NN IVF algorithm 

### DIFF
--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -331,7 +331,7 @@ POST /_plugins/_knn/models/{model_id}/_train?preference={node_id}
         "engine":"faiss",
         "space_type": "l2",
         "parameters":{
-            "nlists":128,
+            "nlist":128,
             "encoder":{
                 "name":"pq",
                 "parameters":{
@@ -361,7 +361,7 @@ POST /_plugins/_knn/models/_train?preference={node_id}
         "engine":"faiss",
         "space_type": "l2",
         "parameters":{
-            "nlists":128,
+            "nlist":128,
             "encoder":{
                 "name":"pq",
                 "parameters":{

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -99,7 +99,7 @@ Paramater Name | Required | Default | Updatable | Description
 
 Paramater Name | Required | Default | Updatable | Description
 :--- | :--- | :--- | :--- | :---
-`nlists` | false | 4 | false | Number of buckets to partition vectors into. Higher values may lead to more accurate searches, at the expense of memory and training latency. For more information about choosing the right value, refer to [*faiss*'s documentation](https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index).
+`nlist` | false | 4 | false | Number of buckets to partition vectors into. Higher values may lead to more accurate searches, at the expense of memory and training latency. For more information about choosing the right value, refer to [*faiss*'s documentation](https://github.com/facebookresearch/faiss/wiki/Guidelines-to-choose-an-index).
 `nprobes` | false | 1 | false | Number of buckets to search over during query. Higher values lead to more accurate but slower searches.
 `encoder` | false | flat | false | Encoder definition for encoding vectors. Encoders can reduce the memory footprint of your index, at the expense of search accuracy.
 


### PR DESCRIPTION
### Description
Fixes typo in ivf algorithm parameter. Correct value is nlist as appears
in
https://github.com/opensearch-project/k-NN/blob/2.0/src/main/java/org/opensearch/knn/common/KNNConstants.java.


### Issues Resolved
#669 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
