### PR TITLE
Revert SAML troubleshooting page to _opendistro route to match existing route

### DIFF
--- a/_troubleshoot/saml.md
+++ b/_troubleshoot/saml.md
@@ -42,7 +42,7 @@ After a successful login, your IdP sends a SAML response using HTTP POST to Open
 The endpoint the OpenSearch Dashboards security plugin provides is:
 
 ```
-/_plugins/_security/saml/acs
+/_opendistro/_security/saml/acs
 ```
 
 Make sure that you have configured this endpoint correctly in your IdP. Some IdPs also require you to add all endpoints to the allow list that they send requests to. Ensure that the ACS endpoint is listed.
@@ -50,7 +50,7 @@ Make sure that you have configured this endpoint correctly in your IdP. Some IdP
 OpenSearch Dashboards also requires you to add this endpoint to the allow list. Make sure you have the following entry in `opensearch_dashboards.yml`:
 
 ```
-server.xsrf.allowlist: [/_plugins/_security/saml/acs]
+server.xsrf.allowlist: [/_opendistro/_security/saml/acs]
 ```
 
 
@@ -94,7 +94,7 @@ This setting prints the SAML response to the OpenSearch log file so that you can
 Another way of inspecting the SAML response is to monitor network traffic while logging in to OpenSearch Dashboards. The IdP uses HTTP POST requests to send Base64-encoded SAML responses to:
 
 ```
-/_plugins/_security/saml/acs
+/_opendistro/_security/saml/acs
 ```
 
 Inspect the payload of this POST request, and use a tool like [base64decode.org](https://www.base64decode.org/) to decode it.


### PR DESCRIPTION
Signed-off-by: Craig Perkins <cwperx@amazon.com>

### Description

The SAML configuration page was previously changed in https://github.com/opensearch-project/documentation-website/pull/877 to replace `/_plugins/_security` with `/_opendistro/_security` for SAML related routes. This PR applies the same change to the troubleshooting page for SAML. A user pointed out the discrepancy here: https://github.com/opensearch-project/security-dashboards-plugin/issues/836#issuecomment-1333758403

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
