### PR TITLE
Change remote store documentation to reflect all the config options

### DIFF
--- a/_opensearch/remote.md
+++ b/_opensearch/remote.md
@@ -63,7 +63,7 @@ If you're running Docker, add the following line to docker-compose.yml underneat
 OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
 ````
 
-### For developers using Gradle, enable feature flag by updating run.gradle
+### Enable for OpenSearch development
 
 To create new indexes with remote-backed storage enabled, you must first enable these features by adding the correct properties to `run.gradle` before building OpenSearch. See the [developer guide](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md) for information about to use how Gradle to build OpenSearch.
 

--- a/_opensearch/remote.md
+++ b/_opensearch/remote.md
@@ -12,7 +12,50 @@ Remote-backed storage is an experimental feature. Therefore, we do not recommend
 Remote-backed storage offers OpenSearch users a new way to protect against data loss by automatically creating backups of all index transactions and sending them to remote storage. In order to expose this feature, segment replication must also be enabled. See [Segment replication]({{site.url}}{{site.baseurl}}/opensearch/segment-replication/) for additional information.
 
 
-## Enable the feature
+## Enabling the feature flag
+
+There are several methods for enabling remote store feature, depending on the install type. You will also need to enable `remote_store` property when creating the index.
+
+Segment replication must also be enabled to use remote-backed storage.
+{: .note}
+
+### Enable on a node using a tarball install
+
+The flag is toggled using a new jvm parameter that is set either in `OPENSEARCH_JAVA_OPTS` or in config/jvm.options.
+
+1. Option 1: Modify jvm.options
+
+Add the following lines to `config/jvm.options` before starting the OpenSearch process to enable the feature and its dependency:
+
+```
+-Dopensearch.experimental.feature.replication_type.enabled=true
+-Dopensearch.experimental.feature.remote_store.enabled=true
+```
+
+Run OpenSearch
+
+```bash
+./bin/opensearch
+```
+
+1. Option 2: Enable from an environment variable
+
+As an alternative to directly modifying `config/jvm.options`, you can define the properties by using an environment variable. This can be done in a single command when you start OpenSearch or by defining the variable with `export`.
+
+To add these flags in-line when starting OpenSearch:
+
+```bash
+OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true" ./opensearch-{{site.opensearch_version}}/bin/opensearch
+```
+
+If you want to define the environment variable separately, prior to running OpenSearch:
+
+```bash
+export OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
+./bin/opensearch
+```
+
+### For developers using Gradle, enable feature flag by updating run.gradle
 
 To create new indexes with remote-backed storage enabled, you must first enable these features by adding the correct properties to `run.gradle` before building OpenSearch. See the [developer guide](https://github.com/opensearch-project/OpenSearch/blob/main/DEVELOPER_GUIDE.md) for information about to use how Gradle to build OpenSearch.
 
@@ -30,42 +73,13 @@ testClusters {
 }
 ```
 
-Segment replication must also be enabled to use remote-backed storage.
-{: .note}
+### Enable with Docker containers
 
-After building OpenSearch with these properties, you must enable the feature for all nodes in your cluster. This can be done by modifying a `config/jvm.options`, or by defining `OPENSEARCH_JAVA_OPS` from the command line.
+If you're running Docker, add the following line to docker-compose.yml underneath the `opensearch-node` and `environment` section:
 
-### Option 1: Modify jvm.options
-
-Add the following lines to `config/jvm.options` before starting the OpenSearch process to enable the feature and its dependency:
-
-```
--Dopensearch.experimental.feature.replication_type.enabled=true
--Dopensearch.experimental.feature.remote_store.enabled=true
-```
-
-Run OpenSearch
-
-```bash
-./bin/opensearch
-```
-
-### Option 2: Enable from an environment variable
-
-As an alternative to directly modifying `config/jvm.options`, you can define the properties by using an environment variable. This can be done in a single command when you start OpenSearch or by defining the variable with `export`.
-
-To add these flags in-line when starting OpenSearch:
-
-```bash
-OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true" ./opensearch-{{site.opensearch_version}}/bin/opensearch
-```
-
-If you want to define the environment variable separately, prior to running OpenSearch:
-
-```bash
-export OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
-./bin/opensearch
-```
+````json
+OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
+````
 
 ## Register a remote repository
 

--- a/_opensearch/remote.md
+++ b/_opensearch/remote.md
@@ -12,7 +12,7 @@ Remote-backed storage is an experimental feature. Therefore, we do not recommend
 Remote-backed storage offers OpenSearch users a new way to protect against data loss by automatically creating backups of all index transactions and sending them to remote storage. In order to expose this feature, segment replication must also be enabled. See [Segment replication]({{site.url}}{{site.baseurl}}/opensearch/segment-replication/) for additional information.
 
 
-## Enabling the feature flag
+## Enable the feature flag
 
 There are several methods for enabling remote store feature, depending on the install type. You will also need to enable `remote_store` property when creating the index.
 
@@ -23,7 +23,7 @@ Segment replication must also be enabled to use remote-backed storage.
 
 The flag is toggled using a new jvm parameter that is set either in `OPENSEARCH_JAVA_OPTS` or in config/jvm.options.
 
-1. Option 1: Modify jvm.options
+#### Option 1: Modify jvm.options
 
 Add the following lines to `config/jvm.options` before starting the OpenSearch process to enable the feature and its dependency:
 
@@ -38,7 +38,7 @@ Run OpenSearch
 ./bin/opensearch
 ```
 
-1. Option 2: Enable from an environment variable
+#### Option 2: Enable from an environment variable
 
 As an alternative to directly modifying `config/jvm.options`, you can define the properties by using an environment variable. This can be done in a single command when you start OpenSearch or by defining the variable with `export`.
 
@@ -54,6 +54,14 @@ If you want to define the environment variable separately, prior to running Open
 export OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
 ./bin/opensearch
 ```
+
+### Enable with Docker containers
+
+If you're running Docker, add the following line to docker-compose.yml underneath the `opensearch-node` and `environment` section:
+
+````json
+OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
+````
 
 ### For developers using Gradle, enable feature flag by updating run.gradle
 
@@ -72,14 +80,6 @@ testClusters {
   }
 }
 ```
-
-### Enable with Docker containers
-
-If you're running Docker, add the following line to docker-compose.yml underneath the `opensearch-node` and `environment` section:
-
-````json
-OPENSEARCH_JAVA_OPTS="-Dopensearch.experimental.feature.replication_type.enabled=true -Dopensearch.experimental.feature.remote_store.enabled=true"
-````
 
 ## Register a remote repository
 


### PR DESCRIPTION
Signed-off-by: Sachin Kale <kalsac@amazon.com>

### Description
 - In 2.3.0 release of OpenSearch, remote store is experimental feature and can be enabled by using 1 of the 3 options:
   - By updating jvm.options file
   - By using OPENSEARCH_JAVA_OPTS environment variable
   - By changing run.gradle
 - In the current documentation for [remote store](https://opensearch.org/docs/latest/opensearch/remote), only first 2 options are mentioned and run.gradle option is documented as a pre-requisite.
 - Please refer Segment Replication [configuration doc](https://opensearch.org/docs/latest/opensearch/segment-replication/configuration/) for these changes 


### Issues Resolved
- https://github.com/opensearch-project/documentation-website/issues/1236

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
