### PR TITLE
add instruction for using parameters and sorting for stored script

### DIFF
--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -131,7 +131,7 @@ To determine whether the script was successfully created, use the [Get stored sc
 :--- | :--- | :---
 | acknowledged | Boolean | Whether the request was received. |
 
-## Create or update stored script with parameter
+## Creating or updating a stored script with parameters
 
 The Painless script supports `params` to pass variables to the script. 
 

--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -91,7 +91,7 @@ curl -XPUT "http://opensearch:9200/_scripts/my-first-script" -H 'Content-Type: a
 ````
 
 
-The following request creates the Painless script `my-first-script` that sums the ratings for each book and displays the sum in the output:
+The following request creates the Painless script `my-first-script`, which sums the ratings for each book and displays the sum in the output:
 
 ````json
 PUT _scripts/my-first-script
@@ -110,9 +110,9 @@ PUT _scripts/my-first-script
 ````
 {% include copy-curl.html %}
 
-See [Execute Painless stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/exec-stored-script/) for information on running the script.
+See [Execute Painless stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/exec-stored-script/) for information about running the script.
 
-#### Sample response
+#### Example response
 
 The `PUT _scripts/my-first-script` request returns the following field:
 
@@ -129,15 +129,15 @@ To determine whether the script was successfully created, use the [Get stored sc
 
 | Field | Data Type | Description | 
 :--- | :--- | :---
-| acknowledged | Boolean | whether the request was received. |
+| acknowledged | Boolean | Whether the request was received. |
 
 ## Create or update stored script with parameter
 
-Painless script supports `params` to pass variables into the script. 
+The Painless script supports `params` to pass variables to the script. 
 
 ### Example
 
-The following request creates the Painless script `multiplier-script`. The request sums the ratings for each book, multiplies the summed value by the `multiplier` param, and displays the result in the output:
+The following request creates the Painless script `multiplier-script`. The request sums the ratings for each book, multiplies the summed value by the `multiplier` parameter, and displays the result in the output:
 
 ````json
 PUT _scripts/multiplier-script

--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -91,7 +91,7 @@ curl -XPUT "http://opensearch:9200/_scripts/my-first-script" -H 'Content-Type: a
 ````
 
 
-The following request creates the Painless script `my-first-script`. It sums the ratings for each book and displays the sum in the output.
+The following request creates the Painless script `my-first-script` that sums the ratings for each book and displays the sum in the output:
 
 ````json
 PUT _scripts/my-first-script
@@ -108,8 +108,9 @@ PUT _scripts/my-first-script
   }
 }
 ````
+{% include copy-curl.html %}
 
-See [Execute Painless stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/exec-stored-script/) for information about running the script.
+See [Execute Painless stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/exec-stored-script/) for information on running the script.
 
 #### Sample response
 
@@ -131,11 +132,12 @@ To determine whether the script was successfully created, use the [Get stored sc
 | acknowledged | Boolean | whether the request was received. |
 
 ## Create or update stored script with parameter
+
 Painless script supports `params` to pass variables into the script. 
 
-### Sample request
+### Example
 
-The following request creates the Painless script `multiplier-script`. It sums the ratings for each book, multiply summed-up value by `multiplier` param and displays the result in the output.
+The following request creates the Painless script `multiplier-script`. The request sums the ratings for each book, multiplies the summed-up value by the `multiplier` param, and displays the result in the output:
 
 ````json
 PUT _scripts/multiplier-script
@@ -152,8 +154,9 @@ PUT _scripts/multiplier-script
   }
 }
 ````
+{% include copy-curl.html %}
 
-### Sample response
+### Example response
 
 The `PUT _scripts/multiplier-script` request returns the following field:
 

--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -137,7 +137,7 @@ Painless script supports `params` to pass variables into the script.
 
 ### Example
 
-The following request creates the Painless script `multiplier-script`. The request sums the ratings for each book, multiplies the summed-up value by the `multiplier` param, and displays the result in the output:
+The following request creates the Painless script `multiplier-script`. The request sums the ratings for each book, multiplies the summed value by the `multiplier` param, and displays the result in the output:
 
 ````json
 PUT _scripts/multiplier-script

--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -90,6 +90,25 @@ curl -XPUT "http://opensearch:9200/_scripts/my-first-script" -H 'Content-Type: a
 }'
 ````
 
+
+The following request creates the Painless script `my-first-script`. It sums the ratings for each book and displays the sum in the output.
+
+````json
+PUT _scripts/my-first-script
+{
+  "script": {
+      "lang": "painless",
+      "source": """
+          int total = 0;
+          for (int i = 0; i < doc['ratings'].length; ++i) {
+            total += doc['ratings'][i];
+          }
+          return total;
+        """
+  }
+}
+````
+
 See [Execute Painless stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/exec-stored-script/) for information about running the script.
 
 #### Sample response
