### PR TITLE
Change url for opensearch_security.openid.scope configuration setting

### DIFF
--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -277,7 +277,7 @@ Name | Description
 `opensearch_security.openid.connect_url` | The URL where the IdP publishes the OpenID metadata. Required.
 `opensearch_security.openid.client_id` | The ID of the OpenID Connect client configured in your IdP. Required.
 `opensearch_security.openid.client_secret` | The client secret of the OpenID Connect client configured in your IdP. Required.
-`opensearch_security.openid.scope` | The [scope of the identity token](https://auth0.com/docs/scopes/current) issued by the IdP. Optional. Default is `openid profile email address phone`.
+`opensearch_security.openid.scope` | The [scope of the identity token](https://openid.net/specs/openid-connect-messages-1_0-20.html#scopes) issued by the IdP. Optional. Default is `openid profile email address phone`.
 `opensearch_security.openid.header` | HTTP header name of the JWT token. Optional. Default is `Authorization`.
 `opensearch_security.openid.logout_url` | The logout URL of your IdP. Optional. Only necessary if your IdP does not publish the logout URL in its metadata.
 `opensearch_security.openid.base_redirect_url` | The base of the redirect URL that will be sent to your IdP. Optional. Only necessary when OpenSearch Dashboards is behind a reverse proxy, in which case it should be different than `server.host` and `server.port` in `opensearch_dashboards.yml`.


### PR DESCRIPTION
### Description
The opensearch_security.openid.scope description referenced the Auth0 website.

This fix replaces that link in order to reference the [official OpenID website](https://openid.net) (the same website is already referenced in this page, see line 115)

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
