### PR TITLE
Add documentation for the plugins.security.cache.ttl_minutes property

### DIFF
--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -275,9 +275,6 @@ eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJsb2dnZWRJbkFzIjoiYWRtaW4iLCJpYXQiOjE0MjI
 
 ### Configure JSON web tokens
 
-If JSON web tokens are the only authentication method that you use, disable the user cache by setting `plugins.security.cache.ttl_minutes: 0`.
-{: .warning }
-
 Set up an authentication domain and choose `jwt` as the HTTP authentication type. Because the tokens already contain all required information to verify the request, `challenge` must be set to `false` and `authentication_backend` to `noop`.
 
 Example:

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -109,6 +109,7 @@ plugins.security.authcz.admin_dn:
 plugins.security.audit.type: internal_opensearch
 plugins.security.enable_snapshot_restore_privilege: true
 plugins.security.check_snapshot_restore_write_privileges: true
+plugins.security.cache.ttl_minutes: 60
 plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]
 plugins.security.system_indices.enabled: true
 plugins.security.system_indices.indices: [".opendistro-alerting-config", ".opendistro-alerting-alert*", ".opendistro-anomaly-results*", ".opendistro-anomaly-detector*", ".opendistro-anomaly-checkpoints", ".opendistro-anomaly-detection-state", ".opendistro-reports-*", ".opendistro-notifications-*", ".opendistro-notebooks", ".opendistro-asynchronous-search-response*"]
@@ -128,6 +129,12 @@ The opensearch.yml file also contains the `plugins.security.allow_default_init_s
 
 ```yml
 plugins.security.allow_default_init_securityindex: true
+```
+
+Authentication cache for the security plugin exists to help speed up authentication by temporarily storing user credentials, thereby bypassing the authentication backend and the response times involved with that process. You can set a timeout value for cashing in minutes with the `plugins.security.cache.ttl_minutes` property. Default is `60`. You can disable caching by adding the value `0`.
+
+```yml
+plugins.security.cache.ttl_minutes: 60
 ```
 
 ## allowlist.yml

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -131,7 +131,7 @@ The opensearch.yml file also contains the `plugins.security.allow_default_init_s
 plugins.security.allow_default_init_securityindex: true
 ```
 
-Authentication cache for the security plugin exists to help speed up authentication by temporarily storing user credentials, thereby bypassing the authentication backend and the response times involved with that process. You can set a timeout value for cashing in minutes with the `plugins.security.cache.ttl_minutes` property. Default is `60`. You can disable caching by adding the value `0`.
+Authentication cache for the security plugin exists to help speed up authentication by temporarily storing user objects returned from the backend so that the security plugin is not required to make repeated requests for them. To determine how long it takes for caching to time out, you can use the `plugins.security.cache.ttl_minutes` property to set a value in minutes. The default is `60`. You can disable caching by setting the value to `0`.
 
 ```yml
 plugins.security.cache.ttl_minutes: 60


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Define `plugins.security.cache.ttl_minutes` property.

### Issues Resolved
Removed guidance for JSON web token configuration that directs users to set the `plugins.security.cache.ttl_minutes` property to zero when it's the only authentication being used (no backend configuration).
Added definition of the property to the "YAML files" section of the security documentation.

See issue #1037 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
