### PR TITLE
Changed cluster manager to master in API section for 1.3

### DIFF
--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -47,8 +47,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 Parameter | Type | Description
 :--- | :--- | :---
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster_manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 ## Response
 

--- a/_api-reference/cat/cat-cluster_manager.md
+++ b/_api-reference/cat/cat-cluster_manager.md
@@ -1,39 +1,39 @@
 ---
 layout: default
-title: CAT cluster manager
+title: CAT master
 parent: CAT API
 
 nav_order: 30
 has_children: false
 ---
 
-# CAT cluster_manager
+# CAT master
 Introduced 1.0
 {: .label .label-purple }
 
-The CAT cluster manager operation lists information that helps identify the elected cluster manager node.
+The CAT master operation lists information that helps identify the elected master node.
 
 ## Example
 
 ```
-GET _cat/cluster_manager?v
+GET _cat/master?v
 ```
 
 ## Path and HTTP methods
 
 ```
-GET _cat/cluster_manager
+GET _cat/master
 ```
 
 ## URL parameters
 
-All CAT cluster manager URL parameters are optional.
+All CAT master URL parameters are optional.
 
 In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-reference/cat/index), you can specify the following parameters:
 
 Parameter | Type | Description
 :--- | :--- | :---
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 ## Response
 
 ```json

--- a/_api-reference/cat/cat-indices.md
+++ b/_api-reference/cat/cat-indices.md
@@ -49,7 +49,7 @@ Parameter | Type | Description
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 health | String | Limit indices based on their health status. Supported values are `green`, `yellow`, and `red`.
 include_unloaded_segments | Boolean | Whether to include information from segments not loaded into memory. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 pri | Boolean | Whether to return information only from the primary shards. Default is false.
 time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 expand_wildcards | Enum | Expands wildcard expressions to concrete indices. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. Default is `open`.

--- a/_api-reference/cat/cat-nodeattrs.md
+++ b/_api-reference/cat/cat-nodeattrs.md
@@ -33,8 +33,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 
 Parameter | Type | Description
 :--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 
 ## Response

--- a/_api-reference/cat/cat-nodes.md
+++ b/_api-reference/cat/cat-nodes.md
@@ -13,7 +13,7 @@ Introduced 1.0
 
 The CAT nodes operation lists node-level information, including node roles and load metrics.
 
-A few important node metrics are `pid`, `name`, `cluster_manager`, `ip`, `port`, `version`, `build`, `jdk`, along with `disk`, `heap`, `ram`, and `file_desc`.
+A few important node metrics are `pid`, `name`, `master`, `ip`, `port`, `version`, `build`, `jdk`, along with `disk`, `heap`, `ram`, and `file_desc`.
 
 ## Example
 
@@ -37,8 +37,8 @@ Parameter | Type | Description
 :--- | :--- | :---
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 full_id | Boolean | If true, return the full node ID. If false, return the shortened node ID. Defaults to false.
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 include_unloaded_segments | Boolean | Whether to include information from segments not loaded into memory. Default is false.
 
@@ -46,6 +46,6 @@ include_unloaded_segments | Boolean | Whether to include information from segmen
 ## Response
 
 ```json
