### PR TITLE
API Template Organization – Response fields to bottom of layout

### DIFF
--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -108,7 +108,7 @@ The following request gets all the settings in your index:
 GET /sample-index1/_settings
 ```
 
-This request copies all your field mappings and settings from a source index to a destination index:
+The following request copies all of your field mappings and settings from a source index to a destination index:
 
 ```json
 POST _reindex
@@ -131,9 +131,29 @@ Field | Data Type | Description
 
 #### Sample response
 
-Include a JSON example response to show what the API returns. 
+Include a JSON example response to show what the API returns. See the examples below.
 
-The example that follows corresponds to the "copy field mappings and settings" request above in the Sample request section.
+The `GET /sample-index1/_settings` request returns the following response fields: 
+
+```json
+{
+  "sample-index1": {
+    "settings": {
+      "index": {
+        "creation_date": "1622672553417",
+        "number_of_shards": "1",
+        "number_of_replicas": "1",
+        "uuid": "GMEA0_TkSaamrnJSzNLzwg",
+        "version": {
+          "created": "135217827",
+          "upgraded": "135238227"
+        },
+        "provided_name": "sample-index1"
+      }
+    }
+  }
+}
+```
 
 The `POST _reindex` request returns the following response fields: 
 

--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -1,6 +1,8 @@
 # API reference page template
 
-This template provides the basic structure for creating OpenSearch API documentation. It includes the most important elements that should appear in the documentation and helpful suggestions to help support them. Depending on the intended purpose of the API, some sections will be required while others may not be applicable. 
+This template provides the basic structure for creating OpenSearch API documentation. It includes the most important elements that should appear in the documentation and helpful suggestions to help support them. 
+
+Depending on the intended purpose of the API, some sections will be required while others may not be applicable.
 
 ### A note on terminology ###
 
