### PR TITLE
Update to breaking changes topic

### DIFF
--- a/breaking-changes.md
+++ b/breaking-changes.md
@@ -20,8 +20,8 @@ In order for OpenSearch to include more inclusive naming conventions, we've repl
 - "Blacklist" is now "Deny list"
 - "Master" is now "Cluster Manager"
 
-If you are still using the outdated terms in the context of the security APIs or for node management, your calls and automation will continue to work until the terms are removed later in 2022. 
-
+If you are using any outdated terms in the context of the security APIs or for node management, your calls and automation will continue to work in all 2.x releases. However, support for the outdated terms will be removed in 3.0 -- which will be a breaking change -- so plan accordingly.  
+{: .warning}
 
 ### Add OpenSearch Notifications plugins
 


### PR DESCRIPTION
### Description
Adds a warning that the deprecated 2.x terms will be removed in 3.0 to the Breaking Changes topic. 

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/1360

When 3.0 is released, we'll publish a topic with all breaking changes, including this one.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
