### PR TITLE
Update remote store documentation to reflect request level durability

### DIFF
--- a/_opensearch/remote.md
+++ b/_opensearch/remote.md
@@ -115,7 +115,7 @@ curl -X PUT "https://localhost:9200/my-index?pretty" -ku admin:admin -H 'Content
 '
 ```
 
-The segment & translog repository can be same or different. All data that is added to the index will also be continuously uploaded to the remote storage on account of refreshes / flushes / translog fsync (to disk) in the form of segment and translog files. Along with this, there are other metadata files uploaded.
+The segment repository and translog repository can be the same or different. As data is added to the index, it will also be continuously uploaded to the remote storage in the form of segment and translog files because of refreshes, flushes, and translog fsync to disk. Along with data, other metadata files will be uploaded.
 
 ### Restoring from a backup
 
@@ -140,17 +140,17 @@ If the security plugin is enabled, a user must have the `cluster:admin/remotesto
 
 ## Potential use cases
 
-The following are potential use cases for the remote-backed storage feature:
+You can use remote-backed storage for the following purposes:
 
-- The ability to restore red clusters / indices.
-- The ability to recover all data until the last acknowledged write regardless of replica count if `index.translog.durability=request`.
+- To restore red clusters or indexes
+- To recover all data up to the last acknowledged write regardless of replica count if `index.translog.durability` is set to `request`
 
 ## Known limitations
 
 The following are known limitations of the remote-backed storage feature:
 
-- Writing data to a remote store can be a high latency operation when compared to writing data on local file system. This, in expectation, impacts the indexing throughput and latency.
+- Writing data to a remote store can be a high latency operation when compared to writing data on local file system. This may impact the indexing throughput and latency.
 - Primary to primary relocation is unstable as handover of upload of translogs from older primary to new is yet to be implemented.
-- Garbage collection of metadata file is yet to be implemented.
-- & [Other known issues](https://github.com/opensearch-project/OpenSearch/issues/5678).
+- Garbage collection of the metadata file is not implemented yet.
+For other limitations, see the [Remote store known issue list](https://github.com/opensearch-project/OpenSearch/issues/5678).
 

--- a/_opensearch/remote.md
+++ b/_opensearch/remote.md
@@ -143,12 +143,14 @@ If the security plugin is enabled, a user must have the `cluster:admin/remotesto
 The following are potential use cases for the remote-backed storage feature:
 
 - The ability to restore red clusters / indices.
-- The ability to recover all data until the last acknowledged write regardless of replica count if `index.translog.durability=request`. 
+- The ability to recover all data until the last acknowledged write regardless of replica count if `index.translog.durability=request`.
 
 ## Known limitations
 
 The following are known limitations of the remote-backed storage feature:
 
-- Writing data to a remote store can be a high latency operation when compared to writing data on local file system. This, in expectation, impacts the indexing throughput.
-- [Known issues](https://github.com/opensearch-project/OpenSearch/issues/5678).
+- Writing data to a remote store can be a high latency operation when compared to writing data on local file system. This, in expectation, impacts the indexing throughput and latency.
+- Primary to primary relocation is unstable as handover of upload of translogs from older primary to new is yet to be implemented.
+- Garbage collection of metadata file is yet to be implemented.
+- & [Other known issues](https://github.com/opensearch-project/OpenSearch/issues/5678).
 


### PR DESCRIPTION
Signed-off-by: Ashish Singh <ssashish@amazon.com>

### Description
In 2.5.0 release of OpenSearch, `Request level durability` has been introduced. The documentation incorporates changes that are required to achieve Request level durability for a remote-backed index. At the same time, we have added below sections -
 - Known limitations
 - Potential use cases

### Issues Resolved
Fixed #2319

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