@@ -22,7 +24,9 @@ See also [Examples](https://alpha-docs-aws.amazon.com/awsstyleguide/latest/style
 
 ## Basic elements for documentation
 
-The following sections describe the basic API documentation structure. Each section is discussed under its respective heading below. Include those elements appropriate to the API. Depending on where the documentation appears within a section or subsection, heading levels may be adjusted to fit with other content.
+The following sections describe the basic API documentation structure. Each section is discussed under its respective heading below. You can include only those elements appropriate to the API. 
+
+Depending on where the documentation appears within a section or subsection, heading levels may be adjusted to fit with other content.
 
 1. Name of API (heading level 2)
 2. Path parameters (heading level 3)
@@ -96,6 +100,8 @@ Field | Data Type | Description
 
 ### Response fields
 
+For PUT and POST APIs: Define all allowable response fields that can be returned in the body of the response.
+
 Field | Data Type | Description
 :--- | :--- | :--- 
 
@@ -104,9 +110,9 @@ Field | Data Type | Description
 Provide a sentence that describes what is shown in the example, followed by a cut-and-paste-ready API request in JSON format. Make sure that you test the request yourself in the Dashboards Dev Tools console to make sure it works.
 
 Here is an example for a request that creates a new mapping for the sample-index index:
-PUT /sample-index/_mapping
 
 ```json
+PUT /sample-index/_mapping
 {
   "properties": {
     "age": {

--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -2,7 +2,7 @@
 
 This template provides the basic structure for creating OpenSearch API documentation. It includes the most important elements that should appear in the documentation and helpful suggestions to help support them. 
 
-Depending on the intended purpose of the API, some sections will be required while others may not be applicable.
+Depending on the intended purpose of the API, *some sections will be required while others may not be applicable*.
 
 ### A note on terminology ###
 
@@ -32,8 +32,8 @@ Depending on where the documentation appears within a section or subsection, hea
 2. Path parameters (heading level 3)
 3. Query parameters (heading level 3)
 4. Request fields (heading level 3)
-5. Response fields (heading level 3)
-6. Sample request (heading level 4)
+5. Sample request (heading level 4)
+6. Response fields (heading level 3)
 7. Sample response (heading level 4)
 
 ## API name
@@ -98,6 +98,30 @@ Include a table with these columns:
 Field | Data Type | Description
 :--- | :--- | :--- 
 
+#### Sample request
+
+Provide a sentence that describes what is shown in the example, followed by a cut-and-paste-ready API request in JSON format. Make sure that you test the request yourself in the Dashboards Dev Tools console to make sure it works. See the examples below.
+
+The following request gets all the settings in your index:
+
+```json
+GET /sample-index1/_settings
+```
+
+This request copies all your field mappings and settings from a source index to a destination index:
+
+```json
+POST _reindex
+{
+   "source":{
+      "index":"sample-index-1"
+   },
+   "dest":{
+      "index":"sample-index-2"
+   }
+}
+```
+
 ### Response fields
 
 For PUT and POST APIs: Define all allowable response fields that can be returned in the body of the response.
@@ -105,40 +129,32 @@ For PUT and POST APIs: Define all allowable response fields that can be returned
 Field | Data Type | Description
 :--- | :--- | :--- 
 
-#### Sample request
-
-Provide a sentence that describes what is shown in the example, followed by a cut-and-paste-ready API request in JSON format. Make sure that you test the request yourself in the Dashboards Dev Tools console to make sure it works.
-
-Here is an example for a request that creates a new mapping for the sample-index index:
-
-```json
-PUT /sample-index/_mapping
-{
-  "properties": {
-    "age": {
-      "type": "integer"
-    },
-    "occupation":{
-      "type": "text"
-    }
-  }
-}
-```
-
-This second example of a request includes the ignore_unavailable query parameter to skip any missing or closed indexes in the response:
-
-```json
-PUT /sample-index/_mapping?ignore_unavailable
-```
-
 #### Sample response
 
-Include a JSON example response to show what the API returns.
+Include a JSON example response to show what the API returns. 
 
-Upon success, the response returns "acknowledged": true
+The example that follows corresponds to the "copy field mappings and settings" request above in the Sample request section.
+
+The `POST _reindex` request returns the following response fields: 
 
 ```json
 {
-"acknowledged": true
+  "took" : 4,
+  "timed_out" : false,
+  "total" : 0,
+  "updated" : 0,
+  "created" : 0,
+  "deleted" : 0,
+  "batches" : 0,
+  "version_conflicts" : 0,
+  "noops" : 0,
+  "retries" : {
+    "bulk" : 0,
+    "search" : 0
+  },
+  "throttled_millis" : 0,
+  "requests_per_second" : -1.0,
+  "throttled_until_millis" : 0,
+  "failures" : [ ]
 }
 ```

--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -33,8 +33,8 @@ Depending on where the documentation appears within a section or subsection, hea
 3. Query parameters (heading level 3)
 4. Request fields (heading level 3)
 5. Sample request (heading level 4)
-6. Response fields (heading level 3)
-7. Sample response (heading level 4)
+6. Sample response (heading level 4)
+7. Response fields (heading level 3)
 
 ## API name
 
@@ -122,13 +122,6 @@ POST _reindex
 }
 ```
 
-### Response fields
-
-For PUT and POST APIs: Define all allowable response fields that can be returned in the body of the response.
-
-Field | Data Type | Description
-:--- | :--- | :--- 
-
 #### Sample response
 
 Include a JSON example response to show what the API returns. See the examples below.
@@ -178,3 +171,10 @@ The `POST _reindex` request returns the following response fields:
   "failures" : [ ]
 }
 ```
+
+### Response fields
+
+For PUT and POST APIs: Define all allowable response fields that can be returned in the body of the response.
+
+Field | Data Type | Description
+:--- | :--- | :--- 

--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -50,12 +50,12 @@ If applicable, provide any caveats to its usage with a note or tip, as in the fo
 
 ### Path parameters
 
-While the API endpoint states a point of entry to a resource, the path parameter identifies a specific resource within it. Path parameters are located in the path of the endpoint just before the query string and following the resource name in the URL.
+While the API endpoint states a point of entry to a resource, the path parameter acts on the resource that precedes it. Path parameters come after the resource name in the URL.
 
 ```json
 GET _search/scroll/<scroll_id>
 ```
-In the example above, the endpoint is `scroll` and its path parameter is `<scroll_id>`.
+In the example above, the resource is `scroll` and its path parameter is `<scroll_id>`.
 
 Introduce what the path parameters can do at a high level. Provide a table with parameter names and descriptions. Include a table with the following columns:
 *Parameter* – Parameter name in plain font.
@@ -135,3 +135,58 @@ PUT /sample-index/_mapping
   }
 }
 ```
