### PR TITLE
Fixes change from doc review that broke ToC linking

### DIFF
--- a/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Rolling upgrade lab
-parent: Upgrades Appendix
+parent: Upgrades appendix
 grand_parent: Upgrading OpenSearch
 nav_order: 50
 redirect_from:


### PR DESCRIPTION
### Description
During doc review a change was suggested to the title of one page, including the front matter, but inconsistent feedback between related pages caused a change in capitalization that broke linking. This fixes it.

### Issues Resolved
N/A small fix, no issue


### Checklist
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
