### PR TITLE
Add changes to remote backed storage documentation for 2.6 release

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/remote.md
+++ b/_tuning-your-cluster/availability-and-recovery/remote.md
@@ -193,7 +193,7 @@ You can have the same repository serve as both the segment repository and transl
 {: .note}
 
 As data is added to the index, it also will be continuously uploaded to remote storage in the form of segment and translog files because of refreshes, flushes, and translog fsyncs to disk. Along with data, other metadata files will be uploaded.
-`buffer_interval` field in settings indicates time interval to buffer translog operations. Instead of uploading small translog files, single translog file is created with all the write operations received during the configured interval. This helps in achieving higher throughput but also increases latency. Default value is 100ms.
+The `buffer_interval` setting specifies the time interval during which translog operations are buffered. Instead of uploading individual translog files, OpenSearch creates a single translog file with all the write operations received during the configured interval. Bundling translog files leads to higher throughput but also increases latency. The default `buffer_interval` value is 100 ms.
 
 Setting `translog.enabled` to `true` is currently an irreversible operation.
 {: .warning}
@@ -230,5 +230,5 @@ You can use remote-backed storage for the following purposes:
 
 The following are known limitations of the remote-backed storage feature:
 
-- Writing data to a remote store can be a high-latency operation when compared to writing data on the local file system. This may impact the indexing throughput and latency. Performance benchamrking results will be tracked in https://github.com/opensearch-project/OpenSearch/issues/6376
+- Writing data to a remote store can be a high-latency operation when compared to writing data on the local file system. This may impact the indexing throughput and latency. For performance benchmarking results, see [issue #6376](https://github.com/opensearch-project/OpenSearch/issues/6376).
 

--- a/_tuning-your-cluster/availability-and-recovery/remote.md
+++ b/_tuning-your-cluster/availability-and-recovery/remote.md
@@ -179,7 +179,8 @@ curl -X PUT "https://localhost:9200/my-index?pretty" -ku admin:admin -H 'Content
         "repository": "segment-repo",
         "translog": {
           "enabled": true,
-          "repository": "translog-repo"
+          "repository": "translog-repo",
+          "buffer_interval": "300ms"
         }
       }
     }
@@ -192,6 +193,7 @@ You can have the same repository serve as both the segment repository and transl
 {: .note}
 
 As data is added to the index, it also will be continuously uploaded to remote storage in the form of segment and translog files because of refreshes, flushes, and translog fsyncs to disk. Along with data, other metadata files will be uploaded.
+`buffer_interval` field in settings indicates time interval to buffer translog operations. Instead of uploading small translog files, single translog file is created with all the write operations received during the configured interval. This helps in achieving higher throughput but also increases latency. Default value is 100ms.
 
 Setting `translog.enabled` to `true` is currently an irreversible operation.
 {: .warning}
@@ -228,8 +230,5 @@ You can use remote-backed storage for the following purposes:
 
 The following are known limitations of the remote-backed storage feature:
 
-- Writing data to a remote store can be a high-latency operation when compared to writing data on the local file system. This may impact the indexing throughput and latency.
-- Primary-to-primary relocation is unstable because handover of translog uploads from older to new primary has not been implemented.
-- Garbage collection of the metadata file has not been implemented.
-For other limitations, see the [Remote store known issue list](https://github.com/opensearch-project/OpenSearch/issues/5678).
+- Writing data to a remote store can be a high-latency operation when compared to writing data on the local file system. This may impact the indexing throughput and latency. Performance benchamrking results will be tracked in https://github.com/opensearch-project/OpenSearch/issues/6376
 


### PR DESCRIPTION
### Description
- Introduced `buffer_interval` setting for remote backed indices as part of OpenSearch 2.6 release.
- This change adds documentation of the new setting.



### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
