### PR TITLE
Revert "Updates all documentation relevant to securityconfig folder n…

### DIFF
--- a/_opensearch/install/docker-security.md
+++ b/_opensearch/install/docker-security.md
@@ -43,11 +43,11 @@ services:
       - ./admin.pem:/usr/share/opensearch/config/admin.pem
       - ./admin-key.pem:/usr/share/opensearch/config/admin-key.pem
       - ./custom-opensearch.yml:/usr/share/opensearch/config/opensearch.yml
-      - ./internal_users.yml:/usr/share/opensearch/config/opensearch-security/internal_users.yml
-      - ./roles_mapping.yml:/usr/share/opensearch/config/opensearch-security/roles_mapping.yml
-      - ./tenants.yml:/usr/share/opensearch/config/opensearch-security/tenants.yml
-      - ./roles.yml:/usr/share/opensearch/config/opensearch-security/roles.yml
-      - ./action_groups.yml:/usr/share/opensearch/config/opensearch-security/action_groups.yml
+      - ./internal_users.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/internal_users.yml
+      - ./roles_mapping.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/roles_mapping.yml
+      - ./tenants.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/tenants.yml
+      - ./roles.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/roles.yml
+      - ./action_groups.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/action_groups.yml
     ports:
       - 9200:9200
       - 9600:9600 # required for Performance Analyzer
@@ -79,11 +79,11 @@ services:
       - ./admin.pem:/usr/share/opensearch/config/admin.pem
       - ./admin-key.pem:/usr/share/opensearch/config/admin-key.pem
       - ./custom-opensearch.yml:/usr/share/opensearch/config/opensearch.yml
-      - ./internal_users.yml:/usr/share/opensearch/config/opensearch-security/internal_users.yml
-      - ./roles_mapping.yml:/usr/share/opensearch/config/opensearch-security/roles_mapping.yml
-      - ./tenants.yml:/usr/share/opensearch/config/opensearch-security/tenants.yml
-      - ./roles.yml:/usr/share/opensearch/config/opensearch-security/roles.yml
-      - ./action_groups.yml:/usr/share/opensearch/config/opensearch-security/action_groups.yml
+      - ./internal_users.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/internal_users.yml
+      - ./roles_mapping.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/roles_mapping.yml
+      - ./tenants.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/tenants.yml
+      - ./roles.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/roles.yml
+      - ./action_groups.yml:/usr/share/opensearch/plugins/opensearch-security/securityconfig/action_groups.yml
     networks:
       - opensearch-net
   opensearch-dashboards:
@@ -133,7 +133,7 @@ opendistro_security.audit.config.disabled_rest_categories: NONE
 opendistro_security.audit.config.disabled_transport_categories: NONE
 ```
 
-Use this same override process to specify new [authentication settings]({{site.url}}{{site.baseurl}}/security-plugin/configuration/configuration/) in `/usr/share/opensearch/config/opensearch-security/config.yml`, as well as new default [internal users, roles, mappings, action groups, and tenants]({{site.url}}{{site.baseurl}}/security-plugin/configuration/yaml/).
+Use this same override process to specify new [authentication settings]({{site.url}}{{site.baseurl}}/security-plugin/configuration/configuration/) in `/usr/share/opensearch/plugins/opensearch-security/securityconfig/config.yml`, as well as new default [internal users, roles, mappings, action groups, and tenants]({{site.url}}{{site.baseurl}}/security-plugin/configuration/yaml/).
 
 To start the cluster, run `docker-compose up`.
 

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -86,7 +86,7 @@ kibana_user:
 
 Hidden resources are automatically reserved.
 
-To add or remove these flags, modify `config/opensearch-security/internal_users.yml` and run `plugins/opensearch-security/tools/securityadmin.sh`.
+To add or remove these flags, modify `plugins/opensearch-security/securityconfig/internal_users.yml` and run `plugins/opensearch-security/tools/securityadmin.sh`.
 
 
 ---

--- a/_security-plugin/access-control/multi-tenancy.md
+++ b/_security-plugin/access-control/multi-tenancy.md
@@ -29,7 +29,7 @@ http://<opensearch_dashboards_host>:5601/app/opensearch-dashboards?security_tena
 
 ## Configuration
 
-Multi-tenancy is enabled by default, but you can disable it or change its settings using `config/opensearch-security/config.yml`:
+Multi-tenancy is enabled by default, but you can disable it or change its settings using `plugins/opensearch-security/securityconfig/config.yml`:
 
 ```yml
 config:

