### PR TITLE
Fix actionsgroups API example response and cleanup topic generally

### DIFF
--- a/_security/access-control/api.md
+++ b/_security/access-control/api.md
@@ -7,7 +7,7 @@ nav_order: 120
 
 # API
 
-The security plugin REST API lets you programmatically create and manage users, roles, role mappings, action groups, and tenants.
+The Security plugin REST API lets you programmatically create and manage users, roles, role mappings, action groups, and tenants.
 
 ---
 
@@ -20,7 +20,7 @@ The security plugin REST API lets you programmatically create and manage users, 
 
 ## Access control for the API
 
-Just like OpenSearch permissions, you control access to the security plugin REST API using roles. Specify roles in `opensearch.yml`:
+Just like OpenSearch permissions, you control access to the Security plugin REST API using roles. Specify roles in `opensearch.yml`:
 
 ```yml
 plugins.security.restapi.roles_enabled: ["<role>", ...]
@@ -101,9 +101,10 @@ Returns account details for the current user. For example, if you sign the reque
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/account
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -147,6 +148,7 @@ PUT _plugins/_security/api/account
     "password" : "new-password"
 }
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -169,11 +171,15 @@ Introduced 1.0
 
 Retrieves one action group.
 
-
-#### Request
-
-```
+```json
 GET _plugins/_security/api/actiongroups/<action-group>
+```
+{% include copy-curl.html %}
+
+#### Example request
+
+```json
+GET _plugins/_security/api/actiongroups/custom_action_group
 ```
 
 #### Example response
@@ -204,10 +210,10 @@ Retrieves all action groups.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/actiongroups/
 ```
-
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -218,10 +224,21 @@ GET _plugins/_security/api/actiongroups/
     "hidden": false,
     "allowed_actions": [
       "indices:data/read*",
-      "indices:admin/mappings/fields/get*"
+      "indices:admin/mappings/fields/get*",
+      "indices:admin/resolve/index"
     ],
     "type": "index",
     "description": "Allow all read operations",
+    "static": true
+  },
+  "cluster_all": {
+    "reserved": true,
+    "hidden": false,
+    "allowed_actions": [
+      "cluster:*"
+    ],
+    "type": "cluster",
+    "description": "Allow everything on cluster level",
     "static": true
   },
   ...
@@ -235,9 +252,10 @@ Introduced 1.0
 
 #### Request
 
-```
+```json
 DELETE _plugins/_security/api/actiongroups/<action-group>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -270,6 +288,7 @@ PUT _plugins/_security/api/actiongroups/<action-group>
   ]
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -297,6 +316,7 @@ PATCH _plugins/_security/api/actiongroups/<action-group>
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -327,6 +347,7 @@ PATCH _plugins/_security/api/actiongroups
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -351,9 +372,10 @@ Introduced 1.0
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/internalusers/<username>
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -378,9 +400,10 @@ Introduced 1.0
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/internalusers/
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -404,9 +427,10 @@ Introduced 1.0
 
 #### Request
 
-```
+```json
 DELETE _plugins/_security/api/internalusers/<username>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -422,9 +446,9 @@ DELETE _plugins/_security/api/internalusers/<username>
 Introduced 1.0
 {: .label .label-purple }
 
-Creates or replaces the specified user. You must specify either `password` (plain text) or `hash` (the hashed user password). If you specify `password`, the security plugin automatically hashes the password before storing it.
+Creates or replaces the specified user. You must specify either `password` (plain text) or `hash` (the hashed user password). If you specify `password`, the Security plugin automatically hashes the password before storing it.
 
-Note that any role you supply in the `opendistro_security_roles` array must already exist for the security plugin to map the user to that role. To see predefined roles, refer to [the list of predefined roles]({{site.url}}{{site.baseurl}}/security/access-control/users-roles#predefined-roles). For instructions on how to create a role, refer to [creating a role](#create-role).
+Note that any role you supply in the `opendistro_security_roles` array must already exist for the Security plugin to map the user to that role. To see predefined roles, refer to [the list of predefined roles]({{site.url}}{{site.baseurl}}/security/access-control/users-roles#predefined-roles). For instructions on how to create a role, refer to [creating a role](#create-role).
 
 #### Request
 
@@ -440,6 +464,7 @@ PUT _plugins/_security/api/internalusers/<username>
   }
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -473,6 +498,7 @@ PATCH _plugins/_security/api/internalusers/<username>
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -505,6 +531,7 @@ PATCH _plugins/_security/api/internalusers
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -529,9 +556,10 @@ Retrieves one role.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/roles/<role>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -577,9 +605,10 @@ Retrieves all roles.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/roles/
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -617,9 +646,10 @@ Introduced 1.0
 
 #### Request
 
-```
+```json
 DELETE _plugins/_security/api/roles/<role>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -667,6 +697,7 @@ PUT _plugins/_security/api/roles/<role>
   }]
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -706,6 +737,7 @@ PATCH _plugins/_security/api/roles/<role>
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -739,6 +771,7 @@ PATCH _plugins/_security/api/roles
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -762,9 +795,10 @@ Retrieves one role mapping.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/rolesmapping/<role>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -787,9 +821,10 @@ Retrieves all role mappings.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/rolesmapping
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -812,9 +847,10 @@ Deletes the specified role mapping.
 
 #### Request
 
-```
+```json
 DELETE _plugins/_security/api/rolesmapping/<role>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -842,6 +878,7 @@ PUT _plugins/_security/api/rolesmapping/<role>
   "users" : [ "worf" ]
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -872,6 +909,7 @@ PATCH _plugins/_security/api/rolesmapping/<role>
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -902,6 +940,7 @@ PATCH _plugins/_security/api/rolesmapping
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -925,9 +964,10 @@ Retrieves one tenant.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/tenants/<tenant>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -951,9 +991,10 @@ Retrieves all tenants.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/tenants/
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -983,9 +1024,10 @@ Deletes the specified tenant.
 
 #### Request
 
-```
+```json
 DELETE _plugins/_security/api/tenants/<tenant>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1011,6 +1053,7 @@ PUT _plugins/_security/api/tenants/<tenant>
   "description": "A tenant for the human resources team."
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1038,6 +1081,7 @@ PATCH _plugins/_security/api/tenants/<tenant>
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1074,6 +1118,7 @@ PATCH _plugins/_security/api/tenants/
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1086,19 +1131,21 @@ PATCH _plugins/_security/api/tenants/
 
 ---
 
+
 ## Configuration
 
 ### Get configuration
 Introduced 1.0
 {: .label .label-purple }
 
-Retrieves the current security plugin configuration in JSON format.
+Retrieves the current Security plugin configuration in JSON format.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/securityconfig
 ```
