### PR TITLE
Fixes Docker command with custom file path

### DIFF
--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -129,7 +129,7 @@ If none of those files exist in your current directory, the `docker-compose` com
 You can specify a custom file location and name when invoking `docker-compose` with the `-f` flag:
 ```bash
 # Use a relative or absolute path to the file.
-docker-compose up -f /path/to/your-file.yml
+docker-compose -f /path/to/your-file.yml up
 ```
 
 If this is your first time launching an OpenSearch cluster using Docker Compose, use the following example `docker-compose.yml` file. Save it in the home directory of your host and name it `docker-compose.yml`. This file will create a cluster that contains three containers: two containers running the OpenSearch service and a single container running OpenSearch Dashboards. These containers will communicate over a bridge network called `opensearch-net` and use two volumes, one for each OpenSearch node. Because this file does not explicitly disable the demo security configuration, self-signed TLS certificates are installed and internal users with default names and passwords are created.


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
Command options were reversed which caused the command to fail. `-f` needs to be specified before `up`.

### Issues Resolved
Fixes #1793 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
