### PR TITLE
Omitting the named anchor from header Download link.

### DIFF
--- a/_data/top_nav.yml
+++ b/_data/top_nav.yml
@@ -4,7 +4,7 @@ items:
     fragments:
       - downloads
       - versions
-    url: /downloads.html#opensearch
+    url: /downloads.html
   -
     label: About
     fragments:


### PR DESCRIPTION
Signed-off-by: Nathan Boot <nateboot@amazon.com>

### Description

The download link in the navbar is suffixed by a html named anchor, which causes the resulting page to not start at the top, but to start at the content that matches the named anchor.

### Issues Resolved

#1514 


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

🤘 