### PR TITLE
Update serach.remote with cluster.remote

### DIFF
--- a/_security-plugin/access-control/cross-cluster-search.md
+++ b/_security-plugin/access-control/cross-cluster-search.md
@@ -153,7 +153,7 @@ On the coordinating cluster, add the remote cluster name and the IP address (wit
 curl -k -XPUT -H 'Content-Type: application/json' -u 'admin:admin' 'https://localhost:9250/_cluster/settings' -d '
 {
   "persistent": {
-    "search.remote": {
+    "cluster.remote": {
       "opensearch-ccs-cluster1": {
         "seeds": ["172.31.0.3:9300"]
       }


### PR DESCRIPTION
Signed-off-by: pawelw1 <pawel.wlodarczyk@eliatra.com>

### Description
search.remote is no longer a valid cross-cluster configuration option. 

### Issues Resolved


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
