### PR TITLE
Add redirect to DP Config

### DIFF
--- a/_data-prepper/managing-data-prepper/configuring-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/configuring-data-prepper.md
@@ -5,11 +5,12 @@ parent: Managing Data Prepper
 nav_order: 5
 redirect_from:
  - /clients/data-prepper/data-prepper-reference/
+ - /monitoring-plugins/trace/data-prepper-reference/
 ---
 
 # Configuring Data Prepper
 
-You can customize your Data Prepper confiuration by editing the `data-prepper-config.yaml` file in your Data Prepper installation. The following configuration options are independent from pipeline configuration options. 
+You can customize your Data Prepper configuration by editing the `data-prepper-config.yaml` file in your Data Prepper installation. The following configuration options are independent from pipeline configuration options. 
 
 
 ## Data Prepper configuration


### PR DESCRIPTION
### Description
Adds a redirect to Data Prepper Config file and fixes spelling error.

### Issues Resolved
n/a


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
