### PR TITLE
Make sure 2.x yum installation match 1.x naming patterns

### DIFF
--- a/_opensearch/install/rpm.md
+++ b/_opensearch/install/rpm.md
@@ -59,11 +59,11 @@ YUM, an RPM package management tool, allows you to pull the RPM package from the
 1. Create a repository file for both OpenSearch and OpenSearch Dashboards:
 
    ```bash
-   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/opensearch-2.x.repo -o /etc/yum.repos.d/2.x.repo
+   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/opensearch-2.x.repo -o /etc/yum.repos.d/opensearch-2.x.repo
    ```
 
    ```bash
-   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/opensearch-dashboards-2.x.repo -o /etc/yum.repos.d/dashboards.2.x.repo
+   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/opensearch-dashboards-2.x.repo -o /etc/yum.repos.d/opensearch-dashboards.2.x.repo
    ```
   
    To verify that the repos appear in your repo list, use `sudo yum repolist`.


### PR DESCRIPTION
Signed-off-by: Peter Zhu <zhujiaxi@amazon.com>

### Description
Make sure 2.x yum installation match 1.x naming patterns

### Issues Resolved
https://github.com/opensearch-project/opensearch-build/issues/1818

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
