### PR TITLE
Update documentation from opensearch_security_roles to opendistro_sec…

### DIFF
--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -32,7 +32,7 @@ new-user:
   hash: "$2y$12$88IFVl6IfIwCFh5aQYfOmuXVL9j2hz/GusQb35o.4sdTDAEMTOD.K"
   reserved: false
   hidden: false
-  opensearch_security_roles:
+  opendistro_security_roles:
   - "specify-some-security-role-here"
   backend_roles:
   - "specify-some-backend-role-here"


### PR DESCRIPTION
…urity_roles

Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Users are reporting an error in the `internal_users.yml` documentation. This PR corrects the error in documentation.

### Issues Resolved

Closes https://github.com/opensearch-project/security/issues/1339

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
