### PR TITLE
clients: python: link to API reference docs

### DIFF
--- a/_clients/python.md
+++ b/_clients/python.md
@@ -29,6 +29,8 @@ from opensearchpy import OpenSearch
 
 If you prefer to add the client manually or just want to examine the source code, see [opensearch-py on GitHub](https://github.com/opensearch-project/opensearch-py).
 
+See also: the [API reference documentation](https://opensearch-project.github.io/opensearch-py/index.html) for the client.
+
 
 ## Sample code
 


### PR DESCRIPTION
### Description
Links to API reference docs for the python client from the main website.

### Issues Resolved
Partially addresses https://github.com/opensearch-project/opensearch-py/issues/171

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