-ip       |   heap.percent | ram.percent | cpu load_1m | load_5m | load_15m | node.role | node.roles |     cluster_manager |  name
+ip       |   heap.percent | ram.percent | cpu load_1m | load_5m | load_15m | node.role | node.roles |     master |  name
 10.11.1.225  |         31   |    32  | 0  |  0.00  |  0.00   | di  | data,ingest,ml  | - |  data-e5b89ad7
 ```

--- a/_api-reference/cat/cat-pending-tasks.md
+++ b/_api-reference/cat/cat-pending-tasks.md
@@ -33,8 +33,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 
 Parameter | Type | Description
 :--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 
 ## Response

--- a/_api-reference/cat/cat-plugins.md
+++ b/_api-reference/cat/cat-plugins.md
@@ -33,8 +33,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 
 Parameter | Type | Description
 :--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster_manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 ## Response
 

--- a/_api-reference/cat/cat-repositories.md
+++ b/_api-reference/cat/cat-repositories.md
@@ -33,8 +33,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 
 Parameter | Type | Description
 :--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster_manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 
 ## Response

--- a/_api-reference/cat/cat-segments.md
+++ b/_api-reference/cat/cat-segments.md
@@ -46,7 +46,7 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 Parameter | Type | Description
 :--- | :--- | :---
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/)..
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 
 ## Response

--- a/_api-reference/cat/cat-shards.md
+++ b/_api-reference/cat/cat-shards.md
@@ -46,8 +46,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 Parameter | Type | Description
 :--- | :--- | :---
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster_manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 
 

--- a/_api-reference/cat/cat-snapshots.md
+++ b/_api-reference/cat/cat-snapshots.md
@@ -33,7 +33,7 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 
 Parameter | Type | Description
 :--- | :--- | :---
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 
 

--- a/_api-reference/cat/cat-templates.md
+++ b/_api-reference/cat/cat-templates.md
@@ -39,8 +39,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 
 Parameter | Type | Description
 :--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 
 ## Response

--- a/_api-reference/cat/cat-thread-pool.md
+++ b/_api-reference/cat/cat-thread-pool.md
@@ -44,8 +44,8 @@ In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-refe
 
 Parameter | Type | Description
 :--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster_manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 
 
 ## Response

--- a/_api-reference/cluster-health.md
+++ b/_api-reference/cluster-health.md
@@ -37,8 +37,8 @@ Parameter | Type | Description
 :--- | :--- | :---
 expand_wildcards | Enum | Expands wildcard expressions to concrete indexes. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. Default is `open`.
 level | Enum | The level of detail for returned health information. Supported values are `cluster`, `indices`, and `shards`. Default is `cluster`.
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is false.
-master_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+local | Boolean | Whether to return information from the local node only instead of from the master node. Default is false.
+master_timeout | Time | The amount of time to wait for a connection to the master node. Default is 30 seconds.
 timeout | Time | The amount of time to wait for a response. If the timeout expires, the request fails. Default is 30 seconds.
 wait_for_active_shards | String | Wait until the specified number of shards is active before returning a response. `all` for all shards. Default is `0`.
 wait_for_nodes | String | Wait for N number of nodes. Use `12` for exact match, `>12` and `<12` for range.
@@ -90,7 +90,7 @@ The following table lists all response fields.
 |status	| String | The cluster health status, which represents the state of shard allocation in the cluster. May be `green`, `yellow`, or `red`. |
 |number_of_nodes | Integer | The number of nodes in the cluster. |
 |number_of_data_nodes | Integer | The number of data nodes in the cluster. |
-|discovered_cluster_manager | Boolean | Specifies whether the cluster manager is discovered. |
+|discovered_master | Boolean | Specifies whether the master node is discovered. |
 |active_primary_shards | Integer |  The number of active primary shards. |
 |active_shards | Integer | The total number of active shards, including primary and replica shards. |
 |relocating_shards | Integer | The number of relocating shards. |

--- a/_api-reference/cluster-settings.md
+++ b/_api-reference/cluster-settings.md
@@ -25,7 +25,7 @@ Parameter | Data type | Description
 :--- | :--- | :---
 flat_settings | Boolean | Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`.
 include_defaults (GET only) | Boolean | Whether to include default settings as part of the response. This parameter is useful for identifying the names and current values of settings you want to update.
-cluster_manager_timeout | Time unit | The amount of time to wait for a response from the cluster manager node. Default is `30 seconds`.
+master_timeout | Time unit | The amount of time to wait for a response from the master node. Default is `30 seconds`.
 timeout (PUT only) | Time unit | The amount of time to wait for a response from the cluster. Default is `30 seconds`.
 
 #### Sample request
@@ -100,7 +100,7 @@ The following request field parameters are compatible with the cluster API.
 | cluster.blocks.read_only_allow_delete | Boolean | Similar to `cluster.blocks.read_only` but allows you to delete indexes. |
 | cluster.max_shards_per_node | Integer | Limits the total number of primary and replica shards for the cluster. The limit is calculated as follows: `cluster.max_shards_per_node` multiplied by the number of non-frozen data nodes. Shards for closed indexes do not count toward this limit. Default is `1000`. |
 | cluster.persistent_tasks.allocation.enable | String | Enables or disables allocation for persistent tasks: <br /> <br /> `all` – Allows persistent tasks to be assigned to nodes. <br /> <br /> `none` – No allocations are allowed for persistent tasks. This does not affect persistent tasks already running. <br /> <br /> Default is `all`. |
