### PR TITLE
Missing documentation for the plugins.security.allow_default_init_securityindex property

### DIFF
--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -145,7 +145,8 @@ If `challenge` is set to `false` and no `Authorization` header field is set, the
 
 ## Kerberos
 
-Kerberos authentication does not work with OpenSearch Dashboards. To track OpenSearch's progress in adding support for Kerberos in OpenSearch Dashboards, see [issue #907 Kerberos Auth does not exist](https://github.com/opensearch-project/security-dashboards-plugin/issues/907) in the Dashboard's Security Plugin repository. {: .warning }
+Kerberos authentication does not work with OpenSearch Dashboards. To track OpenSearch's progress in adding support for Kerberos in OpenSearch Dashboards, see [issue #907 Kerberos Auth does not exist](https://github.com/opensearch-project/security-dashboards-plugin/issues/907) in the Dashboard's Security Plugin repository.
+{: .warning }
 
 Due to the nature of Kerberos, you must define some settings in `opensearch.yml` and some in `config.yml`.
 

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -124,7 +124,7 @@ plugins.security.restapi.password_validation_regex: '(?=.*[A-Z])(?=.*[^a-zA-Z\d]
 plugins.security.restapi.password_validation_error_message: "Password must be minimum 8 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
 ```
 
-The opensearch.yml file also contains the `plugins.security.allow_default_init_securityindex` property. When set to `true`, the security plugin uses default security settings if an attempt to create the security index fails when OpenSearch launches. Default security settings are stored in YAML files contained in the config folder. By default, this setting is `false`.
+The opensearch.yml file also contains the `plugins.security.allow_default_init_securityindex` property. When set to `true`, the security plugin uses default security settings if an attempt to create the security index fails when OpenSearch launches. Default security settings are stored in YAML files contained in the `opensearch-project/security/config` directory. By default, this setting is `false`.
 
 ```yml
 plugins.security.allow_default_init_securityindex: true

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -124,7 +124,7 @@ plugins.security.restapi.password_validation_regex: '(?=.*[A-Z])(?=.*[^a-zA-Z\d]
 plugins.security.restapi.password_validation_error_message: "Password must be minimum 8 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
 ```
 
-You can set the `plugins.security.allow_default_init_securityindex` property to `true` to have the security plugin automatically initialize with default settings in the config folder if the security index fails to initialize when OpenSearch launches. By default, the setting is `false`.
+The opensearch.yml file also contains the `plugins.security.allow_default_init_securityindex` property. When set to `true`, the security plugin uses default security settings if an attempt to create the security index fails when OpenSearch launches. Default security settings are stored in YAML files contained in the config folder. By default, this setting is `false`.
 
 ```yml
 plugins.security.allow_default_init_securityindex: true

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -124,6 +124,12 @@ plugins.security.restapi.password_validation_regex: '(?=.*[A-Z])(?=.*[^a-zA-Z\d]
 plugins.security.restapi.password_validation_error_message: "Password must be minimum 8 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
 ```
 
+You can set the `plugins.security.allow_default_init_securityindex` property to `true` to have the security plugin automatically initialize with default settings in the config file if the security index fails to initialize when OpenSearch launches. By default, the setting is `false`.
+
+```yml
+plugins.security.allow_default_init_securityindex: true
+```
+
 ## allowlist.yml
 
 You can use `allowlist.yml` to add any endpoints and HTTP requests to a list of allowed endpoints and requests. If enabled, all users except the super admin are allowed access to only the specified endpoints and HTTP requests, and all other HTTP requests associated with the endpoint are denied. For example, if GET `_cluster/settings` is added to the allow list, users cannot submit PUT requests to `_cluster/settings` to update cluster settings.

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -124,7 +124,7 @@ plugins.security.restapi.password_validation_regex: '(?=.*[A-Z])(?=.*[^a-zA-Z\d]
 plugins.security.restapi.password_validation_error_message: "Password must be minimum 8 characters long and must contain at least one uppercase letter, one lowercase letter, one digit, and one special character."
 ```
 
-You can set the `plugins.security.allow_default_init_securityindex` property to `true` to have the security plugin automatically initialize with default settings in the config file if the security index fails to initialize when OpenSearch launches. By default, the setting is `false`.
+You can set the `plugins.security.allow_default_init_securityindex` property to `true` to have the security plugin automatically initialize with default settings in the config folder if the security index fails to initialize when OpenSearch launches. By default, the setting is `false`.
 
 ```yml
 plugins.security.allow_default_init_securityindex: true


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

Fixes #676 

### Description
Adds description to the "YAML files" section of security plugin documentation for the `plugins.security.allow_default_init_securityindex` property.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
