### PR TITLE
API documentation to enable audit logging

### DIFF
--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1409,7 +1409,9 @@ GET _plugins/_security/health
 
 ## Audit logs
 
-### Enable audit logs
+The following API is available for audit logging in the security plugin.
+
+### Enable Audit Logs
 
 This API allows you to enable or disable audit logging, define the configuration for audit logging and compliance, and make updates to settings.
 
@@ -1429,7 +1431,7 @@ Field | Data Type | Description
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_rest_categories` | Array | Categories to exclude from REST API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_transport_categories` | Array | Categories to exclude from Transport API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`log_request_body` | Boolean | Includes the body of the request (if available) for both REST and the transport layer. Default is  `true`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Logs all indices affected by a request. Resolves aliases and wildcards/date patterns. Default is `true`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Logs all indexes affected by a request. Resolves aliases and wildcards/date patterns. Default is `true`.
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_bulk_requests` | Boolean | Logs individual operations in a bulk request. Default is `false`.
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`exclude_sensitive_headers` | Boolean | Excludes sensitive headers from being included in the logs. Default is `true`.
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Enables/disables Transport API auditing. Default is `true`.
@@ -1439,11 +1441,11 @@ Field | Data Type | Description
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Logs only diffs for document updates. Default is `false`.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | Array | List of users to ignore for read events. Wildcard patterns are supported.<br>Example: `read_ignore_users: ["test-user", "employee-*"]`
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | Array | List of indices to watch for write events. Wildcard patterns are supported.<br>Example: `write_watched_indices: ["twitter", "logs-*"]`
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | Array | List of indexes to watch for write events. Wildcard patterns are supported.<br>Example: `write_watched_indices: ["twitter", "logs-*"]`
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_ignore_users` | Array | List of users to ignore for write events. Wildcard patterns are supported.<br>Example: `write_ignore_users: ["test-user", "employee-*"]`
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_metadata_only` | Boolean | Logs only metadata of the document for read events. Default is `true`.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_metadata_only` | Boolean | Log only metadata of the document for write events. Default is `true`.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Logs external config files for the node. Default is `false`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Logs external configuration files for the node. Default is `false`.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Logs updates to internal security changes. Default is `true`.
 
 Changes to the `_readonly` property result in a 409 error, as indicated in the response below.

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1415,7 +1415,7 @@ This API allows you to enable or disable audit logging, define the configuration
 
 For details on using audit logging to track access to OpenSearch clusters, as well as information on further configurations, see [Audit logs](https://opensearch.org/docs/latest/security-plugin/audit-logs/index/).
 
-You can do an initial configuration of audit logging in the `audit.yml` file, found in the `opensearch-project/security/config` directory. Thereafter, use the REST API for further changes to the configuration.
+You can do an initial configuration of audit logging in the `audit.yml` file, found in the `opensearch-project/security/config` directory. Thereafter, you can use the REST API or Dashboards for further changes to the configuration.
 {: note.}
 
 #### Request fields
@@ -1446,7 +1446,7 @@ Field | Data Type | Description
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Logs external config files for the node. Default is `false`.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Logs updates to internal security changes. Default is `true`.
 
-Changes to the `_readonly` property must result in a 409 error, as indicated in the response below.
+Changes to the `_readonly` property result in a 409 error, as indicated in the response below.
 {: .note}
 
 ```json
@@ -1506,12 +1506,15 @@ PUT /_opendistro/_security/api/audit/config
 }
 ```
 
-A PATCH call is used to update specified fields in the audit configuration and reset unspecified fields to their default settings.
+A PATCH call is used to update specified fields in the audit configuration. The PATCH method requires an operation, a path, and a value to complete a valid request.
 
+```bash
+curl -X PATCH -k -i --cert <admin_cert file name> --key <admin_cert_key file name> <domain>/_opendistro/_security/api/audit -H 'Content-Type: application/json' -d'[{"op":"add","path":"/config/enabled","value":"true"}]'
 ```
-curl -X PATCH <domain>/_opendistro/_security/api/audit -H 'Content-Type: application/json' -d'[{"op":"add","path":"/config/enabled","value":"true"}]' -u <username:password>
-```
-OpenSearch Dashboards does not support the PATCH method. Use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another method to update the configuration.
+
+Using the PATCH method also requires a user to have a security configuration that includes admin certificates for encryption. To find out more about these certificates, see [Configure admin certificates](https://opensearch.org/docs/latest/security-plugin/configuration/tls/#configure-admin-certificates).
+
+The OpenSearch Dashboards dev tool does not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method.
 {: .note}
 
 #### Sample response
@@ -1567,4 +1570,12 @@ The PUT request produces a response that appears as the following:
   "status" : "OK",
   "message" : "'config' updated."
 }
+```
+
+The PATCH request produces a response similar to the one below.
+
+```bash
+HTTP/1.1 200 OK
+content-type: application/json; charset=UTF-8
+content-length: 45
 ```

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1461,11 +1461,15 @@ Changes to the `_readonly` property result in a 409 error, as indicated in the r
 
 #### Sample request
 
+**GET**
+
 A GET call retrieves the audit configuration.
 
 ```
 GET /_opendistro/_security/api/audit
 ```
+
+**PUT**
 
 A PUT call updates the audit configuration.
 
@@ -1506,20 +1510,22 @@ PUT /_opendistro/_security/api/audit/config
 }
 ```
 
-A PATCH call is used to update specified fields in the audit configuration. The PATCH method requires an operation, a path, and a value to complete a valid request.
+**PATCH**
+
+A PATCH call is used to update specified fields in the audit configuration. The PATCH method requires an operation, a path, and a value to complete a valid request. For details on using the PATCH method, see the following [Patching resources](https://en.wikipedia.org/wiki/PATCH_%28HTTP%29#Patching_resources) description at Wikipedia.
+
+Using the PATCH method also requires a user to have a security configuration that includes admin certificates for encryption. To find out more about these certificates, see [Configure admin certificates](https://opensearch.org/docs/latest/security-plugin/configuration/tls/#configure-admin-certificates).
 
 ```bash
 curl -X PATCH -k -i --cert <admin_cert file name> --key <admin_cert_key file name> <domain>/_opendistro/_security/api/audit -H 'Content-Type: application/json' -d'[{"op":"add","path":"/config/enabled","value":"true"}]'
 ```
 
-Using the PATCH method also requires a user to have a security configuration that includes admin certificates for encryption. To find out more about these certificates, see [Configure admin certificates](https://opensearch.org/docs/latest/security-plugin/configuration/tls/#configure-admin-certificates).
-
-The OpenSearch Dashboards dev tool does not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method.
+The OpenSearch Dashboards dev tool does not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method. To follow the GitHub issue for support of the PATCH method in Dashboards, see [issue #2343](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2343).
 {: .note}
 
 #### Sample response
 
-The GET call produces a response that appears as the following:
+The GET call produces a response that appears similar to the following:
 
 ```json
 {
@@ -1563,7 +1569,7 @@ The GET call produces a response that appears as the following:
   }
 }
 ```
-The PUT request produces a response that appears as the following:
+The PUT request produces a response that appears similar to the following:
 
 ```json
 {
@@ -1572,7 +1578,7 @@ The PUT request produces a response that appears as the following:
 }
 ```
 
-The PATCH request produces a response similar to the one below.
+The PATCH request produces a response similar to the following:
 
 ```bash
 HTTP/1.1 200 OK

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1403,3 +1403,124 @@ GET _plugins/_security/health
   "status": "UP"
 }
 ```
+
+
+---
+
+## Audit logs
+
+### Enable audit logs
+
+Allows you to enable audit logging. By default, audit logging is disabled and does not generate logs.
+
+For details on setting up and using audit logging to track access to OpenSearch clusters, see [Audit logs](https://opensearch.org/docs/latest/security-plugin/audit-logs/index/).
+
+### Request fields
+
+Field | Data Type | Description
+:--- | :--- | :---
+`_readonly` | String | "/audit/exclude_sensitive_headers",<br>"/compliance/internal_config",<br>"/compliance/external_config"<br>Description of these values
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables audit logging. Default is `false`.
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit` | Object | Contains fields for audit logging configuration.
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ignore_users` | String | Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ignore_requests` | String | Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`disabled_rest_categories` | String | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`disabled_transport_categories` | String | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`log_request_body` | Boolean | Default is  `true`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Default is `true`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`resolve_bulk_requests` | Boolean | Default is `true`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`exclude_sensitive_headers` | Boolean | Default is `true`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Default is `true` Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`enable_rest` | Boolean | Default is `true`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance` | Object | Contains fields for compliance configuration. 
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Desfault is `true` Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Default is `false` Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | String | Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | String | Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_ignore_users` | String | Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`read_metadata_only` | Boolean | Default is `true`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_metadata_only` | Boolean | Default is `true`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Default is `false`. Description
+`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Default is `true`. Description
+
+#### Sample request
+
+```
+GET _plugins/_security/api/audit
+```
+
+A GET call retrieves the audit configuration.
+
+```
+PUT _plugins/_security/api/audit/config
+```
+
+A PUT call updates the audit configuration.
+
+Changes to the `_readonly` property must result in a 409 error.
+{: .note}
+
+```json
+{
+  "status" : "error",
+  "reason" : "Invalid configuration",
+  "invalid_keys" : {
+    "keys" : "_readonly,config"
+  }
+}
+```
+
+```
+PATCH _plugins/_security/api/audit
+```
+
+A PATCH call is used to update the audit configuration. It resets missing configurations to their default settings.
+
+Changes to the `_readonly` property must result in a 409 error.
+{: .note}
+
+#### Sample response
+
+```json
+{
+  "_readonly" : [
+    "/audit/exclude_sensitive_headers",
+    "/compliance/internal_config",
+    "/compliance/external_config"
+  ],
+  "config" : {
+    "compliance" : {
+      "enabled" : true,
+      "write_log_diffs" : false,
+      "read_watched_fields" : { },
+      "read_ignore_users" : [ ],
+      "write_watched_indices" : [ ],
+      "write_ignore_users" : [ ],
+      "read_metadata_only" : true,
+      "write_metadata_only" : true,
+      "external_config" : false,
+      "internal_config" : true
+    },
+    "enabled" : true,
+    "audit" : {
+      "ignore_users" : [ ],
+      "ignore_requests" : [ ],
+      "disabled_rest_categories" : [
+        "AUTHENTICATED",
+        "GRANTED_PRIVILEGES"
+      ],
+      "disabled_transport_categories" : [
+        "AUTHENTICATED",
+        "GRANTED_PRIVILEGES"
+      ],
+      "log_request_body" : true,
+      "resolve_indices" : true,
+      "resolve_bulk_requests" : true,
+      "exclude_sensitive_headers" : true,
+      "enable_transport" : true,
+      "enable_rest" : true
+    }
+  }
+}
+```

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1435,7 +1435,7 @@ Field | Data Type | Description
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Enables/disables Transport API auditing. Default is `true`.
 `audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_rest` | Boolean | Enables/disables REST API auditing. Default is `true`.
 `compliance` | Object | Contains fields for compliance configuration. 
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables compliance. Desfault is `true`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables compliance. Default is `true`.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Logs only diffs for document updates. Default is `false`.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields.
 `compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | Array | List of users to ignore for read events. Wildcard patterns are supported.<br>Example: `read_ignore_users: ["test-user", "employee-*"]`

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1411,37 +1411,40 @@ GET _plugins/_security/health
 
 ### Enable audit logs
 
-Allows you to enable audit logging. By default, audit logging is disabled and does not generate logs.
+This API allows you to enable or disable audit logging, define the way audit logging is carried out, and make updates to settings.
 
-For details on setting up and using audit logging to track access to OpenSearch clusters, see [Audit logs](https://opensearch.org/docs/latest/security-plugin/audit-logs/index/).
+For details on using audit logging to track access to OpenSearch clusters, as well as information on further configurations, see [Audit logs](https://opensearch.org/docs/latest/security-plugin/audit-logs/index/).
+
+You can do an initial configuration of audit logging in the `audit.yml` file, found in the `opensearch-project/security/config` directory. Thereafter, use the REST API for further changes to the configuration.
+{: note.}
 
 ### Request fields
 
 Field | Data Type | Description
 :--- | :--- | :---
-`enabled` | Boolean | Enables or disables audit logging. Default is `false`.
+`enabled` | Boolean | Enables or disables audit logging. Default is `true`.
 `audit` | Object | Contains fields for audit logging configuration.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_users` | Array | Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_requests` | Array | Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_rest_categories` | Array | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_transport_categories` | Array | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`log_request_body` | Boolean | Default is  `true`. Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Default is `true`. Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_bulk_requests` | Boolean | Default is `true`. Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`exclude_sensitive_headers` | Boolean | Default is `true`. Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Default is `true` Need description
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_rest` | Boolean | Default is `true`. Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_users` | Array | Users to be excluded from auditing. Wildcard patterns are supported<br>Example: `ignore_users: ["test-user", employee-*"]`
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_requests` | Array | Requests to be excluded from auditing. Wildcard patterns are supported.<br>Example: `ignore_requests: ["indices:data/read/*", "SearchRequest"]`
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_rest_categories` | Array | Categories to exclude from REST API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_transport_categories` | Array | Categories to exclude from Transport API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`log_request_body` | Boolean | Includes the body of the request (if available) for both REST and the transport layer. Default is  `true`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Logs all indices affected by a request. Resolves aliases and wildcards/date patterns. Default is `true`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_bulk_requests` | Boolean | Logs individual operations in a bulk request. Default is `false`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`exclude_sensitive_headers` | Boolean | Excludes sensitive headers from being included in the logs. Default is `true`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Enables/disables Transport API auditing. Default is `true`.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_rest` | Boolean | Enables/disables REST API auditing. Default is `true`.
 `compliance` | Object | Contains fields for compliance configuration. 
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables compliance configurations. Desfault is `true`.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Default is `false` Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | Array | Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | Array | Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_ignore_users` | Array | Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_metadata_only` | Boolean | Default is `true`. Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_metadata_only` | Boolean | Default is `true`. Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Default is `false`. Need description
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Default is `true`. Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables compliance. Desfault is `true`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Logs only diffs for document updates. Default is `false`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | Array | List of users to ignore for read events. Wildcard patterns are supported.<br>Example: `read_ignore_users: ["test-user", "employee-*"]`
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | Array | List of indices to watch for write events. Wildcard patterns are supported.<br>Example: `write_watched_indices: ["twitter", "logs-*"]`
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_ignore_users` | Array | List of users to ignore for write events. Wildcard patterns are supported.<br>Example: `write_ignore_users: ["test-user", "employee-*"]`
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_metadata_only` | Boolean | Logs only metadata of the document for read events. Default is `true`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_metadata_only` | Boolean | Log only metadata of the document for write events. Default is `true`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Logs external config files for the node. Default is `false`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Logs updates to internal security changes. Default is `true`.
 
 Changes to the `_readonly` property must result in a 409 error, as indicated in the response below.
 {: .note}

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1419,46 +1419,31 @@ For details on setting up and using audit logging to track access to OpenSearch 
 
 Field | Data Type | Description
 :--- | :--- | :---
-`_readonly` | String | "/audit/exclude_sensitive_headers",<br>"/compliance/internal_config",<br>"/compliance/external_config"<br>Description of these values
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables audit logging. Default is `false`.
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit` | Object | Contains fields for audit logging configuration.
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ignore_users` | String | Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`ignore_requests` | String | Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`disabled_rest_categories` | String | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`disabled_transport_categories` | String | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`log_request_body` | Boolean | Default is  `true`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Default is `true`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`resolve_bulk_requests` | Boolean | Default is `true`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`exclude_sensitive_headers` | Boolean | Default is `true`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Default is `true` Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`enable_rest` | Boolean | Default is `true`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance` | Object | Contains fields for compliance configuration. 
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Desfault is `true` Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Default is `false` Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | String | Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | String | Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_ignore_users` | String | Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`read_metadata_only` | Boolean | Default is `true`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`write_metadata_only` | Boolean | Default is `true`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Default is `false`. Description
-`config`<br>&nbsp;&nbsp;&nbsp;&nbsp;`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Default is `true`. Description
+`enabled` | Boolean | Enables or disables audit logging. Default is `false`.
+`audit` | Object | Contains fields for audit logging configuration.
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_users` | Array | Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_requests` | Array | Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_rest_categories` | Array | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_transport_categories` | Array | `AUTHENTICATED`, `GRANTED_PRIVILEGES` Others? Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`log_request_body` | Boolean | Default is  `true`. Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Default is `true`. Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_bulk_requests` | Boolean | Default is `true`. Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`exclude_sensitive_headers` | Boolean | Default is `true`. Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Default is `true` Need description
+`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_rest` | Boolean | Default is `true`. Need description
+`compliance` | Object | Contains fields for compliance configuration. 
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables compliance configurations. Desfault is `true`.
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Default is `false` Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | Array | Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | Array | Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_ignore_users` | Array | Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_metadata_only` | Boolean | Default is `true`. Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_metadata_only` | Boolean | Default is `true`. Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Default is `false`. Need description
+`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Default is `true`. Need description
 
-#### Sample request
-
-```
-GET _plugins/_security/api/audit
-```
-
-A GET call retrieves the audit configuration.
-
-```
-PUT _plugins/_security/api/audit/config
-```
-
-A PUT call updates the audit configuration.
-
-Changes to the `_readonly` property must result in a 409 error.
+Changes to the `_readonly` property must result in a 409 error, as indicated in the response below.
 {: .note}
 
 ```json
