### PR TITLE
Configuring Dashboards multi-authentication sign-in window

### DIFF
--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -106,7 +106,7 @@ opensearch_security.multitenancy.enabled: true
 opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
 opensearch_security.readonly_mode.roles: ["<role_for_read_only>"]
 
-# Settings that enable multi-option authentication in sign-in window
+# Settings that enable multi-option authentication in sign-in window #
 opensearch_security.auth.multiple_auth_enabled: true
 opensearch_security.auth.type: ["basicauth","openid"]
 
@@ -125,7 +125,7 @@ opensearch_security.openid.verify_hostnames: false
 opensearch_security.openid.refresh_tokens: false
 opensearch_security.openid.logout_url: <"OIDC logout URL">
 
-opensearch_security.openid.connect_url: "<OIDC connect URL>"
+opensearch_security.openid.connect_url: <"OIDC connect URL">
 opensearch_security.openid.client_id: <Client ID>
 opensearch_security.openid.client_secret: <Client secret>
 ```

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -61,7 +61,7 @@ Setting | Description | Default value
 
 ### OpenID Connect authentication settings
 
-These settings allow you to customize the sign-in button associated with the IdP that integrates with OpenID Connect authentication. For the essential settings required for single sign-in using OpenID Connect, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
+These settings allow you to customize the sign-in button associated with OpenID Connect authentication. For the essential settings required for single sign-in using OpenID Connect, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
 
 Setting | Description | Default value
 :--- | :--- |:--- |:--- |
@@ -72,7 +72,7 @@ Setting | Description | Default value
 
 ### SAML authentication settings
 
-These settings allow you to customize the sign-in button associated with the IdP that integrates with SAML authentication. For the essential settings required for single sign-in using SAML, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
+These settings allow you to customize the sign-in button associated with SAML authentication. For the essential settings required for single sign-in using SAML, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
 
 Setting | Description | Default value
 :--- | :--- |:--- |:--- |

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -12,27 +12,28 @@ You can configure the sign-in window for OpenSearch Dashboards to provide either
 ## General steps for configuring Dashboards sign-in
 
 1. Decide which types of authentication are to be used.
-1. Configure each authentication method to be used, including an authentication domain for the IdP when applicable. (See the related steps for each authentication type in the Configuration section of the security documentation.)
-1. Configure sign-in settings in the `opensearch_dashboards.yml` file.
+1. Configure each authentication method to be used, including an authentication domain for the IdP and essential settings that let the authentication type access OpenSearch Dashboards.
 
-## Enabling multi-authentication
-
-The setting that determines single- or multi-authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, list a single type or multiple types. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multi-authentication and adjusts to accommodate multiple sign-in options.
-
-For basic authentication, you can configure the setting by specifying `"basicauth"` or by simply not defining the setting.
-
-```yml
-opensearch_security.auth.type: "basicauth"
-```
-
-Single sign-in for Dashboards is common to basic authentication, OpenID Connect, SAML, proxy based authentication, and JSON web tokens. Before configuring multi-authentication, see the following sections in the security documentation for details on configuring the essential settings that allow each authentication type to access OpenSearch Dashboards:
+See the related steps for each authentication type in the Configuration section of the security documentation:
 * For OpenID Connect: [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on)
 * For SAML: [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration)
 * For JSON web tokens: [Configure JSON web tokens]({{site.url}}{{site.baseurl}}/security-plugin/configuration/configuration/#configure-json-web-tokens).
 * For Proxy authentication: [OpenSearch Dashboards proxy authentication]({{site.url}}{{site.baseurl}}/security-plugin/configuration/proxy/#opensearch-dashboards-proxy-authentication).
 {: .note }
 
-For multi-authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values.
+1. Configure sign-in settings in the `opensearch_dashboards.yml` file.
+
+## Enabling multi-authentication
+
+The setting that determines single- or multi-authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, list a single type or multiple types. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multi-authentication and adjusts to accommodate multiple sign-in options.
+
+For single sign-on, the authentication type is specified by adding a single type to the setting.
+
+```yml
+opensearch_security.auth.type: "openid"
+```
+
+For multi-authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `'basicauth'`, `'openid'`, and `'saml'`.
 
 ```yml
 opensearch_security.auth.type: ['basicauth','openid']
@@ -47,7 +48,7 @@ When setting up Dashboards for multi-authentication, basic authentication is alw
 
 ## Customizing the sign-in environment
 
-In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the identification provider. After an authentication type is configured for single sign-in, use the settings below to change the look and feel of the different options.
+In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the identification provider. Use the settings below to change the look and feel of the different options.
 
 ### Basic authentication settings
 

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -26,13 +26,13 @@ To specify the multiple authentication types as options during sign-in, add the 
 When setting up Dashboards to provide multiple authentication options, basic authentication is always required as one of the values for the setting.
 {: .note }
 
-For single option sign-in, the authentication type is specified by adding a single type to the setting.
+Add a single value to the setting when only one authentication type is needed.
 
 ```yml
 opensearch_security.auth.type: "openid"
 ```
 
-For multiple option authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `"basicauth"`, `"openid"`, and `"saml"`.
+For multiple authentication options, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `"basicauth"`, `"openid"`, and `"saml"`.
 
 ```yml
 opensearch_security.auth.type: ["basicauth","openid"]

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -39,6 +39,14 @@ opensearch_security.auth.type: ["basicauth","saml"]
 opensearch_security.auth.type: ["basicauth","saml","openid"]
 ```
 
+When the `opensearch_security.auth.type` setting contains `basicauth` and one other authentication type, the sign-in window appears as in the example below.
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/OneOptionWithoutLogo.png" alt="Basic authentication and one other type in the sign-in window" width="350">
+
+With all three valid authentication types specified, the sign-in window appears as in the following example:
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/TwoOptionWithoutLogo.png" alt="All three authentication types specified in the sign-in window" width="350">
+
 When setting up Dashboards for multi-option authentication, basic authentication is always required as one of the values for the setting.
 {: .note }
 
