### PR TITLE
Added note about lack of downgrade support to the install landing page

### DIFF
--- a/_opensearch/install/index.md
+++ b/_opensearch/install/index.md
@@ -10,3 +10,6 @@ has_children: true
 # Install and configure OpenSearch
 
 OpenSearch has two installation options at this time: Docker images and tarballs.
+
+OpenSearch does not support direct version downgrades. If your environment must be downgraded, we recommend [using snapshots to create a restore point](https://opensearch.org/docs/latest/opensearch/snapshot-restore/), then restoring the snapshot to a cluster built with the target version.
+{: .note }


### PR DESCRIPTION
### Description
I added a short blurb under the install landing page (https://opensearch.org/docs/latest/opensearch/install/index/) to call out that version downgrades are not supported.  This mirrors the PR I opened against the project-website repo (https://github.com/opensearch-project/project-website/pull/883) for the same issue.

### Issues Resolved
When this PR and its counterpart from the project-website repo are pushed, it will resolve issue 436.  Since two PRs are linked to that issue it will need to be manually closed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