+{% include copy-curl.html %}
 
 
 ### Update configuration
@@ -1150,6 +1197,7 @@ PUT _plugins/_security/api/securityconfig/config
   }
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1183,6 +1231,7 @@ PATCH _plugins/_security/api/securityconfig
   }
 ]
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1212,9 +1261,10 @@ Retrieves all distinguished names in the allow list.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/nodesdn
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1232,9 +1282,10 @@ To get the distinguished names from a specific cluster's or node's allow list, i
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/nodesdn/<cluster-name>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1263,6 +1314,7 @@ PUT _plugins/_security/api/nodesdn/<cluster-name>
   ]
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1280,9 +1332,10 @@ Deletes all distinguished names in the specified cluster's or node's allow list.
 
 #### Request
 
-```
+```json
 DELETE _plugins/_security/api/nodesdn/<cluster-name>
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1306,9 +1359,10 @@ Retrieves the cluster's security certificates.
 
 #### Request
 
-```
+```json
 GET _plugins/_security/api/ssl/certs
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1340,14 +1394,19 @@ Introduced 1.0
 
 Reloads SSL certificates that are about to expire without restarting the OpenSearch node. 
 
-This call assumes that new certificates are in the same location specified by the security configurations in opensearch.yml. To keep sensitive certificate reloads secure, this call only allows hot reload with certificates issued by the same issuer and subject DN and SAN with expiry dates after the current certificate.
+This call assumes that new certificates are in the same location specified by the security configurations in `opensearch.yml`. To keep sensitive certificate reloads secure, this call only allows hot reload with certificates issued by the same issuer and subject DN and SAN with expiry dates after the current certificate.
 
 #### Request
 