+
+### Response body
+
+Provide a description of the response fields.
+
+Include a table with these columns: 
+*Field* – Field name in plain font.
+*Data Type* – Data type capitalized (such as Boolean, String, or Integer).
+*Description* – Sentence to describe the field’s function, default values or range of values, and any usage examples.
+
+Field | Data Type | Description
+:--- | :--- | :--- 
+
+#### Sample response
+
+Provide a sentence that describes what is shown in the example, followed by a cut-and-paste-ready API response in JSON format.
+
+GET _snapshot/my-opensearch-repo/my-first-snapshot
+
+```json
+{     
+  "snapshots" : [     
+    {     
+      "snapshot" : "my-first-snapshot",     
+      "uuid" : "3P7Qa-M8RU6l16Od5n7Lxg",     
+      "version_id" : 136217927,     
+      "version" : "2.0.1",     
+      "indices" : [     
+        ".opensearch-observability",     
+        ".opendistro-reports-instances",     
+        ".opensearch-notifications-config",     
+        "shakespeare",     
+        ".opendistro-reports-definitions",     
+        "opensearch_dashboards_sample_data_flights",     
+        ".kibana_1"     
+        ],     
+        "data_streams" : [ ],     
+        "include_global_state" : true,     
+        "state" : "SUCCESS",     
+        "start_time" : "2022-08-11T20:30:00.399Z",     
+        "start_time_in_millis" : 1660249800399,     
+        "end_time" : "2022-08-11T20:30:14.851Z",     
+        "end_time_in_millis" : 1660249814851,     
+        "duration_in_millis" : 14452,     
+        "failures" : [ ],     
+        "shards" : {     
+          "total" : 7,     
+          "failed" : 0,     
+          "successful" : 7     
+        }     
+    }   
+  ]   
+}
+```
+

--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -27,10 +27,10 @@ The following sections describe the basic API documentation structure. Each sect
 1. Name of API (heading level 2)
 2. Path parameters (heading level 3)
 3. Query parameters (heading level 3)
-4. Request body (heading level 3)
-5. Sample request (heading level 4)
-6. Sample response (heading level 4)
-7. Response body (heading level 3)
+4. Request fields (heading level 3)
+5. Response fields (heading level 3)
+6. Sample request (heading level 4)
+7. Sample response (heading level 4)
 
 ## API name
 
@@ -82,7 +82,7 @@ For GET and DELETE APIs: Introduce what you can do with the optional parameters.
 Parameter | Data Type | Description
 :--- | :--- | :---
 
-### Request body
+### Request fields
 
 For PUT and POST APIs: Introduce what the request fields are allowed to provide in the body of the request.
 
@@ -90,6 +90,11 @@ Include a table with these columns:
 *Field* – Field name in plain font.
 *Data Type* – Data type capitalized (such as Boolean, String, or Integer).
 *Description* – Sentence to describe the field’s function, default values or range of values, and any usage examples.
+
+Field | Data Type | Description
+:--- | :--- | :--- 
+
+### Response fields
 
 Field | Data Type | Description
 :--- | :--- | :--- 
@@ -131,15 +136,3 @@ Upon success, the response returns "acknowledged": true
 "acknowledged": true
 }
 ```
-
-### Response body
-
-Provide meanings for the fields returned in the response.
-
-Include a table with these columns: 
-*Field* – Field name in plain font.
-*Data Type* – Data type capitalized (such as Boolean, String, or Integer).
-*Description* – Sentence to describe the field’s function, default values or range of values, and any usage examples.
-
-Field | Data Type | Description
-:--- | :--- | :--- 

--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -27,10 +27,11 @@ The following sections describe the basic API documentation structure. Each sect
 1. Name of API (heading level 2)
 2. Path parameters (heading level 3)
 3. Query parameters (heading level 3)
-4. Sample request (heading level 4)
-5. Sample response (heading level 4)
-6. Request body (heading level 3)
-7. Sample request (heading level 4)
+4. Request body (heading level 3)
+5. Sample request (heading level 4)
+6. Sample response (heading level 4)
+7. Response body (heading level 3)
+8. Sample response (heading level 4)
 
 ## API name
 
@@ -82,11 +83,39 @@ For GET and DELETE APIs: Introduce what you can do with the optional parameters.
 Parameter | Data Type | Description
 :--- | :--- | :---
 
+### Request body
+
+For PUT and POST APIs: Introduce what the request fields are allowed to provide in the body of the request.
+
+Include a table with these columns: 
+*Field* – Field name in plain font.
+*Data Type* – Data type capitalized (such as Boolean, String, or Integer).
+*Description* – Sentence to describe the field’s function, default values or range of values, and any usage examples.
+
+Field | Data Type | Description
+:--- | :--- | :--- 
+
 #### Sample request
 
 Provide a sentence that describes what is shown in the example, followed by a cut-and-paste-ready API request in JSON format. Make sure that you test the request yourself in the Dashboards Dev Tools console to make sure it works.
 
-The following request includes the ignore_unavailable query parameter to skip any missing or closed indexes in the response:
+Here is an example for a request that creates a new mapping for the sample-index index:
+PUT /sample-index/_mapping
+
+```json
+{
+  "properties": {
+    "age": {
+      "type": "integer"
+    },
+    "occupation":{
+      "type": "text"
+    }
+  }
+}
+```
+
+This second example of a request includes the ignore_unavailable query parameter to skip any missing or closed indexes in the response:
 
 ```json
 PUT /sample-index/_mapping?ignore_unavailable
