### PR TITLE
Addressing the loss of Open Sans on the documentation website.

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -42,7 +42,7 @@ $table-border-color: $grey-lt-300;
 $toc-width: 232px !default;
 
 body {
-  @include serif;
+  @include sans-serif;
 }
 
 code {
@@ -388,7 +388,7 @@ html {
 }
 
 body {
-  @include serif;
+  @include sans-serif;
   @include font-size(16);
   background: $background-lightest;
   color: $text;


### PR DESCRIPTION
Signed-off-by: Nathan Boot <nateboot@amazon.com>

### Description

The `scss` file has a serif include in the `body` element, which changed the default font to Noto Serif. I've replaced it with sans-serif which uses Open Sans. 


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
