### PR TITLE
[Bug] Fix broken link to Bulk APIs page

### DIFF
--- a/_dashboards/run-queries.md
+++ b/_dashboards/run-queries.md
@@ -93,7 +93,7 @@ To use auto indent, select the queries that you want to format, select the wrenc
 
 Auto indenting a collapsed query expands it.
 
-Auto indenting a well-formatted query puts the request body on a single line. This is useful for working with [bulk APIs]({{site.url}}{{site.baseurl}}/opensearch/rest-api/document-apis/bulk/).
+Auto indenting a well-formatted query puts the request body on a single line. This is useful for working with [bulk APIs]({{site.url}}{{site.baseurl}}/opensearch/api-reference/document-apis/bulk/).
 {: .tip}
 
 ## Viewing your request history


### PR DESCRIPTION
Fix dead link identified by LinkChecker.

Signed-off-by: alicejw <alicejw@amazon.com>

### Description

LinkChecker: [Warning] Found 1 dead link:
/opensearch//api-reference/document-apis/bulk/, linked to in ./_dashboards/run-queries.md
                    ...done in 13.396553 seconds.
                    
      Regenerating: 1 file(s) changed at 2022-10-28 09:53:10
                    _dashboards/run-queries.md
      Remote Theme: Using theme pmarsceill/just-the-docs
### Issues Resolved
N/A


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