-```
+```json
 PUT _opendistro/_security/api/ssl/transport/reloadcerts
+```
+{% include copy-curl.html %}
+
+```json
 PUT _opendistro/_security/api/ssl/http/reloadcerts
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1364,14 +1423,15 @@ PUT _opendistro/_security/api/ssl/http/reloadcerts
 Introduced 1.0
 {: .label .label-purple }
 
-Flushes the security plugin user, authentication, and authorization cache.
+Flushes the Security plugin user, authentication, and authorization cache.
 
 
 #### Request
 
-```
+```json
 DELETE _plugins/_security/api/cache
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -1392,14 +1452,15 @@ DELETE _plugins/_security/api/cache
 Introduced 1.0
 {: .label .label-purple }
 
-Checks to see if the security plugin is up and running. If you operate your cluster behind a load balancer, this operation is useful for determining node health and doesn't require a signed request.
+Checks to see if the Security plugin is up and running. If you operate your cluster behind a load balancer, this operation is useful for determining node health and doesn't require a signed request.
 
 
 #### Request
 
-```
+```json
 GET _plugins/_security/health
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -1417,7 +1478,7 @@ GET _plugins/_security/health
 
 ## Audit logs
 
-The following API is available for audit logging in the security plugin.
+The following API is available for audit logging in the Security plugin.
 
 ### Enable Audit Logs
 
