### PR TITLE
add operation to titles to differentiate from the API group acronym

### DIFF
--- a/_api-reference/cat/cat-aliases.md
+++ b/_api-reference/cat/cat-aliases.md
@@ -7,7 +7,7 @@ nav_order: 1
 has_children: false
 ---
 
-# cat aliases
+# cat aliases operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -7,7 +7,7 @@ nav_order: 5
 has_children: false
 ---
 
-# cat allocation
+# cat allocation operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-cluster_manager.md
+++ b/_api-reference/cat/cat-cluster_manager.md
@@ -7,7 +7,7 @@ nav_order: 30
 has_children: false
 ---
 
-# cat cluster_manager
+# cat cluster_manager operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-count.md
+++ b/_api-reference/cat/cat-count.md
@@ -7,7 +7,7 @@ nav_order: 10
 has_children: false
 ---
 
-# cat count
+# cat count operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-field-data.md
+++ b/_api-reference/cat/cat-field-data.md
@@ -7,7 +7,7 @@ nav_order: 15
 has_children: false
 ---
 
-# cat fielddata
+# cat fielddata operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-health.md
+++ b/_api-reference/cat/cat-health.md
@@ -7,7 +7,7 @@ nav_order: 20
 has_children: false
 ---
 
-# cat health
+# cat health operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-indices.md
+++ b/_api-reference/cat/cat-indices.md
@@ -7,7 +7,7 @@ nav_order: 25
 has_children: false
 ---
 
-# cat indices
+# cat indices operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-nodeattrs.md
+++ b/_api-reference/cat/cat-nodeattrs.md
@@ -7,7 +7,7 @@ nav_order: 35
 has_children: false
 ---
 
-# cat nodeattrs
+# cat nodeattrs operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-nodes.md
+++ b/_api-reference/cat/cat-nodes.md
@@ -7,7 +7,7 @@ nav_order: 40
 has_children: false
 ---
 
-# cat nodes
+# cat nodes operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-pending-tasks.md
+++ b/_api-reference/cat/cat-pending-tasks.md
@@ -7,7 +7,7 @@ nav_order: 45
 has_children: false
 ---
 
-# cat pending tasks
+# cat pending tasks operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-plugins.md
+++ b/_api-reference/cat/cat-plugins.md
@@ -7,7 +7,7 @@ nav_order: 50
 has_children: false
 ---
 
-# cat plugins
+# cat plugins operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-recovery.md
+++ b/_api-reference/cat/cat-recovery.md
@@ -7,7 +7,7 @@ nav_order: 50
 has_children: false
 ---
 
-# cat recovery
+# cat recovery operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-repositories.md
+++ b/_api-reference/cat/cat-repositories.md
@@ -7,7 +7,7 @@ nav_order: 55
 has_children: false
 ---
 
-# cat repositories
+# cat repositories operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-segments.md
+++ b/_api-reference/cat/cat-segments.md
@@ -7,7 +7,7 @@ nav_order: 55
 has_children: false
 ---
 
-# cat segments
+# cat segments operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-shards.md
+++ b/_api-reference/cat/cat-shards.md
@@ -7,7 +7,7 @@ nav_order: 60
 has_children: false
 ---
 
-# cat shards
+# cat shards operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-snapshots.md
+++ b/_api-reference/cat/cat-snapshots.md
@@ -7,7 +7,7 @@ nav_order: 65
 has_children: false
 ---
 
-# cat snapshots
+# cat snapshots operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-tasks.md
+++ b/_api-reference/cat/cat-tasks.md
@@ -7,7 +7,7 @@ nav_order: 70
 has_children: false
 ---
 
-# cat tasks
+# cat tasks operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-templates.md
+++ b/_api-reference/cat/cat-templates.md
@@ -7,7 +7,7 @@ nav_order: 70
 has_children: false
 ---
 
-# cat templates
+# cat templates operation
 Introduced 1.0
 {: .label .label-purple }
 

--- a/_api-reference/cat/cat-thread-pool.md
+++ b/_api-reference/cat/cat-thread-pool.md
@@ -6,7 +6,7 @@ nav_order: 75
 has_children: false
 ---
 
-# cat thread pool
+# cat thread pool operation
 Introduced 1.0
 {: .label .label-purple }
 


### PR DESCRIPTION
Signed-off-by: alicejw <alicejw@amazon.com>

### Description
Differentiate individual component page titles with lowercase component names from the CAT API group acronym.

This solves the visual consistency issue when you look at the left navigation, and you see what appears to be an inconsistent naming scheme for the CAT API pages. 

On first glance, it appears that we are inconsistent in our reference page naming conventions. 

However, the API group index page is correct: Compact and aligned text (CAT) API.
Each subpage contains an individual API component page, with those names in lowercase. 
If we add "component" after the component name in lowercase, that should make it clearer that the uppercase acronym would be incorrect as a page title. See the left navigation image:
![Screen Shot 2022-10-27 at 2 09 56 PM](https://user-images.githubusercontent.com/88908598/198398768-41c205ab-ae0e-4a0a-bfdb-378e3a8de1eb.png)

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/1713


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
