### PR TITLE
Adds list to REST API reference page

### DIFF
--- a/_api-reference/index.md
+++ b/_api-reference/index.md
@@ -11,7 +11,7 @@ redirect_from:
 
 # REST API reference
 
-You can use REST APIs for most operations in OpenSearch. The OpenSearch REST API reference includes the paths, HTTP verbs, supported parameters, request body details, and example responses.
+You can use REST APIs for most operations in OpenSearch. In this reference, we describe how to use each API, including the paths and HTTP methods, supported parameters, and example requests and responses.
 
 Most REST APIs supported by OpenSearch are included in this reference. If you know of any that are missing, feel free to enter feedback or submit a pull request. 
 {: .tip }

--- a/_api-reference/index.md
+++ b/_api-reference/index.md
@@ -2,7 +2,8 @@
 layout: default
 title: REST API reference
 nav_order: 1
-has_toc: true
+has_toc: false
+has_children: true
 nav_exclude: true
 redirect_from:
   - /opensearch/rest-api/index/
@@ -10,7 +11,35 @@ redirect_from:
 
 # REST API reference
 
-OpenSearch uses its REST API for most operations. This _incomplete_ section includes REST API paths, HTTP verbs, supported parameters, request body details, and example responses.
+You can use REST APIs for most operations in OpenSearch. The OpenSearch REST API reference includes the paths, HTTP verbs, supported parameters, request body details, and example responses.
 
-In general, the OpenSearch REST API is no different from the Elasticsearch OSS REST API; most client code that worked with Elasticsearch OSS should also work with OpenSearch.
+Most REST APIs supported by OpenSearch are included in this reference. If you know of any that are missing, feel free to enter feedback or submit a pull request. 
 {: .tip }
+
+## Related articles 
+
+- [Alias]({{site.url}}{{site.baseurl}}/api-reference/alias/)
+- [Analyze API]({{site.url}}{{site.baseurl}}/api-reference/analyze-apis/index/)
+- [CAT APIs]({{site.url}}{{site.baseurl}}/api-reference/cat/index/)
+- [Cluster APIs]({{site.url}}{{site.baseurl}}/api-reference/cluster-api/index/)
+- [Common parameters]({{site.url}}{{site.baseurl}}/api-reference/common-parameters)
+- [Count]({{site.url}}{{site.baseurl}}/api-reference/count/)
+- [Document]({{site.url}}{{site.baseurl}}/api-reference/document-apis/index/)
+- [Explain]({{site.url}}{{site.baseurl}}/api-reference/explain/)
+- [Index APIs]({{site.url}}{{site.baseurl}}/api-reference/index-apis/index/)
+- [Ingest APIs]({{site.url}}{{site.baseurl}}/api-reference/ingest-apis/index/)
+- [Multi-search]({{site.url}}{{site.baseurl}}/api-reference/multi-search/)
+- [Nodes APIs]({{site.url}}{{site.baseurl}}/api-reference/nodes-apis/index/)
+- [Popular APIs]({{site.url}}{{site.baseurl}}/api-reference/popular-api/)
+- [Ranking evaluation]({{site.url}}{{site.baseurl}}/api-reference/rank-eval/)
+- [Reload search analyzer]({{site.url}}{{site.baseurl}}/api-reference/reload-search-analyzer/)
+- [Remove cluster information]({{site.url}}{{site.baseurl}}/api-reference/remote-info/)
+- [Script APIs]({{site.url}}{{site.baseurl}}/api-reference/script-apis/index/)
+- [Scroll]({{site.url}}{{site.baseurl}}/api-reference/scroll/)
+- [Search]({{site.url}}{{site.baseurl}}/api-reference/search/)
+- [Snapshot APIs]({{site.url}}{{site.baseurl}}/api-reference/snapshots/index/)
+- [Supported units]({{site.url}}{{site.baseurl}}/api-reference/units/)
+- [Tasks]({{site.url}}{{site.baseurl}}/api-reference/tasks/)
+
+
+

--- a/_api-reference/index.md
+++ b/_api-reference/index.md
@@ -11,7 +11,7 @@ redirect_from:
 
 # REST API reference
 
-You can use REST APIs for most operations in OpenSearch. In this reference, we describe how to use each API, including the paths and HTTP methods, supported parameters, and example requests and responses.
+You can use REST APIs for most operations in OpenSearch. In this reference, we provide a description of the API, and details that include the paths and HTTP methods, supported parameters, and example requests and responses.
 
 Most REST APIs supported by OpenSearch are included in this reference. If you know of any that are missing, feel free to enter feedback or submit a pull request. 
 {: .tip }


### PR DESCRIPTION
### Description
Adds the list of APIs and other topics on the REST API reference index page. This makes it easy to reference this page from other sections of the doc and users don't have to use the TOC. 

### Issues Resolved
We have gotten feedback on this page that "it is empty". 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
