### PR TITLE
Add documentation to provide notice about deprecation of security tools in the next major release

### DIFF
--- a/_security/configuration/security-admin.md
+++ b/_security/configuration/security-admin.md
@@ -14,6 +14,9 @@ On **Windows**, use **securityadmin.bat** in place of **securityadmin.sh**. For 
 
 The Security plugin stores its configuration—including users, roles, permissions, and backend settings—in a [system index]({{site.url}}{{site.baseurl}}/security/configuration/system-indices) on the OpenSearch cluster. Storing these settings in an index lets you change settings without restarting the cluster and eliminates the need to edit configuration files on every individual node. This is accomplished by running the `securityadmin.sh` script. The script can be found at `plugins/opensearch-security/tools/securityadmin.sh`.
 
+The `securityadmin.sh` and `securityadmin.bat` tools will be deprecated and replaced in the next major release of OpenSearch. To learn more about current plans, see the GitHub issue [Security Plugin Tools will be replaced](https://github.com/opensearch-project/security/issues/1755), where you can leave comments about proposals for the replacement of the tools.
+{: .important }
+
 The first job of the script, however, is to initialize the `.opendistro_security` index. This loads your initial configuration into the index using the configuration files in `config/opensearch-security`. After the `.opendistro_security` index is initialized, you can use OpenSearch Dashboards or the REST API to manage your users, roles, and permissions.
 
 


### PR DESCRIPTION
### Description
The `audit_config_migrater`, `hash`, and `securityadmin` security tools will be deprecated in the next major release. This documentation alerts users to their imminent replacement. 
### Issues Resolved
Added an `important` banner note including the news of this deprecation in relevant places in documentation.


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
