### PR TITLE
Removes 'partners' from footer.yml to align with rest of the website

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -11,9 +11,9 @@ columns:
       -
         title: 'Github'
         url: 'https://github.com/opensearch-project'
-      -
-        title: 'Partners'
-        url: '/partners/'
+      # -
+        # title: 'Partners'
+        # url: '/partners/'
       -
         title: 'Community Projects'
         url: '/community_projects'


### PR DESCRIPTION
Signed-off-by: Heather Halter <hdhalter@amazon.com>
Updated the footer to remove 'Partner' links, as Partners is now in the header. 
Fixes part 2 of this issue: https://github.com/opensearch-project/documentation-website/issues/616 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
