### PR TITLE
Add new settings for SAML and OIDC that allow for cookie splitting

### DIFF
--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -344,7 +344,7 @@ opensearch_security.openid.extra_storage.cookie_prefix: security_authentication_
 opensearch_security.openid.extra_storage.additional_cookies: 3
 ```
 
-Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing a fixed number of additional cookies and not changing the configuration after that.
+Note that reducing the number of additional cookies can cause some of the cookies that were in use before the change to stop working. We recommend establishing a fixed number of additional cookies and not changing the configuration after that.
 
 If the ID token from the IdP is especially large, OpenSearch may throw a server log authentication error indicating that the HTTP header is too large. In this case, you can increase the value for the `http.max_header_size` setting in the `opensearch.yml` file.
 {: .tip }

--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -334,6 +334,22 @@ opensearch.requestHeadersAllowlist: ["Authorization", "security_tenant"]
 To include OpenID Connect with other authentication types in the Dashboards sign-in window, see [Configuring sign-in options]({{site.url}}{{site.baseurl}}/security/configuration/multi-auth/).
 {: .note } 
 
+
+#### Session management with additional cookies
+
+To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides and option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger OpenID Connect assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
+
+```yml
+opensearch_security.openid.extra_storage.cookie_prefix: security_authentication_oidc
+opensearch_security.openid.extra_storage.additional_cookies: 3
+```
+
+Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing an appropriate number of additional cookies and leaving the setting in that configuration.
+
+If the ID token from the IdP is especially large, OpenSearch may throw a server log authentication error indicating that the HTTP header is too large. In this case, you can increase the value for the `http.max_header_size` setting in the `opensearch.yml` file.
+{: .tip }
+
+
 ### OpenSearch security configuration
 
 Because OpenSearch Dashboards requires that the internal OpenSearch Dashboards server user can authenticate through HTTP basic authentication, you must configure two authentication domains. For OpenID Connect, the HTTP basic domain has to be placed first in the chain. Make sure you set the challenge flag to `false`.

--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -337,7 +337,7 @@ To include OpenID Connect with other authentication types in the Dashboards sign
 
 #### Session management with additional cookies
 
-To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides and option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger OpenID Connect assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
+To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger OpenID Connect assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
 
 ```yml
 opensearch_security.openid.extra_storage.cookie_prefix: security_authentication_oidc

--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -337,14 +337,14 @@ To include OpenID Connect with other authentication types in the Dashboards sign
 
 #### Session management with additional cookies
 
-To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger OpenID Connect assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
+To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger OpenID Connect assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
 
 ```yml
 opensearch_security.openid.extra_storage.cookie_prefix: security_authentication_oidc
 opensearch_security.openid.extra_storage.additional_cookies: 3
 ```
 
-Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing an appropriate number of additional cookies and leaving the setting in that configuration.
+Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing a fixed number of additional cookies and not changing the configuration after that.
 
 If the ID token from the IdP is especially large, OpenSearch may throw a server log authentication error indicating that the HTTP header is too large. In this case, you can increase the value for the `http.max_header_size` setting in the `opensearch.yml` file.
 {: .tip }

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -332,6 +332,13 @@ If you use the logout POST binding, you also need to ad the logout endpoint to y
 server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout"]
 ```
 
+To improve session management—especially for users who have multiple roles assigned to them—you can split cookie payloads into multiple cookies and restitch the payloads when receiving them. This can help prevent larger assertions from hitting size limits for each cookie. The following two settings allow you to set a prefix name for additional cookies and choose a default number of cookies:
+
+```yml
+opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_oidc
+opensearch_security.saml.extra_storage.additional_cookies: default: 3
+```
+
 To include SAML with other authentication types in the Dashboards sign-in window, see [Configuring sign-in options]({{site.url}}{{site.baseurl}}/security/configuration/multi-auth/).
 {: .note }
 

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -337,7 +337,7 @@ To include SAML with other authentication types in the Dashboards sign-in window
 
 #### Session management with additional cookies
 
-To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides and option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
+To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
 
 ```yml
 opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_oidc

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -344,7 +344,7 @@ opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_oi
 opensearch_security.saml.extra_storage.additional_cookies: 3
 ```
 
-Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing a fixed number of additional cookies and not changing the configuration after that.
+Note that reducing the number of additional cookies can cause some of the cookies that were in use before the change to stop working. We recommend establishing a fixed number of additional cookies and not changing the configuration after that.
 
 If the ID token from the IdP is especially large, OpenSearch may throw a server log authentication error indicating that the HTTP header is too large. In this case, you can increase the value for the `http.max_header_size` setting in the `opensearch.yml` file.
 {: .tip }

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -332,15 +332,22 @@ If you use the logout POST binding, you also need to ad the logout endpoint to y
 server.xsrf.allowlist: ["/_opendistro/_security/saml/acs", "/_opendistro/_security/saml/logout"]
 ```
 
-To improve session management—especially for users who have multiple roles assigned to them—you can split cookie payloads into multiple cookies and restitch the payloads when receiving them. This can help prevent larger assertions from hitting size limits for each cookie. The following two settings allow you to set a prefix name for additional cookies and choose a default number of cookies:
+To include SAML with other authentication types in the Dashboards sign-in window, see [Configuring sign-in options]({{site.url}}{{site.baseurl}}/security/configuration/multi-auth/).
+{: .note }
+
+#### Session management with additional cookies
+
+To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides and option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
 
 ```yml
 opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_oidc
-opensearch_security.saml.extra_storage.additional_cookies: default: 3
+opensearch_security.saml.extra_storage.additional_cookies: 3
 ```
 
-To include SAML with other authentication types in the Dashboards sign-in window, see [Configuring sign-in options]({{site.url}}{{site.baseurl}}/security/configuration/multi-auth/).
-{: .note }
+Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing an appropriate number of additional cookies and leaving the setting in that configuration.
+
+If the ID token from the IdP is especially large, OpenSearch may throw a server log authentication error indicating that the HTTP header is too large. In this case, you can increase the value for the `http.max_header_size` setting in the `opensearch.yml` file.
+{: .tip }
 
 ### IdP-initiated SSO
 

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -337,14 +337,14 @@ To include SAML with other authentication types in the Dashboards sign-in window
 
 #### Session management with additional cookies
 
-To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then restitch the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
+To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
 
 ```yml
 opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_oidc
 opensearch_security.saml.extra_storage.additional_cookies: 3
 ```
 
-Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing an appropriate number of additional cookies and leaving the setting in that configuration.
+Note that reducing the number of additional cookies can cause some of the cookies in use before the change to stop working. We recommend establishing a fixed number of additional cookies and not changing the configuration after that.
 
 If the ID token from the IdP is especially large, OpenSearch may throw a server log authentication error indicating that the HTTP header is too large. In this case, you can increase the value for the `http.max_header_size` setting in the `opensearch.yml` file.
 {: .tip }


### PR DESCRIPTION
### Description
Two new settings are added to `opensearch_dashboards.yml` that allow for splitting session payloads into multiple cookies to help prevent from hitting cookie limits.

### Issues Resolved
Added documentation for these settings in SAML and OIDC backend configuration.

Fixes #3691 


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
