### PR TITLE
Relocate perf analyzer installation steps to the appropriate page

### DIFF
--- a/_monitoring-plugins/pa/index.md
+++ b/_monitoring-plugins/pa/index.md
@@ -21,6 +21,7 @@ npm install -g @aws/opensearch-perftop
 
 ![PerfTop screenshot]({{site.url}}{{site.baseurl}}/images/perftop.png)
 
+For enabling Performance Analyzer with tarball installations of OpenSearch, see [Configure Performance Analyzer for Tarball Installation](#configure-performance-analyzer-for-tarball-installation).
 
 ## Get started with PerfTop
 
@@ -101,3 +102,93 @@ certificate-file-path = specify_path
 
 private-key-file-path = specify_path
 ```
+
+## Configure Performance Analyzer for Tarball Installation
+
+In a tarball installation, Performance Analyzer collects data when it is enabled. But in order to read that data using the REST API on port 9600, you must first manually launch the associated reader agent process:
+
+1. Make Performance Analyzer accessible outside of the host machine
+
+   ```bash
+   cd /usr/share/opensearch # navigate to the OpenSearch home directory
+   cd config/opensearch-performance-analyzer/
+   vi performance-analyzer.properties
+   ```
+
+   Uncomment the line `#webservice-bind-host` and set it to `0.0.0.0`:
+
+   ```
+   # ======================== OpenSearch performance analyzer plugin config =========================
+
+   # NOTE: this is an example for Linux. Please modify the config accordingly if you are using it under other OS.
+
+   # WebService bind host; default to all interfaces
+   webservice-bind-host = 0.0.0.0
+
+   # Metrics data location
+   metrics-location = /dev/shm/performanceanalyzer/
+
+   # Metrics deletion interval (minutes) for metrics data.
+   # Interval should be between 1 to 60.
+   metrics-deletion-interval = 1
+
+   # If set to true, the system cleans up the files behind it. So at any point, we should expect only 2
+   # metrics-db-file-prefix-path files. If set to false, no files are cleaned up. This can be useful, if you are archiving
+   # the files and wouldn't like for them to be cleaned up.
+   cleanup-metrics-db-files = true
+
+   # WebService exposed by App's port
+   webservice-listener-port = 9600
+
+   # Metric DB File Prefix Path location
+   metrics-db-file-prefix-path = /tmp/metricsdb_
+
+   https-enabled = false
+
+   #Setup the correct path for certificates
+   certificate-file-path = specify_path
+
+   private-key-file-path = specify_path
+
+   # Plugin Stats Metadata file name, expected to be in the same location
+   plugin-stats-metadata = plugin-stats-metadata
+
+   # Agent Stats Metadata file name, expected to be in the same location
+   agent-stats-metadata = agent-stats-metadata
+   ```
+
+1. Make the CLI executable:
+
+   ```bash
+   sudo chmod +x ./bin/performance-analyzer-agent-cli
+   ```
+
+1. Launch the agent CLI:
+
+   ```bash
+   OPENSEARCH_HOME="$PWD" OPENSEARCH_PATH_CONF="$PWD/config" ./bin/performance-analyzer-agent-cli
+   ```
+
+1. In a separate window, enable the Performance Analyzer plugin:
+
+   ```bash
+   curl -XPOST localhost:9200/_plugins/_performanceanalyzer/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}'
+   ```
+
+   If you receive the `curl: (52) Empty reply from server` error, you are likely protecting your cluster with the security plugin and you need to provide credentials. Modify the following command to use your username and password:
+
+   ```bash
+   curl -XPOST https://localhost:9200/_plugins/_performanceanalyzer/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}' -u 'admin:admin' -k
+   ```
+
+1. Finally, enable the Root Cause Analyzer (RCA) framework
+
+   ```bash
+   curl -XPOST localhost:9200/_plugins/_performanceanalyzer/rca/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}'
+   ```
+
+   Similar to step 4, if you run into `curl: (52) Empty reply from server`, run the command below to enable RCA
+
+   ```bash
+   curl -XPOST https://localhost:9200/_plugins/_performanceanalyzer/rca/cluster/config -H 'Content-Type: application/json' -d '{"enabled": true}' -u 'admin:admin' -k
+   ```


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
These steps previously lived under the tarball installation guide. They didn't belong there. Instead, they should be with the rest of the Performance Analyzer instructions.  A link to these instructions will be included as a "related link" in the installation guide, to preserve continuity for anyone that was using it.

### Issues Resolved
Related to #789 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
