### PR TITLE
Adds sample data set to the repo for use in quick start guide

### DIFF
--- a/assets/examples/ecommerce-field_mappings.json
+++ b/assets/examples/ecommerce-field_mappings.json
@@ -16,7 +16,7 @@
         "type" : "date"
       },
       "customer_first_name" : {
-        "type" : "text",
+        "type": "text",
         "fields" : {
           "keyword" : {
             "type" : "keyword",

--- a/assets/examples/ecommerce-field_mappings.json
+++ b/assets/examples/ecommerce-field_mappings.json
@@ -1,0 +1,206 @@
+{
+  "mappings" : {
+    "properties" : {
+      "category" : {
+        "type" : "text",
+        "fields" : {
+          "keyword" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "currency" : {
+        "type" : "keyword"
+      },
+      "customer_birth_date" : {
+        "type" : "date"
+      },
+      "customer_first_name" : {
+        "type" : "text",
+        "fields" : {
+          "keyword" : {
+            "type" : "keyword",
+            "ignore_above" : 256
+          }
+        }
+      },
+      "customer_full_name" : {
+        "type" : "text",
+        "fields" : {
+          "keyword" : {
+            "type" : "keyword",
+            "ignore_above" : 256
+          }
+        }
+      },
+      "customer_gender" : {
+        "type" : "keyword"
+      },
+      "customer_id" : {
+        "type" : "keyword"
+      },
+      "customer_last_name" : {
+        "type" : "text",
+        "fields" : {
+          "keyword" : {
+            "type" : "keyword",
+            "ignore_above" : 256
+          }
+        }
+      },
+      "customer_phone" : {
+        "type" : "keyword"
+      },
+      "day_of_week" : {
+        "type" : "keyword"
+      },
+      "day_of_week_i" : {
+        "type" : "integer"
+      },
+      "email" : {
+        "type" : "keyword"
+      },
+      "event" : {
+        "properties" : {
+          "dataset" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "geoip" : {
+        "properties" : {
+          "city_name" : {
+            "type" : "keyword"
+          },
+          "continent_name" : {
+            "type" : "keyword"
+          },
+          "country_iso_code" : {
+            "type" : "keyword"
+          },
+          "location" : {
+            "type" : "geo_point"
+          },
+          "region_name" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "manufacturer" : {
+        "type" : "text",
+        "fields" : {
+          "keyword" : {
+            "type" : "keyword"
+          }
+        }
+      },
+      "order_date" : {
+        "type" : "date"
+      },
+      "order_id" : {
+        "type" : "keyword"
+      },
+      "products" : {
+        "properties" : {
+          "_id" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword",
+                "ignore_above" : 256
+              }
+            }
+          },
+          "base_price" : {
+            "type" : "half_float"
+          },
+          "base_unit_price" : {
+            "type" : "half_float"
+          },
+          "category" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword"
+              }
+            }
+          },
+          "created_on" : {
+            "type" : "date"
+          },
+          "discount_amount" : {
+            "type" : "half_float"
+          },
+          "discount_percentage" : {
+            "type" : "half_float"
+          },
+          "manufacturer" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword"
+              }
+            }
+          },
+          "min_price" : {
+            "type" : "half_float"
+          },
+          "price" : {
+            "type" : "half_float"
+          },
+          "product_id" : {
+            "type" : "long"
+          },
+          "product_name" : {
+            "type" : "text",
+            "fields" : {
+              "keyword" : {
+                "type" : "keyword"
+              }
+            },
+            "analyzer" : "english"
+          },
+          "quantity" : {
+            "type" : "integer"
+          },
+          "sku" : {
+            "type" : "keyword"
+          },
+          "tax_amount" : {
+            "type" : "half_float"
+          },
+          "taxful_price" : {
+            "type" : "half_float"
+          },
+          "taxless_price" : {
+            "type" : "half_float"
+          },
+          "unit_discount_amount" : {
+            "type" : "half_float"
+          }
+        }
+      },
+      "sku" : {
+        "type" : "keyword"
+      },
+      "taxful_total_price" : {
+        "type" : "half_float"
+      },
+      "taxless_total_price" : {
+        "type" : "half_float"
+      },
+      "total_quantity" : {
+        "type" : "integer"
+      },
+      "total_unique_products" : {
+        "type" : "integer"
+      },
+      "type" : {
+        "type" : "keyword"
+      },
+      "user" : {
+        "type" : "keyword"
+      }
+    }
+  }
+}


### PR DESCRIPTION
### Description
I pulled and groomed the e-commerce sample data being used by OpenSearch Dashboards (https://github.com/opensearch-project/OpenSearch-Dashboards/tree/9041a8278739e2979cdf6b2307629f3f3b802dcd/src/plugins/home/server/services/sample_data/data_sets/ecommerce). I used a script to rewrite the index with the necessary metadata to make it work with the Bulk API, which is how our internal onboarding instructions walk the user through getting started.

### Issues Resolved
Related to issue #789 and PR #1739 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
