### PR TITLE
Adds installation guide for OpenSearch Dashboards debian distribution

### DIFF
--- a/_install-and-configure/index.md
+++ b/_install-and-configure/index.md
@@ -15,6 +15,7 @@ OpenSearch has the following installation options:
 - [Docker]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/docker/)
 - [Tarball]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/tar/)
 - [RPM]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/rpm/)
+- [Debian]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/debian/)
 - [Ansible]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/ansible/)
 - [Helm]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/helm/)
 - [Windows]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/windows/)
@@ -29,6 +30,7 @@ OpenSearch Dashboards has the following installation options:
 - [Docker]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/docker/)
 - [Tarball]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/tar/)
 - [RPM]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/rpm/)
+- [Debian]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/debian/)
 - [Helm]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/helm/)
 - [Windows]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/windows/)
 

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -42,3 +42,23 @@ This guide assumes that you are comfortable working from the Linux command line 
     sudo systemctl status opensearch-dashboards
     ```
 
+### Fingerprint verification
+
+The Debian package is not signed. If you would like to verify the fingerprint, the OpenSearch Project provides a `.sig` file as well as the `.deb` package for use with GNU Privacy Guard (GPG).
+
+1. Download the desired Debian package.
+   ```bash
+   curl -SLO https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/{{site.opensearch_version}}/opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb
+   ```
+1. Download the corresponding signature file.
+   ```bash
+   curl -SLO https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/{{site.opensearch_version}}/opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb.sig
+   ```
+1. Download and import the GPG key.
+   ```bash
+   curl -o- https://artifacts.opensearch.org/publickeys/opensearch.pgp | gpg --import -
+   ```
+1. Verify the signature.
+   ```bash
+   gpg --verify opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb.sig opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb
+   ```

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -9,19 +9,36 @@ nav_order: 55
 
 Installing OpenSearch Dashboards using the Advanced Packaging Tool (APT) package manager simplifies the process considerably compared to the [Tarball]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/tar/) method. Several technical considerations, such as the installation path, location of configuration files, and creation of a service managed by `systemd`, as examples, are handled automatically by the package manager.
 
-OpenSearch Dashboards requires a <waiting-for-tech-feedback-for-prereq-wording>
-
-Generally speaking, installing OpenSearch Dashboards from the Debian distribution can be broken down into a few steps:
-
-1. **Download and install OpenSearch Dashboards.**
-   - Install manually from a Debian package or from an APT repository.
-1. **(Optional) Test OpenSearch.**
-   - Confirm that OpenSearch is able to run before you apply any custom configuration.
-   - This can be done without any security (no password, no certificates) or with a demo security configuration that can be applied by a packaged script.
-1. **Configure OpenSearch for your environment.**
-   -  Apply basic settings to OpenSearch and start using it in your environment.
-
-The Debian distribution provides everything you need to run OpenSearch inside Debian-based Linux Distributions, such as Ubuntu.
+Before installing OpenSearch Dashboards you must configure an OpenSearch cluster. Refer to the OpenSearch [Debian]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/debian/) installation guide for steps.
+{: .important}
 
 This guide assumes that you are comfortable working from the Linux command line interface (CLI). You should understand how to input commands, navigate between directories, and edit text files. Some example commands reference the `vi` text editor, but you may use any text editor available.
 {:.note}
+
+## Install OpenSearch Dashboards from a package
+
+1. Download the Debian package for the desired version directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The Debian package can be downloaded for both **x64** and **arm64** architectures.
+1. From the CLI, install using `dpkg`.
+   ```bash
+   # x64
+   sudo dpkg -i opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb
+   # arm64
+   sudo dpkg -i opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.deb
+   ```
+1. After the installation succeeds, reload the systemd manager configuration.
+    ```bash
+    sudo systemctl daemon-reload
+    ```
+1. Enable OpenSearch as a service.
+    ```bash
+    sudo systemctl enable opensearch-dashboards
+    ```
+1. Start the OpenSearch service.
+    ```bash
+    sudo systemctl start opensearch-dashboards
+    ```
+1. Verify that OpenSearch launched correctly.
+    ```bash
+    sudo systemctl status opensearch-dashboards
+    ```
+

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -63,7 +63,7 @@ The Debian package is not signed. If you would like to verify the fingerprint, t
    gpg --verify opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb.sig opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb
    ```
 
