### PR TITLE
Describe SAML supported private key format and encryption algorithm

### DIFF
--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -176,6 +176,8 @@ Name | Description
 `sp.signature_private_key_filepath` | Path to the private key. The file must be placed under the OpenSearch `config` directory, and the path must be specified relative to that same directory.
 `sp.signature_algorithm` | The algorithm used to sign the requests. See the next table for possible values.
 
+The private key must be in PKCS#8 format. If you want to use an encrypted key, it must be encrypted with a PKCS#12-compatible algorithm (3DES).
+
 The Security plugin supports the following signature algorithms.
 
 Algorithm | Value


### PR DESCRIPTION
### Description
OpenSearch allows signing requests by using a private key in the PKCS#8 format. If a user wants to use an encrypted key, the key must be encrypted with a PKCS#12-compatible algorithm.

The `SAML -> Request signing` documentation is extended with the requirements. It should save time of the customers who use wrong key formats or a good key format, but encrypted with an unsupported algorithm (e.g. PKCS#5 2.0 compatible algorithm).

### Issues Resolved
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
