### PR TITLE
Fix typo on on Opensearch-py-ml

### DIFF
--- a/_clients/opensearch-py-ml.md
+++ b/_clients/opensearch-py-ml.md
@@ -29,7 +29,7 @@ Then import the client into OpenSearch like any other module:
 
 ```python
 from opensearchpy import OpenSearch
-import openseach_py_ml as oml
+import opensearch_py_ml as oml
 ```
 {% include copy.html %}
 


### PR DESCRIPTION
### Description
Feedback from doc website:

There's a typo in the code snippet:

from opensearchpy import OpenSearch
import openseach_py_ml as oml

"openseach_py_ml" is missing the "r" in "search", which makes this an import error

### Issues Resolved
na


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
