### PR TITLE
Feedback on table headings in rename-keys topic

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/rename-keys.md
+++ b/_data-prepper/pipelines/configuration/processors/rename-keys.md
@@ -14,7 +14,7 @@ The `rename_keys` processor renames keys in an event.
 
 You can configure the `rename_keys` processor with the following options.
 
-Option | Required | Description |
+| Option | Required | Description |
 | :--- | :--- | :--- |
 | `entries` | Yes | A list of event entries to rename. |
 | `from_key` | Yes | The key of the entry to be renamed. |


### PR DESCRIPTION
### Description
Feedback on 042823: /docs/latest/data-prepper/pipelines/configuration/processors/rename-keys/; Option column data is blank, last column is missing the header.

### Issues Resolved
na


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
