### PR TITLE
Change securityadmin.sh doc default port to 9200

### DIFF
--- a/_security-plugin/configuration/security-admin.md
+++ b/_security-plugin/configuration/security-admin.md
@@ -182,12 +182,12 @@ Name | Description
 
 ### OpenSearch settings
 
-If you run a default OpenSearch installation, which listens on transport port 9300 and uses `opensearch` as a cluster name, you can omit the following settings altogether. Otherwise, specify your OpenSearch settings by using the following switches.
+If you run a default OpenSearch installation, which listens on port 9200 and uses `opensearch` as a cluster name, you can omit the following settings altogether. Otherwise, specify your OpenSearch settings by using the following switches.
 
 Name | Description
 :--- | :---
 `-h` | OpenSearch hostname. Default is `localhost`.
-`-p` | OpenSearch port. Default is 9300---not the HTTP port.
+`-p` | OpenSearch port. Default is 9200 - not the HTTP port.
 `-cn` | Cluster name. Default is `opensearch`.
 `-icl` | Ignore cluster name.
 `-sniff` | Sniff cluster nodes. Sniffing detects available nodes using the OpenSearch `_cluster/state` API.


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
Change securityadmin.sh doc default port to 9200. This affects 2.x versions only and should not be backported to any 1.x.

### Issues Resolved
Fixes #695 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
