### PR TITLE
Update CODEOWNERS to reflect team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,8 @@
-# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
-*   @opensearch-project/docs
+@ariamarble
+@carolxob
+@cwillum
+@hdhalter
+@JeffH-AWS
+@kolchfa-aws
+@Naarcha-AWS
+@vagimeli


### PR DESCRIPTION
Fixes issue where maintainers and codeowners should match.

Part of issue #2878 2878


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
