### PR TITLE
Remove Dashboard buttons

### DIFF
--- a/_im-plugin/index.md
+++ b/_im-plugin/index.md
@@ -11,8 +11,6 @@ redirect_from:
 ---
 
 # Managing indexes
-OpenSearch Dashboards
-{: .label .label-yellow :}
 
 You index data using the OpenSearch REST API. Two APIs exist: the index API and the `_bulk` API.
 

--- a/_im-plugin/ism/index.md
+++ b/_im-plugin/ism/index.md
@@ -9,8 +9,6 @@ has_toc: false
 ---
 
 # Index State Management
-OpenSearch Dashboards
-{: .label .label-yellow :}
 
 If you analyze time-series data, you likely prioritize new data over old data. You might periodically perform certain operations on older indexes, such as reducing replica count or deleting them.
 

--- a/_observing-your-data/index.md
+++ b/_observing-your-data/index.md
@@ -9,8 +9,6 @@ redirect_from:
 ---
 
 # Observability
-OpenSearch Dashboards
-{: .label .label-yellow :}
 
 Observability is collection of plugins and applications that let you visualize data-driven events by using Piped Processing Language to explore, discover, and query data stored in OpenSearch.
 


### PR DESCRIPTION
### Description
Removes the "OpenSearch Dashboards" buttons from a few of the pages. They don't add any value.

### Issues Resolved
It was mentioned in: https://github.com/opensearch-project/documentation-website/issues/3790


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
