### PR TITLE
Add refresh param to documentation

### DIFF
--- a/_opensearch/rest-api/document-apis/index-document.md
+++ b/_opensearch/rest-api/document-apis/index-document.md
@@ -44,7 +44,7 @@ if_primary_term | Integer | Only perform the index operation if the document has
 op_type | Enum | Specifies the type of operation to complete with the document. Valid values are `create` (create the index if it doesn't exist) and `index`. If a document ID is included in the request, then the default is `index`. Otherwise, the default is `create`. | No
 pipeline | String | Route the index operation to a certain pipeline. | No
 routing | String | value used to assign the index operation to a specific shard. | No
-refresh | Enum | If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are true, false, and wait_for, which tells OpenSearch to wait for a refresh before executing the operation. Default is false. | No
+refresh | Enum | If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are `true`, `false`, and `wait_for`, which tells OpenSearch to wait for a refresh before executing the operation. Default is false. | No
 timeout | Time | How long to wait for a response from the cluster. Default is `1m`. | No
 version | Integer | The document's version number. | No
 version_type | Enum | Assigns a specific type to the document. Valid options are `external` (retrieve the document if the specified version number is greater than the document's current version) and `external_gte` (retrieve the document if the specified version number is greater than or equal to the document's current version). For example, to index version 3 of a document, use `/_doc/1?version=3&version_type=external`. | No

--- a/_opensearch/rest-api/document-apis/index-document.md
+++ b/_opensearch/rest-api/document-apis/index-document.md
@@ -44,6 +44,7 @@ if_primary_term | Integer | Only perform the index operation if the document has
 op_type | Enum | Specifies the type of operation to complete with the document. Valid values are `create` (create the index if it doesn't exist) and `index`. If a document ID is included in the request, then the default is `index`. Otherwise, the default is `create`. | No
 pipeline | String | Route the index operation to a certain pipeline. | No
 routing | String | value used to assign the index operation to a specific shard. | No
+refresh | Enum | If true, OpenSearch refreshes shards to make the operation visible to searching. Valid options are true, false, and wait_for, which tells OpenSearch to wait for a refresh before executing the operation. Default is false. | No
 timeout | Time | How long to wait for a response from the cluster. Default is `1m`. | No
 version | Integer | The document's version number. | No
 version_type | Enum | Assigns a specific type to the document. Valid options are `external` (retrieve the document if the specified version number is greater than the document's current version) and `external_gte` (retrieve the document if the specified version number is greater than or equal to the document's current version). For example, to index version 3 of a document, use `/_doc/1?version=3&version_type=external`. | No


### PR DESCRIPTION
### Description
Adds the `refresh` param to the documentation of Index Document Rest API.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
