### PR TITLE
Add formatting fixes for Security Analytics

### DIFF
--- a/_security-analytics/sec-analytics-config/detectors-config.md
+++ b/_security-analytics/sec-analytics-config/detectors-config.md
@@ -23,6 +23,8 @@ You can define a new detector by naming the detector, selecting a data source an
 1. In the **Log types and rules** section, select the log type for the data source. The Sigma security rules associated with the log data are automatically populated in the **Detection rules** section, as shown in the following image.
 
     <img src="{{site.url}}{{site.baseurl}}/images/Security/detector_rules.png" alt="Selecting threat detector type to auto-populate rules" width="80%">
+
+    When selecting **Network events**, **CloudTrail logs**, or **S3 access logs** as the log type, a detector dashboard is automatically created. The dashboard offers visualizations for the detector and can provide security-related insight into log source data. For more information about visualizations, see [Building data visualizations]({{site.url}}{{site.baseurl}}/dashboards/visualize/viz-index/).
     
     You can skip the next step for applying select rules if you are satisfied with those automatically populated by the system. Otherwise, go to the next step to select rules individually.
     {: .note }
@@ -32,10 +34,8 @@ You can define a new detector by naming the detector, selecting a data source an
     <img src="{{site.url}}{{site.baseurl}}/images/Security/select_rules.png" alt="Select or deselect rules that detector will use for findings" width="85%">
 
     * Use the toggle to the left of **Rule name** to select or deselect rules.
-    * Use the **Log type**, **Rule severity**, and **Source** dropdown lists to filter the rules you want to select from. 
+    * Use the **Rule severity** and **Source** dropdown lists to filter the rules you want to select from. 
     * Use the **Search** bar to search for specific rules.
-
-    When selecting **Network events**, **CloudTrail logs**, or **S3 access logs** as the log type, a detector dashboard is automatically created. The dashboard offers visualizations for the detector and can provide security-related insight into log source data. For more information about visualizations, see [Building data visualizations]({{site.url}}{{site.baseurl}}/dashboards/visualize/viz-index/).
 
     To quickly select one or more known rules and dismiss others, first deselect all rules by moving the **Rule name** toggle to the left, then search for your target rule names and select each individually by moving its toggle to the right.
     {: .tip }
@@ -115,10 +115,10 @@ To set up an alert for a detector, continue with the following steps:
     * Assign a level of severity for the alert to give the recipient an indication of its urgency.
     * Select a channel for the notification. Examples include Slack, Chime, or email. Select the  **Manage channels** link to the right of the field to link the notification to a preferred channel.
     * Select the **Show notify message** label to expand message preferences. You can add a subject for the message and a note to inform recipients of the nature of the message.
-    
+
 1. After configuring the conditions in the preceding fields, select **Next** in the lower-right corner of the screen. The **Review and create** page opens.
 
-After reviewing the specifications for the detector, select **Create** in the lower-right corner of the screen to create the detector. The screen returns to the list of all detectors, and the new detector appears in the list.
+After reviewing the specifications for the detector, choose **Create** in the lower-right corner of the screen to create the detector. The screen returns to the list of all detectors, and the new detector appears in the list.
 
 ## What's next
 

--- a/_security-analytics/sec-analytics-config/detectors-config.md
+++ b/_security-analytics/sec-analytics-config/detectors-config.md
@@ -21,18 +21,21 @@ You can define a new detector by naming the detector, selecting a data source an
     {: .note }
 
 1. In the **Log types and rules** section, select the log type for the data source. The Sigma security rules associated with the log data are automatically populated in the **Detection rules** section, as shown in the following image.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/detector_rules.png" alt="Selecting threat detector type to auto-populate rules" width="80%">
+
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/detector_rules.png" alt="Selecting threat detector type to auto-populate rules" width="80%">
     
     You can skip the next step for applying select rules if you are satisfied with those automatically populated by the system. Otherwise, go to the next step to select rules individually.
     {: .note }
 
 1. In the **Detection rules** section, specify only those rules you want applied to the detector, as shown in the following image.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/select_rules.png" alt="Select or deselect rules that detector will use for findings" width="85%">
