### PR TITLE
Creates standalone pages for OpenSearch Dashboards RPM/YUM Installation

### DIFF
--- a/_dashboards/install/rpm.md
+++ b/_dashboards/install/rpm.md
@@ -9,32 +9,42 @@ nav_order: 31
 
 OpenSearch Dashboards is the default visualization tool for data in OpenSearch. It also serves as a user interface for many of the OpenSearch plugins, including security, alerting, Index State Management, SQL, and more.
 
-1. Download the RPM package directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The RPM package can be download for both `x64` and `arm64` architectures.
+## Install OpenSearch Dashboards from a downloaded package
+
+1. Download the RPM package directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The RPM package can be download for both **x64** and **arm64** architectures.
 1. Import the public GPG key. This key verifies that the your OpenSearch instance is signed.
-   ```bash
-   sudo rpm --import https://artifacts.opensearch.org/publickeys/opensearch.pgp
-   ```
-1. On your host, use `sudo yum install` or `sudo rpm -ivh` to install the package.
+    ```bash
+    sudo rpm --import https://artifacts.opensearch.org/publickeys/opensearch.pgp
+    ```
+1. From the command line interface (CLI), you can install the package with `rpm` or `yum`.
     **x64**
     ```bash
-    # Install the package using yum.
+    # Install the x64 package using yum.
     sudo yum install opensearch-dashboards-{{site.opensearch_version}}-linux-x64.rpm
-
-    # Install the package using rpm.
+    # Install the x64 package using rpm.
     sudo rpm -ivh opensearch-dashboards-{{site.opensearch_version}}-linux-x64.rpm
     ```
     **arm64**
     ```bash
-    # Install the package using yum.
+    # Install the arm64 package using yum.
     sudo yum install opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.rpm
-
-    # Install the package using rpm.
+    # Install the arm64 package using rpm.
     sudo rpm -ivh opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.rpm
     ```
+1. Enable OpenSearch Dashboards as a service.
+    ```bash
+    sudo systemctl enable opensearch-dashboards
+    ```
+1. Start OpenSearch Dashboards.
+    ```bash
+    sudo systemctl start opensearch-dashboards
+    ```
+1. Verify that OpenSearch Dashboards launched correctly.
+    ```bash
+    sudo systemctl status opensearch-dashboards
+    ```
 
-    Once complete, you can run OpenSearch Dashboards inside your distribution.
-
-## YUM method
+## Install OpenSearch Dashboards from a local YUM repository
 
 YUM, the primary package management tool for Red Hat-based operating systems, allows you to download and install the RPM package from the YUM repository library. 
 

--- a/_dashboards/install/rpm.md
+++ b/_dashboards/install/rpm.md
@@ -1,0 +1,77 @@
+---
+layout: default
+title: RPM
+parent: Install OpenSearch Dashboards
+nav_order: 31
+---
+
+# Run OpenSearch Dashboards using RPM Package Manager (RPM)
+
+OpenSearch Dashboards is the default visualization tool for data in OpenSearch. It also serves as a user interface for many of the OpenSearch plugins, including security, alerting, Index State Management, SQL, and more.
+
+1. Download the RPM package directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The RPM package can be download for both `x64` and `arm64` architectures.
+1. Import the public GPG key. This key verifies that the your OpenSearch instance is signed.
+   ```bash
+   sudo rpm --import https://artifacts.opensearch.org/publickeys/opensearch.pgp
+   ```
+1. On your host, use `sudo yum install` or `sudo rpm -ivh` to install the package.
+    **x64**
+    ```bash
+    # Install the package using yum.
+    sudo yum install opensearch-dashboards-{{site.opensearch_version}}-linux-x64.rpm
+
+    # Install the package using rpm.
+    sudo rpm -ivh opensearch-dashboards-{{site.opensearch_version}}-linux-x64.rpm
+    ```
+    **arm64**
+    ```bash
+    # Install the package using yum.
+    sudo yum install opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.rpm
+
+    # Install the package using rpm.
+    sudo rpm -ivh opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.rpm
+    ```
+
+    Once complete, you can run OpenSearch Dashboards inside your distribution.
+
+## YUM method
+
+YUM, the primary package management tool for Red Hat-based operating systems, allows you to download and install the RPM package from the YUM repository library. 
+
+1. Create a local repository file for OpenSearch Dashboards:
+   ```bash
+   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/opensearch-2.x.repo -o /etc/yum.repos.d/opensearch-2.x.repo
+   ```
+   ```bash
+   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/opensearch-dashboards-2.x.repo -o /etc/yum.repos.d/opensearch-dashboards-2.x.repo
+   ```
+1. Verify that the repository was created successfully.
+    ```bash
+    sudo yum repolist
+    ```
+1. Clean your YUM cache, to ensure a smooth installation:
+   ```bash
+   sudo yum clean all
+   ```
+1. With the repository file downloaded, list all available versions of OpenSearch-Dashboards:
+   ```bash
+   sudo yum list opensearch-dashboards --showduplicates
+   ```
+1. Choose the version of OpenSearch Dashboards you want to install: 
+   - Unless otherwise indicated, the highest minor version of OpenSearch installs.
+   ```bash
+   sudo yum install opensearch-dashboards
+   ```
+   - To install a specific version of OpenSearch Dashboards:**
+   ```bash
+   sudo yum install 'opensearch-dashboards-{{site.opensearch_version}}'
+   ```
+1. During installation, the installer stops to see if the GPG key matches the OpenSearch project. Verify that the `Fingerprint` matches the following:
+
+   ```bash
+   Fingerprint: c5b7 4989 65ef d1c2 924b a9d5 39d3 1987 9310 d3fc
+   ```
+
+   If correct, enter `yes` or `y`. The OpenSearch installation continues.
+  
+   Once complete, you can run OpenSearch inside your distribution. 

