### PR TITLE
Update Maintainer.md to match CODEOWNER

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -4,10 +4,14 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 
 ## Current Maintainers
 
-| Maintainer     | GitHub ID                                     | Affiliation |
-| -------------- | --------------------------------------------- | ----------- |
-| Aria Marble | [ariamarble](https://github.com/ariamarble)   | Amazon |
-| Heather Halter | [hdhalter](https://github.com/hdhalter)       | Amazon      |
-| Fanit Kolchina | [kolchfa-aws](https://github.com/kolchfa-aws)  | Amazon  |
-| Nate Archer    | [Naarcha-AWS](https://github.com/Naarcha-AWS) | Amazon      |
+| Maintainer       | GitHub ID                                       | Affiliation |
+| ---------------- | ----------------------------------------------- | ----------- |
+| Aria Marble      | [ariamarble](https://github.com/ariamarble)     | Amazon      |
+| Caroline O'Brien | [carolxob](https://github.com/carolxob)         | Amazon      |
+| Chris Moore      | [cwillum] (https://github.com/cwillum)          | Amazon      |
+| Heather Halter   | [hdhalter](https://github.com/hdhalter)         | Amazon      |
+| Jeff Huss        | [JeffH-AWS](https://github.com/JeffH-AWS)       | Amazon      |
+| Fanit Kolchina   | [kolchfa-aws](https://github.com/kolchfa-aws)   | Amazon      |
+| Nate Archer      | [Naarcha-AWS](https://github.com/Naarcha-AWS)   | Amazon      |
+| Melissa Vagi     | [vagimeli](https://github.com/vagimeli)         | Amazon      |
 


### PR DESCRIPTION
### Description
Based on requirement here:
https://github.com/opensearch-project/.github/issues/125

CODEOWNER should include a subset or all maintainers. This PR updates the original CODEOWNER PR here https://github.com/opensearch-project/documentation-website/pull/3639 based on the request.

Issue Resolve
https://github.com/opensearch-project/documentation-website/issues/2878


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