-* Use the toggle to the left of **Rule name** to select or deselect rules.
-* Use the **Log type**, **Rule severity**, and **Source** dropdown lists to filter the rules you want to select from. 
-* Use the **Search** bar to search for specific rules.
 
-When selecting **Network events**, **CloudTrail logs**, or **S3 access logs** as the log type, a detector dashboard is automatically created. The dashboard offers visualizations for the detector and can provide security-related insight into log source data. For more information about visualizations, see [Building data visualizations]({{site.url}}{{site.baseurl}}/dashboards/visualize/viz-index/).
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/select_rules.png" alt="Select or deselect rules that detector will use for findings" width="85%">
+
+    * Use the toggle to the left of **Rule name** to select or deselect rules.
+    * Use the **Log type**, **Rule severity**, and **Source** dropdown lists to filter the rules you want to select from. 
+    * Use the **Search** bar to search for specific rules.
+
+    When selecting **Network events**, **CloudTrail logs**, or **S3 access logs** as the log type, a detector dashboard is automatically created. The dashboard offers visualizations for the detector and can provide security-related insight into log source data. For more information about visualizations, see [Building data visualizations]({{site.url}}{{site.baseurl}}/dashboards/visualize/viz-index/).
 
     To quickly select one or more known rules and dismiss others, first deselect all rules by moving the **Rule name** toggle to the left, then search for your target rule names and select each individually by moving its toggle to the right.
     {: .tip }
@@ -95,16 +98,24 @@ To set up an alert for a detector, continue with the following steps:
 
 1. In the **Trigger name** box, enter a name for the trigger.
 1. To define rule matches for the alert, select security rules, severity levels, and tags.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/alert_rules.png" alt="Rules used to define an alert" width="70%">
-* Select one rule or multiple rules that will trigger the alert. Put the cursor in the **Rule names** box and type a name to search for it. To remove a rule name, select the **X** beside the name. To remove all rule names, select the **X** beside the dropdown list's down arrow.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/rule_name_delete.png" alt="Deletes all selected rules" width="45%">
-* Select one or more rule severities as conditions for the alert.
-* Select from a list of tags to include as conditions for the alert.
+    
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/alert_rules.png" alt="Rules used to define an alert" width="70%">
+
+    * Select one rule or multiple rules that will trigger the alert. Put the cursor in the **Rule names** box and type a name to search for it. To remove a rule name, select the **X** beside the name. To remove all rule names, select the **X** beside the dropdown list's down arrow.
+
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/rule_name_delete.png" alt="Deletes all selected rules" width="45%">
+
+    * Select one or more rule severities as conditions for the alert.
+    * Select from a list of tags to include as conditions for the alert.
+
 1. To define a notification for the alert, assign an alert severity, select a channel for the notification, and customize a message generated for the alert.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/alert_notify.png" alt="Notification settings for the alert" width="45%">
-* Assign a level of severity for the alert to give the recipient an indication of its urgency.
-* Select a channel for the notification. Examples include Slack, Chime, or email. Select the  **Manage channels** link to the right of the field to link the notification to a preferred channel.
-* Select the **Show notify message** label to expand message preferences. You can add a subject for the message and a note to inform recipients of the nature of the message.
+
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/alert_notify.png" alt="Notification settings for the alert" width="45%">
+
+    * Assign a level of severity for the alert to give the recipient an indication of its urgency.
+    * Select a channel for the notification. Examples include Slack, Chime, or email. Select the  **Manage channels** link to the right of the field to link the notification to a preferred channel.
+    * Select the **Show notify message** label to expand message preferences. You can add a subject for the message and a note to inform recipients of the nature of the message.
+    
 1. After configuring the conditions in the preceding fields, select **Next** in the lower-right corner of the screen. The **Review and create** page opens.
 
 After reviewing the specifications for the detector, select **Create** in the lower-right corner of the screen to create the detector. The screen returns to the list of all detectors, and the new detector appears in the list.