@@ -46,7 +54,7 @@ When setting up Dashboards for multi-option authentication, basic authentication
 
 In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the IdP. Use the settings below to change the look and feel of the different options.
 
-<img src="{{site.url}}{{site.baseurl}}/images/Security/Multi-opt-auth.png" alt="Multi-option sign-in window" width="350">
+<img src="{{site.url}}{{site.baseurl}}/images/Security/TwoOptionWithLogo.png" alt="Multi-option sign-in window with with some customization" width="350">
 
 ### Basic authentication settings
 
@@ -56,8 +64,7 @@ Setting | Description | Default value
 :--- | :--- |:--- |:--- |
 `opensearch_security.ui.basicauth.login.buttonname` |  Display name for the login button | Log in 
 `opensearch_security.ui.basicauth.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null 
-`opensearch_security.ui.basicauth.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | true 
-`opensearch_security.ui.basicauth.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login 
+`opensearch_security.ui.basicauth.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | true  
 
 ### OpenID Connect authentication settings
 
@@ -68,7 +75,6 @@ Setting | Description | Default value
 `opensearch_security.ui.openid.login.buttonname` |  Display name for the login button | Log in with single sign-on
 `opensearch_security.ui.openid.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null
 `opensearch_security.ui.openid.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
-`opensearch_security.ui.openid.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login
 
 ### SAML authentication settings
 
@@ -79,5 +85,4 @@ Setting | Description | Default value
 `opensearch_security.ui.saml.login.buttonname` |  Display name for the login button | Log in
 `opensearch_security.ui.saml.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null
 `opensearch_security.ui.saml.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
-`opensearch_security.ui.saml.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login
 

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -5,7 +5,7 @@ parent: Configuration
 nav_order: 3
 ---
 
