### PR TITLE
Making open sans the default font once again.

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -42,7 +42,7 @@ $table-border-color: $grey-lt-300;
 $toc-width: 232px !default;
 
 body {
-  @include serif;
+  @include sans-serif;
 }
 
 code {
@@ -388,7 +388,7 @@ html {
 }
 
 body {
-  @include serif;
+  @include sans-serif;
   @include font-size(16);
   background: $background-lightest;
   color: $text;


### PR DESCRIPTION

### Description

Changes default font from Noto to Open Sans. 



### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
