### PR TITLE
Correct documentation to clarify which permissions are needed for cross-cluster search

### DIFF
--- a/_opensearch/rest-api/search.md
+++ b/_opensearch/rest-api/search.md
@@ -46,7 +46,7 @@ analyzer | String | Analyzer to use in the query string.
 analyze_wildcard | Boolean | Whether the update operation should include wildcard and prefix queries in the analysis. Default is false.
 batched_reduce_size | Integer | How many shard results to reduce on a node. Default is 512.
 cancel_after_time_interval | Time | The time after which the search request will be canceled. Request-level parameter takes precedence over cancel_after_time_interval [cluster setting]({{site.url}}{{site.baseurl}}/opensearch/rest-api/cluster-settings). Default is -1.
-css_minimize_roundtrips | Boolean | Whether to minimize roundtrips between a node and remote clusters. Default is true.
+ccs_minimize_roundtrips | Boolean | Whether to minimize roundtrips between a node and remote clusters. Default is true.
 default_operator | String | Indicates whether the default operator for a string query should be AND or OR. Default is OR.
 df | String | The default field in case a field prefix is not provided in the query string.
 docvalue_fields | String | The fields that OpenSearch should return using their docvalue forms.

--- a/_security-plugin/access-control/cross-cluster-search.md
+++ b/_security-plugin/access-control/cross-cluster-search.md
@@ -32,12 +32,13 @@ You can have different authentication and authorization configurations on the re
 
 ## Permissions
 
-To query indices on remote clusters, users need to have the following permissions for the index, in addition to `READ` or `SEARCH` permissions:
+To query indexes on remote clusters, users need to have `READ` or `SEARCH` permissions. Furthermore, when the search request includes the query parameter `ccs_minimize_roundtrips=false` – which tells OpenSearch not to minimize outgoing and ingoing requests to remote clusters – users need to have the following additional permission for the index:
 
 ```
 indices:admin/shards/search_shards
 ```
 
+For more information about the `ccs_minimize_roundtrips` parameter, see the list of [parameters](https://opensearch.org/docs/latest/opensearch/rest-api/search/#url-parameters) for the Search API.
 
 #### Sample roles.yml configuration
 
@@ -49,7 +50,7 @@ humanresources:
     'humanresources':
       '*':
         - READ
-        - indices:admin/shards/search_shards # needed for CCS
+        - indices:admin/shards/search_shards # needed when the search request includes parameter setting 'ccs_minimize_roundtrips=false'.
 ```
 
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Documentation inaccurately states that users always need the permission `indices:admin/shards/search_shards` to perform cross-cluster search. This permission is only needed when the search request includes the parameter setting `ccs_minimize_roundtrips=false`.

### Issues Resolved
Edited documentation to specify that the permission is needed only when the parameter setting is set to `false`, meaning when the search request indicates that the number of requests to and from remote clusters should not be minimized.

See issue in #867.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
