### PR TITLE
Add min_rollover_age transition condition to documentation

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -567,7 +567,7 @@ The `conditions` object has the following parameters:
 Parameter | Description | Type | Required
 :--- | :--- |:--- |:--- |
 `min_index_age` | The minimum age of the index required to transition. | `string` | No
-`min_rollover_age` | The minimum age after a rollover has occurred that is required to transition to the next state. | `string` | No
+`min_rollover_age` | The minimum age required after a rollover has occurred to transition to the next state. | `string` | No
 `min_doc_count` | The minimum document count of the index required to transition. | `number` | No
 `min_size` | The minimum size of the total primary shard storage (not counting replicas) required to transition. For example, if you set `min_size` to 100 GiB and your index has 5 primary shards and 5 replica shards of 20 GiB each, the total size of all primary shards is 100 GiB, so your index is transitioned to the next state. | `string` | No
 `cron` | The `cron` job that triggers the transition if no other transition happens first. | `object` | No

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -567,6 +567,7 @@ The `conditions` object has the following parameters:
 Parameter | Description | Type | Required
 :--- | :--- |:--- |:--- |
 `min_index_age` | The minimum age of the index required to transition. | `string` | No
+`min_rollover_age` | The minimum age after a rollover has occurred that is required to transition to the next state. | `string` | No
 `min_doc_count` | The minimum document count of the index required to transition. | `number` | No
 `min_size` | The minimum size of the total primary shard storage (not counting replicas) required to transition. For example, if you set `min_size` to 100 GiB and your index has 5 primary shards and 5 replica shards of 20 GiB each, the total size of all primary shards is 100 GiB, so your index is transitioned to the next state. | `string` | No
 `cron` | The `cron` job that triggers the transition if no other transition happens first. | `object` | No


### PR DESCRIPTION
Signed-off-by: Lauri Moilanen <lauri.moilanen@cloubi.com>

### Description
Adds min_rollover_age transition condition to documentation, as it is already implemented. 

### Issues Resolved
None


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
