### PR TITLE
Correct description of encryption functionality managed by Security

### DIFF
--- a/_security/index.md
+++ b/_security/index.md
@@ -27,11 +27,13 @@ The following topics provide a general description of the features that define s
 
 ### Encryption
 
-Encryption protects both data at rest and in transit. At rest, encryption secures sensitive data stored in a cluster. Some examples of stored data include indexes, logs, swap files, automated snapshots, and all data in the application directory. 
+OpenSearch Project encryption can protect data both in transit and at rest. Security specifically, however, is responsible for managing encryption in transit.
 
-Encryption in transit encrypts data moving to, from, and within the cluster. OpenSearch uses the TLS protocol, which covers both client-to-node encryption (the REST layer) and node-to-node encryption (the transport layer). This combination of in-transit encryption helps ensure that both requests to OpenSearch and the movement of data among different nodes are safe from tampering.
+In transit, Security encrypts data moving to, from, and within the cluster. OpenSearch uses the TLS protocol, which covers both client-to-node encryption (the REST layer) and node-to-node encryption (the transport layer). This combination of in-transit encryption helps ensure that both requests to OpenSearch and the movement of data among different nodes are safe from tampering.
 
 You can find out more about configuring TLS in the [Configuring TLS certificates]({{site.url}}{{site.baseurl}}/security/configuration/tls/) section.
+
+Encryption at rest, on the other hand, protects stored data and is managed by the operating system on each OpenSearch node. For information on enabling encryption at rest, see [Encryption at rest]({{site.url}}{{site.baseurl}}/troubleshoot/index/#encryption-at-rest) in *Common issues*.
 
 ### Authentication
 

--- a/_security/index.md
+++ b/_security/index.md
@@ -33,7 +33,7 @@ In transit, Security encrypts data moving to, from, and within the cluster. Open
 
 You can find out more about configuring TLS in the [Configuring TLS certificates]({{site.url}}{{site.baseurl}}/security/configuration/tls/) section.
 
-Encryption at rest, on the other hand, protects data stored in the cluster, including indexes, logs, swap files, automated snapshots, and all data in the application directory. This type of encryption is managed by the operating system on each OpenSearch node. For information on enabling encryption at rest, see [Encryption at rest]({{site.url}}{{site.baseurl}}/troubleshoot/index/#encryption-at-rest) in *Common issues*.
+Encryption at rest, on the other hand, protects data stored in the cluster, including indexes, logs, swap files, automated snapshots, and all data in the application directory. This type of encryption is managed by the operating system on each OpenSearch node. For information about enabling encryption at rest, see [Encryption at rest]({{site.url}}{{site.baseurl}}/troubleshoot/index/#encryption-at-rest).
 
 ### Authentication
 

--- a/_security/index.md
+++ b/_security/index.md
@@ -27,13 +27,13 @@ The following topics provide a general description of the features that define s
 
 ### Encryption
 
-OpenSearch Project encryption can protect data both in transit and at rest. Security specifically, however, is responsible for managing encryption in transit.
+Encryption typically addresses the protection of data both at rest and in transit. OpenSearch Security is responsible for managing encryption in transit.
 
 In transit, Security encrypts data moving to, from, and within the cluster. OpenSearch uses the TLS protocol, which covers both client-to-node encryption (the REST layer) and node-to-node encryption (the transport layer). This combination of in-transit encryption helps ensure that both requests to OpenSearch and the movement of data among different nodes are safe from tampering.
 
 You can find out more about configuring TLS in the [Configuring TLS certificates]({{site.url}}{{site.baseurl}}/security/configuration/tls/) section.
 
-Encryption at rest, on the other hand, protects stored data and is managed by the operating system on each OpenSearch node. For information on enabling encryption at rest, see [Encryption at rest]({{site.url}}{{site.baseurl}}/troubleshoot/index/#encryption-at-rest) in *Common issues*.
+Encryption at rest, on the other hand, protects data stored in the cluster, including indexes, logs, swap files, automated snapshots, and all data in the application directory. This type of encryption is managed by the operating system on each OpenSearch node. For information on enabling encryption at rest, see [Encryption at rest]({{site.url}}{{site.baseurl}}/troubleshoot/index/#encryption-at-rest) in *Common issues*.
 
 ### Authentication
 

--- a/_troubleshoot/index.md
+++ b/_troubleshoot/index.md
@@ -60,7 +60,7 @@ The operating system for each OpenSearch node handles encryption of data at rest
 cryptsetup luksFormat --key-file <key> <partition>
 ```
 
-For full documentation on the command, see [cryptsetup(8) — Linux manual page](https://man7.org/linux/man-pages/man8/cryptsetup.8.html).
+For full documentation about the command, see [cryptsetup(8) — Linux manual page](https://man7.org/linux/man-pages/man8/cryptsetup.8.html).
 
 {% comment %}
 ## Beats

--- a/_troubleshoot/index.md
+++ b/_troubleshoot/index.md
@@ -60,7 +60,7 @@ The operating system for each OpenSearch node handles encryption of data at rest
 cryptsetup luksFormat --key-file <key> <partition>
 ```
 
-For full documentation on the command, see [the Linux man page](https://man7.org/linux/man-pages/man8/cryptsetup.8.html).
+For full documentation on the command, see [the Linux manual page for cryptsetup](https://man7.org/linux/man-pages/man8/cryptsetup.8.html).
 
 {% comment %}
 ## Beats

--- a/_troubleshoot/index.md
+++ b/_troubleshoot/index.md
@@ -60,7 +60,7 @@ The operating system for each OpenSearch node handles encryption of data at rest
 cryptsetup luksFormat --key-file <key> <partition>
 ```
 
-For full documentation on the command, see [the Linux manual page for cryptsetup](https://man7.org/linux/man-pages/man8/cryptsetup.8.html).
+For full documentation on the command, see [cryptsetup(8) — Linux manual page](https://man7.org/linux/man-pages/man8/cryptsetup.8.html).
 
 {% comment %}
 ## Beats


### PR DESCRIPTION
Signed-off-by: cwillum <cwmmoore@amazon.com>

### Description
Security is responsible for managing encryption in transit while the operating system for each OpenSearch node handles encryption at rest. This needs to be clarified in the *About Security in OpenSearch* section under *Encryption*.

### Issues Resolved
Changed language in the description of Encryption to distinguish between what kind of encryption Security manages and the encryption managed on the OpenSearch node.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
