### PR TITLE
Fix link in docker.md referencing About Security in OpenSearch page

### DIFF
--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -460,8 +460,4 @@ COPY --chown=opensearch:opensearch my-root-cas.pem /usr/share/opensearch/config/
 - [OpenSearch configuration]({{site.url}}{{site.baseurl}}/install-and-configure/configuration/)
 - [Performance analyzer]({{site.url}}{{site.baseurl}}/monitoring-plugins/pa/index/)
 - [Install and configure OpenSearch Dashboards]({{site.url}}{{site.baseurl}}/install-and-configure/install-dashboards/index/)
-<<<<<<< HEAD
-- [About the security plugin]({{site.url}}{{site.baseurl}}/security/index/)
-=======
-- [About the security plugin]({{site.url}}{{site.baseurl}}/security-plugin/index/)
->>>>>>> main
+- [About Security in OpenSearch]({{site.url}}{{site.baseurl}}/security/index/)


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Extraneous text from a merge conflict made it into the "About Security in OpenSearch" link at the bottom of the docker.md file in Installation.

### Issues Resolved
Fixed link.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
