### PR TITLE
Replace forum link with new link to dedicated Security Analytics forum

### DIFF
--- a/_security-analytics/index.md
+++ b/_security-analytics/index.md
@@ -17,7 +17,7 @@ Security Analytics is a security information and event management (SIEM) solutio
 
 As part of the OpenSearch Project, Security Analytics exists in the open source community and benefits from the feedback and contributions of that community. To learn more about proposals for its development, options for making contributions, and general information on the platform, see the [Security Analytics repository](https://github.com/opensearch-project/security-analytics) at GitHub.
 
-If you would like to leave feedback that could help improve Security Analytics, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/t/feedback-experimental-feature-security-analytics/11418).
+If you would like to leave feedback that could help improve Security Analytics, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/c/plugins/security-analytics/73).
 
 ## Components and concepts
 


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
There is now a dedicated forum for Security Analytics, rather than the experimental placeholder URL that we used for the 2.4 release.

### Issues Resolved
Replaced the old link with the new link to the Security Analytics forum page.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