-| cluster.persistent_tasks.allocation.recheck_interval | Time unit | The cluster manager automatically checks whether or not persistent tasks need to be assigned when the cluster state changes in a significant way. There are other factors, such as memory usage, that will affect whether or not persistent tasks are assigned to nodes but do not otherwise cause the cluster state to change. This setting defines how often assignment checks are performed in response to these factors. Default is `30 seconds`, with a minimum of `10 seconds` being required. |
+| cluster.persistent_tasks.allocation.recheck_interval | Time unit | The master node automatically checks whether or not persistent tasks need to be assigned when the cluster state changes in a significant way. There are other factors, such as memory usage, that will affect whether or not persistent tasks are assigned to nodes but do not otherwise cause the cluster state to change. This setting defines how often assignment checks are performed in response to these factors. Default is `30 seconds`, with a minimum of `10 seconds` being required. |
 
 #### Sample request
 

--- a/_api-reference/index-apis/dangling-index.md
+++ b/_api-reference/index-apis/dangling-index.md
@@ -45,7 +45,7 @@ Query parameter | Data Type | Description
 :--- | :--- | :---
 accept_data_loss | Boolean | Must be set to `true` for an `import` or `delete` because Opensearch is unaware of where the dangling index data came from.
 timeout | Time units | The amount of time to wait for a response. If no response is received in the defined time period, an error is returned. Default is `30` seconds.
-master_timeout | Time units | The amount of time to wait for the connection to the cluster manager. If no response is received in the defined time period, an error is returned. Default is `30` seconds.
+master_timeout | Time units | The amount of time to wait for the connection to the master node. If no response is received in the defined time period, an error is returned. Default is `30` seconds.
 
 ## Examples
 

--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -56,7 +56,7 @@ allow_no_indices | Boolean | Whether to ignore wildcards that don’t match any 
 expand_wildcards | String | Expands wildcard expressions to different indexes. Combine multiple values with commas. Available values are `all` (match all indexes), `open` (match open indexes), `closed` (match closed indexes), `hidden` (match hidden indexes), and `none` (do not accept wildcard expressions), which must be used with `open`, `closed`, or both. Default is `open`.
 ignore_unavailable | Boolean | If true, OpenSearch does not include missing or closed indexes in the response.
 ignore_malformed | Boolean | Use this parameter with the `ip_range` data type to specify that OpenSearch should ignore malformed fields. If `true`, OpenSearch does not include entries that do not match the IP range specified in the index in the response. The default is `false`.
-master_timeout | Time | How long to wait for a connection to the cluster manager node. Default is `30s`.
+master_timeout | Time | How long to wait for a connection to the master node. Default is `30s`.
 timeout | Time | How long to wait for the response to return. Default is `30s`.
 write_index_only | Boolean | Whether OpenSearch should apply mapping updates only to the write index.
 

--- a/_api-reference/nodes-apis/nodes-info.md
+++ b/_api-reference/nodes-apis/nodes-info.md
@@ -24,7 +24,7 @@ To get information about all nodes in a cluster, use the following query:
 GET /_nodes
 ```
 
-To get thread pool information about the cluster manager node only, use the following query:
+To get thread pool information about the master node only, use the following query:
 
 ```json
 GET /_nodes/master:true/thread_pool
@@ -77,10 +77,10 @@ timeout | Time | Sets the time limit for node response. Default value is `30s`.
 
 #### Sample request
 
-The following query requests the `process` and `transport` metrics from the cluster manager node: 
+The following query requests the `process` and `transport` metrics from the master node: 
 
 ```json
-GET /_nodes/cluster_manager:true/process,transport
+GET /_nodes/master:true/process,transport
 ```
 
 #### Sample response

--- a/_api-reference/nodes-apis/nodes-usage.md
+++ b/_api-reference/nodes-apis/nodes-usage.md
@@ -34,7 +34,7 @@ You can include the following optional query parameters in your request.
 Parameter | Type | Description
 :--- | :---| :---
 timeout | Time | Sets the time limit for a response from the node. Default is `30s`.