@@ -104,41 +133,9 @@ Upon success, the response returns "acknowledged": true
 }
 ```
 
-### Request body
-
-For PUT and POST APIs: Introduce what the request fields are allowed to provide in the body of the request.
-
-Include a table with these columns: 
-*Field* – Field name in plain font.
-*Data Type* – Data type capitalized (such as Boolean, String, or Integer).
-*Description* – Sentence to describe the field’s function, default values or range of values, and any usage examples.
-
-Field | Data Type | Description
-:--- | :--- | :--- 
-
-#### Sample request
-
-Provide a sentence that describes what is shown in the example, followed by a cut-and-paste-ready API request in JSON format.
-
-The following request creates a new mapping for the sample-index index:
-PUT /sample-index/_mapping
-
-```json
-{
-  "properties": {
-    "age": {
-      "type": "integer"
-    },
-    "occupation":{
-      "type": "text"
-    }
-  }
-}
-```
-
 ### Response body
 
-Provide a description of the response fields.
+Provide meanings for the fields returned in the response.
 
 Include a table with these columns: 
 *Field* – Field name in plain font.
@@ -189,4 +186,3 @@ GET _snapshot/my-opensearch-repo/my-first-snapshot
   ]   
 }
 ```
-

--- a/STYLE_API_TEMPLATE.md
+++ b/STYLE_API_TEMPLATE.md
@@ -31,7 +31,6 @@ The following sections describe the basic API documentation structure. Each sect
 5. Sample request (heading level 4)
 6. Sample response (heading level 4)
 7. Response body (heading level 3)
-8. Sample response (heading level 4)
 
 ## API name
 
@@ -144,45 +143,3 @@ Include a table with these columns:
 
 Field | Data Type | Description
 :--- | :--- | :--- 
-
-#### Sample response
-
-Provide a sentence that describes what is shown in the example, followed by a cut-and-paste-ready API response in JSON format.
-
-GET _snapshot/my-opensearch-repo/my-first-snapshot
-
-```json
-{     
-  "snapshots" : [     
-    {     
-      "snapshot" : "my-first-snapshot",     
-      "uuid" : "3P7Qa-M8RU6l16Od5n7Lxg",     
-      "version_id" : 136217927,     
-      "version" : "2.0.1",     
-      "indices" : [     
-        ".opensearch-observability",     
-        ".opendistro-reports-instances",     
-        ".opensearch-notifications-config",     
-        "shakespeare",     
-        ".opendistro-reports-definitions",     
-        "opensearch_dashboards_sample_data_flights",     
-        ".kibana_1"     
-        ],     
-        "data_streams" : [ ],     
-        "include_global_state" : true,     
-        "state" : "SUCCESS",     
-        "start_time" : "2022-08-11T20:30:00.399Z",     
-        "start_time_in_millis" : 1660249800399,     
-        "end_time" : "2022-08-11T20:30:14.851Z",     
-        "end_time_in_millis" : 1660249814851,     
-        "duration_in_millis" : 14452,     
-        "failures" : [ ],     
-        "shards" : {     
-          "total" : 7,     
-          "failed" : 0,     
-          "successful" : 7     
-        }     
-    }   
-  ]   
-}
-```


### PR DESCRIPTION
### Description
Reformatted to put "Response fields" as the last heading, so they follow the visual in sample response.

Fixes [#788 ](https://github.com/opensearch-project/documentation-website/issues/788)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
