### PR TITLE
Fix server.host to valid address to fix issue with Opensearch-Dashboards 2.0

### DIFF
--- a/_security-plugin/configuration/disable.md
+++ b/_security-plugin/configuration/disable.md
@@ -46,7 +46,7 @@ If you disable the security plugin in `opensearch.yml` (or delete the plugin ent
    ```yml
    ---
    server.name: opensearch-dashboards
-   server.host: "0"
+   server.host: "0.0.0.0"
    opensearch.hosts: http://localhost:9200
    ```
 


### PR DESCRIPTION
Signed-off-by: Brian Saghy <brian@finishbot.com>

### Description
As of Opensearch-dashboards 2.0, server.host: "0" is considered an invalid host address and errors. Changing to 0.0.0.0 seems to resolve this.

Now the example config file will actually work with Opensearch-Dashboards 2.0. 

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
