### PR TITLE
Update permissions.md

### DIFF
--- a/_tuning-your-cluster/replication-plugin/permissions.md
+++ b/_tuning-your-cluster/replication-plugin/permissions.md
@@ -25,7 +25,7 @@ In order for non-admin users to perform replication activities, they must be map
 
 The security plugin has two built-in roles that cover most replication use cases: `cross_cluster_replication_leader_full_access`, which provides replication permissions on the leader cluster, and `cross_cluster_replication_follower_full_access`, which provides replication permissions on the follower cluster. For descriptions of each, see [Predefined roles]({{site.url}}{{site.baseurl}}/security/access-control/users-roles#predefined-roles).
 
-If you don't want to use the default roles, you can combine individual replication [permissions]({{site.url}}{{site.baseurl}}/replication-plugin/permissions/#replication-permissions) to meet your needs. Most permissions correspond to specific REST API operations. For example, the `indices:admin/plugins/replication/index/pause` permission lets you pause replication.
+If you don't want to use the default roles, you can combine individual replication [permissions]({{site.url}}{{site.baseurl}}/tuning-your-cluster/replication-plugin/permissions/#replication-permissions) to meet your needs. Most permissions correspond to specific REST API operations. For example, the `indices:admin/plugins/replication/index/pause` permission lets you pause replication.
 
 ## Map the leader and follower cluster roles
 


### PR DESCRIPTION
Link to permissions at https://opensearch.org/docs/latest/tuning-your-cluster/replication-plugin/permissions/ under Basic permissions is not pointing directly to the anchor on the same page. This causes unneccesary page reload and page redirect. The invalid link provides no benefit as the same page ends up reloading and does not even start from anchor.

### Description
Link to permissions at https://opensearch.org/docs/latest/tuning-your-cluster/replication-plugin/permissions/ under Basic permissions is not pointing directly to the anchor on the same page. This causes unneccesary page reload and page redirect. The invalid link provides no benefit as the same page ends up reloading and does not even start from anchor.


### Issues Resolved
Corrected link


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
