### PR TITLE
Fix table formatting on CAT allocation page

### DIFF
--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -49,6 +49,7 @@ Parameter | Type | Description
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
 cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+
 ## Response
 
 The following response shows that 8 shards are allocated to each the two nodes available:

--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -48,11 +48,11 @@ Parameter | Type | Description
 :--- | :--- | :---
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster_manager node. Default is 30 seconds.
 
 ## Response
 
-The following response shows that 8 shards are allocated to each the two nodes available:
+The following response shows that eight shards are allocated to each the two nodes available:
 
 ```json
 shards | disk.indices | disk.used | disk.avail | disk.total | disk.percent host | ip          | node


### PR DESCRIPTION
Signed-off-by: ariamarble <armarble@amazon.com>

### Description

Fixes table formatting on CAT allocation page

### Issues Resolved

#2077 

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