--- a/_security-plugin/configuration/concepts.md
+++ b/_security-plugin/configuration/concepts.md
@@ -15,7 +15,7 @@ Understanding the authentication flow is a great way to get started with configu
 
 2. The security plugin authenticates the user's credentials against a backend: the internal user database, Lightweight Directory Access Protocol (LDAP), Active Directory, Kerberos, or JSON web tokens.
 
-   The plugin supports chaining backends in `config/opensearch-security/config.yml`. If more than one backend is present, the plugin tries to authenticate the user sequentially against each until one succeeds. A common use case is to combine the internal user database of the security plugin with LDAP/Active Directory.
+   The plugin supports chaining backends in `securityconfig/config.yml`. If more than one backend is present, the plugin tries to authenticate the user sequentially against each until one succeeds. A common use case is to combine the internal user database of the security plugin with LDAP/Active Directory.
 
 3. After a backend verifies the user's credentials, the plugin collects any backend roles. These roles can be arbitrary strings in the internal user database, but in most cases, these backend roles come from LDAP/Active Directory.
 

--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -9,7 +9,7 @@ nav_order: 2
 
 One of the first steps to using the security plugin is to decide on an authentication backend, which handles [steps 2-3 of the authentication flow]({{site.url}}{{site.baseurl}}/security-plugin/configuration/concepts#authentication-flow). The plugin has an internal user database, but many people prefer to use an existing authentication backend, such as an LDAP server, or some combination of the two.
 
-The main configuration file for authentication and authorization backends is `config/opensearch-security/config.yml`. It defines how the security plugin retrieves the user credentials, how it verifies these credentials, and how to fetch additional roles from backend systems (optional).
+The main configuration file for authentication and authorization backends is `plugins/opensearch-security/securityconfig/config.yml`. It defines how the security plugin retrieves the user credentials, how it verifies these credentials, and how to fetch additional roles from backend systems (optional).
 
 `config.yml` has three main parts:
 
@@ -123,7 +123,7 @@ These are the possible values for `type`:
 
 ## Examples
 
-The default `config/opensearch-security/config.yml` that ships with OpenSearch contains many configuration examples. Use these examples as a starting point, and customize them to your needs.
+The default `plugins/opensearch-security/securityconfig/config.yml` that ships with OpenSearch contains many configuration examples. Use these examples as a starting point, and customize them to your needs.
 
 
 ## HTTP basic

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -55,7 +55,7 @@ We provide a fully functional example that can help you understand how to use an
 
 ## Connection settings
 
-To enable LDAP authentication and authorization, add the following lines to `config/opensearch-security/config.yml`:
+To enable LDAP authentication and authorization, add the following lines to `plugins/opensearch-security/securityconfig/config.yml`:
 
 ```yml
 authc:
@@ -247,7 +247,7 @@ Name | Description
 
 ## Use Active Directory and LDAP for authentication
 
-To use Active Directory/LDAP for authentication, first configure a respective authentication domain in the `authc` section of `config/opensearch-security/config.yml`:
+To use Active Directory/LDAP for authentication, first configure a respective authentication domain in the `authc` section of `plugins/opensearch-security/securityconfig/config.yml`:
 
 ```yml
 authc:

--- a/_security-plugin/configuration/saml.md
+++ b/_security-plugin/configuration/saml.md
@@ -37,7 +37,7 @@ We provide a fully functional example that can help you understand how to use SA
 
 ## Activating SAML
 
-To use SAML for authentication, you need to configure a respective authentication domain in the `authc` section of `config/opensearch-security/config.yml`. Because SAML works solely on the HTTP layer, you do not need any `authentication_backend` and can set it to `noop`. Place all SAML-specific configuration options in this chapter in the `config` section of the SAML HTTP authenticator:
+To use SAML for authentication, you need to configure a respective authentication domain in the `authc` section of `plugins/opensearch-security/securityconfig/config.yml`. Because SAML works solely on the HTTP layer, you do not need any `authentication_backend` and can set it to `noop`. Place all SAML-specific configuration options in this chapter in the `config` section of the SAML HTTP authenticator:
 
 ```yml
 authc:

--- a/_security-plugin/configuration/security-admin.md
+++ b/_security-plugin/configuration/security-admin.md
@@ -9,12 +9,12 @@ nav_order: 20
 
 The security plugin stores its configuration---including users, roles, and permissions---in an index on the OpenSearch cluster (`.opendistro_security`). Storing these settings in an index lets you change settings without restarting the cluster and eliminates the need to edit configuration files on every single node.
 
-To initialize the `.opendistro_security` index, however, you must run `plugins/opensearch-security/tools/securityadmin.sh`. This script loads your initial configuration into the index using the configuration files in `config/opensearch-security`. After the `.opendistro_security` index is initialized, use OpenSearch Dashboards or the REST API to manage your users, roles, and permissions.
+To initialize the `.opendistro_security` index, however, you must run `plugins/opensearch-security/tools/securityadmin.sh`. This script loads your initial configuration into the index using the configuration files in `plugins/opensearch-security/securityconfig`. After the `.opendistro_security` index is initialized, use OpenSearch Dashboards or the REST API to manage your users, roles, and permissions.
 
 
 ## A word of caution
 
-If you make changes to the configuration files in `config/opensearch-security`, OpenSearch does _not_ automatically apply these changes. Instead, you must run `securityadmin.sh` to load the updated files into the index.
+If you make changes to the configuration files in `plugins/opensearch-security/securityconfig`, OpenSearch does _not_ automatically apply these changes. Instead, you must run `securityadmin.sh` to load the updated files into the index.
 
 Running `securityadmin.sh` **overwrites** one or more portions of the `.opendistro_security` index. Run it with extreme care to avoid losing your existing resources. Consider the following example:
 
@@ -38,7 +38,7 @@ To avoid this situation, back up your current configuration before making change
 If you use the `-f` argument rather than `-cd`, you can load a single YAML file into the index rather than the entire directory of YAML files. For example, if you create ten new roles, you can safely load `internal_users.yml` into the index without losing your roles; only the internal users get overwritten.
 
 ```bash
-./securityadmin.sh -f ../../../config/opensearch-security/internal_users.yml \
+./securityadmin.sh -f ../securityconfig/internal_users.yml \
   -t internalusers \
   -icl \
   -nhnv \
@@ -50,7 +50,7 @@ If you use the `-f` argument rather than `-cd`, you can load a single YAML file 
 To resolve all environment variables before applying the security configurations, use the `-rev` parameter.
 
 ```bash
-./securityadmin.sh -cd ../../../config/opensearch-security/ \
+./securityadmin.sh -cd ../securityconfig/ \
  -rev \
  -cacert ../../../root-ca.pem \
  -cert ../../../kirk.pem \
@@ -95,7 +95,7 @@ To print all available command line options, run the script with no arguments:
 To load your initial configuration (all YAML files), you might use the following command:
 
 ```bash
-./securityadmin.sh -cd ../../../config/opensearch-security/ -icl -nhnv \
+./securityadmin.sh -cd ../securityconfig/ -icl -nhnv \
   -cacert ../../../config/root-ca.pem \
   -cert ../../../config/kirk.pem \
   -key ../../../config/kirk-key.pem
@@ -118,32 +118,32 @@ Name | Description
 
 ## Sample commands
 
-Apply all YAML files in `config/opensearch-security/` using PEM certificates:
+Apply all YAML files in `securityconfig` using PEM certificates:
 
 ```bash
 /usr/share/opensearch/plugins/opensearch-security/tools/securityadmin.sh \
   -cacert /etc/opensearch/root-ca.pem \
   -cert /etc/opensearch/kirk.pem \
   -key /etc/opensearch/kirk-key.pem \
-  -cd /usr/share/opensearch/config/opensearch-security/
+  -cd /usr/share/opensearch/plugins/opensearch-security/securityconfig/
 ```
 
 Apply a single YAML file (`config.yml`) using PEM certificates:
 
 ```bash
 ./securityadmin.sh \
-  -f ../../../config/opensearch-security/config.yml \
+  -f ../securityconfig/config.yml \
   -icl -nhnv -cert /etc/opensearch/kirk.pem \
   -cacert /etc/opensearch/root-ca.pem \
   -key /etc/opensearch/kirk-key.pem \
   -t config
 ```
 
-Apply all YAML files in `config/opensearch-security/` with keystore and truststore files:
+Apply all YAML files in `securityconfig` with keystore and truststore files:
 
 ```bash
 ./securityadmin.sh \
-  -cd /usr/share/opensearch/config/opensearch-security/ \
+  -cd /usr/share/opensearch/plugins/opensearch-security/securityconfig/ \
   -ks /path/to/keystore.jks \
   -kspass changeit \
   -ts /path/to/truststore.jks \
@@ -158,7 +158,7 @@ Apply all YAML files in `config/opensearch-security/` with keystore and truststo
 You can also use keystore files in JKS format in conjunction with `securityadmin.sh`:
 
 ```bash
-./securityadmin.sh -cd ../../../config/opensearch-security -icl -nhnv
+./securityadmin.sh -cd ../securityconfig -icl -nhnv
   -ts <path/to/truststore> -tspass <truststore password>
   -ks <path/to/keystore> -kspass <keystore password>
 ```
@@ -216,13 +216,13 @@ Name | Description
 To upload all configuration files in a directory, use this:
 
 ```bash
-./securityadmin.sh -cd ../../../config/opensearch-security -ts ... -tspass ... -ks ... -kspass ...
+./securityadmin.sh -cd ../securityconfig -ts ... -tspass ... -ks ... -kspass ...
 ```
 
 If you want to push a single configuration file, use this:
 
 ```bash
-./securityadmin.sh -f ../../../config/opensearch-security/internal_users.yml -t internalusers  \
+./securityadmin.sh -f ../securityconfig/internal_users.yml -t internalusers  \
     -ts ... -tspass ... -ks ... -kspass ...
 ```
 
@@ -274,7 +274,7 @@ To upload the dumped files to another cluster:
 To migrate configuration YAML files from the Open Distro for Elasticsearch 0.x.x format to the OpenSearch 1.x.x format:
 
 ```bash
-./securityadmin.sh -migrate ../../../config/opensearch-security -ts ... -tspass ... -ks ... -kspass ...
+./securityadmin.sh -migrate ../securityconfig -ts ... -tspass ... -ks ... -kspass ...
 ```
 
 Name | Description

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -7,7 +7,7 @@ nav_order: 3
 
 # YAML files
 
-Before running `securityadmin.sh` to load the settings into the `.opendistro_security` index, configure the YAML files in `config/opensearch-security`. You might want to back up these files so that you can reuse them on other clusters.
+Before running `securityadmin.sh` to load the settings into the `.opendistro_security` index, configure the YAML files in `plugins/opensearch-security/securityconfig`. You might want to back up these files so that you can reuse them on other clusters.
 
 The best use of these YAML files is to configure [reserved and hidden resources]({{site.url}}{{site.baseurl}}/security-plugin/access-control/api#reserved-and-hidden-resources), such as the `admin` and `kibanaserver` users. You might find it easier to create other users, roles, mappings, action groups, and tenants using OpenSearch Dashboards or the REST API.
 

--- a/_troubleshoot/security-admin.md
+++ b/_troubleshoot/security-admin.md
@@ -100,7 +100,7 @@ You must use an admin certificate when executing the script. To learn more, see 
 For more information on why `securityadmin.sh` is not executing, add the `--diagnose` option:
 
 ```
-./securityadmin.sh -diagnose -cd ../../../config/opensearch-security/ -cacert ... -cert ... -key ... -keypass ...
+./securityadmin.sh -diagnose -cd ../securityconfig/ -cacert ... -cert ... -key ... -keypass ...
 ```
 
 The script prints the location of the generated diagnostic file.

--- a/_troubleshoot/tls.md
+++ b/_troubleshoot/tls.md
@@ -21,7 +21,7 @@ This page includes troubleshooting steps for configuring TLS certificates with t
 
 ## Validate YAML
 
-`opensearch.yml` and the files in `config/opensearch-security/` are in the YAML format. A linter like [YAML Validator](https://codebeautify.org/yaml-validator) can help verify that you don't have any formatting errors.
+`opensearch.yml` and the files in `opensearch_security/securityconfig/` are in the YAML format. A linter like [YAML Validator](https://codebeautify.org/yaml-validator) can help verify that you don't have any formatting errors.
 
 
 ## View contents of PEM certificates


### PR DESCRIPTION
This reverts commit 2e5bcf192456d93a6d22d325378ced0c2bc19f9d.

Signed-off-by: pawelw1 <pawel.wlodarczyk@eliatra.com>

### Description
This commit should be only applied to version 2.0.x. The config folder security plugin is still in plugins/opensearch-security/securityconfig instead of config/opensearch-security

