### PR TITLE
Document class metadata memory reservation impacts

### DIFF
--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -71,7 +71,7 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/install-and-configu
 
   Disables swapping (along with `memlock`). Swapping can dramatically decrease performance and stability, so you should ensure it is disabled on production clusters.
 
-  Enabling the `bootstrap.memory_lock` setting will cause the JVM to reserve any memory it needs. On VMs with limited memory (such as t2.micro with 1GB) the [default 1GB Class Metadata](https://docs.oracle.com/javase/10/gctuning/other-considerations.htm#JSGCT-GUID-BFB89453-60C0-42AC-81CA-87D59B0ACE2E) native memory reservation result in error due to the lack of native memory. To prevent errors, limit the reserved memory size using `-XX:CompressedClassSpaceSize` or `-XX:MaxMetaspaceSize` and set the size of the Java heap to make sure you have enough system memory.
+  Enabling the `bootstrap.memory_lock` setting will cause the JVM to reserve any memory it needs. On VMs with limited memory, the [default 1 gigabyte (GB) Class Metadata](https://docs.oracle.com/javase/10/gctuning/other-considerations.htm#JSGCT-GUID-BFB89453-60C0-42AC-81CA-87D59B0ACE2E) native memory reservation may result in an error due to the lack of native memory. To prevent errors, limit the reserved memory size using `-XX:CompressedClassSpaceSize` or `-XX:MaxMetaspaceSize` and set the size of the Java heap to make sure you have enough system memory.
 
 - `OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m`
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -71,7 +71,7 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/install-and-configu
 
   Disables swapping (along with `memlock`). Swapping can dramatically decrease performance and stability, so you should ensure it is disabled on production clusters.
 
-  Enabling the `bootstrap.memory_lock` setting will cause the JVM to reserve any memory it needs. On VMs with limited memory, the [default 1 gigabyte (GB) Class Metadata](https://docs.oracle.com/javase/10/gctuning/other-considerations.htm#JSGCT-GUID-BFB89453-60C0-42AC-81CA-87D59B0ACE2E) native memory reservation may result in an error due to the lack of native memory. To prevent errors, limit the reserved memory size using `-XX:CompressedClassSpaceSize` or `-XX:MaxMetaspaceSize` and set the size of the Java heap to make sure you have enough system memory.
+  Enabling the `bootstrap.memory_lock` setting will cause the JVM to reserve any memory it needs. The [Java SE Hotspot VM Garbage Collection Tuning Guide](https://docs.oracle.com/javase/9/gctuning/other-considerations.htm#JSGCT-GUID-B29C9153-3530-4C15-9154-E74F44E3DAD9) documents a default 1 gigabyte (GB) Class Metadata native memory reservation. Combined with Java heap, this may result in an error due to the lack of native memory on VMs with less memory than these requirements. To prevent errors, limit the reserved memory size using `-XX:CompressedClassSpaceSize` or `-XX:MaxMetaspaceSize` and set the size of the Java heap to make sure you have enough system memory.
 
 - `OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m`
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -71,7 +71,7 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/install-and-configu
 
   Disables swapping (along with `memlock`). Swapping can dramatically decrease performance and stability, so you should ensure it is disabled on production clusters.
 
-  Note that this setting will cause the JVM to reserve all the memory it will ever need. On VMs with limited memory (such as t2.micro with 1GB) the [default 1GB Class Metadata](https://docs.oracle.com/javase/10/gctuning/other-considerations.htm#JSGCT-GUID-BFB89453-60C0-42AC-81CA-87D59B0ACE2E) native memory reservation will cause errors. Limiting this reserved memory size using `-XX:CompressedClassSpaceSize` or `-XX:MaxMetaspaceSize` may be required in addition to Java heap limits below.
+  Enabling the `bootstrap.memory_lock` setting will cause the JVM to reserve any memory it needs. On VMs with limited memory (such as t2.micro with 1GB) the [default 1GB Class Metadata](https://docs.oracle.com/javase/10/gctuning/other-considerations.htm#JSGCT-GUID-BFB89453-60C0-42AC-81CA-87D59B0ACE2E) native memory reservation result in error due to the lack of native memory. To prevent errors, limit the reserved memory size using `-XX:CompressedClassSpaceSize` or `-XX:MaxMetaspaceSize` and set the size of the Java heap to make sure you have enough system memory.
 
 - `OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m`
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -71,6 +71,8 @@ The [sample docker-compose.yml]({{site.url}}{{site.baseurl}}/install-and-configu
 
   Disables swapping (along with `memlock`). Swapping can dramatically decrease performance and stability, so you should ensure it is disabled on production clusters.
 
+  Note that this setting will cause the JVM to reserve all the memory it will ever need. On VMs with limited memory (such as t2.micro with 1GB) the [default 1GB Class Metadata](https://docs.oracle.com/javase/10/gctuning/other-considerations.htm#JSGCT-GUID-BFB89453-60C0-42AC-81CA-87D59B0ACE2E) native memory reservation will cause errors. Limiting this reserved memory size using `-XX:CompressedClassSpaceSize` or `-XX:MaxMetaspaceSize` may be required in addition to Java heap limits below.
+
 - `OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m`
 
   Sets the size of the Java heap (we recommend half of system RAM).


### PR DESCRIPTION
### Description

The `bootstrap.memory_lock=true` imposes a hard lower limit on native memory reservation by the JVM, which include 1 GB for class metadata in addition to heap space.

On small VMs (such as t1.micro) with only 1 GB space, this results in out of memory errors.

This change updates the documentation to alert users to this setting.

### Issues Resolved

Fixes https://github.com/opensearch-project/OpenSearch/issues/5865

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
