### PR TITLE
cluster.initial_master_nodes is no longer present in the documentatio…

### DIFF
--- a/_upgrade-to/upgrade-to.md
+++ b/_upgrade-to/upgrade-to.md
@@ -142,7 +142,7 @@ If you are upgrading an Open Distro for Elasticsearch cluster, we recommend firs
       plugins.security.disabled: true
       ```
 
-   1. Port your settings from `elasticsearch.yml` to `opensearch.yml`. Most settings use the same names. At a minimum, specify `cluster.name`, `node.name`, `discovery.seed_hosts`, and `cluster.initial_master_nodes`.
+   1. Port your settings from `elasticsearch.yml` to `opensearch.yml`. Most settings use the same names. At a minimum, specify `cluster.name`, `node.name`, `discovery.seed_hosts`, and `cluster.initial_cluster_manager_nodes`.
 
    1. (Optional) If you're actively connecting to the cluster with legacy clients that check for a particular version number, such as Logstash OSS, add a [compatibility setting]({{site.url}}{{site.baseurl}}/clients/agents-and-ingestion-tools/) to `opensearch.yml`:
 


### PR DESCRIPTION
…n. It was replaced with cluster.initial_cluster_manager_nodes.

Signed-off-by: pawelw1 <pawel.wlodarczyk@eliatra.com>

### Description
`cluster.initial_master_nodes` is no longer present in the documentation. It was replaced with `cluster.initial_cluster_manager_nodes`.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
