### PR TITLE
Add connection pooling settings to LDAP documentation

### DIFF
--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -643,7 +643,7 @@ authz:
 
 ### Connection pooling settings
 
-The security plugin can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way the pooling is carried out. 
+OpenSearch can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way connection pooling is carried out.
 
 Name | Description
 :--- | :---

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -11,7 +11,6 @@ Active Directory and LDAP can be used for both authentication and authorization 
 
 In most cases, you want to configure both authentication and authorization. You can also use authentication only and map the users retrieved from LDAP directly to security plugin roles.
 
-Active Directory 
 
 ## Docker example
 

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -428,7 +428,7 @@ rolesearch_enabled: false
 
 ## Advanced settings
 
-The advanced settings presented below are optional for an essential LDAP configuration. They can, however, improve efficiency and performance for the LDAP implementation. 
+The advanced settings presented below are optional for an essential LDAP configuration. They can, however, improve efficiency, performance, and security for the LDAP implementation. 
 
 ### Control LDAP user attributes
 
@@ -643,7 +643,7 @@ authz:
 
 ### Connection pooling settings
 
-The directory server can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way the pooling is carried out. 
+The security plugin can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way the pooling is carried out. 
 
 Name | Description
 :--- | :---

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -429,13 +429,13 @@ rolesearch_enabled: false
 
 ## Advanced settings
 
-The advanced settings presented below are largely optional, but they can improve efficiency and performance for the LDAP-based authentication and authorization configuration. 
+The advanced settings presented below are optional for an essential LDAP configuration. They can, however, improve efficiency and performance for the LDAP implementation. 
 
 ### Control LDAP user attributes
 
 By default, the security plugin reads all LDAP user attributes and makes them available for index name variable substitution and DLS query variable substitution. If your LDAP entries have a lot of attributes, you might want to control which attributes should be made available. The fewer the attributes, the better the performance.
 
-Note that this setting is made in the authentication `authc` section of the config.yml file.
+Note that this setting is made in the `authc` section of the config.yml file.
 
 Name | Description
 :--- | :---
@@ -459,7 +459,6 @@ authc:
       ...
 ```
 
-
 ### Exclude certain users from role lookup
 
 If you are using multiple authentication methods, it can make sense to exclude certain users from the LDAP role lookup.
@@ -477,7 +476,6 @@ skip_users:
   - '/\S*/'
 ```
 
-
 ### Exclude roles from nested role lookups
 
 If the users in your LDAP installation have a large number of roles, and you have the requirement to resolve nested roles as well, you might run into performance issues.
@@ -491,7 +489,6 @@ nested_role_filter:
   - 'cn=Jane Doe,ou*people,o=TEST'
   - ...
 ```
-
 
 ### Configuration summary
 
@@ -509,7 +506,6 @@ Name | Description
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.
 `custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
 `custom_attr_maxval_len`  | Integer. Specifies the maximum allowed length of each attribute. All attributes longer than this value are discarded. A value of `0` disables custom attributes altogether. Default is 36.
-
 
 ### Complete authorization example
 
@@ -648,21 +644,30 @@ authz:
 
 ### Connection pooling settings
 
-The directory server can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way the pooling is managed. 
+The directory server can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way the pooling is carried out. 
 
 Name | Description
 :--- | :---
 `pool.enabled` | Enables connection pooling. Set to `true` to enable.
-`pool.min_size` | Size of the pool at initialization. Also used for pruning.
+`pool.min_size` | Size of the pool at initialization. Also used to reset pool size for pruning.
 `pool.max_size` | Maximum size the pool can reach.
 `pool.pruning_period` | The interval in minutes at which the pruning implementation is executed. For example: when 5, every five minutes. By default, the period is 5.
-`pool.idle_time` | The length of time elapsed when a connnection is considered idle, then becoming a candidate for pruning from the pool. By default, idle time is 10.
+`pool.idle_time` | The length of time elapsed, in minutes, after a connnection is considered idle. Once elapsed, the connection becomes a candidate for pruning from the pool. By default, idle time is 10.
 
+Connection pooling settings are added to the `authc` section of the configuration.
 
-
-
-
-
-
-
+```yml
+authc:
+  ldap:
+    http_enabled: true
+    transport_enabled: true
+    authentication_backend:
+      type: ldap
+      config:
+        pool.enabled: true
+        pool.min_size: 5
+        pool.max_size: 12
+        pool.pruning_period: 5
+        pool.idle_time: 15
+```
 

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -11,6 +11,7 @@ Active Directory and LDAP can be used for both authentication and authorization 
 
 In most cases, you want to configure both authentication and authorization. You can also use authentication only and map the users retrieved from LDAP directly to security plugin roles.
 
+Active Directory 
 
 ## Docker example
 