-# Multiple option authentication for Dashboards
+# Multiple option authentication for Dashboards sign-in
 
 You can configure the sign-in window for OpenSearch Dashboards to provide either a single option for authenticating users at sign-in or multiple options. Currently, Dashboards supports basic authentication, OpenID Connect, and SAML as the multiple options.
 

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -1,0 +1,78 @@
+---
+layout: default
+title: Multi-authentication sign-in
+parent: Configuration
+nav_order: 3
+---
+
+# Multi-authentication sign-in for Dashboards
+
+You can configure the sign-in window for OpenSearch Dashboards to provide either a single option for authenticating users at login or multiple options. Currently, Dashboards supports basic authentication, OpenID Connect, and SAML as choices for multi-authentication.
+
+## General steps for configuring Dashboards sign-in
+
+1. Decide which types of authentication are to be used.
+1. Configure each authentication method to be used, including an authentication domain for the IdP when applicable. (See the related steps for each authentication type in the Configuration section of the security documentation.)
+1. Configure sign-in settings in the `opensearch_dashboards.yml` file.
+
+## Enabling multi-authentication
+
+The setting that determines single- or multi-authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, list a single type or multiple types. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multi-authentication and adjusts to accommodate multiple sign-in options.
+
+For basic authentication, you can configure the setting by specifying `"basicauth"` or by simply not defining the setting.
+
+```yml
+opensearch_security.auth.type: "basicauth"
+```
+
+> Single sign-in for Dashboards is common to basic authentication, OpenID Connect, SAML, proxy based authentication, and JSON web tokens. Before configuring multi-authentication, see the following sections in the security documentation for details on configuring the essential settings that allow each authentication type to access OpenSearch Dashboards:
+> * For OpenID Connect: [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on)
+> * For SAML: [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration)
+> * For JSON web tokens: [Configure JSON web tokens]({{site.url}}{{site.baseurl}}/security-plugin/configuration/configuration/#configure-json-web-tokens).
+> * For Proxy authentication: [OpenSearch Dashboards proxy authentication]({{site.url}}{{site.baseurl}}/security-plugin/configuration/proxy/#opensearch-dashboards-proxy-authentication).
+{: .note }
+
+For multi-authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values.
+
+```yml
+opensearch_security.auth.type: ['basicauth','openid']
+```
+
+```yml
+opensearch_security.auth.type: ['basicauth','saml','openid']
+```
+
+When setting up Dashboards for multi-authentication, basic authentication is always required as one of the values for the setting.
+{: .note }
+
+## Customizing the sign-in environment
+
+In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the identification provider. After an authentication type is configured for single sign-in, use the settings below to change the look and feel of the different options.
+
+### Basic authentication settings
+
+Setting | Description | Default value 
+:--- | :--- |:--- |:--- |
+`opensearch_security.ui.basicauth.login.buttonname` |  Display name for the login button | Log in 
+`opensearch_security.ui.basicauth.login.brandimage` |  Logo for the login button | null 
+`opensearch_security.ui.basicauth.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | true 
+`opensearch_security.ui.basicauth.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login 
+
+### OpenID Connect authentication settings
+
+Setting | Description | Default value | Required
+:--- | :--- |:--- |:--- |
+`opensearch_security.ui.openid.login.buttonname` |  Display name for the login button | Log in with single sign-on | No
+`opensearch_security.ui.openid.login.brandimage` |  Logo for the login button | null | No
+`opensearch_security.ui.openid.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false | No
+`opensearch_security.ui.openid.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login | No
+
+### SAML authentication settings
+
+Setting | Description | Default value
+:--- | :--- |:--- |:--- |
+`opensearch_security.ui.saml.login.buttonname` |  Display name for the login button | Log in
+`opensearch_security.ui.saml.login.brandimage` |  Logo for the login button | null
+`opensearch_security.ui.saml.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
+`opensearch_security.ui.saml.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login
+

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -25,11 +25,11 @@ For basic authentication, you can configure the setting by specifying `"basicaut
 opensearch_security.auth.type: "basicauth"
 ```
 
-> Single sign-in for Dashboards is common to basic authentication, OpenID Connect, SAML, proxy based authentication, and JSON web tokens. Before configuring multi-authentication, see the following sections in the security documentation for details on configuring the essential settings that allow each authentication type to access OpenSearch Dashboards:
-> * For OpenID Connect: [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on)
-> * For SAML: [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration)
-> * For JSON web tokens: [Configure JSON web tokens]({{site.url}}{{site.baseurl}}/security-plugin/configuration/configuration/#configure-json-web-tokens).
-> * For Proxy authentication: [OpenSearch Dashboards proxy authentication]({{site.url}}{{site.baseurl}}/security-plugin/configuration/proxy/#opensearch-dashboards-proxy-authentication).
+Single sign-in for Dashboards is common to basic authentication, OpenID Connect, SAML, proxy based authentication, and JSON web tokens. Before configuring multi-authentication, see the following sections in the security documentation for details on configuring the essential settings that allow each authentication type to access OpenSearch Dashboards:
+* For OpenID Connect: [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on)
+* For SAML: [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration)
+* For JSON web tokens: [Configure JSON web tokens]({{site.url}}{{site.baseurl}}/security-plugin/configuration/configuration/#configure-json-web-tokens).
+* For Proxy authentication: [OpenSearch Dashboards proxy authentication]({{site.url}}{{site.baseurl}}/security-plugin/configuration/proxy/#opensearch-dashboards-proxy-authentication).
 {: .note }
 
 For multi-authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values.

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -11,13 +11,15 @@ You can configure the sign-in window for OpenSearch Dashboards to provide either
 
 ## General steps for configuring multi-option sign-in
 
-1. Decide which types of authentication are to be made available at sign-in.
-1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards (see steps for each type in the Configuration section of the security documentation).
-1. Add and configure multi-option authentication sign-in settings in the `opensearch_dashboards.yml` file.
+1. Decide which types of authentication to make available at sign-in.
+1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards (see steps for each authentication type in the Configuration section of the security documentation).
+1. Add, enable, and configure multi-option authentication sign-in settings in the `opensearch_dashboards.yml` file.
 
 ## Enabling multi-option sign-in
 
-The setting `opensearch_security.auth.type` determines whether the sign-in window provides for single- or multi-option authentication. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, enter a single type or multiple types as values. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
+By default, Dashboards provides a single sign-in environment for basic authentication. To enable multiple options for authentication at sign-in, begin by adding `opensearch_security.auth.multiple_auth_enabled` to the `opensearch_dashboards.yml` file and setting it to `true`.
+
+To specify the authentication types for multi-option sign-in, add the `opensearch_security.auth.type` setting to the `opensearch_dashboards.yml` file and enter multiple types as values. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
 
 For single sign-in, the authentication type is specified by adding a single type to the setting.
 
@@ -29,14 +31,17 @@ For multi-option authentication, add values to the setting as an array separated
 
 ```yml
 opensearch_security.auth.type: ["basicauth","openid"]
+opensearch_security.auth.multiple_auth_enabled: true
 ```
 
 ```yml
 opensearch_security.auth.type: ["basicauth","saml"]
+opensearch_security.auth.multiple_auth_enabled: true
 ```
 
 ```yml
 opensearch_security.auth.type: ["basicauth","saml","openid"]
+opensearch_security.auth.multiple_auth_enabled: true
 ```
 
 When the `opensearch_security.auth.type` setting contains `basicauth` and one other authentication type, the sign-in window appears as in the example below.
@@ -60,29 +65,67 @@ In addition to the essential sign-in settings for each authentication type, you 
 
 The settings below are used to customize the basic username and password sign-in button.
 
-Setting | Description | Default value 
+Setting | Description
 :--- | :--- |:--- |:--- |
-`opensearch_security.ui.basicauth.login.buttonname` |  Display name for the login button | Log in 
-`opensearch_security.ui.basicauth.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null 
-`opensearch_security.ui.basicauth.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | true  
+`opensearch_security.ui.basicauth.login.buttonname` |  Display name for the login button. "Log in" by default.
+`opensearch_security.ui.basicauth.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF.
+`opensearch_security.ui.basicauth.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. Default is `true`. 
 
 ### OpenID Connect authentication settings
 
 These settings allow you to customize the sign-in button associated with OpenID Connect authentication. For the essential settings required for single sign-in using OpenID Connect, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
 
-Setting | Description | Default value
+Setting | Description
 :--- | :--- |:--- |:--- |
-`opensearch_security.ui.openid.login.buttonname` |  Display name for the login button | Log in with single sign-on
-`opensearch_security.ui.openid.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null
-`opensearch_security.ui.openid.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
+`opensearch_security.ui.openid.login.buttonname` |  Display name for the login button. "Log in with single sign-on" by default.
+`opensearch_security.ui.openid.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF.
+`opensearch_security.ui.openid.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. Default is `false`.
 
 ### SAML authentication settings
 
 These settings allow you to customize the sign-in button associated with SAML authentication. For the essential settings required for single sign-in using SAML, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
 
-Setting | Description | Default value
+Setting | Description
 :--- | :--- |:--- |:--- |
-`opensearch_security.ui.saml.login.buttonname` |  Display name for the login button | Log in
-`opensearch_security.ui.saml.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null
-`opensearch_security.ui.saml.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
+`opensearch_security.ui.saml.login.buttonname` |  Display name for the login button. "Log in with single sign-on" by default.
+`opensearch_security.ui.saml.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF.
+`opensearch_security.ui.saml.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. Default is `false`.
 
+## Sample setup
+The following example shows basic settings in the `opensearch_dashboards.yml` file  when configured for two options at sign-in.
+
+```yml
+server.host: 0.0.0.0
+server.port: 5601
+opensearch.hosts: ["https://localhost:9200"]
+opensearch.ssl.verificationMode: none
+opensearch.username: <preferred username>
+opensearch.password: <preferred password>
+opensearch.requestHeadersAllowlist: ["securitytenant","Authorization"]
+opensearch_security.multitenancy.enabled: true
+opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
+opensearch_security.readonly_mode.roles: ["<role_for_read_only>"]
+
+# Settings that enable multi-option authentication in sign-in window
+opensearch_security.auth.multiple_auth_enabled: true
+opensearch_security.auth.type: ["basicauth","openid"]
+
+# Basic authentication customization #
+opensearch_security.ui.basicauth.login.buttonname: Log in
+opensearch_security.ui.basicauth.login.brandimage: <path/to/OSlogo.png>
+opensearch_security.ui.basicauth.login.showbrandimage: true
+
+# OIDC auth customization and start #
+opensearch_security.ui.openid.login.buttonname: Log in with <IdP name or other> 
+opensearch_security.ui.openid.login.brandimage: <path/to/brand-logo.png>
+opensearch_security.ui.openid.login.showbrandimage: true
+
+opensearch_security.openid.base_redirect_url: <"OIDC redirect URL">
+opensearch_security.openid.verify_hostnames: false
+opensearch_security.openid.refresh_tokens: false
+opensearch_security.openid.logout_url: <"OIDC logout URL">
+
+opensearch_security.openid.connect_url: "<OIDC connect URL>"
+opensearch_security.openid.client_id: <Client ID>
+opensearch_security.openid.client_secret: <Client secret>
+```

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -28,11 +28,15 @@ opensearch_security.auth.type: "openid"
 For multi-authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `'basicauth'`, `'openid'`, and `'saml'`.
 
 ```yml
-opensearch_security.auth.type: ['basicauth','openid']
+opensearch_security.auth.type: ["basicauth","openid"]
 ```
 
 ```yml
-opensearch_security.auth.type: ['basicauth','saml','openid']
+opensearch_security.auth.type: ["basicauth","saml"]
+```
+
+```yml
+opensearch_security.auth.type: ["basicauth","saml","openid"]
 ```
 
 When setting up Dashboards for multi-authentication, basic authentication is always required as one of the values for the setting.

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -17,7 +17,7 @@ You can configure the sign-in window for OpenSearch Dashboards to provide either
 
 ## Enabling multi-option sign-in
 
-The setting that determines single- or multi-option authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, provide a single type or multiple types for the setting. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate multiple sign-in options.
+The setting that determines single- or multi-option authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, provide a single type or multiple types for the setting. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
 
 For single sign-in, the authentication type is specified by adding a single type to the setting.
 

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -1,31 +1,31 @@
 ---
 layout: default
-title: Multi-authentication sign-in
+title: Multi-option sign-in
 parent: Configuration
 nav_order: 3
 ---
 
-# Multi-authentication sign-in for Dashboards
+# Multi-option sign-in for Dashboards
 
-You can configure the sign-in window for OpenSearch Dashboards to provide either a single option for authenticating users at login or multiple options. Currently, Dashboards supports basic authentication, OpenID Connect, and SAML as choices for multi-authentication.
+You can configure the sign-in window for OpenSearch Dashboards to provide either a single option for authenticating users at login or multiple options. Currently, Dashboards supports basic authentication, OpenID Connect, and SAML as choices for multi-option authentication.
 
-## General steps for configuring Dashboards sign-in
+## General steps for configuring multi-option sign-in
 
 1. Decide which types of authentication are to be made available at sign-in.
 1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards (see steps for each type in the Configuration section of the security documentation).
-1. Add and configure multi-authentication sign-in settings in the `opensearch_dashboards.yml` file.
+1. Add and configure multi-option authentication sign-in settings in the `opensearch_dashboards.yml` file.
 
-## Enabling multi-authentication
+## Enabling multi-option sign-in
 
-The setting that determines single- or multi-authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, list a single type or multiple types. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multi-authentication and adjusts to accommodate multiple sign-in options.
+The setting that determines single- or multi-option authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, provide a single type or multiple types for the setting. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate multiple sign-in options.
 
-For single sign-on, the authentication type is specified by adding a single type to the setting.
+For single sign-in, the authentication type is specified by adding a single type to the setting.
 
 ```yml
 opensearch_security.auth.type: "openid"
 ```
 
-For multi-authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `'basicauth'`, `'openid'`, and `'saml'`.
+For multi-option authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `"basicauth"`, `"openid"`, and `"saml"`.
 
 ```yml
 opensearch_security.auth.type: ["basicauth","openid"]
@@ -39,12 +39,14 @@ opensearch_security.auth.type: ["basicauth","saml"]
 opensearch_security.auth.type: ["basicauth","saml","openid"]
 ```
 
-When setting up Dashboards for multi-authentication, basic authentication is always required as one of the values for the setting.
+When setting up Dashboards for multi-option authentication, basic authentication is always required as one of the values for the setting.
 {: .note }
 
-## Customizing the sign-in environment
+## Customizing the multi-option sign-in environment
 
 In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the IdP. Use the settings below to change the look and feel of the different options.
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/Multi-opt-auth.png" alt="Multi-option sign-in window" width="350">
 
 ### Basic authentication settings
 
@@ -53,7 +55,7 @@ The settings below are used to customize the basic username and password sign-in
 Setting | Description | Default value 
 :--- | :--- |:--- |:--- |
 `opensearch_security.ui.basicauth.login.buttonname` |  Display name for the login button | Log in 
-`opensearch_security.ui.basicauth.login.brandimage` |  Logo for the login button | null 
+`opensearch_security.ui.basicauth.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null 
 `opensearch_security.ui.basicauth.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | true 
 `opensearch_security.ui.basicauth.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login 
 
@@ -64,7 +66,7 @@ These settings allow you to customize the sign-in button associated with the IdP
 Setting | Description | Default value
 :--- | :--- |:--- |:--- |
 `opensearch_security.ui.openid.login.buttonname` |  Display name for the login button | Log in with single sign-on
-`opensearch_security.ui.openid.login.brandimage` |  Logo for the login button | null
+`opensearch_security.ui.openid.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null
 `opensearch_security.ui.openid.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
 `opensearch_security.ui.openid.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login
 
@@ -75,7 +77,7 @@ These settings allow you to customize the sign-in button associated with the IdP
 Setting | Description | Default value
 :--- | :--- |:--- |:--- |
 `opensearch_security.ui.saml.login.buttonname` |  Display name for the login button | Log in
-`opensearch_security.ui.saml.login.brandimage` |  Logo for the login button | null
+`opensearch_security.ui.saml.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF. | null
 `opensearch_security.ui.saml.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
 `opensearch_security.ui.saml.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login
 

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -1,33 +1,36 @@
 ---
 layout: default
-title: Multi-option sign-in
+title: Multiple option authentication
 parent: Configuration
 nav_order: 3
 ---
 
-# Multi-option sign-in for Dashboards
+# Multiple option authentication for Dashboards
 
-You can configure the sign-in window for OpenSearch Dashboards to provide either a single option for authenticating users at login or multiple options. Currently, Dashboards supports basic authentication, OpenID Connect, and SAML as choices for multi-option authentication.
+You can configure the sign-in window for OpenSearch Dashboards to provide either a single option for authenticating users at sign-in or multiple options. Currently, Dashboards supports basic authentication, OpenID Connect, and SAML as the multiple options.
 
-## General steps for configuring multi-option sign-in
+## General steps for configuring multiple option authentication
 
 1. Decide which types of authentication to make available at sign-in.
 1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards (see steps for each authentication type in the Configuration section of the security documentation).
-1. Add, enable, and configure multi-option authentication sign-in settings in the `opensearch_dashboards.yml` file.
+1. Add, enable, and configure multiple option authentication settings in the `opensearch_dashboards.yml` file.
 
-## Enabling multi-option sign-in
+## Enabling multiple option authentication
 
-By default, Dashboards provides a single sign-in environment for basic authentication. To enable multiple options for authentication at sign-in, begin by adding `opensearch_security.auth.multiple_auth_enabled` to the `opensearch_dashboards.yml` file and setting it to `true`.
+By default, Dashboards provides basic authentication as a single option for signing in. To enable multiple options for authentication, begin by adding `opensearch_security.auth.multiple_auth_enabled` to the `opensearch_dashboards.yml` file and setting it to `true`.
 
-To specify the authentication types for multi-option sign-in, add the `opensearch_security.auth.type` setting to the `opensearch_dashboards.yml` file and enter multiple types as values. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
+To specify the multiple authentication types as options during sign-in, add the `opensearch_security.auth.type` setting to the `opensearch_dashboards.yml` file and enter multiple types as values. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
 
-For single sign-in, the authentication type is specified by adding a single type to the setting.
+When setting up Dashboards to provide multiple authentication options, basic authentication is always required as one of the values for the setting.
+{: .note }
+
+For single option sign-in, the authentication type is specified by adding a single type to the setting.
 
 ```yml
 opensearch_security.auth.type: "openid"
 ```
 
-For multi-option authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `"basicauth"`, `"openid"`, and `"saml"`.
+For multiple option authentication, add values to the setting as an array separated by commas. As a reminder, Dashboards currently supports a combination of basic authentication, OpenID Connect, and SAML as a valid set of values. In the setting, these values are expressed as `"basicauth"`, `"openid"`, and `"saml"`.
 
 ```yml
 opensearch_security.auth.type: ["basicauth","openid"]
@@ -52,10 +55,7 @@ With all three valid authentication types specified, the sign-in window appears 
 
 <img src="{{site.url}}{{site.baseurl}}/images/Security/TwoOptionWithoutLogo.png" alt="All three authentication types specified in the sign-in window" width="350">
 
-When setting up Dashboards for multi-option authentication, basic authentication is always required as one of the values for the setting.
-{: .note }
-
-## Customizing the multi-option sign-in environment
+## Customizing the sign-in environment
 
 In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the IdP. Use the settings below to change the look and feel of the different options.
 
@@ -73,7 +73,7 @@ Setting | Description
 
 ### OpenID Connect authentication settings
 
-These settings allow you to customize the sign-in button associated with OpenID Connect authentication. For the essential settings required for single sign-in using OpenID Connect, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
+These settings allow you to customize the sign-in button associated with OpenID Connect authentication. For the essential settings required to use OpenID Connect as a single sign-in option, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
 
 Setting | Description
 :--- | :--- |:--- |:--- |
@@ -83,7 +83,7 @@ Setting | Description
 
 ### SAML authentication settings
 
-These settings allow you to customize the sign-in button associated with SAML authentication. For the essential settings required for single sign-in using SAML, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
+These settings allow you to customize the sign-in button associated with SAML authentication. For the essential settings required to use SAML as a sign-in option, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
 
 Setting | Description
 :--- | :--- |:--- |:--- |
@@ -92,9 +92,10 @@ Setting | Description
 `opensearch_security.ui.saml.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. Default is `false`.
 
 ## Sample setup
-The following example shows basic settings in the `opensearch_dashboards.yml` file  when configured for two options at sign-in.
+The following example shows basic settings in the `opensearch_dashboards.yml` file  when configured for two types of authentication at sign-in.
 
 ```yml
+# The several settings directly below are typical of all `opensearch_dashboards.yml` configurations. #
 server.host: 0.0.0.0
 server.port: 5601
 opensearch.hosts: ["https://localhost:9200"]
@@ -106,7 +107,7 @@ opensearch_security.multitenancy.enabled: true
 opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]
 opensearch_security.readonly_mode.roles: ["<role_for_read_only>"]
 
-# Settings that enable multi-option authentication in sign-in window #
+# Settings that enable multiple option authentication in the sign-in window #
 opensearch_security.auth.multiple_auth_enabled: true
 opensearch_security.auth.type: ["basicauth","openid"]
 
@@ -115,7 +116,7 @@ opensearch_security.ui.basicauth.login.buttonname: Log in
 opensearch_security.ui.basicauth.login.brandimage: <path/to/OSlogo.png>
 opensearch_security.ui.basicauth.login.showbrandimage: true
 
-# OIDC auth customization and start #
+# OIDC auth customization and start settings #
 opensearch_security.ui.openid.login.buttonname: Log in with <IdP name or other> 
 opensearch_security.ui.openid.login.brandimage: <path/to/brand-logo.png>
 opensearch_security.ui.openid.login.showbrandimage: true

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -17,7 +17,7 @@ You can configure the sign-in window for OpenSearch Dashboards to provide either
 
 ## Enabling multi-option sign-in
 
-The setting that determines single- or multi-option authentication is `opensearch_security.auth.type`. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, provide a single type or multiple types for the setting. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
+The setting `opensearch_security.auth.type` determines whether the sign-in window provides for single- or multi-option authentication. You can add this setting to the `opensearch_dashboards.yml` file. By default, Dashboards provides a single sign-in environment for basic authentication. To specify the authentication type, enter a single type or multiple types as values. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
 
 For single sign-in, the authentication type is specified by adding a single type to the setting.
 

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -1,23 +1,25 @@
 ---
 layout: default
-title: Multiple option authentication
+title: Multiple authentication options for Dashboards sign-in
 parent: Configuration
 nav_order: 3
 ---
 
-# Multiple option authentication for Dashboards sign-in
+# Configure Dashboards sign-in for multiple authentication options
 
 You can configure the sign-in window for OpenSearch Dashboards to provide either a single option for authenticating users at sign-in or multiple options. Currently, Dashboards supports basic authentication, OpenID Connect, and SAML as the multiple options.
 
-## General steps for configuring multiple option authentication
+## General steps for configuring multiple authentication options
+
+Consider the following sequence of steps before configuring the sign-in window for multiple authentication options. 
 
 1. Decide which types of authentication to make available at sign-in.
-1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards. For OpenId Connect backend configuration, see [OpenID Connect]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/); For SAML backend configuration, see [SAML]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/).
+1. Configure each authentication type, including an authentication domain for the identity provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards. For OpenId Connect backend configuration, see [OpenID Connect]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/); For SAML backend configuration, see [SAML]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/).
 1. Add, enable, and configure multiple option authentication settings in the `opensearch_dashboards.yml` file.
 
-## Enabling multiple option authentication
+## Enabling multiple authentication options
 
-By default, Dashboards provides basic authentication as a single option for signing in. To enable multiple options for authentication, begin by adding `opensearch_security.auth.multiple_auth_enabled` to the `opensearch_dashboards.yml` file and setting it to `true`.
+By default, Dashboards provides basic authentication for sign-in. To enable multiple options for authentication, begin by adding `opensearch_security.auth.multiple_auth_enabled` to the `opensearch_dashboards.yml` file and setting it to `true`.
 
 To specify the multiple authentication types as options during sign-in, add the `opensearch_security.auth.type` setting to the `opensearch_dashboards.yml` file and enter multiple types as values. When more than one authentication type is added to the setting, the Dashboards sign-in window recognizes multiple types and adjusts to accommodate the sign-in options.
 
@@ -47,23 +49,23 @@ opensearch_security.auth.type: ["basicauth","saml","openid"]
 opensearch_security.auth.multiple_auth_enabled: true
 ```
 
-When the `opensearch_security.auth.type` setting contains `basicauth` and one other authentication type, the sign-in window appears as in the example below.
+When the `opensearch_security.auth.type` setting contains `basicauth` and one other authentication type, the sign-in window appears as in the following example.
 
 <img src="{{site.url}}{{site.baseurl}}/images/Security/OneOptionWithoutLogo.png" alt="Basic authentication and one other type in the sign-in window" width="350">
 
-With all three valid authentication types specified, the sign-in window appears as in the following example:
+With all three valid authentication types specified, the sign-in window appears as in the following example.
 
 <img src="{{site.url}}{{site.baseurl}}/images/Security/TwoOptionWithoutLogo.png" alt="All three authentication types specified in the sign-in window" width="350">
 
 ## Customizing the sign-in environment
 
-In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the IdP. Use the settings below to change the look and feel of the different options.
+In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the IdP. Refer to the settings and descriptions that follow.
 
 <img src="{{site.url}}{{site.baseurl}}/images/Security/TwoOptionWithLogo.png" alt="Multi-option sign-in window with with some customization" width="350">
 
 ### Basic authentication settings
 
-The settings below are used to customize the basic username and password sign-in button.
+The following settings are used to customize the basic username and password sign-in button.
 
 Setting | Description
 :--- | :--- |:--- |:--- |
@@ -91,7 +93,7 @@ Setting | Description
 `opensearch_security.ui.saml.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. Default is `false`.
 
 ## Sample setup
-The following example shows basic settings in the `opensearch_dashboards.yml` file  when configured for two types of authentication at sign-in.
+The following example shows basic settings in the `opensearch_dashboards.yml` file  when it is configured for two types of authentication at sign-in.
 
 ```yml
 # The several settings directly below are typical of all `opensearch_dashboards.yml` configurations. #

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -11,17 +11,9 @@ You can configure the sign-in window for OpenSearch Dashboards to provide either
 
 ## General steps for configuring Dashboards sign-in
 
-1. Decide which types of authentication are to be used.
-1. Configure each authentication method to be used, including an authentication domain for the IdP and essential settings that let the authentication type access OpenSearch Dashboards.
-
-See the related steps for each authentication type in the Configuration section of the security documentation:
-* For OpenID Connect: [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on)
-* For SAML: [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration)
-* For JSON web tokens: [Configure JSON web tokens]({{site.url}}{{site.baseurl}}/security-plugin/configuration/configuration/#configure-json-web-tokens).
-* For Proxy authentication: [OpenSearch Dashboards proxy authentication]({{site.url}}{{site.baseurl}}/security-plugin/configuration/proxy/#opensearch-dashboards-proxy-authentication).
-{: .note }
-
-1. Configure sign-in settings in the `opensearch_dashboards.yml` file.
+1. Decide which types of authentication are to be made available at sign-in.
+1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards (see steps for each type in the Configuration section of the security documentation).
+1. Add and configure multi-authentication sign-in settings in the `opensearch_dashboards.yml` file.
 
 ## Enabling multi-authentication
 
@@ -48,9 +40,11 @@ When setting up Dashboards for multi-authentication, basic authentication is alw
 
 ## Customizing the sign-in environment
 
-In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the identification provider. Use the settings below to change the look and feel of the different options.
+In addition to the essential sign-in settings for each authentication type, you can configure additional settings in the `opensearch_dashboards.yml` file to customize the sign-in window so that it clearly represents the options that are available. For example, you can replace the label on the sign-in button with the name and icon of the IdP. Use the settings below to change the look and feel of the different options.
 
 ### Basic authentication settings
+
+These are settings to customize the basic username and password sign-in button.
 
 Setting | Description | Default value 
 :--- | :--- |:--- |:--- |
@@ -61,14 +55,18 @@ Setting | Description | Default value
 
 ### OpenID Connect authentication settings
 
-Setting | Description | Default value | Required
+These settings allow you to customize the sign-in button associated with OpenID Connect authentication. For the essential settings required for single sign-in using OpenID Connect, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
+
+Setting | Description | Default value
 :--- | :--- |:--- |:--- |
-`opensearch_security.ui.openid.login.buttonname` |  Display name for the login button | Log in with single sign-on | No
-`opensearch_security.ui.openid.login.brandimage` |  Logo for the login button | null | No
-`opensearch_security.ui.openid.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false | No
-`opensearch_security.ui.openid.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login | No
+`opensearch_security.ui.openid.login.buttonname` |  Display name for the login button | Log in with single sign-on
+`opensearch_security.ui.openid.login.brandimage` |  Logo for the login button | null
+`opensearch_security.ui.openid.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. | false
+`opensearch_security.ui.openid.login.buttonstyle` |  Login button style (what are other options for this setting? Styled in what way?) | btn-login
 
 ### SAML authentication settings
+
+These settings allow you to customize the sign-in button associated with SAML authentication. For the essential settings required for single sign-in using SAML, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
 
 Setting | Description | Default value
 :--- | :--- |:--- |:--- |

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -44,7 +44,7 @@ In addition to the essential sign-in settings for each authentication type, you 
 
 ### Basic authentication settings
 
-These are settings to customize the basic username and password sign-in button.
+The settings below are used to customize the basic username and password sign-in button.
 
 Setting | Description | Default value 
 :--- | :--- |:--- |:--- |
@@ -55,7 +55,7 @@ Setting | Description | Default value
 
 ### OpenID Connect authentication settings
 
-These settings allow you to customize the sign-in button associated with OpenID Connect authentication. For the essential settings required for single sign-in using OpenID Connect, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
+These settings allow you to customize the sign-in button associated with the IdP that integrates with OpenID Connect authentication. For the essential settings required for single sign-in using OpenID Connect, see [OpenSearch Dashboards single sign-on]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/#opensearch-dashboards-single-sign-on).
 
 Setting | Description | Default value
 :--- | :--- |:--- |:--- |
@@ -66,7 +66,7 @@ Setting | Description | Default value
 
 ### SAML authentication settings
 
-These settings allow you to customize the sign-in button associated with SAML authentication. For the essential settings required for single sign-in using SAML, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
+These settings allow you to customize the sign-in button associated with the IdP that integrates with SAML authentication. For the essential settings required for single sign-in using SAML, see [OpenSearch Dashboards configuration]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/#opensearch-dashboards-configuration).
 
 Setting | Description | Default value
 :--- | :--- |:--- |:--- |

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -14,7 +14,7 @@ You can configure the sign-in window for OpenSearch Dashboards to provide either
 Consider the following sequence of steps before configuring the sign-in window for multiple authentication options. 
 
 1. Decide which types of authentication to make available at sign-in.
-1. Configure each authentication type, including an authentication domain for the identity provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards. For OpenId Connect backend configuration, see [OpenID Connect]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/); For SAML backend configuration, see [SAML]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/).
+1. Configure each authentication type, including an authentication domain for the identity provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards. For OpenId Connect backend configuration, see [OpenID Connect]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/). For SAML backend configuration, see [SAML]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/).
 1. Add, enable, and configure multiple option authentication settings in the `opensearch_dashboards.yml` file.
 
 ## Enabling multiple authentication options
