### PR TITLE
Relocate legacy kibana names note to Configuration pages

### DIFF
--- a/_security-plugin/configuration/index.md
+++ b/_security-plugin/configuration/index.md
@@ -22,3 +22,6 @@ The plugin includes demo certificates so that you can get up and running quickly
 1. [Add users, roles, role mappings, and tenants]({{site.url}}{{site.baseurl}}/security-plugin/access-control/index/).
 
 If you don't want to use the plugin, see [Disable security]({{site.url}}{{site.baseurl}}/security-plugin/configuration/disable).
+
+The security plugin has several default users, roles, action groups, permissions, and settings for OpenSearch Dashboards that use kibana in their names. We will change these names in a future release.
+{: .note }


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Relocate note on kibana name in various properties from overview to configuration index page.

### Issues Resolved
Moved the note alerting users of the legacy use of kibana in names for roles, users, action groups, and various settings from the security overview to the security Configuration landing page.
Related to issue #1013.


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
