### PR TITLE
Fixes the metrics-pipeline to use otel_metrics_source

### DIFF
--- a/_clients/data-prepper/pipelines.md
+++ b/_clients/data-prepper/pipelines.md
@@ -194,7 +194,7 @@ To set up a metrics pipeline:
 ```yml
 metrics-pipeline:
   source:
-    otel_trace_source:
+    otel_metrics_source:
   processor:
     - otel_metrics_raw_processor:
   sink:


### PR DESCRIPTION
### Description

The `metrics-pipeline` needs to use the `otel_metrics_source` source plugin. This fixes that error.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