@@ -65,7 +65,7 @@ In addition to the essential sign-in settings for each authentication type, you 
 
 ### Basic authentication settings
 
-The following settings are used to customize the basic username and password sign-in button.
+These settings allow you to customize the basic username and password sign-in button.
 
 Setting | Description
 :--- | :--- |:--- |:--- |

--- a/_security-plugin/configuration/multi-auth.md
+++ b/_security-plugin/configuration/multi-auth.md
@@ -12,7 +12,7 @@ You can configure the sign-in window for OpenSearch Dashboards to provide either
 ## General steps for configuring multiple option authentication
 
 1. Decide which types of authentication to make available at sign-in.
-1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards (see steps for each authentication type in the Configuration section of the security documentation).
+1. Configure each authentication type, including an authentication domain for the identification provider (IdP) and the essential settings that give each type sign-in access to OpenSearch Dashboards. For OpenId Connect backend configuration, see [OpenID Connect]({{site.url}}{{site.baseurl}}/security-plugin/configuration/openid-connect/); For SAML backend configuration, see [SAML]({{site.url}}{{site.baseurl}}/security-plugin/configuration/saml/).
 1. Add, enable, and configure multiple option authentication settings in the `opensearch_dashboards.yml` file.
 
 ## Enabling multiple option authentication
