### PR TITLE
Add issue template default states

### DIFF
--- a/.github/ISSUE_TEMPLATE/issue_template.md
+++ b/.github/ISSUE_TEMPLATE/issue_template.md
@@ -1,3 +1,11 @@
+---
+name: 📃 Documentation issue
+about: Need docs? Create an issue to request or add new documentation.
+title: '[DOC]'
+labels: 'untriaged'
+assignees: ''
+---
+
 ## What do you want to do?
  
 - [ ] Request a change to existing documentation
@@ -13,4 +21,4 @@ For example, what feature or area does it affect? What versions? If it’s a cha
 
 For example, a link to a related fixed issue, a design doc, or any particular POCs (Eng or PM) who have more information?
 
-## Is there anything else you'd like to add?**
+## Is there anything else you'd like to add?


### PR DESCRIPTION
Signed-off-by: Naarcha-AWS <naarcha@amazon.com>

### Description

This changes adds issue template metadata that adds default labels to issues upon issue creation. It also moves the templates to an `ISSUE_TEMPLATE` directory. My hope is that the move will override the default templates, as suggested by @dblock. 



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