@@ -110,3 +129,36 @@ To determine whether the script was successfully created, use the [Get stored sc
 | Field | Data Type | Description | 
 :--- | :--- | :---
 | acknowledged | Boolean | whether the request was received. |
+
+## Create or update stored script with parameter
+Painless script supports `params` to pass variables into the script. 
+
+### Sample request
+
+The following request creates the Painless script `multiplier-script`. It sums the ratings for each book, multiply summed-up value by `multiplier` param and displays the result in the output.
+
+````json
+PUT _scripts/multiplier-script
+{
+  "script": {
+      "lang": "painless",
+      "source": """
+          int total = 0;
+          for (int i = 0; i < doc['ratings'].length; ++i) {
+            total += doc['ratings'][i];
+          }
+          return total * params['multiplier'];
+        """
+  }
+}
+````
+
+### Sample response
+
+The `PUT _scripts/multiplier-script` request returns the following field:
+
+````json
+{
+  "acknowledged" : true
+}
+````

--- a/_api-reference/script-apis/exec-stored-script.md
+++ b/_api-reference/script-apis/exec-stored-script.md
@@ -133,15 +133,15 @@ To pass different parameters to the script each time when running a query, defin
 
 ### Example
 
-The following request runs the stored script that was created in [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/). The script sums the ratings for each book, multiplies the summed-up value by the `multiplier` param, and displays the result in the output.
+The following request runs the stored script that was created in [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/). The script sums the ratings for each book, multiplies the summed value by the `multiplier` parameter, and displays the result in the output.
 
 * The script's target is the `books` index.
 
-* The `"match_all": {}` property value is an empty object indicating that it processes each document in the index.
+* The `"match_all": {}` property value is an empty object, indicating that it processes each document in the index.
 
 * The `total_ratings` field value is the result of the `multiplier-script` execution. See [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/).
 
-* `"multiplier": 2` in `params` field is a variable passed into the stored script `multiplier-script`.
+* `"multiplier": 2` in the `params` field is a variable passed to the stored script `multiplier-script`:
 
 ````json
 GET books/_search

--- a/_api-reference/script-apis/exec-stored-script.md
+++ b/_api-reference/script-apis/exec-stored-script.md
@@ -127,7 +127,7 @@ The `GET books/_search` request returns the following fields:
 | _score | Float | Document's relevance score. |
 | fields | Object | Fields and their value returned from the script. |
 
-## Execute Painless stored script with parameters
+## Running a Painless stored script with parameters
 
 To pass different parameters to the script each time when running a query, define `params` in `script_fields`.
 
@@ -139,7 +139,7 @@ The following request runs the stored script that was created in [Create or upda
 
 * The `"match_all": {}` property value is an empty object, indicating that it processes each document in the index.
 
-* The `total_ratings` field value is the result of the `multiplier-script` execution. See [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/).
+* The `total_ratings` field value is the result of the `multiplier-script` execution. See [Creating or updating a stored script with parameters]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/).
 
 * `"multiplier": 2` in the `params` field is a variable passed to the stored script `multiplier-script`:
 

--- a/_api-reference/script-apis/exec-stored-script.md
+++ b/_api-reference/script-apis/exec-stored-script.md
@@ -137,7 +137,7 @@ The following request runs the stored script that was created in [Create or upda
 
 * The script's target is the `books` index.
 
-* The `"match_all": {}` property value is an empty object indicating processing each document in the index.
+* The `"match_all": {}` property value is an empty object indicating that it processes each document in the index.
 
 * The `total_ratings` field value is the result of the `multiplier-script` execution. See [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/).
 

--- a/_api-reference/script-apis/exec-stored-script.md
+++ b/_api-reference/script-apis/exec-stored-script.md
@@ -128,17 +128,18 @@ The `GET books/_search` request returns the following fields:
 | fields | Object | Fields and their value returned from the script. |
 
 ## Execute Painless stored script with parameters
-If you want to pass different parameters to the script each time of running query, define `params` in script_fields
 
-### Sample request
+To pass different parameters to the script each time when running a query, define `params` in `script_fields`.
 
-The following request runs the stored script that was created in [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/). The script sums the ratings for each book, multiply summed-up value by `multiplier` param and displays the result in the output.
+### Example
+
+The following request runs the stored script that was created in [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/). The script sums the ratings for each book, multiplies the summed-up value by the `multiplier` param, and displays the result in the output.
 
 * The script's target is the `books` index.
 
-* The `"match_all": {}` property value is an empty object indicating to process each document in the index.
+* The `"match_all": {}` property value is an empty object indicating processing each document in the index.
 
-* The `total_ratings` field value is the result of the `multiplier-script` execution. See  [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/).
+* The `total_ratings` field value is the result of the `multiplier-script` execution. See [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/).
 
 * `"multiplier": 2` in `params` field is a variable passed into the stored script `multiplier-script`.
 
@@ -160,8 +161,9 @@ GET books/_search
   }
 }
 ````
