### PR TITLE
[Data Prepper 2.0]MAINT: documentation change regarding record type

### DIFF
--- a/_clients/data-prepper/data-prepper-reference.md
+++ b/_clients/data-prepper/data-prepper-reference.md
@@ -176,7 +176,14 @@ Prior to Data Prepper 1.3, Processors were named Preppers. Starting in Data Prep
 ### otel_trace_raw
 
 This processor is a Data Prepper event record type replacement of `otel_trace_raw_prepper` (no longer supported since Data Prepper 2.0). 
-The processor fills in trace group related fields into all incoming Data Prepper span records by statefully caching the root span info per traceId. 
+The processor fills in trace group related fields including 
+
+* `traceGroup`: root span name
+* `endTime`: end time of the entire trace in ISO 8601
+* `durationInNanos`: duration of the entire trace in nanoseconds
+* `statusCode`: status code for the entire trace in nanoseconds
+
+in all incoming Data Prepper span records by state caching the root span info per traceId. 
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---

--- a/_clients/data-prepper/data-prepper-reference.md
+++ b/_clients/data-prepper/data-prepper-reference.md
@@ -53,9 +53,6 @@ useAcmCertForSSL | No | Boolean | Whether to enable TLS/SSL using certificate an
 acmCertificateArn | Conditionally | String | Represents the ACM certificate ARN. ACM certificate take preference over S3 or local file system certificate. Required if `useAcmCertForSSL` is set to `true`.
 awsRegion | Conditionally | String | Represents the AWS region to use ACM or S3. Required if `useAcmCertForSSL` is set to `true` or `sslKeyCertChainFile` and `sslKeyFile` are AWS S3 paths.
 authentication | No | Object | An authentication configuration. By default, an unauthenticated server is created for the pipeline. This parameter uses pluggable authentication for HTTPS. To use basic authentication, define the `http_basic` plugin with a `username` and `password`. To provide customer authentication, use or create a plugin that implements [GrpcAuthenticationProvider](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-plugins/armeria-common/src/main/java/com/amazon/dataprepper/armeria/authentication/GrpcAuthenticationProvider.java).
-record_type | No | String | A string represents the supported record data type that is written into the buffer plugin. Value options are `otlp` or `event`. Default is `otlp`.
-`otlp` | No | String | Otel-trace-source writes each incoming `ExportTraceServiceRequest` request as record data type into the buffer.
-`event` | No | String | Otel-trace-source decodes each incoming `ExportTraceServiceRequest` request into a collection of Data Prepper internal spans serving as buffer items. To achieve better performance in this mode, we recommend setting buffer capacity proportional to the estimated number of spans in the incoming request payload.
 
 ### http_source
 
@@ -176,17 +173,10 @@ Prior to Data Prepper 1.3, Processors were named Preppers. Starting in Data Prep
 {: .note }
 
 
-### otel_trace_raw_prepper
-
-Converts OpenTelemetry data to OpenSearch-compatible JSON documents and fills in trace group related fields in those JSON documents. It requires `record_type` to be set as `otlp` in `otel_trace_source`.
-
-Option | Required | Type | Description
-:--- | :--- | :--- | :---
-trace_flush_interval | No | Integer | Represents the time interval in seconds to flush all the descendant spans without any root span. Default is 180.
-
 ### otel_trace_raw
 
-This processor is a Data Prepper event record type compatible version of `otel_trace_raw_prepper` that fills in trace group related fields into all incoming Data Prepper span records. It requires `record_type` to be set as `event` in `otel_trace_source`.
+This processor is a Data Prepper event record type replacement of `otel_trace_raw_prepper` (no longer supported since Data Prepper 2.0). 
+The processor fills in trace group related fields into all incoming Data Prepper span records by statefully caching the root span info per traceId. 
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---

--- a/_clients/data-prepper/pipelines.md
+++ b/_clients/data-prepper/pipelines.md
@@ -75,53 +75,8 @@ This example uses weak security. We strongly recommend securing all plugins whic
 
 The following example demonstrates how to build a pipeline that supports the [Trace Analytics OpenSearch Dashboards plugin]({{site.url}}{{site.baseurl}}/observability-plugin/trace/ta-dashboards/). This pipeline takes data from the OpenTelemetry Collector and uses two other pipelines as sinks. These two separate pipelines index trace and the service map documents for the dashboard plugin.
 
-#### Classic
-
-This pipeline definition will be deprecated in 2.0. Users are recommended to use [Event record type](#event-record-type) pipeline definition.
-
-```yml
-entry-pipeline:
-  delay: "100"
-  source:
-    otel_trace_source:
-      ssl: false
-  sink:
-    - pipeline:
-        name: "raw-pipeline"
-    - pipeline:
-        name: "service-map-pipeline"
-raw-pipeline:
-  source:
-    pipeline:
-      name: "entry-pipeline"
-  processor:
-    - otel_trace_raw_prepper:
-  sink:
-    - opensearch:
-        hosts: ["https://localhost:9200"]
-        insecure: true
-        username: admin
-        password: admin
-        index_type: trace-analytics-raw
-service-map-pipeline:
-  delay: "100"
-  source:
-    pipeline:
-      name: "entry-pipeline"
-  processor:
-    - service_map_stateful:
-  sink:
-    - opensearch:
-        hosts: ["https://localhost:9200"]
-        insecure: true
-        username: admin
-        password: admin
-        index_type: trace-analytics-service-map
-```
-
-#### Event record type
-
-Starting from Data Prepper 1.4, Data Prepper supports event record type in trace analytics pipeline source, buffer, and processors.
+Starting from Data Prepper 2.0, Data Prepper no longer supports `otel_trace_raw_prepper` processor due to the Data Prepper internal data model evolution. 
+Instead, users should use `otel_trace_raw`.
 
 ```yml
 entry-pipeline:
@@ -129,7 +84,6 @@ entry-pipeline:
   source:
     otel_trace_source:
       ssl: false
-      record_type: event
   buffer:
     bounded_blocking:
       buffer_size: 10240


### PR DESCRIPTION
Signed-off-by: Chen <qchea@amazon.com>

### Description
Changes wrt record_type in otel_trace_source as well as processors that will no longer be supported in Data Prepper 2.0.

### Issues Resolved
Closes https://github.com/opensearch-project/data-prepper/issues/1272

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
