### PR TITLE
Fixes Data Prepper example pipelines

### DIFF
--- a/_clients/data-prepper/pipelines.md
+++ b/_clients/data-prepper/pipelines.md
@@ -85,6 +85,7 @@ entry-pipeline:
   source:
     otel_trace_source:
       ssl: false
+      record_type: event
   sink:
     - pipeline:
         name: "raw-pipeline"
@@ -194,7 +195,7 @@ To set up a metrics pipeline:
 ```yml
 metrics-pipeline:
   source:
-    otel_trace_source:
+    otel_metrics_source:
   processor:
     - otel_metrics_raw_processor:
   sink:


### PR DESCRIPTION
### Description

Two fixes:

* The `otel_trace_source` pipeline needs to configure `record_type: event`
* The `metrics-pipeline` needs to use `otel_metrics_source` instead of `otel_trace_source`.

### Issues Resolved

This resolves an issue raised in Data Prepper: https://github.com/opensearch-project/data-prepper/issues/1735


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
