### PR TITLE
Change /_plugins/_security/.. routes to /_opendistro/_security/... fo…

### DIFF
--- a/_security-plugin/configuration/saml.md
+++ b/_security-plugin/configuration/saml.md
@@ -305,13 +305,13 @@ opensearch_security.auth.type: "saml"
 In addition, you must add the OpenSearch Dashboards endpoint for validating the SAML assertions to your allow list:
 
 ```yml
-server.xsrf.allowlist: ["/_plugins/_security/saml/acs"]
+server.xsrf.allowlist: ["/_opendistro/_security/saml/acs"]
 ```
 
 If you use the logout POST binding, you also need to ad the logout endpoint to your allow list:
 
 ```yml
-server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout"]
+server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout"]
 ```
 
 ### IdP-initiated SSO
@@ -319,11 +319,11 @@ server.xsrf.allowlist: ["/_plugins/_security/saml/acs", "/_plugins/_security/sam
 To use IdP-initiated SSO, set the Assertion Consumer Service endpoint of your IdP to this:
 
 ```
-/_plugins/_security/saml/acs/idpinitiated
+/_opendistro/_security/saml/acs/idpinitiated
 ```
 
 Then add this endpoint to `server.xsrf.allowlist` in `opensearch_dashboards.yml`:
 
 ```yml
-server.xsrf.allowlist: ["/_plugins/_security/saml/acs/idpinitiated", "/_plugins/_security/saml/acs", "/_plugins/_security/saml/logout"]
+server.xsrf.allowlist: ["/_opendistro/_security/saml/acs/idpinitiated", "/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout"]
 ```


### PR DESCRIPTION
…r SAML until plugins route is supported

Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Security included a change in 2.1 that broke SAML integration and is being reverted in 2.2. There was a change in the `security-dashboards-plugin` to migrate to route `/_plugins/_security/...` from `/_opendistro/_security/...` for SAML integration without a coordinated change on the backend. The migration off of the `/_opendistro/_security/...` path is targeted for the 3.0.0 release.

This PR is to update the documentation to use the correct URLs.

### Issues Resolved

PR to fix the regression: https://github.com/opensearch-project/security-dashboards-plugin/pull/1035

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
