### PR TITLE
Updated the header on the Doc site with new navigation

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -30,11 +30,12 @@
     <div class="menu-button"><i class="icon icon-reorder"></i><span>Menu</span></div>
     <div class="nav-menu-on" role="navigation">
       <ul class="small-nav">
-        {%- include nav_item.html text="News" href="/blog" url_full="/blog/" url_fragment="blog" -%}
-        {%- include nav_item.html text="Source" href="/source.html" url_full="/source.html" url_fragment="source" -%}
+        {%- include nav_item.html text="Download" href="/downloads.html#opensearch" url_full="/downloads.html#opensearch" url_fragment="downloads" -%}
         {%- include nav_item.html text="Documentation" href="/docs" url_full="/docs/" url_fragment="docs" -%}
-        {%- include nav_item.html text="Events" href="/events" url_full="/events/" url_fragment="events" -%}
-        {%- include nav_item.html text="Get Started" href="/downloads.html" url_full="/downloads.html" url_fragment="downloads" -%}
+        {%- include nav_item.html text="Blog" href="/blog/" url_full="/blog/" url_fragment="blog" -%}
+        {%- include nav_item.html text="Forum" href="https://forum.opensearch.org/" url_full="https://forum.opensearch.org/" url_fragment="forum" -%}
+        {%- include nav_item.html text="Events" href="/events/" url_full="/events/" url_fragment="events" -%}
+        {%- include nav_item.html text="Partners" href="/partners/" url_full="/partners/" url_fragment="partners" -%}
       </ul>
     </div>
   </div>


### PR DESCRIPTION
Signed-off-by: Heather Halter <hdhalter@amazon.com>

### Description
Fixes the header of the documentation page so it matches the rest of the pages on the site. I still need to make the change to the footer to close the issue.

### Issues Resolved
(https://github.com/opensearch-project/documentation-website/issues/616)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
