### PR TITLE
Provide users with warning about special characters in query DSL and API query fields

### DIFF
--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -121,9 +121,9 @@ With query DSL, however, you can include an HTTP request body to look for result
 ```
 The OpenSearch query DSL comes in three varieties: term-level queries, full-text queries, and boolean queries. You can even perform more complicated searches by using different elements from each variety to find whatever data you need.
 
-## A note on special characters in field values 
+## A note on Unicode special characters in text fields
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access. 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index a [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) value as a whole value when it includes one of these special characters. As a result, a text field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements on either side of it. This can lead to unintentional filtering of documents and potentially compromise control over their access. 
 
 The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 

--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -123,7 +123,7 @@ The OpenSearch query DSL comes in three varieties: term-level queries, full-text
 
 ## A note on special characters in field values 
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access. 
 
 The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 

--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -120,3 +120,34 @@ With query DSL, however, you can include an HTTP request body to look for result
 }
 ```
 The OpenSearch query DSL comes in three varieties: term-level queries, full-text queries, and boolean queries. You can even perform more complicated searches by using different elements from each variety to find whatever data you need.
+
+## A note on field values and special characters
+
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in query DSL fields unless a custom analyzer is used. The examples below illustrate values that will be misinterpreted as the same when a special character – such as the hyphen/minus sign – exists in the value:
+
+```json
+{
+  "bool": {
+    "must": {
+      "match": {
+        "user.id": "User-1"
+      }
+    }
+  }
+}
+```
+
+```json
+{
+  "bool": {
+    "must": {
+      "match": {
+        "user.id": "User-2"
+      }
+    }
+  }
+}
+```
+
+For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+

--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -151,7 +151,7 @@ The examples below illustrate values containing special characters that will be 
 }
 ```
 
-To avoid this circumstance when using either query DSL or the REST API, you can use a custom analyzer or map the field type as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
+To avoid this circumstance when using either query DSL or the REST API, you can use a custom analyzer or map the field as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
 
 For a list of characters that should be avoided when field type is `text`, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 

--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -123,7 +123,7 @@ The OpenSearch query DSL comes in three varieties: term-level queries, full-text
 
 ## A note on special characters in field values 
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index field values as whole values when they contain these special characters. As a result, a field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. Therefore, special characters should be avoided in field values handled by query DSL unless a custom analyzer is used. 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. 
 
 The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 
@@ -151,5 +151,7 @@ The examples below illustrate values containing special characters that will be 
 }
 ```
 
-For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+To avoid this circumstance when using either query DSL or the REST API, you can use a custom analyzer or map the field type as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
+
+For a list of characters that should be avoided when field type is `text`, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 

--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -121,9 +121,11 @@ With query DSL, however, you can include an HTTP request body to look for result
 ```
 The OpenSearch query DSL comes in three varieties: term-level queries, full-text queries, and boolean queries. You can even perform more complicated searches by using different elements from each variety to find whatever data you need.
 
-## A note on field values and special characters
+## A note on special characters in field values 
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in query DSL fields unless a custom analyzer is used. The examples below illustrate values that will be misinterpreted as the same when a special character – such as the hyphen/minus sign – exists in the value:
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index field values as whole values when they contain these special characters. As a result, a field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. Therefore, special characters should be avoided in field values handled by query DSL unless a custom analyzer is used. 
+
+The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 
 ```json
 {

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -682,7 +682,7 @@ PUT _plugins/_security/api/roles/<role>
 >
 >For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access.
 >
->To avoid this circumstance, you can use a custom analyzer or map the field type as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
+>To avoid this circumstance, you can use a custom analyzer or map the field as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
 >
 >For a list of characters that should be avoided when field type is `text`, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 {: .warning}

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -678,9 +678,9 @@ PUT _plugins/_security/api/roles/<role>
 }
 ```
 
->Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it.
+>Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index a [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) value as a whole value when it includes one of these special characters. As a result, a text field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements on either side of it.
 >
->For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access.
+>For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional filtering of documents and potentially compromise control over their access.
 >
 >To avoid this circumstance, you can use a custom analyzer or map the field as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
 >

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -678,7 +678,9 @@ PUT _plugins/_security/api/roles/<role>
 }
 ```
 
->Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. For example, the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` can be misinterpreted as the same when the hyphen/minus sign is included in the value.
+>Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index field values as whole values when they contain these special characters. As a result, a field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it.
+
+>For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security.
 >
 >Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.
 >

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -677,9 +677,13 @@ PUT _plugins/_security/api/roles/<role>
   "message": "'test-role' updated."
 }
 ```
