### PR TITLE
Added reference to OS 2.x and fixed version ranges in the existing tables

### DIFF
--- a/_clients/agents-and-ingestion-tools/index.md
+++ b/_clients/agents-and-ingestion-tools/index.md
@@ -63,30 +63,32 @@ Some users report compatibility issues with ingest pipelines on these versions o
 
 ### Compatibility Matrix for Logstash
 
-| | Logstash OSS 7.x to 7.11.x | Logstash OSS 7.12.x\* | Logstash 7.13.x-7.16.x without OpenSearch output plugin | Logstash 7.13.x-7.16.x with OpenSearch output plugin | Logstash 8.x+ with OpenSearch output plugin 
+| | Logstash OSS 7.0.0 to 7.11.x | Logstash OSS 7.12.x\* | Logstash 7.13.x-7.16.x without OpenSearch output plugin | Logstash 7.13.x-7.16.x with OpenSearch output plugin | Logstash 8.x+ with OpenSearch output plugin 
 | :---| :--- | :--- | :--- | :--- | :--- |
-| Elasticsearch OSS 7.x to 7.9.x | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
+| Elasticsearch OSS 7.0.0 to 7.9.x | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
 | Elasticsearch OSS 7.10.2 | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
-| ODFE 1.x to 1.12 | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
+| ODFE 1.0 to 1.12 | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
 | ODFE 1.13 | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
-| OpenSearch 1.x | Yes via version setting | Yes via version setting | *No* | *Yes* | Yes, with Elastic Common Schema Setting |
+| OpenSearch 1.x to 2.x | Yes via version setting | Yes via version setting | *No* | *Yes* | Yes, with Elastic Common Schema Setting |
 
 \* Most current compatible version with Elasticsearch OSS.
 
 
 ### Compatibility Matrix for Beats
 
-| | Beats OSS 7.x to 7.11.x\*\* | Beats OSS 7.12.x\* | Beats 7.13.x |
+| | Beats OSS 7.0.0 to 7.11.x\*\* | Beats OSS 7.12.x\* | Beats 7.13.x \*\*\*|
 | :--- | :--- | :--- | :--- |
-| Elasticsearch OSS 7.x to 7.9.x | *Yes* | *Yes* | No |
+| Elasticsearch OSS 7.0.0 to 7.9.x | *Yes* | *Yes* | No |
 | Elasticsearch OSS 7.10.2 | *Yes* | *Yes* | No |
-| ODFE 1.x to 1.12 | *Yes* | *Yes* | No |
+| ODFE 1.0 to 1.12 | *Yes* | *Yes* | No |
 | ODFE 1.13 | *Yes* | *Yes* | No |
-| OpenSearch 1.x | Yes via version setting | Yes via version setting | No |
-| Logstash OSS 7.x to 7.11.x | *Yes* | *Yes* | *Yes* |
+| OpenSearch 1.x to 2.x | Yes via version setting | Yes via version setting | No |
+| Logstash OSS 7.0.0 to 7.11.x | *Yes* | *Yes* | *Yes* |
 | Logstash OSS 7.12.x\* | *Yes* | *Yes* | *Yes* |
 | Logstash 7.13.x with OpenSearch output plugin | *Yes* | *Yes* | *Yes* |
 
 \* Most current compatible version with Elasticsearch OSS.
 
 \*\* Beats OSS includes all Apache 2.0 Beats agents (i.e. Filebeat, Metricbeat, Auditbeat, Heartbeat, Winlogbeat, Packetbeat).
+
+\*\*\* Beats versions newer than 7.12.x are not supported by OpenSearch. If you must update the Beats agent(s) in your environment to a version newer than 7.12.x, you can restore the pipeline by directing traffic to Logstah and using the Logstash Output plugin to forward the data to OpenSearch.


### PR DESCRIPTION
### Description
Added OpenSearch 2.x to the compatibility matrices and fixed version ranges to make them more readable.

### Issues Resolved
Along with a PR against the FAQ under the project-website repo, this will fix https://github.com/opensearch-project/documentation-website/issues/728

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
