### PR TITLE
update frontmatter for parent name to include all CAT API pages in left nav menu

### DIFF
--- a/_api-reference/cat/cat-aliases.md
+++ b/_api-reference/cat/cat-aliases.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat aliases
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 1
 has_children: false

--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat allocation
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 5
 has_children: false

--- a/_api-reference/cat/cat-cluster_manager.md
+++ b/_api-reference/cat/cat-cluster_manager.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat cluster manager
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 30
 has_children: false

--- a/_api-reference/cat/cat-count.md
+++ b/_api-reference/cat/cat-count.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat count
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 10
 has_children: false

--- a/_api-reference/cat/cat-field-data.md
+++ b/_api-reference/cat/cat-field-data.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat field data
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 15
 has_children: false

--- a/_api-reference/cat/cat-health.md
+++ b/_api-reference/cat/cat-health.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat health
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 20
 has_children: false

--- a/_api-reference/cat/cat-indices.md
+++ b/_api-reference/cat/cat-indices.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat indices
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 25
 has_children: false

--- a/_api-reference/cat/cat-nodeattrs.md
+++ b/_api-reference/cat/cat-nodeattrs.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat nodeattrs
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 35
 has_children: false

--- a/_api-reference/cat/cat-nodes.md
+++ b/_api-reference/cat/cat-nodes.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat nodes
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 40
 has_children: false

--- a/_api-reference/cat/cat-pending-tasks.md
+++ b/_api-reference/cat/cat-pending-tasks.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat pending tasks
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 45
 has_children: false

--- a/_api-reference/cat/cat-plugins.md
+++ b/_api-reference/cat/cat-plugins.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat plugins
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 50
 has_children: false

--- a/_api-reference/cat/cat-recovery.md
+++ b/_api-reference/cat/cat-recovery.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat recovery
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 50
 has_children: false

--- a/_api-reference/cat/cat-repositories.md
+++ b/_api-reference/cat/cat-repositories.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat repositories
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 55
 has_children: false

--- a/_api-reference/cat/cat-segments.md
+++ b/_api-reference/cat/cat-segments.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat segments
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 55
 has_children: false

--- a/_api-reference/cat/cat-shards.md
+++ b/_api-reference/cat/cat-shards.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat shards
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 60
 has_children: false

--- a/_api-reference/cat/cat-snapshots.md
+++ b/_api-reference/cat/cat-snapshots.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat snapshots
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 65
 has_children: false

--- a/_api-reference/cat/cat-tasks.md
+++ b/_api-reference/cat/cat-tasks.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat tasks
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 70
 has_children: false

--- a/_api-reference/cat/cat-templates.md
+++ b/_api-reference/cat/cat-templates.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat templates
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 
 nav_order: 70
 has_children: false

--- a/_api-reference/cat/cat-thread-pool.md
+++ b/_api-reference/cat/cat-thread-pool.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: cat thread pool
-parent: CAT API
+parent: Compact and aligned text (CAT) API
 nav_order: 75
 has_children: false
 ---


### PR DESCRIPTION
Signed-off-by: alicejw <alicejw@amazon.com>

### Description
Rename frontmatter entries for new parent title, so that all CAT API pages get added to the left nav menu. 


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
