### PR TITLE
Link checker update: fail on PRs and run for all branches

### DIFF
--- a/.github/workflows/jekyll-build.yml
+++ b/.github/workflows/jekyll-build.yml
@@ -13,4 +13,4 @@ jobs:
         ruby-version: '3.0'
         bundler-cache: true
     - run: |
-        JEKYLL_LINK_CHECKER=internal bundle exec jekyll build --future
+        JEKYLL_FATAL_LINK_CHECKER=internal bundle exec jekyll build --future

--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -5,9 +5,14 @@ on:
     - cron: "30 11 * * *"
 jobs:
   check:
+    strategy:
+      matrix:
+        branch: [main, 2.*, 1.3]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
+      with:
+        ref: ${{ matrix.branch }}
     - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.0'


### PR DESCRIPTION
Modifies the link checker workflow to:
 - fail a PR on a broken link
 - run the cron schedule for 2.x and 1.3 branches

### Checklist
- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