@@ -67,7 +67,6 @@ The settings below are used to customize the basic username and password sign-in
 
 Setting | Description
 :--- | :--- |:--- |:--- |
-`opensearch_security.ui.basicauth.login.buttonname` |  Display name for the login button. "Log in" by default.
 `opensearch_security.ui.basicauth.login.brandimage` |  Login button logo. Supported file types are SVG, PNG, and GIF.
 `opensearch_security.ui.basicauth.login.showbrandimage` |  Determines whether a logo for the login button is displayed or not. Default is `true`. 
 
@@ -112,7 +111,6 @@ opensearch_security.auth.multiple_auth_enabled: true
 opensearch_security.auth.type: ["basicauth","openid"]
 
 # Basic authentication customization #
-opensearch_security.ui.basicauth.login.buttonname: Log in
 opensearch_security.ui.basicauth.login.brandimage: <path/to/OSlogo.png>
 opensearch_security.ui.basicauth.login.showbrandimage: true
 

--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -313,7 +313,7 @@ opensearch.ssl.verificationMode: none
 opensearch.requestHeadersAllowlist: ["Authorization", "security_tenant"]
 ```
 
-To include OpenID Connect with other authentication options in the Dashboards sign-in window, see [Multi-option sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
+To include OpenID Connect with other authentication types in the Dashboards sign-in window, see [Multiple option authentication for Dashboards sign-in]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
 {: .note } 
 
 ### OpenSearch security configuration

--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -313,7 +313,7 @@ opensearch.ssl.verificationMode: none
 opensearch.requestHeadersAllowlist: ["Authorization", "security_tenant"]
 ```
 
