### PR TITLE
Add the two clear cache APIs

### DIFF
--- a/_opensearch/rest-api/index-apis/clear-index-cache.md
+++ b/_opensearch/rest-api/index-apis/clear-index-cache.md
@@ -1,0 +1,110 @@
+---
+layout: default
+title: Clear Index or Data Stream Cache
+parent: Index APIs
+grand_parent: REST API reference
+nav_order: 320
+---
+
+## Clear index or data stream cache
+
+Clears the caches of one or more indexes. For data streams, the API clears the caches of the stream’s backing indexes.
+
+If you use the security plugin, you must have the `manage index` privileges.
+{: .note}
+
+### Path parameters
+
+| Parameter | Data Type | Description | 
+:--- | :--- | :---
+| target | String | Comma-delimited list of data streams, indexes, and index aliases to apply cache clearing. Wildcard expressions (`*`) are supported. To target all data streams and indexes in a cluster, omit this parameter or use `_all` or `*`. Optional. |
+
+### Query parameters
+
+All query parameters are optional.
+
+| Parameter | Data Type | Description | 
+:--- | :--- | :---
+| allow_no_indices | Boolean | Whether to ignore wildcards, index aliases, or `_all` target (`target` path parameter) values that don’t match any indexes. If `false`, the request returns an error if any wildcard expression, index alias, or `_all` target values don't match any indexes. This behavior also applies if the request targets include other open indexes. For example, a request where the target is `fig*,app*` returns an error if an index starts with `fig` but no index starts with `app`. Defaults to `true`. |
+| expand_wildcards | String | Determines the index types that wildcard expressions can expand to. Accepts multiple values separated by a comma, such as  `open,hidden`. Valid values are: <br /><br /> `all` - Expand to open, closed, and hidden indexes.<br /><br />`open` - Expand only to open indexes.<br /><br />`closed` - Expand only to close indexes<br /><br />`hidden` - Expand to include hidden indexes. Must be combined with `open`, `closed`, or `both`.<br /><br />`none` - Expansions are not accepted.<br /><br /> Defaults to `open`. |
+| fielddata | Boolean | If `true`, clears the fields cache. Use the `fields` parameter to clear specific fields' caches.  Defaults to `true`. |
+| fields | String | Used in conjunction with the `fielddata` parameter. Comma-delimited list of field names to clear cache. Does not support objects or field aliases. Defaults to all fields. |
+| index | String | Comma-delimited list of index names to clear cache. |
+| ignore_unavailable | Boolean | If `true`, OpenSearch ignores missing or closed indexes. Defaults to `false`. |
+| query | Boolean | If `true`, clears the query cache. Defaults to `true`. |
+| request | Boolean | If `true`, clears the request cache. Defaults to `true`. |
+
+#### Sample requests
+
+##### Clear a specific cache
+
+The following request clears the fields cache only:
+
+````json
+POST /my-index/_cache/clear?fielddata=true
+````
+
+<hr />
+
+The following request clears the query cache only:
+
+````json
+POST /my-index/_cache/clear?query=true
+````
+
+<hr />
+
+The following request clears the request cache only:
+
+````json
+POST /my-index/_cache/clear?request=true
+````
+
+##### Clear the cache for specific fields
+
+The following request clears the fields caches of `fielda` and `fieldb`:
+
+````json
+POST /my-index/_cache/clear?fields=fielda,fieldb
+````
+
+##### Clear caches for specific data streams and indexes
+
+The following request clears the cache for two specific indexes:
+
+````json
+POST /my-index,my-index2/_cache/clear
+````
+
+##### Clear caches for all data streams and indexes
+
+The following request clears the cache for all data streams and indexes:
+
+````json
+POST /_cache/clear
+````
+
+#### Sample response
+
+The `POST /books,hockey/_cache/clear` request returns the following fields:
+
+````json
+{
+  "_shards" : {
+    "total" : 4,
+    "successful" : 2,
+    "failed" : 0
+  }
+}
+````
+
+### Response fields
+
+The `POST /books,hockey/_cache/clear` request returns the following response fields:
+
+| Field | Data Type | Description | 
+:--- | :--- | :---
+| _shards | Object | Shard information. |
+| total | Integer | Total number of shards. |
+| successful | Integer | Number of index shards with caches successfully cleared. |
+| failed | Integer | Number of index shards with caches that failed to clear. |


### PR DESCRIPTION
Signed-off-by: alicejw <alicejw@amazon.com>

### Description
Added the POST /<target>/_cache/clear and POST /_cache/clear APIs. Both are in one file.
**Note:** This PR replaces the original content from [PR 1093.](https://github.com/opensearch-project/documentation-website/pull/1093) We had an issue getting it checked in.
Also note - Alice's review changes are incorporated here, but technically we need 2 more doc reviewers.

### Issues Resolved
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
