### PR TITLE
Removes max_primary_shard_size parameter

### DIFF
--- a/_api-reference/index-apis/shrink-index.md
+++ b/_api-reference/index-apis/shrink-index.md
@@ -58,4 +58,3 @@ You can use the request body to configure some index settings for the target ind
 Field | Type | Description
 alias | Object | Sets an alias for the target index. Can have the fields `filter`, `index_routing`, `is_hidden`, `is_write_index`, `routing`, and `search_routing`. See [Index Aliases]({{site.url}}{{site.baseurl}}/api-reference/alias/#request-body).
 settings | Object | Index settings you can apply to your target index. See [Index Settings]({{site.url}}{{site.baseurl}}/api-reference/index-apis/create-index/#index-settings).
-max_primary_shard_size | Bytes | Sets the maximum size of a primary shard in the target index. For example, if this field is set to 100 GB, and the source index's primary shards total to 300 GB, then the target index has 3 primary shards of 100 GB each.

--- a/_api-reference/index-apis/shrink-index.md
+++ b/_api-reference/index-apis/shrink-index.md
@@ -58,3 +58,8 @@ You can use the request body to configure some index settings for the target ind
 Field | Type | Description
 alias | Object | Sets an alias for the target index. Can have the fields `filter`, `index_routing`, `is_hidden`, `is_write_index`, `routing`, and `search_routing`. See [Index Aliases]({{site.url}}{{site.baseurl}}/api-reference/alias/#request-body).
 settings | Object | Index settings you can apply to your target index. See [Index Settings]({{site.url}}{{site.baseurl}}/api-reference/index-apis/create-index/#index-settings).
+
+{% comment %}
+The new parameter to be called max_shard_size. 
+max_primary_shard_size | Bytes | Sets the maximum size of a primary shard in the target index. For example, if this field is set to 100 GB, and the source index's primary shards total to 300 GB, then the target index has 3 primary shards of 100 GB each.
+{% endcomment %}


### PR DESCRIPTION
Removes the max_primary_shard_size parameter because this parameter does not exist for this API.

### Checklist
- [x ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
