### PR TITLE
Remove _mappings from create mapping url

### DIFF
--- a/_opensearch/supported-field-types/join.md
+++ b/_opensearch/supported-field-types/join.md
@@ -16,7 +16,7 @@ A join field type establishes a parent/child relationship between documents in t
 Create a mapping to establish a parent-child relationship between products and their brands:
 
 ```json
-PUT testindex1/_mappings
+PUT testindex1
 {
   "mappings": {
     "properties": {


### PR DESCRIPTION
### Description
_mappings and mappings should not be specified at the same time when sending out create mapping request If index doesn't exist, the url should not include _mappings as part of it's path, otherwise it will throw index not exist error If index already exists, the mappings object should not be included in the body, other wise it will throw mapping parse error exception

Signed-off-by: xluo-aws <lxuesong@amazon.com>

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/1174

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
