### PR TITLE
add note regarding required use of TLS transport

### DIFF
--- a/_security-plugin/configuration/security-admin.md
+++ b/_security-plugin/configuration/security-admin.md
@@ -80,7 +80,8 @@ You can't use node certificates as admin certificates. The two must be separate.
 
 The `securityadmin.sh` tool can be run from any machine that has access to the http port of your OpenSearch cluster (the default port is 9200). You can change the security plugin configuration without having to access your nodes through SSH.
 
-**Note:** `securityadmin.sh` requires that SSL/TLS transport is enabled on your opensearch cluster. In other words, make sure that the following is set in `opensearch.yml` before proceeding:
+`securityadmin.sh` requires that SSL/TLS transport is enabled on your opensearch cluster. In other words, make sure that the `plugins.security.ssl.http.enabled: true` is set in `opensearch.yml` before proceeding.
+{: .note}
 `plugins.security.ssl.http.enabled: true`
 
 Each node also includes the tool at `plugins/opensearch-security/tools/securityadmin.sh`. You might need to make the script executable before running it:

--- a/_security-plugin/configuration/security-admin.md
+++ b/_security-plugin/configuration/security-admin.md
@@ -80,6 +80,9 @@ You can't use node certificates as admin certificates. The two must be separate.
 
 The `securityadmin.sh` tool can be run from any machine that has access to the http port of your OpenSearch cluster (the default port is 9200). You can change the security plugin configuration without having to access your nodes through SSH.
 
+**Note:** `securityadmin.sh` requires that SSL/TLS transport is enabled on your opensearch cluster. In other words, make sure that the following is set in `opensearch.yml` before proceeding:
+`plugins.security.ssl.http.enabled: true`
+
 Each node also includes the tool at `plugins/opensearch-security/tools/securityadmin.sh`. You might need to make the script executable before running it:
 
 ```bash


### PR DESCRIPTION

### Description
"basic usage" doesn't mention that the securityadmin.sh command will fail outright if `plugins.security.ssl.http.enabled` is set to `false`

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
