### PR TITLE
fix aliases example for shrink policy action

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -178,7 +178,9 @@ Allows you to reduce the number of primary shards in your indexes. With this act
         "source": "{{ctx.index}}_shrunken"
     },
     "aliases": [
-       "my-alias": {}
+      {
+        "my-alias": {}
+      }
     ],
     "force_unsafe": false
 }


### PR DESCRIPTION
### Description
I fixed a broken example for defining an alias on the shrink action in a policy