@@ -1434,27 +1495,27 @@ Field | Data Type | Description
 :--- | :--- | :---
 `enabled` | Boolean | Enables or disables audit logging. Default is `true`.
 `audit` | Object | Contains fields for audit logging configuration.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_users` | Array | Users to be excluded from auditing. Wildcard patterns are supported<br>Example: `ignore_users: ["test-user", employee-*"]`
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`ignore_requests` | Array | Requests to be excluded from auditing. Wildcard patterns are supported.<br>Example: `ignore_requests: ["indices:data/read/*", "SearchRequest"]`
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_rest_categories` | Array | Categories to exclude from REST API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`disabled_transport_categories` | Array | Categories to exclude from Transport API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`log_request_body` | Boolean | Includes the body of the request (if available) for both REST and the transport layer. Default is  `true`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_indices` | Boolean | Logs all indexes affected by a request. Resolves aliases and wildcards/date patterns. Default is `true`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`resolve_bulk_requests` | Boolean | Logs individual operations in a bulk request. Default is `false`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`exclude_sensitive_headers` | Boolean | Excludes sensitive headers from being included in the logs. Default is `true`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_transport` | Boolean | Enables/disables Transport API auditing. Default is `true`.
-`audit`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enable_rest` | Boolean | Enables/disables REST API auditing. Default is `true`.
+`audit.ignore_users` | Array | Users to be excluded from auditing. Wildcard patterns are supported<br>Example: `ignore_users: ["test-user", employee-*"]`
+`audit.ignore_requests` | Array | Requests to be excluded from auditing. Wildcard patterns are supported.<br>Example: `ignore_requests: ["indices:data/read/*", "SearchRequest"]`
+`audit.disabled_rest_categories` | Array | Categories to exclude from REST API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
+`audit.disabled_transport_categories` | Array | Categories to exclude from Transport API auditing. Default categories are `AUTHENTICATED`, `GRANTED_PRIVILEGES`.
+`audit.log_request_body` | Boolean | Includes the body of the request (if available) for both REST and the transport layer. Default is  `true`.
+`audit.resolve_indices` | Boolean | Logs all indexes affected by a request. Resolves aliases and wildcards/date patterns. Default is `true`.
+`audit.resolve_bulk_requests` | Boolean | Logs individual operations in a bulk request. Default is `false`.
+`audit.exclude_sensitive_headers` | Boolean | Excludes sensitive headers from being included in the logs. Default is `true`.
+`audit.enable_transport` | Boolean | Enables/disables Transport API auditing. Default is `true`.
+`audit.enable_rest` | Boolean | Enables/disables REST API auditing. Default is `true`.
 `compliance` | Object | Contains fields for compliance configuration. 
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`enabled` | Boolean | Enables or disables compliance. Default is `true`.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_log_diffs` | Boolean | Logs only diffs for document updates. Default is `false`.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_watched_fields` | Object | Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_ignore_users` | Array | List of users to ignore for read events. Wildcard patterns are supported.<br>Example: `read_ignore_users: ["test-user", "employee-*"]`
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_watched_indices` | Array | List of indexes to watch for write events. Wildcard patterns are supported.<br>Example: `write_watched_indices: ["twitter", "logs-*"]`
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_ignore_users` | Array | List of users to ignore for write events. Wildcard patterns are supported.<br>Example: `write_ignore_users: ["test-user", "employee-*"]`
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`read_metadata_only` | Boolean | Logs only metadata of the document for read events. Default is `true`.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`write_metadata_only` | Boolean | Log only metadata of the document for write events. Default is `true`.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`external_config` | Boolean | Logs external configuration files for the node. Default is `false`.
-`compliance`<br>&nbsp;&nbsp;&nbsp;&nbsp;`internal_config` | Boolean | Logs updates to internal security changes. Default is `true`.
+`compliance.enabled` | Boolean | Enables or disables compliance. Default is `true`.
+`compliance.write_log_diffs` | Boolean | Logs only diffs for document updates. Default is `false`.
+`compliance.read_watched_fields` | Object | Map of indexes and fields to monitor for read events. Wildcard patterns are supported for both index names and fields.
+`compliance.read_ignore_users` | Array | List of users to ignore for read events. Wildcard patterns are supported.<br>Example: `read_ignore_users: ["test-user", "employee-*"]`
+`compliance.write_watched_indices` | Array | List of indexes to watch for write events. Wildcard patterns are supported.<br>Example: `write_watched_indices: ["twitter", "logs-*"]`
+`compliance.write_ignore_users` | Array | List of users to ignore for write events. Wildcard patterns are supported.<br>Example: `write_ignore_users: ["test-user", "employee-*"]`
+`compliance.read_metadata_only` | Boolean | Logs only metadata of the document for read events. Default is `true`.
+`compliance.write_metadata_only` | Boolean | Log only metadata of the document for write events. Default is `true`.
+`compliance.external_config` | Boolean | Logs external configuration files for the node. Default is `false`.
+`compliance.internal_config` | Boolean | Logs updates to internal security changes. Default is `true`.
 
 Changes to the `_readonly` property result in a 409 error, as indicated in the response below.
 {: .note}
@@ -1475,9 +1536,10 @@ Changes to the `_readonly` property result in a 409 error, as indicated in the r
 
 A GET call retrieves the audit configuration.
 
-```
+```json
 GET /_opendistro/_security/api/audit
 ```
+{% include copy-curl.html %}
 
 **PUT**
 
@@ -1519,6 +1581,7 @@ PUT /_opendistro/_security/api/audit/config
   }
 }
 ```
+{% include copy-curl.html %}
 
 **PATCH**
 
@@ -1529,8 +1592,9 @@ Using the PATCH method also requires a user to have a security configuration tha
 ```bash
 curl -X PATCH -k -i --cert <admin_cert file name> --key <admin_cert_key file name> <domain>/_opendistro/_security/api/audit -H 'Content-Type: application/json' -d'[{"op":"add","path":"/config/enabled","value":"true"}]'
 ```
+{% include copy-curl.html %}
 
-The OpenSearch Dashboards dev tool does not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method. To follow the GitHub issue for support of the PATCH method in Dashboards, see [issue #2343](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2343).
+The OpenSearch Dashboards Dev tool does not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method. To follow the GitHub issue for support of the PATCH method in Dashboards, see [issue #2343](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2343).
 {: .note}
 
 #### Example response

--- a/_security/access-control/api.md
+++ b/_security/access-control/api.md
@@ -1603,7 +1603,7 @@ Using the PATCH method also requires a user to have a security configuration tha
 ```bash
 curl -X PATCH -k -i --cert <admin_cert file name> --key <admin_cert_key file name> <domain>/_opendistro/_security/api/audit -H 'Content-Type: application/json' -d'[{"op":"add","path":"/config/enabled","value":"true"}]'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 OpenSearch Dashboards Dev Tools do not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method. To follow the GitHub issue for support of the PATCH method in Dashboards, see [issue #2343](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2343).
 {: .note}

--- a/_security/access-control/api.md
+++ b/_security/access-control/api.md
@@ -184,7 +184,7 @@ GET _plugins/_security/api/actiongroups/<action-group>
 ```
 {% include copy-curl.html %}
 
-#### Example request
+#### Request
 
 ```json
 GET _plugins/_security/api/actiongroups/custom_action_group

--- a/_security/access-control/api.md
+++ b/_security/access-control/api.md
@@ -3,6 +3,8 @@ layout: default
 title: API
 parent: Access control
 nav_order: 120
+redirect_from: 
+ - /security-plugin/access-control/api/
 ---
 
 # API
@@ -25,12 +27,14 @@ Just like OpenSearch permissions, you control access to the Security plugin REST
 ```yml
 plugins.security.restapi.roles_enabled: ["<role>", ...]
 ```
+{% include copy.html %}
 
 These roles can now access all APIs. To prevent access to certain APIs:
 
 ```yml
 plugins.security.restapi.endpoints_disabled.<role>.<endpoint>: ["<method>", ...]
 ```
+{% include copy.html %}
 
 Possible values for `endpoint` are:
 
@@ -57,12 +61,14 @@ plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access
 plugins.security.restapi.endpoints_disabled.test-role.ROLES: ["PUT", "POST", "DELETE", "PATCH"]
 plugins.security.restapi.endpoints_disabled.test-role.INTERNALUSERS: ["PUT", "POST", "DELETE", "PATCH"]
 ```
+{% include copy.html %}
 
 To use the PUT and PATCH methods for the [configuration APIs](#configuration), add the following line to `opensearch.yml`:
 
 ```yml
 plugins.security.unsupported.restapi.allow_securityconfig_modification: true
 ```
+{% include copy.html %}
 
 
 ## Reserved and hidden resources
@@ -75,6 +81,7 @@ To mark a resource as reserved, add the following flag:
 kibana_user:
   reserved: true
 ```
+{% include copy.html %}
 
 Likewise, you can mark users, role, role mappings, and action groups as hidden. Resources that have this flag set to true are not returned by the REST API and not visible in OpenSearch Dashboards:
 
@@ -82,6 +89,7 @@ Likewise, you can mark users, role, role mappings, and action groups as hidden. 
 kibana_user:
   hidden: true
 ```
+{% include copy.html %}
 
 Hidden resources are automatically reserved.
 
@@ -181,6 +189,7 @@ GET _plugins/_security/api/actiongroups/<action-group>
 ```json
 GET _plugins/_security/api/actiongroups/custom_action_group
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1220,6 +1229,7 @@ Before you can execute the operation, you must first add the following line to `
 ```yml
 plugins.security.unsupported.restapi.allow_securityconfig_modification: true
 ```
+{% include copy.html %}
 
 #### Request
 
@@ -1253,6 +1263,7 @@ Before you can use the REST API to configure the allow list, you must first add 
 ```yml
 plugins.security.nodes_dn_dynamic_config_enabled: true
 ```
+{% include copy.html %}
 
 
 ### Get distinguished names
@@ -1594,7 +1605,7 @@ curl -X PATCH -k -i --cert <admin_cert file name> --key <admin_cert_key file nam
 ```
 {% include copy-curl.html %}
 
-The OpenSearch Dashboards Dev tool does not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method. To follow the GitHub issue for support of the PATCH method in Dashboards, see [issue #2343](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2343).
+OpenSearch Dashboards Dev Tools do not currently support the PATCH method. You can use [curl](https://curl.se/), [Postman](https://www.postman.com/), or another alternative process to update the configuration using this method. To follow the GitHub issue for support of the PATCH method in Dashboards, see [issue #2343](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/2343).
 {: .note}
 
 #### Example response


### PR DESCRIPTION
### Description
The actiongroups API GET call that retrieves all actions groups includes an example response in need of an update. This whole topic could benefit from the addition of copy/copy curl tags for requests, capitalization of "Security plugin" instances, and language tags for the basic JSON code examples for requests.  

### Issues Resolved
Made changes based on description above.
Fixes #3751 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