--- a/_dashboards/install/rpm.md
+++ b/_dashboards/install/rpm.md
@@ -15,7 +15,7 @@ The following liquid syntax declares a variable, major_version_mask, which is tr
 
 OpenSearch Dashboards is the default visualization tool for data in OpenSearch. It also serves as a user interface for many of the OpenSearch plugins, including security, alerting, Index State Management, SQL, and more.
 
-## Install OpenSearch Dashboards from a downloaded package
+## Install OpenSearch Dashboards from a package
 
 1. Download the RPM package for the desired version directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The RPM package can be download for both **x64** and **arm64** architectures.
 1. Import the public GPG key. This key verifies that your OpenSearch instance is signed.

--- a/_dashboards/install/rpm.md
+++ b/_dashboards/install/rpm.md
@@ -31,7 +31,7 @@ OpenSearch Dashboards is the default visualization tool for data in OpenSearch. 
     # Install the arm64 package using rpm.
     sudo rpm -ivh opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.rpm
     ```
-1. Enable OpenSearch Dashboards as a service.
+1. After the installation succeeds, enable OpenSearch Dashboards as a service.
     ```bash
     sudo systemctl enable opensearch-dashboards
     ```

--- a/_dashboards/install/rpm.md
+++ b/_dashboards/install/rpm.md
@@ -5,6 +5,12 @@ parent: Install OpenSearch Dashboards
 nav_order: 31
 ---
 
+{% comment %}
+The following liquid syntax declares a variable, major_version_mask, which is transformed into "N.x" where "N" is the major version number. This is required for proper versioning references to the Yum repo.
+{% endcomment %}
+{% assign version_parts = site.opensearch_major_minor_version | split: "." %}
+{% assign major_version_mask = version_parts[0] | append: ".x" %}
+
 # Run OpenSearch Dashboards using RPM Package Manager (RPM)
 
 OpenSearch Dashboards is the default visualization tool for data in OpenSearch. It also serves as a user interface for many of the OpenSearch plugins, including security, alerting, Index State Management, SQL, and more.
@@ -50,10 +56,7 @@ YUM, the primary package management tool for Red Hat-based operating systems, al
 
 1. Create a local repository file for OpenSearch Dashboards:
    ```bash
-   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/opensearch-2.x.repo -o /etc/yum.repos.d/opensearch-2.x.repo
-   ```
-   ```bash
-   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/opensearch-dashboards-2.x.repo -o /etc/yum.repos.d/opensearch-dashboards-2.x.repo
+   sudo curl -SL https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/{{major_version_mask}}/opensearch-dashboards-{{major_version_mask}}.repo -o /etc/yum.repos.d/opensearch-dashboards-{{major_version_mask}}.repo
    ```
 1. Verify that the repository was created successfully.
     ```bash
@@ -72,16 +75,16 @@ YUM, the primary package management tool for Red Hat-based operating systems, al
    ```bash
    sudo yum install opensearch-dashboards
    ```
-   - To install a specific version of OpenSearch Dashboards:**
+   - To install a specific version of OpenSearch Dashboards:
    ```bash
    sudo yum install 'opensearch-dashboards-{{site.opensearch_version}}'
    ```
-1. During installation, the installer stops to see if the GPG key matches the OpenSearch project. Verify that the `Fingerprint` matches the following:
-
+1. During installation, the installer will present you with the GPG key fingerprint. Verify that the information matches the following:
    ```bash
    Fingerprint: c5b7 4989 65ef d1c2 924b a9d5 39d3 1987 9310 d3fc
    ```
-
-   If correct, enter `yes` or `y`. The OpenSearch installation continues.
-  
-   Once complete, you can run OpenSearch inside your distribution. 
+    - If correct, enter `yes` or `y`. The OpenSearch installation continues.
+1. Once complete, you can run OpenSearch Dashboards.
+    ```bash
+    sudo systemctl start opensearch-dashboards
+    ```

--- a/_dashboards/install/rpm.md
+++ b/_dashboards/install/rpm.md
@@ -11,8 +11,8 @@ OpenSearch Dashboards is the default visualization tool for data in OpenSearch. 
 
 ## Install OpenSearch Dashboards from a downloaded package
 
-1. Download the RPM package directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The RPM package can be download for both **x64** and **arm64** architectures.
-1. Import the public GPG key. This key verifies that the your OpenSearch instance is signed.
+1. Download the RPM package for the desired version directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The RPM package can be download for both **x64** and **arm64** architectures.
+1. Import the public GPG key. This key verifies that your OpenSearch instance is signed.
     ```bash
     sudo rpm --import https://artifacts.opensearch.org/publickeys/opensearch.pgp
     ```


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
Previously, steps for installing OpenSearch Dashboards by way of RPM/YUM were not included under the OpenSearch Dashboards section. Rather, they were interlaced with OpenSearch (core) installation instructions. This is confusing for users. This PR extracts and reformats the existing installation steps for OpenSearch Dashboards, without conflating plugins with the core product.

These installation steps are MORE COMPLETE and MORE ACCURATE than what was originally included. This PR does not represent a final form for these steps. However, they need to live somewhere and there isn't room for them in the refactored RPM/YUM installation doc for OpenSearch (core).

### Issues Resolved
Fixes #1112 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
