### PR TITLE
Update data-prepper's default buffer values

### DIFF
--- a/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
+++ b/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
@@ -14,8 +14,8 @@ The default buffer. Memory-based.
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
-buffer_size | No | Integer | The maximum number of records the buffer accepts. Default is `512`.
-batch_size | No | Integer | The maximum number of records the buffer drains after each read. Default is `8`.
+buffer_size | No | Integer | The maximum number of records the buffer accepts. Default is `12800`.
+batch_size | No | Integer | The maximum number of records the buffer drains after each read. Default is `200`.
 
 ## Configuration
 


### PR DESCRIPTION
Signed-off-by: Jannik Brand <jannik.brand@sap.com>

### Description
This PR updates the documented default buffer values (`buffer_size`, `batch_size`) for data-prepper. There are new default values due to https://github.com/opensearch-project/data-prepper/pull/1906 (since version [2.0.0](https://github.com/opensearch-project/data-prepper/releases/tag/2.0.0)).
The default `buffer_size` (previously: 512) and default `batch_size` (previously: 8) were increased by the factor 25.
The new default values are: `buffer_size`: 12800 and `batch_size`: 200.

### Issues Resolved
Resolves https://github.com/opensearch-project/data-prepper/issues/1983 (in combination with https://github.com/opensearch-project/data-prepper/pull/2233)


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).