### PR TITLE
Fix put rollup job api documentation

### DIFF
--- a/_im-plugin/index-rollups/rollup-api.md
+++ b/_im-plugin/index-rollups/rollup-api.md
@@ -107,8 +107,8 @@ Options | Description | Type | Required
 `description` | Optionally, describe the rollup job. | String | No
 `enabled` | When true, the index rollup job is scheduled. Default is true. | Boolean | Yes
 `continuous` | Specify whether or not the index rollup job continuously rolls up data forever or just executes over the current data set once and stops. Default is false. | Boolean | Yes
-`error_notification` | Set up a Mustache message template sent for error notifications. For example, if an index rollup job fails, the system sends a message to a Slack channel. | Object | No
-`page_size` | Specify the number of buckets to paginate through at a time while rolling up. | Number | Yes
+`error_notification` | Set up a Mustache message template for error notifications. For example, if an index rollup job fails, the system sends a message to a Slack channel. | Object | No
+`page_size` | Specify the number of buckets to paginate at a time during rollup. | Number | Yes
 `delay` | The number of milliseconds to delay execution of the index rollup job. | Long | No
 `dimensions` | Specify aggregations to create dimensions for the roll up time window. Supported groups are `terms`, `histogram`, and `date_histogram`. For more information, see [Bucket Aggregations]({{site.url}}{{site.baseurl}}/opensearch/bucket-agg). | Array | Yes
 `metrics` | Specify a list of objects that represent the fields and metrics that you want to calculate. Supported metrics are `sum`, `max`, `min`, `value_count` and `avg`. For more information, see [Metric Aggregations]({{site.url}}{{site.baseurl}}/opensearch/metric-agg). | Array | No


### PR DESCRIPTION
### Description
- In the current example request for `Index Rollup API` -> `Create or update an index rollup job`, `dimensions` and `metrics` fields are incorrect and will encounter `parsing_exception` when calling with OpenSearch. 
- This PR fix the the example request following the correct format. Tested against OpenSearch and the call succeeded. 
- Referred to [Index Rollup ISM operation](https://opensearch.org/docs/latest/im-plugin/ism/policies/#rollup) and [Index Rollup API source code](https://github.com/opensearch-project/index-management/blob/main/src/main/kotlin/org/opensearch/indexmanagement/rollup/model/Rollup.kt#L304-L315) to come up with the correct request.
- Also updated the description of `dimensions` and `metrics` field. Referred to [Index Transform API documentation](https://github.com/opensearch-project/documentation-website/blob/main/_im-plugin/index-transforms/transforms-apis.md) for the wording. 

### Issues Resolved
More details described in #3636 


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