+#### A note on field values and special characters
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer does not interpret the portion of an index field value that follows a special character. For example, the following fields can be misinterpreted as the same with the hyphen/minus sign included in the value.<br>* ```"user.id": "User-1"*```<br>* ```"user.id": "User-2"```*<br>Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is being used.<br>For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
-{: .warning }
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. For example, the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` can be misinterpreted as the same when the hyphen/minus sign is included in the value.
+
+Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.
+
+For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 
 
 ### Patch role

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -678,6 +678,9 @@ PUT _plugins/_security/api/roles/<role>
 }
 ```
 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer does not interpret the portion of an index field value that follows a special character. For example, the following fields can be misinterpreted as the same with the hyphen/minus sign included in the value.<br>* ```"user.id": "User-1"*```<br>* ```"user.id": "User-2"```*<br>Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is being used.<br>For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+{: .warning }
+
 
 ### Patch role
 Introduced 1.0

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -679,7 +679,7 @@ PUT _plugins/_security/api/roles/<role>
 ```
 
 >Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index field values as whole values when they contain these special characters. As a result, a field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it.
-
+>
 >For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security.
 >
 >Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -678,13 +678,13 @@ PUT _plugins/_security/api/roles/<role>
 }
 ```
 
->Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index field values as whole values when they contain these special characters. As a result, a field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it.
+>Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it.
 >
 >For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security.
 >
->Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.
+>To avoid this circumstance, you can use a custom analyzer or map the field type as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
 >
->For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+>For a list of characters that should be avoided when field type is `text`, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 {: .warning}
 
 

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -680,7 +680,7 @@ PUT _plugins/_security/api/roles/<role>
 
 >Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it.
 >
->For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security.
+>For example, since the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` contain the hyphen/minus sign, this special character will prevent the analyzer from distinguishing between the two different users for `user.id` and interpret them as one and the same. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access.
 >
 >To avoid this circumstance, you can use a custom analyzer or map the field type as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
 >

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -677,13 +677,13 @@ PUT _plugins/_security/api/roles/<role>
   "message": "'test-role' updated."
 }
 ```
-#### A note on field values and special characters
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. For example, the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` can be misinterpreted as the same when the hyphen/minus sign is included in the value.
-
-Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.
-
-For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+>Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. For example, the values in the fields ```"user.id": "User-1"``` and ```"user.id": "User-2"``` can be misinterpreted as the same when the hyphen/minus sign is included in the value.
+>
+>Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.
+>
+>For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+{: .warning}
 
 
 ### Patch role

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -55,6 +55,35 @@ PUT _plugins/_security/api/roles/public_data
 These queries can be as complex as you want, but we recommend keeping them simple to minimize the performance impact that the document-level security feature has on the cluster.
 {: .warning }
 
+### A note on field values and special characters
+
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer does not interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is being used. The examples below illustrate values that will be misinterpreted as the same when a special character – such as the hyphen/minus sign – exists in the value:
+
+````json
+{
+  "bool": {
+    "must": {
+      "match": {
+        "user.id": "User-1"
+      }
+    }
+  }
+}
+````
+
+````json
+{
+  "bool": {
+    "must": {
+      "match": {
+        "user.id": "User-2"
+      }
+    }
+  }
+}
+
+For a list of these characters, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+
 
 ## Parameter substitution
 

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -57,7 +57,7 @@ These queries can be as complex as you want, but we recommend keeping them simpl
 
 ### A note on special characters in field values
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index field values as whole values when they contain these special characters. As a result, a field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. Therefore, special characters should be avoided in field values handled by query DSL and the REST API unless a custom analyzer is used. 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. 
 
 The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 
@@ -85,7 +85,9 @@ The examples below illustrate values containing special characters that will be 
 }
 ```
 
-For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+To avoid this circumstance when using either query DSL or the REST API, you can use a custom analyzer or map the field type as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
+
+For a list of characters that should be avoided when field type is `text`, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 
 
 ## Parameter substitution

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -55,9 +55,11 @@ PUT _plugins/_security/api/roles/public_data
 These queries can be as complex as you want, but we recommend keeping them simple to minimize the performance impact that the document-level security feature has on the cluster.
 {: .warning }
 
-### A note on field values and special characters
+### A note on special characters in field values
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used. The examples below illustrate values that will be misinterpreted as the same when a special character – such as the hyphen/minus sign – exists in the value:
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index field values as whole values when they contain these special characters. As a result, a field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. Therefore, special characters should be avoided in field values handled by query DSL and the REST API unless a custom analyzer is used. 
+
+The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 
 ```json
 {

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -57,9 +57,9 @@ These queries can be as complex as you want, but we recommend keeping them simpl
 
 ### A note on field values and special characters
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer does not interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is being used. The examples below illustrate values that will be misinterpreted as the same when a special character – such as the hyphen/minus sign – exists in the value:
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used. The examples below illustrate values that will be misinterpreted as the same when a special character – such as the hyphen/minus sign – exists in the value:
 
-````json
+```json
 {
   "bool": {
     "must": {
@@ -69,9 +69,9 @@ Due to word boundaries associated with Unicode special characters, the Unicode s
     }
   }
 }
