### PR TITLE
Edit LDAP documentation for custom_attr_allowlist

### DIFF
--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -431,9 +431,11 @@ rolesearch_enabled: false
 
 By default, the security plugin reads all LDAP user attributes and makes them available for index name variable substitution and DLS query variable substitution. If your LDAP entries have a lot of attributes, you might want to control which attributes should be made available. The fewer the attributes, the better the performance.
 
+Note that this setting is made in the authentication `authc` section of the config.yml file.
+
 Name | Description
 :--- | :---
-`custom_attr_whitelist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
+`custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
 `custom_attr_maxval_len`  | Integer. Specifies the maximum allowed length of each attribute. All attributes longer than this value are discarded. A value of `0` disables custom attributes altogether. Default is 36.
 
 Example:
@@ -446,7 +448,7 @@ authc:
     authentication_backend:
       type: ldap
       config:
-        custom_attr_whitelist:
+        custom_attr_allowlist:
           - attribute1
           - attribute2
         custom_attr_maxval_len: 36


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
The `custom_attr_whitelist` setting used for enabling variable substitution in LDAP has been changed to `custom_attr_allowlist` to address inclusive language. 

### Issues Resolved
Renamed this setting in LDAP documentation and specified that it is added to `authc` in the `config.yml` file for clarity (rather than `authz`).

For original issue, see #1584.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
