### PR TITLE
Fixed liquid syntax for RPM install which fixes the yum repo command paths

### DIFF
--- a/_opensearch/install/rpm.md
+++ b/_opensearch/install/rpm.md
@@ -9,6 +9,7 @@ nav_order: 51
 The following liquid syntax declares a variable, major_version_mask, which is transformed into "N.x" where "N" is the major version number. This is required for proper versioning references to the Yum repo.
 {% endcomment %}
 {% assign version_parts = site.opensearch_major_minor_version | split: "." %}
+{% assign major_version_mask = version_parts[0] | append: ".x" %}
 
 # RPM
 


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
Fixed the liquid syntax so commands for local yum repo show up correctly in the code samples.

### Issues Resolved
Fixes #1412 


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