-### Install OpenSearch Dashboards from an APT repository
+## Install OpenSearch Dashboards from an APT repository
 
 APT, the primary package management tool for Debian–based operating systems, allows you to download and install the Debian package from the APT repository. 
 
@@ -92,10 +92,6 @@ APT, the primary package management tool for Debian–based operating systems, a
    ```bash
    # Specify the version manually using opensearch=<version>
    sudo apt-get install opensearch-dashboards={{site.opensearch_version}}
-   ```
-1. During installation, the installer will present you with the GPG key fingerprint. Verify that the information matches the following:
-   ```bash
-   Fingerprint: c5b7 4989 65ef d1c2 924b a9d5 39d3 1987 9310 d3fc
    ```
 1. Once complete, enable OpenSearch.
     ```bash

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -1,0 +1,6 @@
+---
+layout: default
+title: Debian
+parent: Install OpenSearch Dashboards
+nav_order: 55
+---

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -2,7 +2,7 @@
 layout: default
 title: Debian
 parent: Install OpenSearch Dashboards
-nav_order: 55
+nav_order: 33
 ---
 
 # Install OpenSearch Dashboards (Debian)
@@ -106,3 +106,24 @@ APT, the primary package management tool for Debian–based operating systems, a
     sudo systemctl status opensearch-dashboards
     ```
 
+## Explore OpenSearch Dashboards
+
+By default, OpenSearch Dashboards, like OpenSearch, binds to `localhost` when you initially install it. As a result, OpenSearch Dashboards is not reachable from a remote host unless the configuration is updated.
+
+1. Open `opensearch_dashboards.yml`.
+    ```bash
+    sudo vi /etc/opensearch-dashboards/opensearch_dashboards.yml
+    ```
+1. Specify a network interface that OpenSearch Dashboards should bind to.
+    ```bash
+    # Use 0.0.0.0 to bind to any available interface.
+    server.host: 0.0.0.0
+    ```
+1. Save and quit.
+1. Restart OpenSearch Dashboards to apply the configuration change.
+    ```bash
+    sudo systemctl restart opensearch-dashboards
+    ```
+1. From a web browser, navigate to OpenSearch Dashboards. The default port is 5601.
+1. Log in with the default username `admin` and the default password `admin`.
+1. Visit [Getting started with OpenSearch Dashboards]({{site.url}}{{site.baseurl}}/dashboards/index/) to learn more.

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -73,7 +73,7 @@ APT, the primary package management tool for Debian–based operating systems, a
     ```
 1. Create an APT repository for OpenSearch:
    ```bash
-   echo "deb https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opensearch-2.x.list
+   echo "deb https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opensearch-dashboards-2.x.list
    ```
 1. Verify that the repository was created successfully.
     ```bash

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -101,7 +101,7 @@ APT, the primary package management tool for Debian–based operating systems, a
     ```bash
     sudo systemctl enable opensearch-dashboards
     ```
-1. Start OpenSear h.
+1. Start OpenSearch.
     ```bash
     sudo systemctl start opensearch-dashboards
     ```
@@ -109,3 +109,4 @@ APT, the primary package management tool for Debian–based operating systems, a
     ```bash
     sudo systemctl status opensearch-dashboards
     ```
+

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -4,3 +4,24 @@ title: Debian
 parent: Install OpenSearch Dashboards
 nav_order: 55
 ---
+
+# Install OpenSearch Dashboards (Debian)
+
+Installing OpenSearch Dashboards using the Advanced Packaging Tool (APT) package manager simplifies the process considerably compared to the [Tarball]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/tar/) method. Several technical considerations, such as the installation path, location of configuration files, and creation of a service managed by `systemd`, as examples, are handled automatically by the package manager.
+
+OpenSearch Dashboards requires a <waiting-for-tech-feedback-for-prereq-wording>
+
+Generally speaking, installing OpenSearch Dashboards from the Debian distribution can be broken down into a few steps:
+
+1. **Download and install OpenSearch Dashboards.**
+   - Install manually from a Debian package or from an APT repository.
+1. **(Optional) Test OpenSearch.**
+   - Confirm that OpenSearch is able to run before you apply any custom configuration.
+   - This can be done without any security (no password, no certificates) or with a demo security configuration that can be applied by a packaged script.
+1. **Configure OpenSearch for your environment.**
+   -  Apply basic settings to OpenSearch and start using it in your environment.
+
+The Debian distribution provides everything you need to run OpenSearch inside Debian-based Linux Distributions, such as Ubuntu.
+
+This guide assumes that you are comfortable working from the Linux command line interface (CLI). You should understand how to input commands, navigate between directories, and edit text files. Some example commands reference the `vi` text editor, but you may use any text editor available.
+{:.note}

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -62,3 +62,50 @@ The Debian package is not signed. If you would like to verify the fingerprint, t
    ```bash
    gpg --verify opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb.sig opensearch-dashboards-{{site.opensearch_version}}-linux-x64.deb
    ```
