### PR TITLE
Fix typo on Drag and Drop page

### DIFF
--- a/_dashboards/drag-drop-wizard.md
+++ b/_dashboards/drag-drop-wizard.md
@@ -4,7 +4,7 @@ title: Drag-and-drop wizard
 nav_order: 8
 ---
 
-The drag-and-drop visualization wizard is an experimental feature in OpenSearch 2.3. Therefore, we do not recommend the use of the drag-and-drop wizard in a production environment. For updates on the progress of drag and drop, or if you want leave feedback that could help improve the feature, see the [Drag and drop git issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2280). 
+The drag-and-drop visualization wizard is an experimental feature in OpenSearch 2.3. Therefore, we do not recommend the use of the drag-and-drop wizard in a production environment. For updates on the progress of drag and drop, or if you want to leave feedback that could help improve the feature, see the [Drag and drop git issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2280). 
 {: .warning}
 
 # Drag-and-drop wizard

--- a/_dashboards/drag-drop-wizard.md
+++ b/_dashboards/drag-drop-wizard.md
@@ -4,7 +4,7 @@ title: Drag-and-drop wizard
 nav_order: 8
 ---
 
-The drag-and-drop visualization wizard is an experimental feature with OpenSearch 2.3. Therefore, we do not recommend the use of drag-and-drop wizard in a production environment. For updates on the progress of drag and drop or if you want leave feedback that could help improve the feature, see the [Drag and drop git issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2280). 
+The drag-and-drop visualization wizard is an experimental feature in OpenSearch 2.3. Therefore, we do not recommend the use of the drag-and-drop wizard in a production environment. For updates on the progress of drag and drop, or if you want leave feedback that could help improve the feature, see the [Drag and drop git issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2280). 
 {: .warning}
 
 # Drag-and-drop wizard

--- a/_dashboards/drag-drop-wizard.md
+++ b/_dashboards/drag-drop-wizard.md
@@ -4,7 +4,7 @@ title: Drag-and-drop wizard
 nav_order: 8
 ---
 
-The drag-and-drop visualization wizard an experimental feature with OpenSearch 2.3. Therefore, we do not recommend the use of drag-and-drop wizard in a production environment. For updates on the progress of drag and drop or if you want leave feedback that could help improve the feature, see the [Drag and drop git issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2280). 
+The drag-and-drop visualization wizard is an experimental feature with OpenSearch 2.3. Therefore, we do not recommend the use of drag-and-drop wizard in a production environment. For updates on the progress of drag and drop or if you want leave feedback that could help improve the feature, see the [Drag and drop git issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2280). 
 {: .warning}
 
 # Drag-and-drop wizard


### PR DESCRIPTION
### Description

Fixes a typo in the warning on the top of the page.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
