### PR TITLE
Added instructions for enabling opensearch as a service with systemd

### DIFF
--- a/_opensearch/cluster.md
+++ b/_opensearch/cluster.md
@@ -152,7 +152,7 @@ After you set the configurations, start OpenSearch on all nodes:
 sudo systemctl start opensearch.service
 ```
 
-Installing OpenSearch from a tar archive will not automatically create a service with `systemd`. See [Run OpenSearch as a service with systemd]({{site.url}}{{site.baseurl}}/opensearch/install/tar/#run-opensearch-as-a-service-with-systemd) for instructions about how to create and start the service if you receive an error like `Failed to start opensearch.service: Unit not found.`
+Installing OpenSearch from a tar archive will not automatically create a service with `systemd`. See [Run OpenSearch as a service with systemd]({{site.url}}{{site.baseurl}}/opensearch/install/tar/#run-opensearch-as-a-service-with-systemd) for instructions on how to create and start the service if you receive an error like `Failed to start opensearch.service: Unit not found.`
 {: .tip}
 
 Then go to the logs file to see the formation of the cluster:

--- a/_opensearch/cluster.md
+++ b/_opensearch/cluster.md
@@ -152,6 +152,9 @@ After you set the configurations, start OpenSearch on all nodes:
 sudo systemctl start opensearch.service
 ```
 
+Installing OpenSearch from a tar archive will not automatically create a service with `systemd`. See [Run OpenSearch as a service with systemd]({{site.url}}{{site.baseurl}}/opensearch/install/tar/#run-opensearch-as-a-service-with-systemd) for instructions about how to create and start the service if you receive an error like `Failed to start opensearch.service: Unit not found.`
+{: .tip}
+
 Then go to the logs file to see the formation of the cluster:
 
 ```bash
@@ -172,7 +175,7 @@ x.x.x.x           34          38   0    0.12    0.07     0.06 md        -      o
 x.x.x.x           23          38   0    0.12    0.07     0.06 md        -      opensearch-c1
 ```
 
-To better understand and monitor your cluster, use the [cat API]({{site.url}}{{site.baseurl}}/opensearch/catapis/).
+To better understand and monitor your cluster, use the [CAT API]({{site.url}}{{site.baseurl}}/opensearch/catapis/).
 
 ## (Advanced) Step 6: Configure shard allocation awareness or forced awareness
 

--- a/_opensearch/install/tar.md
+++ b/_opensearch/install/tar.md
@@ -453,6 +453,83 @@ $ curl https://your.host.address:9200 -u admin:yournewpassword -k
 }
 ```
 
+### Run OpenSearch as a service with systemd
+
+Create a service for OpenSearch and register it with `systemd`. After the service has been defined, you can enable, start, and stop the OpenSearch process using `systemctl` commands. The following steps reflect an environment where OpenSearch has been installed to `/opt/opensearch`. Change the paths in the following commands and example file to reflect your installation path.
+
+1. Create a user for the OpenSearch service.
+   ```bash
+   sudo adduser --system --shell /bin/bash -U --no-create-home opensearch
+   ```
+
+1. Add your user to the `opensearch` user group.
+   ```bash
+   sudo usermod -aG opensearch $USER
+   ```
+
+1. Change the file owner to `opensearch`. Make sure to change the path if your OpenSearch files are in a different directory.
+   ```bash
+   sudo chown -R opensearch /opt/opensearch/
+   ```
+
+1. Create the service file and open it for editing.
+   ```bash
+   sudo vi /etc/systemd/system/opensearch.service
+   ```
+
+1. Enter the following example service configuration. Make sure to change references to the path if your OpenSearch files are in a different directory.
+   ```bash
+   [Unit]
+   Description=OpenSearch
+   Wants=network-online.target
+   After=network-online.target
+
+   [Service]
+   Type=forking
+   RuntimeDirectory=data
+
+   WorkingDirectory=/opt/opensearch
+   ExecStart=/opt/opensearch/bin/opensearch -d
+
+   User=opensearch
+   Group=opensearch
+   StandardOutput=journal
+   StandardError=inherit
+   LimitNOFILE=65535
+   LimitNPROC=4096
+   LimitAS=infinity
+   LimitFSIZE=infinity
+   TimeoutStopSec=0
+   KillSignal=SIGTERM
+   KillMode=process
+   SendSIGKILL=no
+   SuccessExitStatus=143
+   TimeoutStartSec=75
+
+   [Install]
+   WantedBy=multi-user.target
+   ```
+
+1. Reload `systemd` manager configuration.
+   ```bash
+   sudo systemctl daemon-reload
+   ```
+
+1. Enable the OpenSearch service.
+   ```bash
+   sudo systemctl enable opensearch.service
+   ```
+
+1. Start the OpenSearch service.
+   ```bash
+   sudo systemctl start opensearch
+   ```
+
+1. Verify that the service is running.
+   ```bash
+   sudo systemctl status opensearch
+   ```
+
 ## Related links
 
 - [OpenSearch configuration]({{site.url}}{{site.baseurl}}/opensearch/configuration/)

--- a/_opensearch/install/tar.md
+++ b/_opensearch/install/tar.md
@@ -510,6 +510,9 @@ Create a service for OpenSearch and register it with `systemd`. After the servic
    WantedBy=multi-user.target
    ```
 
+   // possible term = masquerade for moving the software and replacing it with something malicious
+   // Need lots and lots of disclaimers - do this in DEV ONLY!
+
 1. Reload `systemd` manager configuration.
    ```bash
    sudo systemctl daemon-reload

--- a/_opensearch/install/tar.md
+++ b/_opensearch/install/tar.md
@@ -455,7 +455,10 @@ $ curl https://your.host.address:9200 -u admin:yournewpassword -k
 
 ### Run OpenSearch as a service with systemd
 
-Create a service for OpenSearch and register it with `systemd`. After the service has been defined, you can enable, start, and stop the OpenSearch process using `systemctl` commands. The following steps reflect an environment where OpenSearch has been installed to `/opt/opensearch`. Change the paths in the following commands and example file to reflect your installation path.
+Create a service for OpenSearch and register it with `systemd`. After the service has been defined, you can enable, start, and stop the OpenSearch service using `systemctl` commands. The commands in this section reflect an environment where OpenSearch has been installed to `/opt/opensearch` and should be changed depending on your installation path.
+
+The following configuration is only suitable for testing in a non-production environment. We do not recommend using the following configuration in a production environment. You should install OpenSearch with the [RPM]({{site.url}}{{site.baseurl}}/opensearch/install/rpm/) distribution if you want to run OpenSearch as a systemd-managed service on your host. The tarball installation does not define a specific installation path, users, roles, or permissions. Failure to properly secure your host environment can result in unexpected behavior.
+{: .warning}
 
 1. Create a user for the OpenSearch service.
    ```bash
@@ -509,9 +512,6 @@ Create a service for OpenSearch and register it with `systemd`. After the servic
    [Install]
    WantedBy=multi-user.target
    ```
-
-   // possible term = masquerade for moving the software and replacing it with something malicious
-   // Need lots and lots of disclaimers - do this in DEV ONLY!
 
 1. Reload `systemd` manager configuration.
    ```bash


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
Add a section to the tar installation guide, as an extension of running OS in your own environment, to walk the user through creating a service with systemd. Also added a note to the cluster configuration page so that users who installed OS from a tarball are not blocked from proceeding with cluster configuration.

### Issues Resolved
Fixes #1722 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
