### PR TITLE
Minor ToC edits.

### DIFF
--- a/_data-prepper/configuration/data-prepper-configuration.md
+++ b/_data-prepper/configuration/data-prepper-configuration.md
@@ -2,7 +2,7 @@
 layout: default
 title: Configuring Data Prepper
 has_children: true
-nav_order: 40
+nav_order: 100
 ---
 
 # Configuring Data Prepper

--- a/_data-prepper/configure-logstash-data-prepper.md
+++ b/_data-prepper/configure-logstash-data-prepper.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Configure Logstash for Data Prepper
-parent: Data Prepper
 nav_order: 12
 ---
 

--- a/_data-prepper/expression-syntax.md
+++ b/_data-prepper/expression-syntax.md
@@ -1,12 +1,12 @@
 ---
 layout: default
 title: Expression syntax
-nav_order: 12
+nav_order: 40
 ---
 
 # Expression syntax 
 
-The following sections provide information about expression syntax.
+The following sections provide information about expression syntax in Data Prepper.
 
 ## Supported operators
 

--- a/_data-prepper/get-started.md
+++ b/_data-prepper/get-started.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Getting started
-nav_order: 20
+nav_order: 5
 redirect_from:
   - /clients/data-prepper/get-started/
 ---

--- a/_data-prepper/log-analytics.md
+++ b/_data-prepper/log-analytics.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Log analytics
-nav_order: 12
+nav_order: 30
 ---
 
 # Log analytics

--- a/_data-prepper/migrate-open-distro.md
+++ b/_data-prepper/migrate-open-distro.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Migrating from Open Distro Data Prepper
-nav_order: 50
+nav_order: 10
 ---
 
 # Migrating from Open Distro Data Prepper

--- a/_data-prepper/pipelines.md
+++ b/_data-prepper/pipelines.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Pipelines
-nav_order: 41
+nav_order: 20
 ---
 
 # Pipelines


### PR DESCRIPTION
Signed-off-by: carolxob <carolxob@amazon.com>

### Description
Changes the nav order for Data Prepper documentation to put configuration at the bottom. This also addresses the Expression Syntax introduction. 

### Issues Resolved
Addresses #1947. 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
