### PR TITLE
Fix table header in Bounded blocking doc.

### DIFF
--- a/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
+++ b/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
@@ -12,11 +12,10 @@ nav_order: 50
 
 `Bounded blocking` is the default buffer and is memory based. The following table describes the `Bounded blocking` parameters.
 
-Option | Required | Type | Description
-:--- | :--- | :--- | :---
-
-buffer_size | No | Integer | The maximum number of records the buffer accepts. Default value is `12800`.
-batch_size | No | Integer | The maximum number of records the buffer drains after each read. Default value is `200`.
+| Option | Required | Type | Description |
+| --- | --- | --- | --- |
+| buffer_size | No | Integer | The maximum number of records the buffer accepts. Default value is `12800`. |
+| batch_size | No | Integer | The maximum number of records the buffer drains after each read. Default value is `200`. |
 
 <!--- ## Configuration
 


### PR DESCRIPTION
### Description
Fixes an error the table header justification definitions for Bounded blocking. 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
