### PR TITLE
Add upsert description to Update document API information

### DIFF
--- a/_opensearch/rest-api/document-apis/update-document.md
+++ b/_opensearch/rest-api/document-apis/update-document.md
@@ -89,7 +89,7 @@ You can also use a script to tell OpenSearch how to update your document.
 
 ### Upsert
 
-Upsert is an operation that conditionally updates an existing document or inserts a new one based on information in the object. In the sample below, the `upsert` object updates the name and adds the `age` field if a document already exists. If a document does not exist, a new one is indexed using content in the `upsert` object.
+Upsert is an operation that conditionally either updates an existing document or inserts a new one based on information in the object. In the sample below, the `upsert` object updates the last name and adds the `age` field if a document already exists. If a document does not exist, a new one is indexed using content in the `upsert` object.
 
 ```json
 {
@@ -98,7 +98,7 @@ Upsert is an operation that conditionally updates an existing document or insert
     "last_name": "Wayne"
   },
   "upsert": {
-    "last_name": "Payne",
+    "last_name": "Brower",
     "age": "35"
   }
 }
@@ -109,7 +109,7 @@ You can also add `doc_as_upsert` to the request and set it to `true` to use the 
 {
   "doc": {
     "first_name": "Thomas",
-    "last_name": "Payne",
+    "last_name": "Brower",
     "age": "35"
   },
   "doc_as_upsert": true

--- a/_opensearch/rest-api/document-apis/update-document.md
+++ b/_opensearch/rest-api/document-apis/update-document.md
@@ -87,6 +87,35 @@ You can also use a script to tell OpenSearch how to update your document.
 }
 ```
 
+### Upsert
+
+Upsert is an operation that conditionally updates an existing document or inserts a new one based on information in the object. In the sample below, the `upsert` object updates the name and adds the `age` field if a document already exists. If a document does not exist, a new one is indexed using content in the `upsert` object.
+
+```json
+{
+  "doc": {
+    "first_name": "Thomas",
+    "last_name": "Wayne"
+  },
+  "upsert": {
+    "last_name": "Payne",
+    "age": "35"
+  }
+}
+```
+You can also add `doc_as_upsert` to the request and set it to `true` to use the information in `doc` for performing the upsert operation.
+
+```json
+{
+  "doc": {
+    "first_name": "Thomas",
+    "last_name": "Payne",
+    "age": "35"
+  },
+  "doc_as_upsert": true
+}
+```
+
 ## Response
 ```json
 {

--- a/_opensearch/rest-api/document-apis/update-document.md
+++ b/_opensearch/rest-api/document-apis/update-document.md
@@ -94,12 +94,12 @@ Upsert is an operation that conditionally either updates an existing document or
 ```json
 {
   "doc": {
-    "first_name": "Thomas",
-    "last_name": "Wayne"
+    "first_name": "Martha",
+    "last_name": "Rivera"
   },
   "upsert": {
-    "last_name": "Brower",
-    "age": "35"
+    "last_name": "Oliveira",
+    "age": "31"
   }
 }
 ```
@@ -108,9 +108,9 @@ You can also add `doc_as_upsert` to the request and set it to `true` to use the 
 ```json
 {
   "doc": {
-    "first_name": "Thomas",
-    "last_name": "Brower",
-    "age": "35"
+    "first_name": "Martha",
+    "last_name": "Oliveira",
+    "age": "31"
   },
   "doc_as_upsert": true
 }


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Added information for `upsert` and `doc_as_upsert` in the _Update document_ section of REST API reference documentation.

### Issues Resolved
This addresses issue [#755](https://github.com/opensearch-project/documentation-website/issues/755).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
