### PR TITLE
Adds note about duplicating java opts in multiple places

### DIFF
--- a/_opensearch/install/important-settings.md
+++ b/_opensearch/install/important-settings.md
@@ -39,7 +39,7 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/opensearch/install/
 
   Allows you to access Performance Analyzer on port 9600.
 
-Do not declare the same Java options in multiple locations. If you declare Java options using an environment variable, such as `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, then you should comment out any references to that Java option in `config/jvm.options`. Conversely, if you define Java options in `config/jvm.options`, then you should not define those Java options using environment variables.
+Do not declare the same JVM options in multiple locations. If you declare JVM options using an environment variable, such as `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, then you should comment out any references to that JVM option in `config/jvm.options`. Conversely, if you define JVM options in `config/jvm.options`, then you should not define those JVM options using environment variables.
 {: .note}
 
 ### Network requirements

--- a/_opensearch/install/important-settings.md
+++ b/_opensearch/install/important-settings.md
@@ -39,6 +39,9 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/opensearch/install/
 
   Allows you to access Performance Analyzer on port 9600.
 
+Do not declare the same Java options in multiple locations. If you declare Java options using an environment variable, such as `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, then you should comment out any references to that Java option in `config/jvm.options`. Conversely, if you define Java options in `config/jvm.options`, then you should not define those Java options in environment variables.
+{: .note}
+
 ### Network requirements
 
   The following ports need to be open for OpenSearch components.

--- a/_opensearch/install/important-settings.md
+++ b/_opensearch/install/important-settings.md
@@ -39,7 +39,7 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/opensearch/install/
 
   Allows you to access Performance Analyzer on port 9600.
 
-Do not declare the same JVM options in multiple locations. If you declare JVM options using an environment variable, such as `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, then you should comment out any references to that JVM option in `config/jvm.options`. Conversely, if you define JVM options in `config/jvm.options`, then you should not define those JVM options using environment variables.
+Do not declare the same JVM options in multiple locations because it can result in unexpected behavior or a failure of the OpenSearch service to start. If you declare JVM options using an environment variable, such as `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, then you should comment out any references to that JVM option in `config/jvm.options`. Conversely, if you define JVM options in `config/jvm.options`, then you should not define those JVM options using environment variables.
 {: .note}
 
 ### Network requirements

--- a/_opensearch/install/important-settings.md
+++ b/_opensearch/install/important-settings.md
@@ -39,7 +39,7 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/opensearch/install/
 
   Allows you to access Performance Analyzer on port 9600.
 
-Do not declare the same Java options in multiple locations. If you declare Java options using an environment variable, such as `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, then you should comment out any references to that Java option in `config/jvm.options`. Conversely, if you define Java options in `config/jvm.options`, then you should not define those Java options in environment variables.
+Do not declare the same Java options in multiple locations. If you declare Java options using an environment variable, such as `OPENSEARCH_JAVA_OPTS=-Xms3g -Xmx3g`, then you should comment out any references to that Java option in `config/jvm.options`. Conversely, if you define Java options in `config/jvm.options`, then you should not define those Java options using environment variables.
 {: .note}
 
 ### Network requirements


### PR DESCRIPTION
### Description
Add a note about how declaring java opts in multiple locations can lead to unexpected results.

### Issues Resolved
Fixes #1361 


### Checklist
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
