### PR TITLE
Moved index_template permission to cluster section

### DIFF
--- a/_security/access-control/permissions.md
+++ b/_security/access-control/permissions.md
@@ -180,7 +180,7 @@ These permissions are for the cluster and can't be applied granularly. For examp
 - cluster:monitor/task/get
 - cluster:monitor/tasks/list
 
-These permissions are for indices but apply globally to the cluster
+The following permissions are for indexes but apply globally to the cluster:
 
 - indices:admin/index_template/delete
 - indices:admin/index_template/get

--- a/_security/access-control/permissions.md
+++ b/_security/access-control/permissions.md
@@ -180,6 +180,14 @@ These permissions are for the cluster and can't be applied granularly. For examp
 - cluster:monitor/task/get
 - cluster:monitor/tasks/list
 
+These permissions are for indices but apply globally to the cluster
+
+- indices:admin/index_template/delete
+- indices:admin/index_template/get
+- indices:admin/index_template/put
+- indices:admin/index_template/simulate
+- indices:admin/index_template/simulate_index
+
 
 ## Index permissions
 
@@ -202,11 +210,6 @@ These permissions apply to an index or index pattern. You might want a user to h
 - indices:admin/flush*
 - indices:admin/forcemerge
 - indices:admin/get (retrieve index and mapping)
-- indices:admin/index_template/delete
-- indices:admin/index_template/get
-- indices:admin/index_template/put
-- indices:admin/index_template/simulate
-- indices:admin/index_template/simulate_index
 - indices:admin/mapping/put
 - indices:admin/mappings/fields/get
 - indices:admin/mappings/fields/get*


### PR DESCRIPTION
Moved index_template permissions from index section to cluster section to avoid confusion when generating roles

### Description
This PR try to solve a common mistake when generating roles that allows index_template permissions.

### Issues Resolved
- Resolves #619 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
