### PR TITLE
small fix: update with 'cluster manager' terminology

### DIFF
--- a/_opensearch/rest-api/cat/cat-templates.md
+++ b/_opensearch/rest-api/cat/cat-templates.md
@@ -39,8 +39,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/opensear
 
 Parameter | Type | Description
 :--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
-master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is false.
+cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
 
 
 ## Response


### PR DESCRIPTION
Signed-off-by: alicejw <alicejw@amazon.com>

### Description
Small fix to replace 'master' with 'cluster manager' terminology

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
