### PR TITLE
Replace deprecated pipeline configuration fields in Data Prepper examples

### DIFF
--- a/_clients/data-prepper/pipelines.md
+++ b/_clients/data-prepper/pipelines.md
@@ -102,7 +102,7 @@ raw-pipeline:
         insecure: true
         username: admin
         password: admin
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
 service-map-pipeline:
   delay: "100"
   source:
@@ -116,7 +116,7 @@ service-map-pipeline:
         insecure: true
         username: admin
         password: admin
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map
 ```
 
 #### Event record type
@@ -155,7 +155,7 @@ raw-pipeline:
         insecure: true
         username: admin
         password: admin
-        trace_analytics_raw: true
+        index_type: trace-analytics-raw
 service-map-pipeline:
   delay: "100"
   source:
@@ -173,7 +173,7 @@ service-map-pipeline:
         insecure: true
         username: admin
         password: admin
-        trace_analytics_service_map: true
+        index_type: trace-analytics-service-map
 ```
 
 Note that it is recommended to scale the `buffer_size` and `batch_size` by the estimated maximum batch size in the client request payload to maintain similar ingestion throughput and latency as in [Classic](#classic).


### PR DESCRIPTION
Signed-off-by: Hai Yan <oeyh@amazon.com>

### Description
This PR updates pipeline configuration examples for Data Prepper to avoid using deprecated fields (`trace_analytics_raw` and `trace_analytics_service_map`). They are replaced with the up-to-date `index_type` field.

### Issues Resolved
None

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
