### PR TITLE
Adds disclaimer about Maven coords URL formation and details about local zip files

### DIFF
--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -80,18 +80,43 @@ $ sudo ./opensearch-plugin install analysis-icu
 
 ### Install a plugin from a zip file:
 
+For zip files hosted on a remote server, replace `<zip-file>` with the URL of the hosted file. For zip files in a local directory, replace `<zip-file>` with `file:` followed by the absolute or relative path to the plugin zip file.
+
 #### Usage:
 ```bash
-# zip-file can be a local path to the zip file, or
-# a URL for a zip file hosted on a network.
 bin/opensearch-plugin install <zip-file>
 ```
 
 #### Example:
 ```bash
+# Zip file is hosted on a remote server - in this case, Maven central repository.
 $ sudo ./opensearch-plugin install https://repo1.maven.org/maven2/org/opensearch/plugin/opensearch-anomaly-detection/2.2.0.0/opensearch-anomaly-detection-2.2.0.0.zip
 -> Installing https://repo1.maven.org/maven2/org/opensearch/plugin/opensearch-anomaly-detection/2.2.0.0/opensearch-anomaly-detection-2.2.0.0.zip
 -> Downloading https://repo1.maven.org/maven2/org/opensearch/plugin/opensearch-anomaly-detection/2.2.0.0/opensearch-anomaly-detection-2.2.0.0.zip
+[=================================================] 100%   
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+@     WARNING: plugin requires additional permissions     @
+@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
+* java.lang.RuntimePermission accessClassInPackage.sun.misc
+* java.lang.RuntimePermission accessDeclaredMembers
+* java.lang.RuntimePermission getClassLoader
+* java.lang.RuntimePermission setContextClassLoader
+* java.lang.reflect.ReflectPermission suppressAccessChecks
+* java.net.SocketPermission * connect,resolve
+* javax.management.MBeanPermission org.apache.commons.pool2.impl.GenericObjectPool#-[org.apache.commons.pool2:name=pool,type=GenericObjectPool] registerMBean
+* javax.management.MBeanPermission org.apache.commons.pool2.impl.GenericObjectPool#-[org.apache.commons.pool2:name=pool,type=GenericObjectPool] unregisterMBean
+* javax.management.MBeanServerPermission createMBeanServer
+* javax.management.MBeanTrustPermission register
+See http://docs.oracle.com/javase/8/docs/technotes/guides/security/permissions.html
+for descriptions of what these permissions allow and the associated risks.
+
+Continue with installation? [y/N]y
+-> Installed opensearch-anomaly-detection with folder name opensearch-anomaly-detection
+
+# Zip file
+$ sudo ./opensearch-plugin install file:/home/user/opensearch-anomaly-detection-2.2.0.0.zip
+-> Installing file:/home/user/opensearch-anomaly-detection-2.2.0.0.zip
+-> Downloading file:/home/user/opensearch-anomaly-detection-2.2.0.0.zip
 [=================================================] 100%   
 @@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@@
 @     WARNING: plugin requires additional permissions     @

--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -140,7 +140,7 @@ Continue with installation? [y/N]y
 
 ### Install a plugin using Maven coordinates:
 
-The `opensearch-plugin install` tool also accepts Maven coordinates for available artifacts and versions hosted on [Maven Central](https://search.maven.org/search?q=org.opensearch.plugin). `opensearch-plugin` will parse the Maven coordinates you provide and construct a URL. As a result, the host must be able to connect directoy to [Maven Central](https://search.maven.org/search?q=org.opensearch.plugin). The plugin installation will fail if you pass coordinates to a proxy or local repository.
+The `opensearch-plugin install` tool also accepts Maven coordinates for available artifacts and versions hosted on [Maven Central](https://search.maven.org/search?q=org.opensearch.plugin). `opensearch-plugin` will parse the Maven coordinates you provide and construct a URL. As a result, the host must be able to connect directly to [Maven Central](https://search.maven.org/search?q=org.opensearch.plugin). The plugin installation will fail if you pass coordinates to a proxy or local repository.
 
 #### Usage:
 ```bash

--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -140,6 +140,8 @@ Continue with installation? [y/N]y
 
 ### Install a plugin using Maven coordinates:
 
+The `opensearch-plugin install` tool also accepts Maven coordinates for available artifacts and versions hosted on [Maven Central](https://search.maven.org/search?q=org.opensearch.plugin). `opensearch-plugin` will parse the Maven coordinates you provide and construct a URL. As a result, the host must be able to connect directoy to [Maven Central](https://search.maven.org/search?q=org.opensearch.plugin). The plugin installation will fail if you pass coordinates to a proxy or local repository.
+
 #### Usage:
 ```bash
 bin/opensearch-plugin install <groupId>:<artifactId>:<version>

--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -80,7 +80,7 @@ $ sudo ./opensearch-plugin install analysis-icu
 
 ### Install a plugin from a zip file:
 
-For zip files hosted on a remote server, replace `<zip-file>` with the URL of the hosted file. For zip files in a local directory, replace `<zip-file>` with `file:` followed by the absolute or relative path to the plugin zip file.
+Remote zip files can be installed by replacing `<zip-file>` with the URL of the hosted file. The tool only supports downloading over HTTP/HTTPS protocols. For local zip files, replace `<zip-file>` with `file:` followed by the absolute or relative path to the plugin zip file as in the second example below.
 
 #### Usage:
 ```bash
@@ -113,7 +113,7 @@ for descriptions of what these permissions allow and the associated risks.
 Continue with installation? [y/N]y
 -> Installed opensearch-anomaly-detection with folder name opensearch-anomaly-detection
 
-# Zip file
+# Zip file in a local directory.
 $ sudo ./opensearch-plugin install file:/home/user/opensearch-anomaly-detection-2.2.0.0.zip
 -> Installing file:/home/user/opensearch-anomaly-detection-2.2.0.0.zip
 -> Downloading file:/home/user/opensearch-anomaly-detection-2.2.0.0.zip


### PR DESCRIPTION
### Description
Added clarification for readers about how Maven coordinates are used so that it's very clear that a host needs connectivity to Maven Central in order to pull down a plugin using this method.

Also added a blurb about installing from a local zip, and mentioned that the only protocols supported are HTTP and HTTPS (no s3 or s3ssl, for example).

### Issues Resolved
Fixes #1051 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
