### PR TITLE
[Backport 1.3] Tweak debian installation for newer debian testing servers

### DIFF
--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -67,13 +67,17 @@ The Debian package is not signed. If you would like to verify the fingerprint, t
 
 APT, the primary package management tool for Debian–based operating systems, allows you to download and install the Debian package from the APT repository. 
 
+1. Install the necessary packages.
+   ```bash
+   sudo apt-get update && sudo apt-get -y install lsb-release ca-certificates curl gnupg2
+   ```
 1. Import the public GPG key. This key is used to verify that the APT repository is signed.
     ```bash
-    curl -o- https://artifacts.opensearch.org/publickeys/opensearch.pgp | sudo apt-key add -
+    curl -o- https://artifacts.opensearch.org/publickeys/opensearch.pgp | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/opensearch-keyring
     ```
 1. Create an APT repository for OpenSearch.
    ```bash
-   echo "deb https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opensearch-dashboards-2.x.list
+   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch-dashboards/2.x/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-dashboards-2.x.list
    ```
 1. Verify that the repository was created successfully.
     ```bash

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -80,13 +80,17 @@ The Debian package is not signed. If you would like to verify the fingerprint, t
 
 APT, the primary package management tool for Debian–based operating systems, allows you to download and install the Debian package from the APT repository. 
 
+1. Install the necessary packages.
+   ```bash
+   sudo apt-get update && sudo apt-get -y install lsb-release ca-certificates curl gnupg2
+   ```
 1. Import the public GPG key. This key is used to verify that the APT repository is signed.
     ```bash
-    curl -o- https://artifacts.opensearch.org/publickeys/opensearch.pgp | sudo apt-key add -
+    curl -o- https://artifacts.opensearch.org/publickeys/opensearch.pgp | sudo gpg --dearmor --batch --yes -o /usr/share/keyrings/opensearch-keyring
     ```
 1. Create an APT repository for OpenSearch:
    ```bash
-   echo "deb https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt stable main" | sudo tee -a /etc/apt/sources.list.d/opensearch-2.x.list
+   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-2.x.list
    ```
 1. Verify that the repository was created successfully.
     ```bash


### PR DESCRIPTION
### Description
 [Backport 1.3] Tweak debian installation for newer debian testing servers

### Issues Resolved
Backport https://github.com/opensearch-project/documentation-website/pull/4142 1.3


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
