### PR TITLE
Correct the spelling of the Galician analzyer.

### DIFF
--- a/_opensearch/query-dsl/text-analyzers.md
+++ b/_opensearch/query-dsl/text-analyzers.md
@@ -73,7 +73,7 @@ If you want to select one of the text analyzers, see [Text analyzers reference](
 ## Language analyzer
 
 OpenSearch supports the following language values with the `analyzer` option:
-arabic, armenian, basque, bengali, brazilian, bulgarian, catalan, czech, danish, dutch, english, estonian, finnish, french, galicia, german, greek, hindi, hungarian, indonesian, irish, italian, latvian, lithuanian, norwegian, persian, portuguese, romanian, russian, sorani, spanish, swedish, turkish, and thai.
+arabic, armenian, basque, bengali, brazilian, bulgarian, catalan, czech, danish, dutch, english, estonian, finnish, french, galician, german, greek, hindi, hungarian, indonesian, irish, italian, latvian, lithuanian, norwegian, persian, portuguese, romanian, russian, sorani, spanish, swedish, turkish, and thai.
 
 To use the analyzer when you map an index, specify the value within your query. For example, to map your index with the French language analyzer, specify the `french` value for the analyzer field:
 


### PR DESCRIPTION
The correct analyzer is `galician`, not `galicia`.

Signed-off-by: Mike Benza <mbenza@momentive.ai>

### Description
Corrects the name of the Galician analyzer.

### Issues Resolved


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
