### PR TITLE
Data Prepper documentation for the SNS to SQS fan out pattern in S3

### DIFF
--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -171,16 +171,10 @@ We recommend that you have one SQS queue per Data Prepper pipeline. In addition,
 
 If you have multiple pipelines, you must create multiple SQS queues for each pipeline, even if both pipelines use the same S3 bucket.
 
-## Amazon SNS fan out pattern
+## Amazon SNS fanout pattern
 
-Often a team needs to have multiple event handlers for an S3 bucket.
-A standard solution here is to use an [Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (SNS) to SQS [fan out pattern](https://docs.aws.amazon.com/sns/latest/dg/sns-common-scenarios.html).
-In this setup, you will have S3 event notifications go directly to a single SNS topic.
-Then you can subscribe multiple SQS queues to the SNS topic.
+To meet the scale of logs produced in S3, some users require multiple SQS queues for their logs. You can use the [Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (SNS) to route event notifications from S3 to an SQS [fanout pattern](https://docs.aws.amazon.com/sns/latest/dg/sns-common-scenarios.html). Using SNS, all S3 event notifications go directly to a single SNS topic, where you can subscribe to multiple SQS queues.
 
-In order for this to work with Data Prepper, you must configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription.
-This configuration allows Data Prepper to parse the incoming data correctly.
-The raw message delivery option is on the connection between SNS and SQS.
-Thus, you can have some SQS queues which do not enable raw message delivery.
-Using Data Prepper will not interfere with those queues.
+To make sure that Data Prepper can parse the event from the SNS topic directly, configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription. If you want Data Prepper to ignore an SQS queue that sends notifications to your SNS topic, do not enable raw message delivery those queues.
+
 

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -175,6 +175,6 @@ If you have multiple pipelines, you must create multiple SQS queues for each pip
 
 To meet the scale of logs produced in S3, some users require multiple SQS queues for their logs. You can use the [Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (SNS) to route event notifications from S3 to an SQS [fanout pattern](https://docs.aws.amazon.com/sns/latest/dg/sns-common-scenarios.html). Using SNS, all S3 event notifications go directly to a single SNS topic, where you can subscribe to multiple SQS queues.
 
-To make sure that Data Prepper can parse the event from the SNS topic directly, configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription. If you want Data Prepper to ignore an SQS queue that sends notifications to your SNS topic, do not enable raw message delivery those queues.
+To make sure that Data Prepper can parse the event from the SNS topic directly, configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription. Setting this option will not affect other SQS queues which are subscribed to that SNS topic.
 
 

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -175,6 +175,6 @@ If you have multiple pipelines, you must create multiple SQS queues for each pip
 
 To meet the scale of logs produced in S3, some users require multiple SQS queues for their logs. You can use the [Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (SNS) to route event notifications from S3 to an SQS [fanout pattern](https://docs.aws.amazon.com/sns/latest/dg/sns-common-scenarios.html). Using SNS, all S3 event notifications go directly to a single SNS topic, where you can subscribe to multiple SQS queues.
 
-To make sure that Data Prepper can parse the event from the SNS topic directly, configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription. Setting this option will not affect other SQS queues which are subscribed to that SNS topic.
+To make sure that Data Prepper can directly parse the event from the SNS topic, configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription. Setting this option will not affect other SQS queues that are subscribed to that SNS topic.
 
 

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -173,7 +173,7 @@ If you have multiple pipelines, you must create multiple SQS queues for each pip
 
 ## Amazon SNS fanout pattern
 
-To meet the scale of logs produced in S3, some users require multiple SQS queues for their logs. You can use the [Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (SNS) to route event notifications from S3 to an SQS [fanout pattern](https://docs.aws.amazon.com/sns/latest/dg/sns-common-scenarios.html). Using SNS, all S3 event notifications go directly to a single SNS topic, where you can subscribe to multiple SQS queues.
+To meet the scale of logs produced by S3, some users require multiple SQS queues for their logs. You can use [Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (Amazon SNS) to route event notifications from S3 to an SQS [fanout pattern](https://docs.aws.amazon.com/sns/latest/dg/sns-common-scenarios.html). Using SNS, all S3 event notifications are sent directly to a single SNS topic, where you can subscribe to multiple SQS queues.
 
 To make sure that Data Prepper can directly parse the event from the SNS topic, configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription. Setting this option will not affect other SQS queues that are subscribed to that SNS topic.
 

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -171,6 +171,16 @@ We recommend that you have one SQS queue per Data Prepper pipeline. In addition,
 
 If you have multiple pipelines, you must create multiple SQS queues for each pipeline, even if both pipelines use the same S3 bucket.
 
+## Amazon SNS fan out pattern
 
+Often a team needs to have multiple event handlers for an S3 bucket.
+A standard solution here is to use an [Amazon Simple Notification Service](https://docs.aws.amazon.com/sns/latest/dg/welcome.html) (SNS) to SQS [fan out pattern](https://docs.aws.amazon.com/sns/latest/dg/sns-common-scenarios.html).
+In this setup, you will have S3 event notifications go directly to a single SNS topic.
+Then you can subscribe multiple SQS queues to the SNS topic.
 
+In order for this to work with Data Prepper, you must configure [raw message delivery](https://docs.aws.amazon.com/sns/latest/dg/sns-large-payload-raw-message-delivery.html) on the SNS to SQS subscription.
+This configuration allows Data Prepper to parse the incoming data correctly.
+The raw message delivery option is on the connection between SNS and SQS.
+Thus, you can have some SQS queues which do not enable raw message delivery.
+Using Data Prepper will not interfere with those queues.
 


### PR DESCRIPTION
### Description

Some users have hit an issue using Data Prepper with an SNS/SQS fan out. This can be overcome and this documentation change conveys what a user needs to do for it.

### Issues Resolved

N/A


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
