### PR TITLE
Update version and add link to examples - Javascript client

### DIFF
--- a/_clients/javascript/helpers.md
+++ b/_clients/javascript/helpers.md
@@ -68,7 +68,7 @@ When creating a new bulk helper instance, you can use the following configuratio
 
 ### Examples
 
-The following examples illustrate the index, create, update, and delete bulk helper operations. For more information and advanced index actions, see the [opensearch-js guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
+The following examples illustrate the index, create, update, and delete bulk helper operations. For more information and advanced index actions, see the [`opensearch-js` guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
 
 #### Index
 

--- a/_clients/javascript/helpers.md
+++ b/_clients/javascript/helpers.md
@@ -7,7 +7,7 @@ nav_order: 2
 
 # Helper methods
 
-Helper methods simplify the use of complicated API tasks.
+Helper methods simplify the use of complicated API tasks. For the client's complete API documentation and additional examples, see the [JS client API documentation](https://opensearch-project.github.io/opensearch-js/2.2/index.html).
 
 ## Bulk helper
 
@@ -68,7 +68,7 @@ When creating a new bulk helper instance, you can use the following configuratio
 
 ### Examples
 
-The following examples illustrate the index, create, update, and delete bulk helper operations.
+The following examples illustrate the index, create, update, and delete bulk helper operations. For more information and advanced index actions, see the [opensearch-js guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
 
 #### Index
 

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -13,7 +13,7 @@ The OpenSearch JavaScript (JS) client provides a safer and easier way to interac
 
 The client contains a library of APIs that let you perform different operations on your cluster and return a standard response body. The example here demonstrates some basic operations like creating an index, adding documents, and searching your data. 
 
-You can use helper methods to simplify the use of complicated API tasks. For more information, see [Helper methods]({{site.url}}{{site.baseurl}}/clients/javascript/helpers/) and for more advanced index actions, see the [opensearch-js guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
+You can use helper methods to simplify the use of complicated API tasks. For more information, see [Helper methods]({{site.url}}{{site.baseurl}}/clients/javascript/helpers/). For more advanced index actions, see the [`opensearch-js` guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
 
 ## Setup
 

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -9,9 +9,9 @@ redirect_from:
 
 # JavaScript client
 
-The OpenSearch JavaScript (JS) client provides a safer and easier way to interact with your OpenSearch cluster. Rather than using OpenSearch from the browser and potentially exposing your data to the public, you can build an OpenSearch client that takes care of sending requests to your cluster. For the client's complete API documentation and additional examples, see the [JS client API documentation](https://opensearch-project.github.io/opensearch-js/2.1/index.html).
+The OpenSearch JavaScript (JS) client provides a safer and easier way to interact with your OpenSearch cluster. Rather than using OpenSearch from the browser and potentially exposing your data to the public, you can build an OpenSearch client that takes care of sending requests to your cluster. For the client's complete API documentation and additional examples, see the [JS client API documentation](https://opensearch-project.github.io/opensearch-js/2.2/index.html).
 
-The client contains a library of APIs that let you perform different operations on your cluster and return a standard response body. The example here demonstrates some basic operations like creating an index, adding documents, and searching your data.
+The client contains a library of APIs that let you perform different operations on your cluster and return a standard response body. The example here demonstrates some basic operations like creating an index, adding documents, and searching your data. For more information and advanced index actions, see the [opensearch-js guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
 
 ## Setup
 

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -11,7 +11,9 @@ redirect_from:
 
 The OpenSearch JavaScript (JS) client provides a safer and easier way to interact with your OpenSearch cluster. Rather than using OpenSearch from the browser and potentially exposing your data to the public, you can build an OpenSearch client that takes care of sending requests to your cluster. For the client's complete API documentation and additional examples, see the [JS client API documentation](https://opensearch-project.github.io/opensearch-js/2.2/index.html).
 
-The client contains a library of APIs that let you perform different operations on your cluster and return a standard response body. The example here demonstrates some basic operations like creating an index, adding documents, and searching your data. For more information and advanced index actions, see the [opensearch-js guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
+The client contains a library of APIs that let you perform different operations on your cluster and return a standard response body. The example here demonstrates some basic operations like creating an index, adding documents, and searching your data. 
+
+You can use helper methods to simplify the use of complicated API tasks. For more information, see [Helper methods]({{site.url}}{{site.baseurl}}/clients/javascript/helpers/) and for more advanced index actions, see the [opensearch-js guides](https://github.com/opensearch-project/opensearch-js/tree/main/guides) in GitHub.  
 
 ## Setup
 


### PR DESCRIPTION
### Description
Updates the JS version of the API docs to 2.2 and adds a link to Github where samples reside.

### Issues Resolved
Resolves https://github.com/opensearch-project/opensearch-js/issues/437
Resolves https://github.com/opensearch-project/opensearch-js/issues/458


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
