### PR TITLE
949: Added missing transform cluster privileges in privilege list

### DIFF
--- a/_security-plugin/access-control/permissions.md
+++ b/_security-plugin/access-control/permissions.md
@@ -123,6 +123,13 @@ These permissions are for the cluster and can't be applied granularly. For examp
 - cluster:admin/rollup/start
 - cluster:admin/rollup/stop
 - cluster:admin/rollup/explain
+- cluster:admin/opendistro/transform/index
+- cluster:admin/opendistro/transform/get
+- cluster:admin/opendistro/transform/preview
+- cluster:admin/opendistro/transform/delete
+- cluster:admin/opendistro/transform/start
+- cluster:admin/opendistro/transform/stop
+- cluster:admin/opendistro/transform/explain
 - cluster:admin/reports/definition/create
 - cluster:admin/reports/definition/update
 - cluster:admin/reports/definition/on_demand


### PR DESCRIPTION
Signed-off-by: Stevan Buzejic <buzejic.stevan@gmail.com>

### Description
Adds transform cluster related privileges to privilege list

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/949

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
