### PR TITLE
Update put-mapping.md: add "dynamic"

### DIFF
--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -42,9 +42,9 @@ The request body must contain `properties`, which has all of the mappings that y
 
 ## Optional request body fields
 
-### Field "dynamic"
+### dynamic
 
-To enforce document structure to match the structure of the index mapping, specify property "dynamic" and set its value to "strict":
+You can make the document structure match the structure of the index mapping by setting the `dynamic` request body field to `strict`, as seen in the following example:
 
 ```json
 {

--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -40,6 +40,23 @@ The request body must contain `properties`, which has all of the mappings that y
 }
 ```
 
+## Optional request body fields
+
+### Field "dynamic"
+
+To enforce document structure to match the structure of the index mapping, specify property "dynamic" and set its value to "strict":
+
+```json
+{
+  "properties":{
+    "dynamic": "strict",
+    "color":{
+      "type": "text"
+    }
+  }
+}
+```
+
 ## Optional query parameters
 
 Optionally, you can add query parameters to make a more specific request. For example, to skip any missing or closed indexes in the response, you can add the `ignore_unavailable` query parameter to your request as follows:


### PR DESCRIPTION
Update put-mapping.md: add an example for "dynamic": "strict" in index JSON

### Description
Adds documentation for index mapping property "dynamic", which is a sibling property of "properties".

### Issues Resolved
Closes [https://github.com/opensearch-project/documentation-website/issues/3383]

### Checklist
- [ x ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
