### PR TITLE
Remove experimental warning note for Security Analytics 2.5

### DIFF
--- a/_security-analytics/index.md
+++ b/_security-analytics/index.md
@@ -11,14 +11,13 @@ redirect_from:
 
 # About Security Analytics
 
-Security Analytics is an experimental plugin for OpenSearch 2.4. Therefore, we do not recommend the use of Security Analytics in a production environment at this time. For updates on the progress of Security Analytics or for information on how to make contributions, visit the [Security Analytics repository](https://github.com/opensearch-project/security-analytics) on GitHub. If you would like to leave feedback that could help improve Security Analytics, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/t/feedback-experimental-feature-security-analytics/11418).
-{: .warning }
-
 Security Analytics is a security information and event management (SIEM) solution for OpenSearch, designed to investigate, detect, analyze, and respond to security threats that can jeopardize the success of businesses and organizations and their online operations. These threats include the potential exposure of confidential data, cyber attacks, and other adverse security events. Security Analytics provides an out-of-the-box solution that installs automatically with any OpenSearch distribution. It includes the tools and features necessary for defining detection parameters, generating alerts, and responding effectively to potential threats.
 
 ### Resources and information
 
 As part of the OpenSearch Project, Security Analytics exists in the open source community and benefits from the feedback and contributions of that community. To learn more about proposals for its development, options for making contributions, and general information on the platform, see the [Security Analytics repository](https://github.com/opensearch-project/security-analytics) at GitHub.
+
+If you would like to leave feedback that could help improve Security Analytics, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/t/feedback-experimental-feature-security-analytics/11418).
 
 ## Components and concepts
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
The experimental flag in the Security Analytics UI is being removed for v2.5. This removes the analogous information in the About Security Analytics section of documentation.

### Issues Resolved
Removed the warning note but preserved the comment about joining the forum and bumped that sentence down into "Resources and information". 


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
