### PR TITLE
added some of the params undisclosed in the API. still missing more i…

### DIFF
--- a/_observing-your-data/alerting/api.md
+++ b/_observing-your-data/alerting/api.md
@@ -1342,6 +1342,19 @@ Introduced 1.0
 
 Returns an array of all alerts.
 
+**Query Parameters**
+
+Parameter | Data type | Description
+:--- | :--- | :---
+sortOrder     | string | Determines the order of the results. can be "asc" or "desc". defaults to "asc"
+missing       | string | Optional
+size          | string | Determines the size of the request to be returned. defaults to 20
+startIndex    | string | The start index to start from. used for paginating results. defaults to 0
+searchString  | string | Search string for looking for a specific alert. defaults to empty string
+severityLevel | string | Severity level to filter for. defaults to "ALL"
+alertState    | string | Alert state to filter for. defaults to "ALL"
+monitorId     | string | Filter by monitorId
+
 #### Request
 
 ```json


### PR DESCRIPTION
…nfo for missing and searchString

### Description
issue-3368 - adds missing query parameters for the GET Alerts endpoint api documentation.

### Issues Resolved
issue 3368 - adds missing query parameters for the GET Alerts endpoint.


### Checklist
- [X ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
