### PR TITLE
Replace `IndexRequest.Builder.value()` call with call to `.document()`

### DIFF
--- a/_clients/java.md
+++ b/_clients/java.md
@@ -172,7 +172,7 @@ You can index data into OpenSearch using the following code:
 
 ```java
 IndexData indexData = new IndexData("first_name", "Bruce");
-IndexRequest<IndexData> indexRequest = new IndexRequest.Builder<IndexData>().index(index).id("1").value(indexData).build();
+IndexRequest<IndexData> indexRequest = new IndexRequest.Builder<IndexData>().index(index).id("1").document(indexData).build();
 client.index(indexRequest);
 ```
 {% include copy.html %}
@@ -283,7 +283,7 @@ public class OpenSearchClientExample {
 
     //Index some data
     IndexData indexData = new IndexData("first_name", "Bruce");
-    IndexRequest<IndexData> indexRequest = new IndexRequest.Builder<IndexData>().index(index).id("1").value(indexData).build();
+    IndexRequest<IndexData> indexRequest = new IndexRequest.Builder<IndexData>().index(index).id("1").document(indexData).build();
     client.index(indexRequest);
 
     //Search for the document


### PR DESCRIPTION
### Description
Current documentation for the new  Java client uses a call to `org.opensearch.client.opensearch.core.IndexRequest.Builder.value()` but as of `2.2.0` I do not *believe* this method exists. I believe the correct method to call is `document()`

**Please double check that this is correct! I have not scoured the commit history of the relevant project to make sure that this method used to be called `value()`! Maybe I'm just being dumb here!**

### Issues Resolved
Update documentation to reflect the state of the `2.2.0` release of the `opensearch-java` client with regards to [indexing a document](https://opensearch.org/docs/1.2/clients/java/#index-data).


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