-cluster_manager_timeout | Time | Sets the time limit for a response from the cluster manager. Default is `30s`.
+master_timeout | Time | Sets the time limit for a response from the master node. Default is `30s`.
 
 #### Sample request
 

--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -29,7 +29,7 @@ All parameters are optional.
 | Parameter | Data Type | Description | 
 :--- | :--- | :---
 | context | String | Context in which the script or search template is to run. To prevent errors, the API immediately compiles the script or template in this context. |
-| cluster_manager_timeout | Time | Amount of time to wait for a connection to the cluster manager. Defaults to 30 seconds. |
+| master_timeout | Time | Amount of time to wait for a connection to the master. Defaults to 30 seconds. |
 | timeout | Time | The period of time to wait for a response. If a response is not received before the timeout value, the request fails and returns an error. Defaults to 30 seconds.|
 
 ### Request fields

--- a/_api-reference/script-apis/delete-script.md
+++ b/_api-reference/script-apis/delete-script.md
@@ -21,7 +21,7 @@ Path parameters are optional.
 
 | Parameter | Data Type | Description | 
 :--- | :--- | :---
-| cluster_manager_timeout | Time | Amount of time to wait for a connection to the cluster manager. Optional, defaults to `30s`. |
+| master_timeout | Time | Amount of time to wait for a connection to the master node. Optional, defaults to `30s`. |
 | timeout | Time | The period of time to wait for a response. If a response is not received before the timeout value, the request will be dropped.
 
 #### Sample request

--- a/_api-reference/script-apis/get-stored-script.md
+++ b/_api-reference/script-apis/get-stored-script.md
@@ -19,7 +19,7 @@ Retrieves a stored script.
 
 | Parameter | Data Type | Description | 
 :--- | :--- | :---
-| cluster_manager_timeout | Time | Amount of time to wait for a connection to the cluster manager. Optional, defaults to `30s`. |
+| master_timeout | Time | Amount of time to wait for a connection to the master node. Optional, defaults to `30s`. |
 
 #### Sample request
 

--- a/_api-reference/snapshots/get-snapshot-repository.md
+++ b/_api-reference/snapshots/get-snapshot-repository.md
@@ -25,7 +25,7 @@ You can also get details about a snapshot during and after snapshot creation. Se
 | Parameter | Data Type | Description | 
 :--- | :--- | :---
 | local | Boolean | Whether to get information from the local node. Optional, defaults to `false`.|
-| cluster_manager_timeout | Time | Amount of time to wait for a connection to the master node. Optional, defaults to 30 seconds. |
+| master_timeout | Time | Amount of time to wait for a connection to the master node. Optional, defaults to 30 seconds. |
 
 #### Sample request
 

--- a/_api-reference/snapshots/verify-snapshot-repository.md
+++ b/_api-reference/snapshots/verify-snapshot-repository.md
@@ -27,7 +27,7 @@ Path parameters are optional.
 
 | Parameter | Data Type | Description | 
 :--- | :--- | :---
-| cluster_manager_timeout | Time | Amount of time to wait for a connection to the master node. Optional, defaults to `30s`. |
+| master_timeout | Time | Amount of time to wait for a connection to the master node. Optional, defaults to `30s`. |
 | timeout | Time | The period of time to wait for a response. If a response is not received before the timeout value, the request fails and returns an error. Defaults to `30s`. |
 
 #### Sample request
@@ -35,14 +35,14 @@ Path parameters are optional.
 The following request verifies that the my-opensearch-repo is functional:
 
 ````json
-POST /_snapshot/my-opensearch-repo/_verify?timeout=0s&cluster_manager_timeout=50s
+POST /_snapshot/my-opensearch-repo/_verify?timeout=0s&master_timeout=50s
 ````
 
 #### Sample response
 
 The example that follows corresponds to the request above in the [Sample request](#sample-request) section.
 
-The `POST /_snapshot/my-opensearch-repo/_verify?timeout=0s&cluster_manager_timeout=50s` request returns the following fields:
+The `POST /_snapshot/my-opensearch-repo/_verify?timeout=0s&master_timeout=50s` request returns the following fields:
 
 ````json
 {


### PR DESCRIPTION
Changed cluster manager to master in API section for 1.3

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
