### PR TITLE
Add examples for bulk script & upsert updates

### DIFF
--- a/_opensearch/rest-api/document-apis/bulk.md
+++ b/_opensearch/rest-api/document-apis/bulk.md
@@ -103,13 +103,26 @@ All actions support the same metadata: `_index`, `_id`, and `_require_alias`. If
 
 - Update
 
-  This action updates existing documents and returns an error if the document doesn't exist. The next line must include a full or partial JSON document, depending on how much of the document you want to update. It can also include a script or upsert for more complex document updates.
+  This action updates existing documents and returns an error if the document doesn't exist. The next line must include a full or partial JSON document, depending on how much of the document you want to update.
 
   ```json
   { "update": { "_index": "movies", "_id": "tt0816711" } }
   { "doc" : { "title": "World War Z" } }
   ```
+  
+  It can also include a script or upsert for more complex document updates.
 
+  - Script
+  ```json
+  { "update": { "_index": "movies", "_id": "tt0816711" } }
+  { "script" : { "source": "ctx._source.title = \"World War Z\"" } }
+  ```
+  
+  - Upsert
+  ```json
+  { "update": { "_index": "movies", "_id": "tt0816711" } }
+  { "doc" : { "title": "World War Z" }, "doc_as_upsert": true }
+  ```
 
 ## Response
 


### PR DESCRIPTION
### Description
There is no mention of doc_as_upsert in OS documention, but it appears to be supported. Adding some examples to go along with the passing mention of scripts & especially upsert would go a long way.

### Issues Resolved
#755 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