-````
+```
 
-````json
+```json
 {
   "bool": {
     "must": {
@@ -81,8 +81,9 @@ Due to word boundaries associated with Unicode special characters, the Unicode s
     }
   }
 }
+```
 
-For a list of these characters, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 
 
 ## Parameter substitution

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -55,9 +55,9 @@ PUT _plugins/_security/api/roles/public_data
 These queries can be as complex as you want, but we recommend keeping them simple to minimize the performance impact that the document-level security feature has on the cluster.
 {: .warning }
 
-### A note on special characters in field values
+### A note on Unicode special characters in text fields
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements on either side of it. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access. 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index a [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) value as a whole value when it includes one of these special characters. As a result, a text field value that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements on either side of it. This can lead to unintentional filtering of documents and potentially compromise control over their access.
 
 The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 
@@ -85,7 +85,7 @@ The examples below illustrate values containing special characters that will be 
 }
 ```
 
-To avoid this circumstance when using either query DSL or the REST API, you can use a custom analyzer or map the field as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
+To avoid this circumstance when using either Query DSL or the REST API, you can use a custom analyzer or map the field as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
 
 For a list of characters that should be avoided when field type is `text`, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -57,7 +57,7 @@ These queries can be as complex as you want, but we recommend keeping them simpl
 
 ### A note on special characters in field values
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access. 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements on either side of it. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access. 
 
 The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 
@@ -85,7 +85,7 @@ The examples below illustrate values containing special characters that will be 
 }
 ```
 
-To avoid this circumstance when using either query DSL or the REST API, you can use a custom analyzer or map the field type as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
+To avoid this circumstance when using either query DSL or the REST API, you can use a custom analyzer or map the field as `keyword`, which performs an exact-match search. See [Keyword field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/keyword/) for the latter option.
 
 For a list of characters that should be avoided when field type is `text`, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -57,7 +57,7 @@ These queries can be as complex as you want, but we recommend keeping them simpl
 
 ### A note on special characters in field values
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional requests and search query outcomes, including those that can have an impact on security. 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot index [text field type](https://opensearch.org/docs/2.2/opensearch/supported-field-types/text/) values as whole values when they contain these special characters. As a result, a field value of this type that includes a special character is parsed by the standard analyzer as multiple values separated by the special character, effectively tokenizing the different elements either side of it. This can lead to unintentional filtering of documents and potentially compromise the safeguards that control access. 
 
 The examples below illustrate values containing special characters that will be parsed improperly by the standard analyzer. In this example, the existence of the hyphen/minus sign in the value prevents the analyzer from distinguishing between the two different users for `user.id` and interprets them as one and the same:
 

--- a/_security-plugin/access-control/field-level-security.md
+++ b/_security-plugin/access-control/field-level-security.md
@@ -95,8 +95,6 @@ someonerole:
 
 See [Create role]({{site.url}}{{site.baseurl}}/security-plugin/access-control/api#create-role).
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.<br>For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
-{: .warning }
 
 ## Interaction with multiple roles
 

--- a/_security-plugin/access-control/field-level-security.md
+++ b/_security-plugin/access-control/field-level-security.md
@@ -95,6 +95,8 @@ someonerole:
 
 See [Create role]({{site.url}}{{site.baseurl}}/security-plugin/access-control/api#create-role).
 
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer does not interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is being used.<br>For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+{: .warning }
 
 ## Interaction with multiple roles
 

--- a/_security-plugin/access-control/field-level-security.md
+++ b/_security-plugin/access-control/field-level-security.md
@@ -95,7 +95,7 @@ someonerole:
 
 See [Create role]({{site.url}}{{site.baseurl}}/security-plugin/access-control/api#create-role).
 
-Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer does not interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is being used.<br>For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
+Due to word boundaries associated with Unicode special characters, the Unicode standard analyzer cannot interpret the portion of an index field value that follows a special character. Therefore, special characters should not be used for values in either query DSL fields or REST API query fields unless a custom analyzer is used.<br>For a list of characters that should be avoided, see [Word Boundaries](https://unicode.org/reports/tr29/#Word_Boundaries).
 {: .warning }
 
 ## Interaction with multiple roles


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Added warnings about the use of special characters in query DSL and REST API query fields values when configuring roles for document-level security and field level security.

CHANGE: looks like this doesn't impact field-level security. Also added the note/warning to the query-dsl/index.md file since this is a characteristic in core OpenSearch.

### Issues Resolved
Fixes issue #1196 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