--- a/_security-analytics/usage/alerts.md
+++ b/_security-analytics/usage/alerts.md
@@ -25,9 +25,12 @@ You can use the **Quick select** settings to specify an exact window of time.
 * Select a number in the second dropdown list to define a value for the range.
 * Select a unit of time in the third dropdown list. Available options are seconds, minutes, hours, days, weeks, months, and years.
 Select the **Apply** button to apply the range of dates to the graph. Information on the graph changes accordingly.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/quickset.png" alt="Quick select settings example" width="40%">
-<br>You can use the left and right arrows to move the window of time behind the current range of dates or ahead of the current range of dates. When you use these arrows, the start date and end date appear in the date range field. You can then select each one to set an absolute, relative, or current date and time. For absolute and relative changes, select the **Update** button to apply the changes.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/date-pick.png" alt="Altering date range" width="55%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/quickset.png" alt="Quick select settings example" width="40%">
+
+You can use the left and right arrows to move the window of time behind the current range of dates or ahead of the current range of dates. When you use these arrows, the start date and end date appear in the date range field. You can then select each one to set an absolute, relative, or current date and time. For absolute and relative changes, select the **Update** button to apply the changes.
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/date-pick.png" alt="Altering date range" width="55%">
 
 As an alternative, you can select an option in the **Commonly used** section (see the preceding image of the calendar dropdown list) to conveniently set a window of time. Options include date ranges such as **Today**, **Yesterday**, **this week**, and **week to date**. 
 

--- a/_security-analytics/usage/detectors.md
+++ b/_security-analytics/usage/detectors.md
@@ -8,7 +8,8 @@ nav_order: 30
 # Working with detectors
 
 After creating a detector, it appears on the Threat detectors page along with others saved to the system. You can then perform a number of actions for each detector, from editing its details to changing its status. See the following sections for description of the available actions.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/threat-detector.png" alt="Threat detector page" width="60%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/threat-detector.png" alt="Threat detector page" width="60%">
 
 ## Threat detector list
 
@@ -20,20 +21,24 @@ The list of threat detectors includes the search bar, the **Status** dropdown li
 ### Editing a detector
 
 To edit a detector, begin by selecting the link to the detector in the Detector name column of the list. The detector's details window opens and shows details about the detector's configuration.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/detector-details.png" alt="Detector details window for editig the detector" width="50%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/detector-details.png" alt="Detector details window for editig the detector" width="50%">