+{% include copy-curl.html %}
 
-### Sample response
+### Example response
 ````json
 {
   "took" : 12,

--- a/_api-reference/script-apis/exec-stored-script.md
+++ b/_api-reference/script-apis/exec-stored-script.md
@@ -126,3 +126,195 @@ The `GET books/_search` request returns the following fields:
 | _id | String | Document ID. |
 | _score | Float | Document's relevance score. |
 | fields | Object | Fields and their value returned from the script. |
+
+## Execute Painless stored script with parameters
+If you want to pass different parameters to the script each time of running query, define `params` in script_fields
+
+### Sample request
+
+The following request runs the stored script that was created in [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/). The script sums the ratings for each book, multiply summed-up value by `multiplier` param and displays the result in the output.
+
+* The script's target is the `books` index.
+
+* The `"match_all": {}` property value is an empty object indicating to process each document in the index.
+
+* The `total_ratings` field value is the result of the `multiplier-script` execution. See  [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/).
+
+* `"multiplier": 2` in `params` field is a variable passed into the stored script `multiplier-script`.
+
+````json
+GET books/_search
+{
+   "query": {
+    "match_all": {}
+  },
+  "script_fields": {
+    "total_ratings": {
+      "script": {
+        "id": "multiplier-script", 
+        "params": {
+          "multiplier": 2
+        }        
+      }
+    }
+  }
+}
+````
+
+### Sample response
+````json
+{
+  "took" : 12,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 3,
+      "relation" : "eq"
+    },
+    "max_score" : 1.0,
+    "hits" : [
+      {
+        "_index" : "books",
+        "_type" : "_doc",
+        "_id" : "3",
+        "_score" : 1.0,
+        "fields" : {
+          "total_ratings" : [
+            16
+          ]
+        }
+      },
+      {
+        "_index" : "books",
+        "_type" : "_doc",
+        "_id" : "2",
+        "_score" : 1.0,
+        "fields" : {
+          "total_ratings" : [
+            30
+          ]
+        }
+      },
+      {
+        "_index" : "books",
+        "_type" : "_doc",
+        "_id" : "1",
+        "_score" : 1.0,
+        "fields" : {
+          "total_ratings" : [
+            24
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+## Sort results using painless stored script
+You can use painless stored script to sort results.
+
+### Sample request
+
+````json
+GET books/_search
+{
+   "query": {
+    "match_all": {}
+  },
+  "script_fields": {
+    "total_ratings": {
+      "script": {
+        "id": "multiplier-script",
+        "params": {
+          "multiplier": 2
+        }
+      }
+    }
+  },
+  "sort": {
+    "_script": {
+       "type": "number",
+       "script": {
+         "id": "multiplier-script",
+         "params": {
+           "multiplier": 2
+          }
+       },
+       "order": "desc"
+    }
+  }
+}
+```
+
+### Sample response
+
+````json
+{
+  "took" : 90,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 5,
+    "successful" : 5,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 3,
+      "relation" : "eq"
+    },
+    "max_score" : null,
+    "hits" : [
+      {
+        "_index" : "books",
+        "_type" : "_doc",
+        "_id" : "2",
+        "_score" : null,
+        "fields" : {
+          "total_ratings" : [
+            30
+          ]
+        },
+        "sort" : [
+          30.0
+        ]
+      },
+      {
+        "_index" : "books",
+        "_type" : "_doc",
+        "_id" : "1",
+        "_score" : null,
+        "fields" : {
+          "total_ratings" : [
+            24
+          ]
+        },
+        "sort" : [
+          24.0
+        ]
+      },
+      {
+        "_index" : "books",
+        "_type" : "_doc",
+        "_id" : "3",
+        "_score" : null,
+        "fields" : {
+          "total_ratings" : [
+            16
+          ]
+        },
+        "sort" : [
+          16.0
+        ]
+      }
+    ]
+  }
+}
+```


### PR DESCRIPTION
…mple results using stored script

Signed-off-by: syrinx05p <4161768+syrinx05p@users.noreply.github.com>

### Description
- add instruction for using parameters in stored script
- add instruction for sorting results using stored script

### Issues Resolved
- Current OpenSearch document does not explain how to use param in stored script. Users need to refer elastic.co reference.
- Current OpenSearch document does not explain how to sort results using stored script. This instruction doesn't exist officially on OpenSearch and Elastic guide. It makes users having concern if scripted field has a capability to be used in sort.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