+
+### Install OpenSearch Dashboards from an APT repository
+
+APT, the primary package management tool for Debian–based operating systems, allows you to download and install the Debian package from the APT repository. 
+
+1. Import the public GPG key. This key is used to verify that the APT repository is signed.
+    ```bash
+    curl -o- https://artifacts.opensearch.org/publickeys/opensearch.pgp | sudo apt-key add -
+    ```
+1. Create an APT repository for OpenSearch:
+   ```bash
+   echo "deb https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opensearch-2.x.list
+   ```
+1. Verify that the repository was created successfully.
+    ```bash
+    sudo apt-get update
+    ```
+1. With the repository information added, list all available versions of OpenSearch:
+   ```bash
+   sudo apt list -a opensearch-dashboards
+   ```
+1. Choose the version of OpenSearch you want to install: 
+   - Unless otherwise indicated, the latest available version of OpenSearch is installed.
+   ```bash
+   sudo apt-get install opensearch-dashboards
+   ```
+   - To install a specific version of OpenSearch Dashboards:
+   ```bash
+   # Specify the version manually using opensearch=<version>
+   sudo apt-get install opensearch-dashboards={{site.opensearch_version}}
+   ```
+1. During installation, the installer will present you with the GPG key fingerprint. Verify that the information matches the following:
+   ```bash
+   Fingerprint: c5b7 4989 65ef d1c2 924b a9d5 39d3 1987 9310 d3fc
+   ```
+1. Once complete, enable OpenSearch.
+    ```bash
+    sudo systemctl enable opensearch-dashboards
+    ```
+1. Start OpenSear h.
+    ```bash
+    sudo systemctl start opensearch-dashboards
+    ```
+1. Verify that OpenSearch launched correctly.
+    ```bash
+    sudo systemctl status opensearch-dashboards
+    ```

--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -7,7 +7,7 @@ nav_order: 33
 
 # Install OpenSearch Dashboards (Debian)
 
-Installing OpenSearch Dashboards using the Advanced Packaging Tool (APT) package manager simplifies the process considerably compared to the [Tarball]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/tar/) method. Several technical considerations, such as the installation path, location of configuration files, and creation of a service managed by `systemd`, as examples, are handled automatically by the package manager.
+Installing OpenSearch Dashboards using the Advanced Packaging Tool (APT) package manager simplifies the process considerably compared to the [Tarball]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/tar/) method. For example, the package manager handles several technical considerations, such as the installation path, location of configuration files, and creation of a service managed by `systemd`.
 
 Before installing OpenSearch Dashboards you must configure an OpenSearch cluster. Refer to the OpenSearch [Debian]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/debian/) installation guide for steps.
 {: .important}