+
 * In the upper-left portion of the window, the details window shows the name of the detector and its status, either Active or Inactive.
 * In the upper-right corner of the window, you can select **View alerts** to go to the Alerts window or **View findings** to go to the Findings window. You can also select **Actions** to perform actions for the detector. See [Detector actions]({{site.url}}{{site.baseurl}}/security-analytics/usage/detectors/#detector-actions).
 * In the lower portion of the window, select the **Edit** button for either Detector details or Detection rules to make changes accordingly.
 * Finally, you can select the **Field mappings** tab to edit field mappings for the detector, or select the **Alert triggers** tab to make edits to alerts associated with the detector.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/detector-details2.png" alt="Field mappings and Alert triggers tabs" width="40%">
 
-    After you select the **Alert triggers** tab, you also have the option to add additional alerts for the detector by selecting **Add another alert condition** at the bottom of the page.
-    {: .tip }
+<img src="{{site.url}}{{site.baseurl}}/images/Security/detector-details2.png" alt="Field mappings and Alert triggers tabs" width="40%">
+
+After you select the **Alert triggers** tab, you also have the option to add additional alerts for the detector by selecting **Add another alert condition** at the bottom of the page.
+{: .tip }
 
 ## Detector actions
 
 Threat detector actions allow you to stop and start detectors or delete a detector. To enable actions, first select the checkbox beside one or more detectors in the list.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/detector-action.png" alt="Threat detector actions" width="50%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/detector-action.png" alt="Threat detector actions" width="50%">
 
 ### Changing detector status
 

--- a/_security-analytics/usage/findings.md
+++ b/_security-analytics/usage/findings.md
@@ -50,7 +50,7 @@ Use the **Rule severity** dropdown list to filter the list of findings by severi
 The **Actions** column includes two options for each finding:
 * The diagonal arrow provides a way to open the **Finding details** pane, which describes the finding by parameters defined when creating the detector and includes the document that generated the finding.
 * The bell icon allows you to open the **Create detector alert trigger** pane, where you can quickly set up an alert for the specific finding and modify rules and their conditions as required.
-For details on setting up an alert, see [Set up alerts]({{site.url}}{{site.baseurl}}/security-analytics/sec-analytics-config/detectors-config/#step-3-set-up-alerts) in detector creation documentation.
+For details on setting up an alert, see [Step 3. Set up alerts]({{site.url}}{{site.baseurl}}/security-analytics/sec-analytics-config/detectors-config/#step-3-set-up-alerts) in detector creation documentation.
 
 Each finding in the list also includes a **Finding ID**. In addition to using the diagonal arrow in **Actions**, you can select the ID to open the **Finding details** pane. An example of **Finding details** is shown in the following image.
 

--- a/_security-analytics/usage/overview.md
+++ b/_security-analytics/usage/overview.md
@@ -21,7 +21,9 @@ Each section provides a summary description for each element of Security Analyti
 The upper portion of the Overview page contains two control buttons for refreshing information and getting started with Security Analytics. You can select the **Refresh** button to refresh all of the information on the page. 
 
 You can also select the **Getting started** link to expand the Get started with Security Analytics window, which includes a summary of the setup steps as well as control buttons that allow you to jump to any of the steps.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/overview.png" alt="The overview page with getting started quick launch window" width="85%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/overview.png" alt="The overview page with getting started quick launch window" width="85%">
+
 * In step 1 of setup, select **Create detector** to define a detector. 
 * In step 2, select **View findings** to go to the Findings page. For details about this page, see [Working with findings]({{site.url}}{{site.baseurl}}/security-analytics/usage/findings/).
 * In step 3, select **View alerts** to go to the Security alerts page. For details about this page, see [Working with alerts]({{site.url}}{{site.baseurl}}/security-analytics/usage/alerts/).
@@ -42,7 +44,8 @@ The Recent findings table displays recent findings by time, rule name, rule seve
 ## Most frequent detection rules
 
 This section provides a graphical representation of detection rules that trigger findings most often and how they compare to others as a percentage of the whole. The rule names represented by the graph are listed to the right.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/rule_graph.png" alt="The detection rule graph on the Overview page" width="50%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/rule_graph.png" alt="The detection rule graph on the Overview page" width="50%">
 
 ## Detectors
 

--- a/_security-analytics/usage/rules.md
+++ b/_security-analytics/usage/rules.md
@@ -8,36 +8,41 @@ nav_order: 40
 # Working with rules
 
 The Rules window lists all security rules and provides options for filtering the list and viewing details for each rule. Further options let you import rules and create new rules by first duplicating a Sigma rule then modifying it. This section covers navigation of the Rules page and description of the actions you can perform.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/Rules.png" alt="The Rules page" width="90%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/Rules.png" alt="The Rules page" width="90%">
 
 ## Viewing and filtering rules
 
 When you open the Rules page, all rules are listed in the table. Use the search bar to search for specific rules by entering a full or partial name and pressing **Return/Enter** on your keyboard. The list is filtered and displays matching results.
 
 Alternatively, you can use the **Rule type**, **Rule severity**, and **Source** dropdown lists to drill down in the alerts and filter for preferred results. You can select multiple options from each list and use all three in combination to narrow results.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/rule-menu.png" alt="Rule menus for filtering results" width="40%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/rule-menu.png" alt="Rule menus for filtering results" width="40%">
 
 ### Rule details
 
 To see rule details, select the rule in the Rule name column of the list. The rule details pane opens.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/Rule_details.png" alt="The rule details pane" width="50%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/Rule_details.png" alt="The rule details pane" width="50%">
 
 In Visual view, rule details are arranged in fields, and the links are active. Select **YAML** to display the rule in YAML file format.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/rule_detail_yaml.png" alt="The rule details pane in YAML file view" width="50%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/rule_detail_yaml.png" alt="The rule details pane in YAML file view" width="50%">
+
 * Rule details are formatted as a YAML file according to the Sigma rule specification.
 * To copy the rule, select the copy icon in the top right corner of the rule. To quickly create a new and customized rule, you can paste the rule into the YAML editor and make any modifications before saving it. See [Customizing rules](#customizing-rules) for details.
 
 ## Creating rules
 
 There are several ways to create rules on the Rules page. The first is to manually fill in the necessary fields that complete the rule, using either the Visual Editor or YAML Editor. To do this, select the **Create new rule** button in the uppper-right corner of the Rules window. The Create a rule window opens.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/create-a-rule.png" alt="The Create a rule window, which includes the Visual Editor and YAML editor." width="50%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/create-a-rule.png" alt="The Create a rule window, which includes the Visual Editor and YAML editor." width="50%">
 
 If you choose to create the rule manually, you can refer to Sigma's [Rule Creation Guide](https://github.com/SigmaHQ/sigma/wiki/Rule-Creation-Guide) to help understand details for each field.
 * By default, the Visual Editor is displayed. Enter the appropriate content in each field and select **Create** in the lower-right corner of the window to save the rule.
 * The Create a rule window also provides the YAML Editor so that you can create the rule directly in a YAML file format. Select **YAML Editor** and then enter information for the pre-populated field types.
 
 The alternatives to manually creating a rule, however, simplify and speed up the process. They involve either importing a rule in a YAML file or duplicating an existing rule and customizing it. See the next two sections for detailed steps.
-
 
 ## Importing rules
 
@@ -85,15 +90,21 @@ status: experimental
 ## Customizing rules
 
 An alternative to importing a rule is duplicating a Sigma rule and then modifying it to create a custom rule. First search for or filter rules in the Rules list to locate the rule you want to duplicate.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/rules-dup1.png" alt="Selecting a rule in the Rules name list" width="75%">
+
+<img src="{{site.url}}{{site.baseurl}}/images/Security/rules-dup1.png" alt="Selecting a rule in the Rules name list" width="75%">
 
 1. To begin, select the rule in the Rule name column. The rule details pane opens.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/rule-dup2.png" alt="Opening the rule details pane" width="50%">
+
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/rule-dup2.png" alt="Opening the rule details pane" width="50%">
+
 1. Select the **Duplicate** button in the upper-right corner of the pane. The Duplicate rule window opens in Visual Editor view and all of the fields are automatically populated with the rule's details. Details are also populated in YAML Editor view.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/dupe-rule.png" alt="Selecting the duplicate button opens the Duplicate rule window" width="50%">
+
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/dupe-rule.png" alt="Selecting the duplicate button opens the Duplicate rule window" width="50%">
+
 1. In either Visual Editor view or YAML Editor view, modify any of the fields to customize the rule.
 1. After performing any modifications to the rule, select the **Create** button in the lower-right corner of the window. A new and customized rule is created, and it appears in the list of rules on the main page of the Rules window.
-<br><img src="{{site.url}}{{site.baseurl}}/images/Security/custom-rule.png" alt="The custom rule now appears in the list of rules." width="70%">
+
+    <img src="{{site.url}}{{site.baseurl}}/images/Security/custom-rule.png" alt="The custom rule now appears in the list of rules." width="70%">
 
 You cannot modify the Sigma rule itself. The original Sigma rule always remains in the system. Its duplicate, after modification, becomes the custom rule that is added to the list of rules.
 {: .note }


### PR DESCRIPTION
### Description
There are some poor formatting choices made in the Security Analytics docs. This PR will solve them.

### Issues Resolved
Fixed numerous cases where spacing, or lack of spacing, created problems rendering content in the documentation.

Fixes #3126.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
