### PR TITLE
Fix graphics links for v 2.5 and 2.6 documentation

### DIFF
--- a/_dashboards/visualize/gantt.md
+++ b/_dashboards/visualize/gantt.md
@@ -23,6 +23,6 @@ To create a Gantt chart, perform the following steps:
 1. Choose **Panel settings** to adjust axis labels, time format, and colors.
 1. Choose **Update**.
 
-![Gantt Chart]({{site.url}}{{site.baseurl}}/images/gantt-chart.png)
+![Gantt Chart]({{site.url}}{{site.baseurl}}/images/dashboards/gantt-chart.png)
 
 This Gantt chart displays the ID of each log on the y-axis. Each bar is a unique event that spans some amount of time. Hover over a bar to see the duration of that event.

--- a/_dashboards/visualize/visbuilder.md
+++ b/_dashboards/visualize/visbuilder.md
@@ -18,7 +18,7 @@ You can use the VisBuilder visualization type in OpenSearch Dashboards to create
 * The flexibility to change visualization types and index patterns quickly.
 * The ability to easily navigate between multiple screens.
 
-<img src="{{site.url}}{{site.baseurl}}/images/vis-builder-2.png" alt="VisBuilder new visualization start page">
+<img src="{{site.url}}{{site.baseurl}}/images/dashboards/vis-builder-2.png" alt="VisBuilder new visualization start page">
 
 ## Try VisBuilder in the OpenSearch Dashboards playground
 
@@ -48,7 +48,7 @@ Follow these steps to create a new visualization using VisBuilder in your enviro
 
 3. From the top menu, select **Visualize** **>** **Create visualization** **>** **VisBuilder**.
 
-   <img src="{{site.url}}{{site.baseurl}}/images/vis-builder-1.png" alt="Select the VisBuilder visualization type" width="550">  
+   <img src="{{site.url}}{{site.baseurl}}/images/dashboards/vis-builder-1.png" alt="Select the VisBuilder visualization type" width="550">  
 
 4. Drag and drop field names from the left column into the **Configuration** panel to generate a visualization.
 


### PR DESCRIPTION
### Description
Fix graphics links for 2.5 and 2.6 documentation for Gantt charts and VisBuilder

Fixes https://github.com/opensearch-project/documentation-website/issues/3096

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