-To include OpenID Connect with other authentication options in the Dashboards sign-in window, see [Multi-authentication sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
+To include OpenID Connect with other authentication options in the Dashboards sign-in window, see [Multi-option sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
 {: .note } 
 
 ### OpenSearch security configuration

--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -21,7 +21,7 @@ The security plugin can integrate with identify providers that use the OpenID Co
 
   You can change the keys used for signing the JWTs directly in your IdP. If the security plugin detects an unknown key, it tries to retrieve it from the IdP. This rollover is transparent to the user.
 
-* OpenSearch Dashboards single sign-on
+* OpenSearch Dashboards single sign-on or one of multiple other authentication options in the sign-in window. See [Multi-authentication sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/) for details on including OpenID Connect in configuring sign-in preferences.
 
 
 ## Configure OpenID Connect integration
@@ -313,6 +313,8 @@ opensearch.ssl.verificationMode: none
 opensearch.requestHeadersAllowlist: ["Authorization", "security_tenant"]
 ```
 
+To include OpenID Connect with other authentication options in the Dashboards sign-in window, see [Multi-authentication sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
+{: .note } 
 
 ### OpenSearch security configuration
 

--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -21,7 +21,7 @@ The security plugin can integrate with identify providers that use the OpenID Co
 
   You can change the keys used for signing the JWTs directly in your IdP. If the security plugin detects an unknown key, it tries to retrieve it from the IdP. This rollover is transparent to the user.
 
-* OpenSearch Dashboards single sign-on or one option for multi- authentication sign-on.
+* OpenSearch Dashboards as single sign-on or as one option among multiple authentication types in the Dashboards sign-in window.
 
 
 ## Configure OpenID Connect integration

--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -21,7 +21,7 @@ The security plugin can integrate with identify providers that use the OpenID Co
 
   You can change the keys used for signing the JWTs directly in your IdP. If the security plugin detects an unknown key, it tries to retrieve it from the IdP. This rollover is transparent to the user.
 
-* OpenSearch Dashboards single sign-on or one of multiple other authentication options in the sign-in window. See [Multi-authentication sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/) for details on including OpenID Connect in configuring sign-in preferences.
+* OpenSearch Dashboards single sign-on or one option for multi- authentication sign-on.
 
 
 ## Configure OpenID Connect integration
@@ -270,7 +270,7 @@ OpenID Connect providers usually publish their configuration in JSON format unde
   Beyond the ID, each client also has a client secret assigned. The client secret is usually generated when the client is created. Applications can obtain an identity token only when they provide a client secret. You can find this secret in the settings of the client on your IdP.
 
 
-### Configuration parameters
+### Configuration settings
 
 Name | Description
 :--- | :---

--- a/_security-plugin/configuration/saml.md
+++ b/_security-plugin/configuration/saml.md
@@ -314,7 +314,7 @@ If you use the logout POST binding, you also need to ad the logout endpoint to y
 server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout"]
 ```
 
-To include SAML with other authentication options in the Dashboards sign-in window, see [Multi-option sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
+To include SAML with other authentication types in the Dashboards sign-in window, see [Multiple option authentication for Dashboards sign-in]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
 {: .note }
 
 ### IdP-initiated SSO

--- a/_security-plugin/configuration/saml.md
+++ b/_security-plugin/configuration/saml.md
@@ -314,7 +314,7 @@ If you use the logout POST binding, you also need to ad the logout endpoint to y
 server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout"]
 ```
 
-To include SAML with other authentication options in the Dashboards sign-in window, see [Multi-authentication sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
+To include SAML with other authentication options in the Dashboards sign-in window, see [Multi-option sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
 {: .note }
 
 ### IdP-initiated SSO

--- a/_security-plugin/configuration/saml.md
+++ b/_security-plugin/configuration/saml.md
@@ -314,6 +314,9 @@ If you use the logout POST binding, you also need to ad the logout endpoint to y
 server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout"]
 ```
 
+To include SAML with other authentication options in the Dashboards sign-in window, see [Multi-authentication sign-in for Dashboards]({{site.url}}{{site.baseurl}}/security-plugin/configuration/multi-auth/).
+{: .note }
+
 ### IdP-initiated SSO
 
 To use IdP-initiated SSO, set the Assertion Consumer Service endpoint of your IdP to this:

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -2,7 +2,7 @@
 layout: default
 title: YAML files
 parent: Configuration
-nav_order: 3
+nav_order: 4
 ---
 
 # YAML files


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
This documentation describes a new feature and steps for setting it up that will allow users to sign in to Dashboards using one of two or three authentication types presented as options in the sign-in window.

### Issues Resolved
New documentation creates a section for describing steps for configuring Dashboards multi-authentication sign-in.

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
