### PR TITLE
Update multi-tenancy route to match name change

### DIFF
--- a/_observability-plugin/notebooks.md
+++ b/_observability-plugin/notebooks.md
@@ -18,7 +18,7 @@ You can also generate [reports]({{site.url}}{{site.baseurl}}/dashboards/reportin
 
 Common use cases include creating postmortem reports, designing runbooks, building live infrastructure reports, and writing documentation.
 
-Tenants in OpenSearch Dashboards are spaces for saving notebooks and other OpenSearch Dashboards objects. For more information, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config/).
+Tenants in OpenSearch Dashboards are spaces for saving notebooks and other OpenSearch Dashboards objects. For more information, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/tenant-index/).
 {: .note }
 
 

--- a/_observability-plugin/notebooks.md
+++ b/_observability-plugin/notebooks.md
@@ -18,7 +18,7 @@ You can also generate [reports]({{site.url}}{{site.baseurl}}/dashboards/reportin
 
 Common use cases include creating postmortem reports, designing runbooks, building live infrastructure reports, and writing documentation.
 
-Tenants in OpenSearch Dashboards are spaces for saving notebooks and other OpenSearch Dashboards objects. For more information, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/access-control/multi-tenancy/).
+Tenants in OpenSearch Dashboards are spaces for saving notebooks and other OpenSearch Dashboards objects. For more information, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config).
 {: .note }
 
 

--- a/_observability-plugin/notebooks.md
+++ b/_observability-plugin/notebooks.md
@@ -18,7 +18,7 @@ You can also generate [reports]({{site.url}}{{site.baseurl}}/dashboards/reportin
 
 Common use cases include creating postmortem reports, designing runbooks, building live infrastructure reports, and writing documentation.
 
-Tenants in OpenSearch Dashboards are spaces for saving notebooks and other OpenSearch Dashboards objects. For more information, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config).
+Tenants in OpenSearch Dashboards are spaces for saving notebooks and other OpenSearch Dashboards objects. For more information, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config/).
 {: .note }
 
 

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -328,7 +328,7 @@ _meta:
 
 ## tenants.yml
 
-You can use this file to specify and add any number of OpenSearch Dashboards tenants to your OpenSearch cluster. For more information about tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config).
+You can use this file to specify and add any number of OpenSearch Dashboards tenants to your OpenSearch cluster. For more information about tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/tenant-index).
 
 Like all of the other YAML files, we recommend you use `tenants.yml` to add any tenants you must have in your cluster, and then use OpenSearch Dashboards or the [REST API]({{site.url}}{{site.baseurl}}/security-plugin/access-control/api/#tenants) if you need to further configure or create any other tenants.
 

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -328,7 +328,7 @@ _meta:
 
 ## tenants.yml
 
-You can use this file to specify and add any number of OpenSearch Dashboards tenants to your OpenSearch cluster. For more information about tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/access-control/multi-tenancy).
+You can use this file to specify and add any number of OpenSearch Dashboards tenants to your OpenSearch cluster. For more information about tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config).
 
 Like all of the other YAML files, we recommend you use `tenants.yml` to add any tenants you must have in your cluster, and then use OpenSearch Dashboards or the [REST API]({{site.url}}{{site.baseurl}}/security-plugin/access-control/api/#tenants) if you need to further configure or create any other tenants.
 

--- a/_security-plugin/index.md
+++ b/_security-plugin/index.md
@@ -60,7 +60,7 @@ OpenSearch includes other features that complement the security infrastructure.
 ### Dashboards multi-tenancy
 
 One such feature is OpenSearch Dashboards multi-tenancy. Tenants are work spaces that include visualizations, index patterns, and other Dashboards objects. Multi-tenancy allows for the sharing of tenants among users of Dashboards and leverages OpenSearch roles to manage access to tenants and safely make them available to others.
-For more information on creating tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config/).
+For more information on creating tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/tenant-index/).
 
 ### Cross-cluster search
 

--- a/_security-plugin/index.md
+++ b/_security-plugin/index.md
@@ -60,7 +60,7 @@ OpenSearch includes other features that complement the security infrastructure.
 ### Dashboards multi-tenancy
 
 One such feature is OpenSearch Dashboards multi-tenancy. Tenants are work spaces that include visualizations, index patterns, and other Dashboards objects. Multi-tenancy allows for the sharing of tenants among users of Dashboards and leverages OpenSearch roles to manage access to tenants and safely make them available to others.
-For more information on creating tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/access-control/multi-tenancy/).
+For more information on creating tenants, see [OpenSearch Dashboards multi-tenancy]({{site.url}}{{site.baseurl}}/security-plugin/multi-tenancy/multi-tenancy-config/).
 
 ### Cross-cluster search
 


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

The route to multi-tenancy config was renamed in this PR https://github.com/opensearch-project/documentation-website/pull/1786 and broke existing links elsewhere in the documentation. This PR updates the existing links to account for the name change.

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
