### PR TITLE
Move Alias under Index APIs and reorder topics

### DIFF
--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -1,9 +1,11 @@
 ---
 layout: default
 title: Alias
+parent: Index APIs
 nav_order: 5
 redirect_from: 
  - /opensearch/rest-api/alias/
+ - /api-reference/alias/
 ---
 
 # Alias

--- a/_api-reference/index-apis/clear-index-cache.md
+++ b/_api-reference/index-apis/clear-index-cache.md
@@ -2,10 +2,10 @@
 layout: default
 title: Clear Index or Data Stream Cache
 parent: Index APIs
-nav_order: 320
+nav_order: 10
 ---
 
-## Clear index or data stream cache
+# Clear index or data stream cache
 
 The clear cache API operation clears the caches of one or more indexes. For data streams, the API clears the caches of the stream’s backing indexes.
 
@@ -13,14 +13,14 @@ The clear cache API operation clears the caches of one or more indexes. For data
 If you use the Security plugin, you must have the `manage index` privileges.
 {: .note}
 
-### Path parameters
+## Path parameters
 
 | Parameter | Data type | Description |
 :--- | :--- | :---
 | target | String | Comma-delimited list of data streams, indexes, and index aliases to which cache clearing will be applied. Wildcard expressions (`*`) are supported. To target all data streams and indexes in a cluster, omit this parameter or use `_all` or `*`. Optional. |
 
 
-### Query parameters
+## Query parameters
 
 All query parameters are optional.
 
@@ -35,11 +35,11 @@ All query parameters are optional.
 | query | Boolean | If `true`, clears the query cache. Defaults to `true`. |
 | request | Boolean | If `true`, clears the request cache. Defaults to `true`. |
 
-#### Example requests
+## Example requests
 
 The following example requests show multiple clear cache API uses.
 
-##### Clear a specific cache
+### Clear a specific cache
 
 The following request clears the fields cache only:
 
@@ -66,7 +66,7 @@ POST /my-index/_cache/clear?request=true
 ````
 {% include copy-curl.html %}
 
-##### Clear the cache for specific fields
+### Clear the cache for specific fields
 
 The following request clears the fields caches of `fielda` and `fieldb`:
 
@@ -75,7 +75,7 @@ POST /my-index/_cache/clear?fields=fielda,fieldb
 ````
 {% include copy-curl.html %}
 
-##### Clear caches for specific data streams and indexes
+### Clear caches for specific data streams and indexes
 
 The following request clears the cache for two specific indexes:
 
@@ -84,7 +84,7 @@ POST /my-index,my-index2/_cache/clear
 ````
 {% include copy-curl.html %}
 
-##### Clear caches for all data streams and indexes
+### Clear caches for all data streams and indexes
 
 The following request clears the cache for all data streams and indexes:
 
@@ -93,7 +93,7 @@ POST /_cache/clear
 ````
 {% include copy-curl.html %}
 
-#### Example response
+## Example response
 
 The `POST /books,hockey/_cache/clear` request returns the following fields:
 
@@ -107,7 +107,7 @@ The `POST /books,hockey/_cache/clear` request returns the following fields:
 }
 ````
 
-### Response fields
+## Response fields
 
 The `POST /books,hockey/_cache/clear` request returns the following response fields:
 

--- a/_api-reference/index-apis/clone.md
+++ b/_api-reference/index-apis/clone.md
@@ -2,7 +2,7 @@
 layout: default
 title: Clone index
 parent: Index APIs
-nav_order: 70
+nav_order: 15
 redirect_from:
   - /opensearch/rest-api/index-apis/clone/
 ---

--- a/_api-reference/index-apis/close-index.md
+++ b/_api-reference/index-apis/close-index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Close index
 parent: Index APIs
-nav_order: 30
+nav_order: 20
 redirect_from:
   - /opensearch/rest-api/index-apis/close-index/
 ---
@@ -32,10 +32,10 @@ All parameters are optional.
 
 Parameter | Type | Description
 :--- | :--- | :---
