### PR TITLE
Revert "Add connection pooling settings to LDAP documentation"

### DIFF
--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -426,15 +426,12 @@ If you don't use or have a role subtree, you can disable the role search complet
 rolesearch_enabled: false
 ```
 
-## Advanced settings
 
-The advanced settings presented below are optional for an essential LDAP configuration. They can, however, improve efficiency, performance, and security for the LDAP implementation. 
-
-### Control LDAP user attributes
+### (Advanced) Control LDAP user attributes
 
 By default, the security plugin reads all LDAP user attributes and makes them available for index name variable substitution and DLS query variable substitution. If your LDAP entries have a lot of attributes, you might want to control which attributes should be made available. The fewer the attributes, the better the performance.
 
-Note that this setting is made in the `authc` section of the config.yml file.
+Note that this setting is made in the authentication `authc` section of the config.yml file.
 
 Name | Description
 :--- | :---
@@ -458,7 +455,8 @@ authc:
       ...
 ```
 
-### Exclude certain users from role lookup
+
+### (Advanced) Exclude certain users from role lookup
 
 If you are using multiple authentication methods, it can make sense to exclude certain users from the LDAP role lookup.
 
@@ -475,9 +473,10 @@ skip_users:
   - '/\S*/'
 ```
 
-### Exclude roles from nested role lookups
 
-If the users in your LDAP installation are mapped to a large number of roles and you have requirements to resolve nested roles, you might encounter performance issues.
+### (Advanced) Exclude roles from nested role lookups
+
+If the users in your LDAP installation have a large number of roles, and you have the requirement to resolve nested roles as well, you might run into performance issues.
 
 In most cases, however, not all user roles are related to OpenSearch and OpenSearch Dashboards. You might need only a couple of roles. In this case, you can use the nested role filter feature to define a list of roles that are filtered out from the list of the user's roles. Wildcards and regular expressions are supported.
 
@@ -488,6 +487,7 @@ nested_role_filter:
   - 'cn=Jane Doe,ou*people,o=TEST'
   - ...
 ```
+
 
 ### Configuration summary
 
@@ -505,6 +505,7 @@ Name | Description
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.
 `custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
 `custom_attr_maxval_len`  | Integer. Specifies the maximum allowed length of each attribute. All attributes longer than this value are discarded. A value of `0` disables custom attributes altogether. Default is 36.
+
 
 ### Complete authorization example
 
@@ -539,9 +540,9 @@ authz:
           - '/\S*/'
 ```
 
-### Configuring multiple user and role bases
+### (Advanced) Configuring multiple user and role bases
 
-To configure multiple user bases in the `authc` or `authz` section, use the following syntax:
+To configure multiple user bases in the authc and/or authz section, use the following syntax:
 
 ```yml
         ...
@@ -640,33 +641,3 @@ authz:
         rolename: cn
         resolve_nested_roles: true
 ```
-
-### Connection pooling settings
-
-OpenSearch can maintain a pool of connections at the ready, assigning them when needed and returning them to the pool after a connection is closed. This arrangement can lower demands on the resources used to create connections, improve OpenSearch performance, and reduce load on the server. You can use the settings below to control the way connection pooling is carried out.
-
-Name | Description
-:--- | :---
-`pool.enabled` | Enables connection pooling. Set to `true` to enable.
-`pool.min_size` | Size of the pool at initialization. Also used as a lower limit when pruning.
-`pool.max_size` | Maximum size the pool can reach.
-`pool.pruning_period` | The interval in minutes at which the pruning implementation is executed. For example: when 5, the implementation is executed every five minutes. By default, the period is 5.
-`pool.idle_time` | The length of time elapsed, in minutes, after a connnection is considered idle. Once elapsed, the connection becomes a candidate for pruning from the pool. By default, idle time is 10.
-
-Connection pooling settings are added to the `authc` section of the configuration.
-
-```yml
-authc:
-  ldap:
-    http_enabled: true
-    transport_enabled: true
-    authentication_backend:
-      type: ldap
-      config:
-        pool.enabled: true
-        pool.min_size: 5
-        pool.max_size: 12
-        pool.pruning_period: 5
-        pool.idle_time: 15
-```
-


### PR DESCRIPTION
Reverts opensearch-project/documentation-website#1698

After some investigation, we now realize there are two different backends for LDAP: LDAP and LDAP2. Recent and previous code additions for connection pooling settings keys were made against LDAP2, but OpenSearch guides users to configure the LDAP backend for implementations.

Therefore, we are reverting these changes to documentation until the problem between the two backends is resolved. At that point we will reintroduce this documentation.