### PR TITLE
Update securityconfig path based on path reorganization

### DIFF
--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -24,7 +24,7 @@ opensearch_security:
       ...
 ```
 
-For a more complete example, see the [sample file on GitHub](https://github.com/opensearch-project/security/blob/main/securityconfig/config.yml).
+For a more complete example, see the [sample file on GitHub](https://github.com/opensearch-project/security/blob/main/config/config.yml).
 
 
 ## HTTP

--- a/_security-plugin/configuration/tls.md
+++ b/_security-plugin/configuration/tls.md
@@ -9,7 +9,7 @@ nav_order: 10
 
 TLS is configured in `opensearch.yml`. There are two main configuration sections: the transport layer and the REST layer. TLS is optional for the REST layer and mandatory for the transport layer.
 
-You can find an example configuration template with all options on [GitHub](https://github.com/opensearch-project/security/blob/main/securityconfig/opensearch.yml.example).
+You can find an example configuration template with all options on [GitHub](https://github.com/opensearch-project/security/blob/main/config/opensearch.yml.example).
 {: .note }
 
 


### PR DESCRIPTION
### Description
Securities paths for config were updates for the 2.1.0 release.

### Issues Resolved
* Related https://github.com/opensearch-project/security/issues/1673 - As part of this migration the security plugin did this work in 2.1.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
