### PR TITLE
Fix backport from PR 929

### DIFF
--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -29,12 +29,12 @@ The install command takes a plugin id, which may be any of the following:
 - A URL to a plugin zip file
 
 If you're installing an official OpenSearch plugin, use:
-```
+```bash
 bin/opensearch-plugin install <plugin-name>
 ```
 
 For a plugin installed via zip, use:
-```
+```bash
 bin/opensearch-plugin install <name|Zip File|Url>
 ```
 
@@ -45,13 +45,13 @@ Restart your OpenSearch node after installing a plugin.
 When installing plugins that require additional privileges not included by default, the plugins will prompt the user for confirmation of the required privileges. To grant all requested privileges, use batch mode to skip the confirmation prompt.
 
 To force batch mode when installing plugins, add the `-b` or `--batch` option:
-```
+```bash
 bin/opensearch-plugin install --batch <plugin-name>
 ```
 
 ## Remove a plugin
 
-```
+```bash
 bin/opensearch-plugin remove <plugin-name>
 ```
 Restart your OpenSearch node after removing a plugin.
@@ -60,7 +60,7 @@ Restart your OpenSearch node after removing a plugin.
 
 To check which plugins are currently installed:
 
-```
+```bash
 bin/opensearch-plugin list
 ```
 


### PR DESCRIPTION
… new PR with proper backport

Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
Previous PR didn't backport correctly because the labels weren't added until after squash and merge.  I fixed some syntax for the code blocks (added `bash`).  Otherwise no changes.

### Issues Resolved
Related to #909 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