@@ -1471,16 +1456,62 @@ Changes to the `_readonly` property must result in a 409 error.
 }
 ```
 
+#### Sample request
+
+A GET call retrieves the audit configuration.
+
 ```
-PATCH _plugins/_security/api/audit
+GET /_opendistro/_security/api/audit
+```
+
+A PUT call updates the audit configuration.
+
+```json
+PUT /_opendistro/_security/api/audit/config
+{
+  "enabled": true,
+  "audit": {
+    "ignore_users": [],
+    "ignore_requests": [],
+    "disabled_rest_categories": [
+      "AUTHENTICATED",
+      "GRANTED_PRIVILEGES"
+    ],
+    "disabled_transport_categories": [
+      "AUTHENTICATED",
+      "GRANTED_PRIVILEGES"
+    ],
+    "log_request_body": false,
+    "resolve_indices": false,
+    "resolve_bulk_requests": false,
+    "exclude_sensitive_headers": true,
+    "enable_transport": false,
+    "enable_rest": true
+  },
+  "compliance": {
+    "enabled": true,
+    "write_log_diffs": false,
+    "read_watched_fields": {},
+    "read_ignore_users": [],
+    "write_watched_indices": [],
+    "write_ignore_users": [],
+    "read_metadata_only": true,
+    "write_metadata_only": true,
+    "external_config": false,
+    "internal_config": true
+  }
+}
 ```
 
 A PATCH call is used to update the audit configuration. It resets missing configurations to their default settings.
 
-Changes to the `_readonly` property must result in a 409 error.
-{: .note}
+```
+PATCH /_opendistro/_security/api/audit
+```
 
 #### Sample response
+
+The GET call produces a response that appears as the following:
 
 ```json
 {
@@ -1524,3 +1555,13 @@ Changes to the `_readonly` property must result in a 409 error.
   }
 }
 ```
+The PUT request produces a response that appears as the following:
+
+```json
+{
+  "status" : "OK",
+  "message" : "'config' updated."
+}
+```
+
+The PATCH request produces a response that appears as the following:

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -1411,14 +1411,14 @@ GET _plugins/_security/health
 
 ### Enable audit logs
 
-This API allows you to enable or disable audit logging, define the way audit logging is carried out, and make updates to settings.
+This API allows you to enable or disable audit logging, define the configuration for audit logging and compliance, and make updates to settings.
 
 For details on using audit logging to track access to OpenSearch clusters, as well as information on further configurations, see [Audit logs](https://opensearch.org/docs/latest/security-plugin/audit-logs/index/).
 
 You can do an initial configuration of audit logging in the `audit.yml` file, found in the `opensearch-project/security/config` directory. Thereafter, use the REST API for further changes to the configuration.
 {: note.}
 
-### Request fields
+#### Request fields
 
 Field | Data Type | Description
 :--- | :--- | :---
@@ -1506,11 +1506,13 @@ PUT /_opendistro/_security/api/audit/config
 }
 ```
 
-A PATCH call is used to update the audit configuration. It resets missing configurations to their default settings.
+A PATCH call is used to update specified fields in the audit configuration and reset unspecified fields to their default settings.
 
 ```
-PATCH /_opendistro/_security/api/audit
+curl -X PATCH <domain>/_opendistro/_security/api/audit -H 'Content-Type: application/json' -d'[{"op":"add","path":"/config/enabled","value":"true"}]' -u <username:password>
 ```
+OpenSearch Dashboards does not support the PATCH method. Use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another method to update the configuration.
+{: .note}
 
 #### Sample response
 
@@ -1566,5 +1568,3 @@ The PUT request produces a response that appears as the following:
   "message" : "'config' updated."
 }
 ```
-
-The PATCH request produces a response that appears as the following:


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

Fixes #816 

### Description
API documentation for audit logging and compliance configuration.

### Issues Resolved
This documentation provides explanation for the API used to enable audit logging for the security plugin. Includes description for the fields used to configure audit logging and compliance.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
