### PR TITLE
Fix example using custom_attr_whitelist and custom_attr_maxval_len in…

### DIFF
--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -439,11 +439,11 @@ Name | Description
 Example:
 
 ```yml
-authz:
+authc:
   ldap:
     http_enabled: true
     transport_enabled: true
-    authorization_backend:
+    authentication_backend:
       type: ldap
       config:
         custom_attr_whitelist:


### PR DESCRIPTION
… ldap documentation

Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

The section on [(Advanced) Control LDAP user attributes](https://opensearch.org/docs/latest/security-plugin/configuration/ldap/#advanced-control-ldap-user-attributes) contains a mistake in the example of how to configure the attributes `custom_attr_whitelist` and `custom_attr_maxval_len`, this PR updates the documentation to ensure the example is in the correct area of the security configuration.

### Issues Resolved

Related Issue issue from the `security` repo: https://github.com/opensearch-project/security/issues/2032

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
