### PR TITLE
Rename cluster.initial_master_nodes environment setting in sample docker compose file

### DIFF
--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -104,7 +104,7 @@ services:
       - cluster.name=opensearch-cluster
       - node.name=opensearch-node1
       - discovery.seed_hosts=opensearch-node1,opensearch-node2
-      - cluster.initial_master_nodes=opensearch-node1,opensearch-node2
+      - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true # along with the memlock settings below, disables swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # minimum and maximum Java heap size, recommend setting both to 50% of system RAM
     ulimits:


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Issue #450 replaced "master" nomenclature with more inclusive language. The sample docker compose file on the [Docker image](https://opensearch.org/docs/latest/opensearch/install/docker/) page, however, still contains an environment setting with the old nomenclature. 

### Issues Resolved
Replaced the `cluster.initial_master_nodes` setting name with `cluster.initial_cluster_manager_nodes` in the sample docker compose file on the [Docker image](https://opensearch.org/docs/latest/opensearch/install/docker/) page.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
