### PR TITLE
resolve_hostname should be singular

### DIFF
--- a/_security-plugin/configuration/tls.md
+++ b/_security-plugin/configuration/tls.md
@@ -135,7 +135,7 @@ With `enforce_hostname_verification` enabled, the security plugin verifies that 
 [ERROR][c.a.o.s.s.t.opensearchSecuritySSLNettyTransport] [WX6omJY] SSL Problem Received fatal alert: certificate_unknown
 ```
 
-In addition, when `resolve_hostnames` is enabled, the security plugin resolves the (verified) hostname against your DNS. If the hostname does not resolve, errors are thrown:
+In addition, when `resolve_hostname` is enabled, the security plugin resolves the (verified) hostname against your DNS. If the hostname does not resolve, errors are thrown:
 
 
 Name | Description


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

Fixes small inconsistency in TLS security configuration documentation. The full setting is `plugins.security.ssl.transport.resolve_hostname`, but there is an instance in the documentation website where this is pluralized. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
