### PR TITLE
Add editorial to maintainers and codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*   @ariamarble @carolxob @cwillum @hdhalter @JeffH-AWS @kolchfa-aws @Naarcha-AWS @vagimeli @ananzh @seanneumann @AMoo-Miki
+*   @ariamarble @carolxob @cwillum @hdhalter @JeffH-AWS @kolchfa-aws @Naarcha-AWS @vagimeli @ananzh @seanneumann @AMoo-Miki @natebower

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -13,6 +13,7 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Jeff Huss        | [JeffH-AWS](https://github.com/JeffH-AWS)       | Amazon      |
 | Fanit Kolchina   | [kolchfa-aws](https://github.com/kolchfa-aws)   | Amazon      |
 | Nate Archer      | [Naarcha-AWS](https://github.com/Naarcha-AWS)   | Amazon      |
+| Nate Bower       | [natebower](https://github.com/natebower)       | Amazon      |
 | Melissa Vagi     | [vagimeli](https://github.com/vagimeli)         | Amazon      |
 | Anan Zhuang      | [ananzh](https://github.com/ananzh)             | Amazon      |
 | Sean Neumann     | [seanneumann](https://github.com/seanneumann)   | Amazon      |


### PR DESCRIPTION
Adds Nate Bower as a maintainer, so he has the same permissions he had previously.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