@@ -25,7 +25,7 @@ This guide assumes that you are comfortable working from the Linux command line 
    # arm64
    sudo dpkg -i opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.deb
    ```
-1. After the installation succeeds, reload the systemd manager configuration.
+1. After the installation completes, reload the systemd manager configuration.
     ```bash
     sudo systemctl daemon-reload
     ```

--- a/_install-and-configure/install-dashboards/index.md
+++ b/_install-and-configure/install-dashboards/index.md
@@ -19,6 +19,7 @@ OpenSearch Dashboards has the following installation options:
 - [Docker]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/docker/)
 - [Tarball]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/tar/)
 - [RPM]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/rpm/)
+- [Debian]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/debian/)
 - [Helm]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/helm/)
 - [Windows]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/windows/)
 

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -114,7 +114,7 @@ APT, the primary package management tool for Debian–based operating systems, a
     ```bash
     sudo systemctl enable opensearch
     ```
-1. Start OpenSear h.
+1. Start OpenSearch.
     ```bash
     sudo systemctl start opensearch
     ```

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -140,21 +140,21 @@ An OpenSearch node in its default configuration (with demo certificates and user
       You should get a response that looks like this:
       ```bash
       {
-         "name" : "hostname",
-         "cluster_name" : "opensearch",
-         "cluster_uuid" : "oG0pPKNWT42HT3UqWgmxuw",
-         "version" : {
-            "distribution" : "opensearch",
-            "number" : "2.5.0",
-            "build_type" : "deb",
-            "build_hash" : "744ca260b892d119be8164f48d92b8810bd7801c",
-            "build_date" : "2023-01-06T22:20:28.713671066Z",
-            "build_snapshot" : false,
-            "lucene_version" : "9.4.1",
-            "minimum_wire_compatibility_version" : "7.10.0",
-            "minimum_index_compatibility_version" : "7.0.0"
+         "name":"hostname",
+         "cluster_name":"opensearch",
+         "cluster_uuid":"QqgpHCbnSRKcPAizqjvoOw",
+         "version":{
+            "distribution":"opensearch",
+            "number":"2.5.0",
+            "build_type":"deb",
+            "build_hash":"b8a8b6c4d7fc7a7e32eb2cb68ecad8057a4636ad",
+            "build_date":"2023-01-18T23:48:43.426713304Z",
+            "build_snapshot":false,
+            "lucene_version":"9.4.2",
+            "minimum_wire_compatibility_version":"7.10.0",
+            "minimum_index_compatibility_version":"7.0.0"
          },
-         "tagline" : "The OpenSearch Project: https://opensearch.org/"
+         "tagline":"The OpenSearch Project: https://opensearch.org/"
       }
       ```
    - Query the plugins endpoint:
@@ -414,21 +414,21 @@ You should add trust for the root certificate to your client before sending requ
 ```bash
 $ curl https://your.host.address:9200 -u admin:yournewpassword -k
 {
-  "name" : "hostname",
-  "cluster_name" : "opensearch",
-  "cluster_uuid" : "oG0pPKNWT42HT3UqWgmxuw",
-  "version" : {
-    "distribution" : "opensearch",
-    "number" : "2.5.0",
-    "build_type" : "deb",
-    "build_hash" : "744ca260b892d119be8164f48d92b8810bd7801c",
-    "build_date" : "2023-01-06T22:20:28.713671066Z",
-    "build_snapshot" : false,
-    "lucene_version" : "9.4.1",
-    "minimum_wire_compatibility_version" : "7.10.0",
-    "minimum_index_compatibility_version" : "7.0.0"
-  },
-  "tagline" : "The OpenSearch Project: https://opensearch.org/"
+   "name":"hostname",
+   "cluster_name":"opensearch",
+   "cluster_uuid":"QqgpHCbnSRKcPAizqjvoOw",
+   "version":{
+      "distribution":"opensearch",
+      "number":"2.5.0",
+      "build_type":"deb",
+      "build_hash":"b8a8b6c4d7fc7a7e32eb2cb68ecad8057a4636ad",
+      "build_date":"2023-01-18T23:48:43.426713304Z",
+      "build_snapshot":false,
+      "lucene_version":"9.4.2",
+      "minimum_wire_compatibility_version":"7.10.0",
+      "minimum_index_compatibility_version":"7.0.0"
+   },
+   "tagline":"The OpenSearch Project: https://opensearch.org/"
 }
 ```
 

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -57,7 +57,7 @@ This guide assumes that you are comfortable working from the Linux command line 
 
 ### Fingerprint verification
 
-The Debian package is not signed. If you would like to verify the fingerprint, the OpenSearch Project provides a `.sig` file as well as the `.deb` package for us with GNU Privacy Guard (GPG).
+The Debian package is not signed. If you would like to verify the fingerprint, the OpenSearch Project provides a `.sig` file as well as the `.deb` package for use with GNU Privacy Guard (GPG).
 
 1. Download the desired Debian package.
    ```bash


### PR DESCRIPTION
### Description
Adds documentation for installing OpenSearch Dashboards from the Debian distribution using `dpkg` and `apt`. This should only be merged to the `2.5` branch.

### Issues Resolved
Related to issue #2439 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