@@ -426,8 +427,11 @@ If you don't use or have a role subtree, you can disable the role search complet
 rolesearch_enabled: false
 ```
 
+## Advanced settings
 
-### (Advanced) Control LDAP user attributes
+The advanced settings presented below are largely optional, but they can improve efficiency and performance for the LDAP-based authentication and authorization configuration. 
+
+### Control LDAP user attributes
 
 By default, the security plugin reads all LDAP user attributes and makes them available for index name variable substitution and DLS query variable substitution. If your LDAP entries have a lot of attributes, you might want to control which attributes should be made available. The fewer the attributes, the better the performance.
 
@@ -456,7 +460,7 @@ authc:
 ```
 
 
-### (Advanced) Exclude certain users from role lookup
+### Exclude certain users from role lookup
 
 If you are using multiple authentication methods, it can make sense to exclude certain users from the LDAP role lookup.
 
@@ -474,7 +478,7 @@ skip_users:
 ```
 
 
-### (Advanced) Exclude roles from nested role lookups
+### Exclude roles from nested role lookups
 
 If the users in your LDAP installation have a large number of roles, and you have the requirement to resolve nested roles as well, you might run into performance issues.
 
@@ -540,7 +544,7 @@ authz:
           - '/\S*/'
 ```
 
-### (Advanced) Configuring multiple user and role bases
+### Configuring multiple user and role bases
 
 To configure multiple user bases in the authc and/or authz section, use the following syntax:
 
@@ -641,3 +645,24 @@ authz:
         rolename: cn
         resolve_nested_roles: true
 ```
+
+### Connection pooling settings
+
+The directory server can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way the pooling is managed. 
+
+Name | Description
+:--- | :---
+`pool.enabled` | Enables connection pooling. Set to `true` to enable.
+`pool.min_size` | Size of the pool at initialization. Also used for pruning.
+`pool.max_size` | Maximum size the pool can reach.
+`pool.pruning_period` | The interval in minutes at which the pruning implementation is executed. For example: when 5, every five minutes. By default, the period is 5.
+`pool.idle_time` | The length of time elapsed when a connnection is considered idle, then becoming a candidate for pruning from the pool. By default, idle time is 10.
+
+
+
+
+
+
+
+
+

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -477,7 +477,7 @@ skip_users:
 
 ### Exclude roles from nested role lookups
 
-If the users in your LDAP installation have a large number of roles, and you have the requirement to resolve nested roles as well, you might run into performance issues.
+If the users in your LDAP installation are mapped to a large number of roles and you have requirements to resolve nested roles, you might encounter performance issues.
 
 In most cases, however, not all user roles are related to OpenSearch and OpenSearch Dashboards. You might need only a couple of roles. In this case, you can use the nested role filter feature to define a list of roles that are filtered out from the list of the user's roles. Wildcards and regular expressions are supported.
 
@@ -541,7 +541,7 @@ authz:
 
 ### Configuring multiple user and role bases
 
-To configure multiple user bases in the authc and/or authz section, use the following syntax:
+To configure multiple user bases in the `authc` or `authz` section, use the following syntax:
 
 ```yml
         ...

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -648,9 +648,9 @@ The directory server can maintain a pool of connections at the ready, assigning 
 Name | Description
 :--- | :---
 `pool.enabled` | Enables connection pooling. Set to `true` to enable.
-`pool.min_size` | Size of the pool at initialization. Also used to reset pool size for pruning.
+`pool.min_size` | Size of the pool at initialization. Also used as a lower limit when pruning.
 `pool.max_size` | Maximum size the pool can reach.
-`pool.pruning_period` | The interval in minutes at which the pruning implementation is executed. For example: when 5, every five minutes. By default, the period is 5.
+`pool.pruning_period` | The interval in minutes at which the pruning implementation is executed. For example: when 5, the implementation is executed every five minutes. By default, the period is 5.
 `pool.idle_time` | The length of time elapsed, in minutes, after a connnection is considered idle. Once elapsed, the connection becomes a candidate for pruning from the pool. By default, idle time is 10.
 
 Connection pooling settings are added to the `authc` section of the configuration.


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Upon request to add documentation for new pool pruning period and pool pruning idle time settings to LDAP documentation, it became apparent that all connection pooling settings keys needed to be added to LDAP documentation.

### Issues Resolved

Fixes issue #1583.

Added connection pooling settings to LDAP documentation:
pool.enabled: true
pool.min_size: 0
pool.max_size: 5
pool.idle_time: 2
pool.pruning_period: 1

Also created a new heading for advanced settings (which includes connection pooling settings) so that essential configuration for connection, authentication, and authorization are clearly distinct from these optional settings.

See PR [#2091](https://github.com/opensearch-project/security/pull/2091) in security for original request to add the settings to the code.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
