### PR TITLE
Fix setting name for LDAP custom attribute filter

### DIFF
--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -433,7 +433,7 @@ By default, the security plugin reads all LDAP user attributes and makes them av
 
 Name | Description
 :--- | :---
-`custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
+`custom_attr_whitelist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
 `custom_attr_maxval_len`  | Integer. Specifies the maximum allowed length of each attribute. All attributes longer than this value are discarded. A value of `0` disables custom attributes altogether. Default is 36.
 
 Example:
@@ -446,7 +446,7 @@ authz:
     authorization_backend:
       type: ldap
       config:
-        custom_attr_allowlist:
+        custom_attr_whitelist:
           - attribute1
           - attribute2
         custom_attr_maxval_len: 36
@@ -501,7 +501,7 @@ Name | Description
 `skip_users`  | Array of users that should be skipped when retrieving roles. Wildcards and regular expressions are supported.
 `nested_role_filter`  | Array of role DNs that should be filtered before resolving nested roles. Wildcards and regular expressions are supported.
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.
-`custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
+`custom_attr_whitelist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
 `custom_attr_maxval_len`  | Integer. Specifies the maximum allowed length of each attribute. All attributes longer than this value are discarded. A value of `0` disables custom attributes altogether. Default is 36.
 
 


### PR DESCRIPTION
### Description
Fix setting name for LDAP custom attribute filter to the setting name used in the security plugin

### Issues Resolved
* Related to https://github.com/opensearch-project/security/issues/2032

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
