### PR TITLE
Moves PA plugin info to the correct page

### DIFF
--- a/_monitoring-plugins/pa/index.md
+++ b/_monitoring-plugins/pa/index.md
@@ -103,7 +103,17 @@ certificate-file-path = specify_path
 private-key-file-path = specify_path
 ```
 
-## Configure Performance Analyzer for Tarball Installation
+## Enable Performance Analyzer for RPM/YUM installations
+
+If you installed OpenSearch from an RPM distribution, you can start and stop Performance Analyzer with `systemctl`:
+```bash
+# Start OpenSearch Performance Analyzer
+sudo systemctl start opensearch-performance-analyzer.service
+# Stop OpenSearch Performance Analyzer
+sudo systemctl stop opensearch-performance-analyzer.service
+```
+
+## Configure Performance Analyzer for tarball installations
 
 In a tarball installation, Performance Analyzer collects data when it is enabled. But in order to read that data using the REST API on port 9600, you must first manually launch the associated reader agent process:
 


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
As we did with the tarball installation, I am removing instructions specific to the Performance Analyzer plugin to the correct page. This PR is required so I can proceed with the install guide for RPM/YUM.

### Issues Resolved
Fixes #1133

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
