### PR TITLE
Fix typo on correlation page

### DIFF
--- a/_security-analytics/sec-analytics-config/correlation-config.md
+++ b/_security-analytics/sec-analytics-config/correlation-config.md
@@ -10,7 +10,7 @@ nav_order: 16
 The correlation engine is an experimental feature released in OpenSearch 2.7. Therefore, we do not recommend using the feature in a production environment at this time. For updates on the progress of the correlation engine, see [Security Analytics Correlation Engine](https://github.com/opensearch-project/security-analytics/issues/369) on GitHub. To share ideas and provide feedback, join the [Security Analytics forum](https://forum.opensearch.org/c/plugins/security-analytics/73).
 {: .warning }
 
-Correlation rules allow you to define threat scenarios involving multiple systems in an infrastructure by matching the signatures of threat events occuring in different log types. Once a rule contains at least two different log sources and the preferred fields and field values that define an intended threat secenario, the correlation engine can query the indexes specified in the correlation rule and identify any correlations between the findings.
+Correlation rules allow you to define threat scenarios involving multiple systems in an infrastructure by matching the signatures of threat events occuring in different log types. Once a rule contains at least two different log sources and the preferred fields and field values that define an intended threat scenario, the correlation engine can query the indexes specified in the correlation rule and identify any correlations between the findings.
 
 
 ## Configuring rules


### PR DESCRIPTION
Fix a small typo on the correlation engine page.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
