### PR TITLE
Fix cat/templates doc

### DIFF
--- a/_opensearch/rest-api/cat/cat-templates.md
+++ b/_opensearch/rest-api/cat/cat-templates.md
@@ -19,7 +19,7 @@ The cat templates operation lists the names, patterns, order numbers, and versio
 GET _cat/templates?v
 ```
 
-If you want to get information for specific template or pattern:
+If you want to get information for a specific template or pattern:
 
 ```
 GET _cat/templates/{name}

--- a/_opensearch/rest-api/cat/cat-templates.md
+++ b/_opensearch/rest-api/cat/cat-templates.md
@@ -19,11 +19,10 @@ The cat templates operation lists the names, patterns, order numbers, and versio
 GET _cat/templates?v
 ```
 
-If you want to get information for more than one template, separate the template names with commas:
+If you want to get information for specific template or pattern:
 
 ```
-GET _cat/shards/template_name_1,template_name_2,template_name_3
-```
+GET _cat/templates/nameOrpattern```
 
 ## Path and HTTP methods
 

--- a/_opensearch/rest-api/cat/cat-templates.md
+++ b/_opensearch/rest-api/cat/cat-templates.md
@@ -22,7 +22,8 @@ GET _cat/templates?v
 If you want to get information for specific template or pattern:
 
 ```
-GET _cat/templates/nameOrpattern```
+GET _cat/templates/{name}
+```
 
 ## Path and HTTP methods
 


### PR DESCRIPTION
### Description
_cat/templates api don't support fetch more templates with comma separated values_

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
