### PR TITLE
Fix cookie-splitting setting example for SAML backend documentation

### DIFF
--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -337,7 +337,7 @@ To include OpenID Connect with other authentication types in the Dashboards sign
 
 #### Session management with additional cookies
 
-To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger OpenID Connect assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
+To improve session management---especially for users who have multiple roles assigned to them---Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger OpenID Connect assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. They are added to the `opensearch_dashboards.yml` file. The default number of additional cookies is three:
 
 ```yml
 opensearch_security.openid.extra_storage.cookie_prefix: security_authentication_oidc

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -337,7 +337,7 @@ To include SAML with other authentication types in the Dashboards sign-in window
 
 #### Session management with additional cookies
 
-To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. They are added to the `opensearch_dashboards.yml` file. The default number of additional cookies is three:
+To improve session management---especially for users who have multiple roles assigned to them---Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. They are added to the `opensearch_dashboards.yml` file. The default number of additional cookies is three:
 
 ```yml
 opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_saml

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -337,10 +337,10 @@ To include SAML with other authentication types in the Dashboards sign-in window
 
 #### Session management with additional cookies
 
-To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. The default number of additional cookies is three:
+To improve session management—especially for users who have multiple roles assigned to them—Dashboards provides an option to split cookie payloads into multiple cookies and then recombine the payloads when receiving them. This can help prevent larger SAML assertions from exceeding size limits for each cookie. The two settings in the following example allow you to set a prefix name for additional cookies and specify the number of them. They are added to the `opensearch_dashboards.yml` file. The default number of additional cookies is three:
 
 ```yml
-opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_oidc
+opensearch_security.saml.extra_storage.cookie_prefix: security_authentication_saml
 opensearch_security.saml.extra_storage.additional_cookies: 3
 ```
 


### PR DESCRIPTION
### Description
Fix the example for the cookie-splitting setting that adds a prefix name so that it indicates "saml" instead of "oidc".

### Issues Resolved
Fixes #3947 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
