### PR TITLE
Rectify rpm installation for dashboards

### DIFF
--- a/_opensearch/install/rpm.md
+++ b/_opensearch/install/rpm.md
@@ -63,7 +63,7 @@ YUM, an RPM package management tool, allows you to pull the RPM package from the
    ```
 
    ```bash
-   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/opensearch-dashboards-2.x.repo -o /etc/yum.repos.d/2.x.repo
+   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/opensearch-dashboards-2.x.repo -o /etc/yum.repos.d/dashboards.2.x.repo
    ```
   
    To verify that the repos appear in your repo list, use `sudo yum repolist`.


### PR DESCRIPTION
Signed-off-by: Sayali Gaikawad <gaiksaya@amazon.com>

### Description
The `-o` (output) was similar for opensearch and opensearch dashboards overwriting the opensearch yum repo.
This change fixes that.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
