### PR TITLE
Updating Data Prepper links to point to doc website.

### DIFF
--- a/_data-prepper/getting-started.md
+++ b/_data-prepper/getting-started.md
@@ -129,7 +129,7 @@ Log ingestion is also an important Data Prepper use case. To learn more, see [Lo
 
 To learn how to run Data Prepper with a Logstash configuration, see [Migrating from Logstash]({{site.url}}{{site.baseurl}}/data-prepper/migrating-from-logstash-data-prepper/).
 
-For information on how to monitor Data Prepper, see the [Monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/monitoring.md) page.
+For information on how to monitor Data Prepper, see the [Monitoring]({{site.url}}{{site.baseurl}}/data-prepper/managing-data-prepper/monitoring/) page.
 
 ## Other examples
 

--- a/_data-prepper/getting-started.md
+++ b/_data-prepper/getting-started.md
@@ -41,7 +41,7 @@ You will configure two files:
 
 Depending on your use case, we have a few different guides to configuring Data Prepper.
 
-* [Trace Analytics](https://github.com/opensearch-project/data-prepper/blob/main/docs/trace_analytics.md)
+* [Trace Analytics]({{site.url}}{{site.baseurl}}/data-prepper/common-use-cases/trace-analytics/): Learn how to collect trace data and customize a pipeline that ingests and transforms that data. 
 * [Log Analytics]({{site.url}}{{site.baseurl}}/data-prepper/common-use-cases/log-analytics/): Learn how to set up Data Prepper for log observability.
 * [Simple Pipeline](https://github.com/opensearch-project/data-prepper/blob/main/docs/simple_pipelines.md): Learn the basics of Data Prepper pipelines with some simple configurations.
 
@@ -123,16 +123,14 @@ like to pass a custom log4j2 properties file. If no properties file is provided,
 
 ## Next steps
 
-Trace Analytics is an important Data Prepper use case. If you haven't yet configured it,
-see the [Trace Analytics](https://github.com/opensearch-project/data-prepper/blob/main/docs/trace_analytics.md).
+Trace Analytics is an important Data Prepper use case. If you haven't yet configured it, see the [Trace Analytics]({{site.url}}{{site.baseurl}}/data-prepper/common-use-cases/trace-analytics/).
 
-Log Ingestion is also an important Data Prepper use case. To learn more, see the [Log Ingestion Documentation](https://github.com/opensearch-project/data-prepper/blob/main/docs/log_analytics.md).
+Log ingestion is also an important Data Prepper use case. To learn more, see [Log analytics]({{site.url}}{{site.baseurl}}/data-prepper/common-use-cases/log-analytics/).
 
-To learn how to run Data Prepper with a Logstash configuration, see the [Logstash Migration Guide]({{site.url}}{{site.baseurl}}/data-prepper/configure-logstash-data-prepper/).
+To learn how to run Data Prepper with a Logstash configuration, see [Migrating from Logstash]({{site.url}}{{site.baseurl}}/data-prepper/migrating-from-logstash-data-prepper/).
 
 For information on how to monitor Data Prepper, see the [Monitoring](https://github.com/opensearch-project/data-prepper/blob/main/docs/monitoring.md) page.
 
 ## Other examples
 
-We have several other Docker [examples](https://github.com/opensearch-project/data-prepper/tree/main/examples/)
-that allow you to run Data Prepper in different scenarios.
+We have several other Docker [examples](https://github.com/opensearch-project/data-prepper/tree/main/examples/) that allow you to run Data Prepper in different scenarios.

--- a/_data-prepper/managing-data-prepper/core-apis.md
+++ b/_data-prepper/managing-data-prepper/core-apis.md
@@ -72,7 +72,7 @@ authentication:
 
 ### Peer Forwarder
 
-Peer Forwarder can be configured to enable stateful aggregation across multiple Data Prepper nodes. For more information about configuring Peer Forwarder, see [Peer Forwarder configuration](https://github.com/opensearch-project/data-prepper/blob/main/docs/peer_forwarder.md). It is supported by the `service_map_stateful`, `otel_trace_raw`, and `aggregate` processors.
+Peer Forwarder can be configured to enable stateful aggregation across multiple Data Prepper nodes. For more information about configuring Peer Forwarder, see [Peer forwarder]({{site.url}}{{site.baseurl}}/data-prepper/managing-data-prepper/peer-forwarder/). It is supported by the `service_map_stateful`, `otel_trace_raw`, and `aggregate` processors.
 
 ### Shutdown timeouts
 

--- a/_data-prepper/managing-data-prepper/monitoring.md
+++ b/_data-prepper/managing-data-prepper/monitoring.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Monitoring
-parent: Administrating Data Prepper
+parent: Managing Data Prepper
 nav_order: 25
 ---
 

--- a/_data-prepper/migrating-from-logstash-data-prepper.md
+++ b/_data-prepper/migrating-from-logstash-data-prepper.md
@@ -28,7 +28,7 @@ As of the Data Prepper 1.2 release, the following plugins from the Logstash conf
 
 ## Running Data Prepper with a Logstash configuration
 
-1. To install Data Prepper's Docker image, see Installing Data Prepper in [Getting Started]({{site.url}}{{site.baseurl}}/data-prepper/getting-started#1-installing-data-prepper).
+1. To install Data Prepper's Docker image, see Installing Data Prepper in [Getting Started with Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/getting-started#1-installing-data-prepper).
 
 2. Run the Docker image installed in Step 1 by supplying your `logstash.conf` configuration.
 


### PR DESCRIPTION
Signed-off-by: carolxob <carolxob@amazon.com>

### Description
Updates links that currently point to Data Prepper doc pages. The corrected links point to the documentation website.

### Issues Resolved



### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
