### PR TITLE
Add documentation to rename opensearch_dashboards predefined roles to kibana

### DIFF
--- a/_security/access-control/users-roles.md
+++ b/_security/access-control/users-roles.md
@@ -113,8 +113,8 @@ Role | Description
 `cross_cluster_replication_leader_full_access` | Grants full access to perform cross-cluster replication actions on the leader cluster.
 `observability_full_access` | Grants full access to perform actions on Observability objects such as visualizations, notebooks, and operational panels.
 `observability_read_access` | Grants permission to view Observability objects such as visualizations, notebooks, and operational panels, but not create, modify, or delete them.
-`opensearch_dashboards_read_only` | A special role that prevents users from making changes to visualizations, dashboards, and other OpenSearch Dashboards objects. See `opensearch_security.readonly_mode.roles` in `opensearch_dashboards.yml`. Pair with the `opensearch_dashboards_user` role.
-`opensearch_dashboards_user` | Grants permissions to use OpenSearch Dashboards: cluster-wide searches, index monitoring, and write to various OpenSearch Dashboards indices.
+`kibana_read_only` | A special role that prevents users from making changes to visualizations, dashboards, and other OpenSearch Dashboards objects. See `opensearch_security.readonly_mode.roles` in `opensearch_dashboards.yml`. Pair with the `kibana_user` role.
+`kibana_user` | Grants permissions to use OpenSearch Dashboards: cluster-wide searches, index monitoring, and write to various OpenSearch Dashboards indices.
 `logstash` | Grants permissions for Logstash to interact with the cluster: cluster-wide searches, cluster monitoring, and write to the various Logstash indices.
 `manage_snapshots` | Grants permissions to manage snapshot repositories, take snapshots, and restore snapshots.
 `readall` | Grants permissions for cluster-wide searches like `msearch` and search permissions for all indices.


### PR DESCRIPTION
### Description
Somehow the predefined roles for providing permissions for all functionality in Dashboards and read-only permissions became named `openesarch_dashboards_user` and `opensearch_dashboards_read_only` while in the code they remain `kibana_user` and `kibana_read_only`. Need to name them properly to agree with the code.

### Issues Resolved
renamed these roles `kibana_user` and `kibana_read_only` in the [Predefined roles](https://opensearch.org/docs/latest/security/access-control/users-roles/#predefined-roles) table in Users and Roles documentation.

Fixes #2723.

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
