### PR TITLE
Moved guidance on passing env vars as args to Configuration page

### DIFF
--- a/_opensearch/configuration.md
+++ b/_opensearch/configuration.md
@@ -10,6 +10,13 @@ Most OpenSearch configuration can take place in the cluster settings API. Certai
 
 Whenever possible, use the cluster settings API instead; `opensearch.yml` is local to each node, whereas the API applies the setting to all nodes in the cluster. Certain settings, however, require `opensearch.yml`. In general, these settings relate to networking, cluster formation, and the local file system. To learn more, see [Cluster formation]({{site.url}}{{site.baseurl}}/opensearch/cluster/).
 
+## Specify settings as environment variables
+
+You can specify environment variables as arguments using `-E` when launching OpenSearch:
+
+```bash
+./opensearch -Ecluster.name=opensearch-cluster -Enode.name=opensearch-node1 -Ehttp.host=0.0.0.0 -Ediscovery.type=single-node
+```
 
 ## Update cluster settings using the API
 


### PR DESCRIPTION
### Description
As part of the installation guide refactor I wanted to move some extra info to the correct pages. The tarball install guide, for example, contained extraneous/arbitrary information about passing commands to the executable as environment variables using `-E`.

### Issues Resolved
Relates to #789 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
