### PR TITLE
Added warning about restoring opendistro_security index through snapshot restore

### DIFF
--- a/_opensearch/snapshots/snapshot-restore.md
+++ b/_opensearch/snapshots/snapshot-restore.md
@@ -381,3 +381,6 @@ The `.opendistro_security` index contains sensitive data, so we recommend exclud
 ```bash
 curl -k --cert ./kirk.pem --key ./kirk-key.pem -XPOST 'https://localhost:9200/_snapshot/my-repository/3/_restore?pretty'
 ```
+
+We strongly recommend against restoring `.opendistro_security` using an admin certificate because doing so can alter the security posture of the entire cluster. See [A word of caution]({{site.url}}{{site.baseurl}}/security-plugin/configuration/security-admin/#a-word-of-caution) for a recommended process to back up and restore your security plugin configuration.
+{: .warning}


### PR DESCRIPTION
Signed-off-by: JeffH-AWS <jeffhuss@amazon.com>

### Description
Added warning about restoring opendistro_security index through snapshot restore.

This can't be backported earlier than 2.1 because the page doesn't exist. Will need the full content of snapshots backported to 2.0 and earlier, if necessary, to make it more uniform. I opened a separate issue for that issue #2257.

### Issues Resolved
Fixes #2254 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