-&lt;index-name&gt; | String | The index to close. Can be a comma-separated list of multiple index names. Use `_all` or * to close all indices.
-allow_no_indices | Boolean | Whether to ignore wildcards that don't match any indices. Default is true.
-expand_wildcards | String | Expands wildcard expressions to different indices. Combine multiple values with commas. Available values are all (match all indices), open (match open indices), closed (match closed indices), hidden (match hidden indices), and none (do not accept wildcard expressions). Default is open.
-ignore_unavailable | Boolean | If true, OpenSearch does not search for missing or closed indices. Default is false.
+&lt;index-name&gt; | String | The index to close. Can be a comma-separated list of multiple index names. Use `_all` or * to close all indexes.
+allow_no_indices | Boolean | Whether to ignore wildcards that don't match any indexes. Default is true.
+expand_wildcards | String | Expands wildcard expressions to different indexes. Combine multiple values with commas. Available values are all (match all indexes), open (match open indexes), closed (match closed indexes), hidden (match hidden indexes), and none (do not accept wildcard expressions). Default is open.
+ignore_unavailable | Boolean | If true, OpenSearch does not search for missing or closed indexes. Default is false.
 wait_for_active_shards | String | Specifies the number of active shards that must be available before OpenSearch processes the request. Default is 1 (only the primary shard). Set to all or a positive integer. Values greater than 1 require replicas. For example, if you specify a value of 3, the index must have two replicas distributed across two additional nodes for the request to succeed.
 master_timeout | Time | How long to wait for a connection to the master node. Default is `30s`.
 timeout | Time | How long to wait for a response from the cluster. Default is `30s`.

--- a/_api-reference/index-apis/create-index.md
+++ b/_api-reference/index-apis/create-index.md
@@ -2,10 +2,10 @@
 layout: default
 title: Create index
 parent: Index APIs
-nav_order: 1
+nav_order: 25
 redirect_from:
   - /opensearch/rest-api/index-apis/create-index/
-  - opensearch/rest-api/create-index/
+  - /opensearch/rest-api/create-index/
 ---
 
 # Create index

--- a/_api-reference/index-apis/dangling-index.md
+++ b/_api-reference/index-apis/dangling-index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Dangling indexes
 parent: index-apis
-nav_order: 84
+nav_order: 30
 ---
 
 # Dangling indexes API

--- a/_api-reference/index-apis/delete-index.md
+++ b/_api-reference/index-apis/delete-index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Delete index
 parent: Index APIs
-nav_order: 10
+nav_order: 35
 redirect_from:
   - /opensearch/rest-api/index-apis/delete-index/
 ---

--- a/_api-reference/index-apis/exists.md
+++ b/_api-reference/index-apis/exists.md
@@ -2,7 +2,7 @@
 layout: default
 title: Index exists
 parent: Index APIs
-nav_order: 5
+nav_order: 50
 redirect_from:
   - /opensearch/rest-api/index-apis/exists/
 ---

--- a/_api-reference/index-apis/get-index.md
+++ b/_api-reference/index-apis/get-index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Get index
 parent: Index APIs
-nav_order: 20
+nav_order: 40
 redirect_from:
   - /opensearch/rest-api/index-apis/get-index/
 ---

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -2,7 +2,7 @@
 layout: default
 title: Get settings
 parent: Index APIs
-nav_order: 100
+nav_order: 45
 redirect_from:
   - /opensearch/rest-api/index-apis/get-index/
 ---

--- a/_api-reference/index-apis/open-index.md
+++ b/_api-reference/index-apis/open-index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Open index
 parent: Index APIs
-nav_order: 40
+nav_order: 55
 redirect_from:
   - /opensearch/rest-api/index-apis/open-index/
 ---

--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -2,7 +2,7 @@
 layout: default
 title: Create or update mappings
 parent: Index APIs
-nav_order: 220
+nav_order: 27
 redirect_from:
   - /opensearch/rest-api/index-apis/update-mapping/
 ---

--- a/_api-reference/index-apis/shrink-index.md
+++ b/_api-reference/index-apis/shrink-index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Shrink index
 parent: Index APIs
-nav_order: 50
+nav_order: 65
 redirect_from:
   - /opensearch/rest-api/index-apis/shrink-index/
 ---

--- a/_api-reference/index-apis/split.md
+++ b/_api-reference/index-apis/split.md
@@ -2,7 +2,7 @@
 layout: default
 title: Split index
 parent: Index APIs
-nav_order: 80
+nav_order: 70
 redirect_from:
   - /opensearch/rest-api/index-apis/split/
 ---

--- a/_api-reference/index-apis/update-settings.md
+++ b/_api-reference/index-apis/update-settings.md
@@ -2,7 +2,7 @@
 layout: default
 title: Update settings
 parent: Index APIs
-nav_order: 120
+nav_order: 75
 redirect_from:
   - /opensearch/rest-api/index-apis/update-settings/
 ---


### PR DESCRIPTION
### Description
Moves the Alias topic under "Index APIs" and reorders the topics under Index APIs to be alphabetical.

### Issues Resolved
Addresses feedback from https://github.com/opensearch-project/documentation-website/issues/3790


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
