### PR TITLE
Update SQL limitations page for release 2.8 features

### DIFF
--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -97,4 +97,4 @@ Such queries are successfully executed by the `V2` engine unless they have `V1`-
 Suggested change
 * The `V2` query engine does not support aggregation queries such as `histogram`, `date_histogram`, `percentiles`, `topHits`, `stats`, `extended_stats`, `terms`, or `range`.
 * JOINs and sub-queries are not supported. To stay up to date on the development for JOINs and sub-queries, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).
-* PartiQL syntax for `nested` queries are not supported.  Additionally, arrays of objects and primitive types return the first index of the array, while in `V1` they return the entire array as a json object. 
+* PartiQL syntax for `nested` queries are not supported.  Additionally, arrays of objects and primitive types return the first index of the array, while in `V1` they return the entire array as a JSON object. 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -96,5 +96,5 @@ Such queries are successfully executed by the `V2` engine unless they have `V1`-
 * The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complex queries. Accordingly, the `explain` output is no longer OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
 Suggested change
 * The `V2` query engine does not support aggregation queries such as `histogram`, `date_histogram`, `percentiles`, `topHits`, `stats`, `extended_stats`, `terms`, or `range`.
-* JOINs and sub-queries are not supported, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).
+* JOINs and sub-queries are not supported. To stay up to date on the development for JOINs and sub-queries, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).
 * PartiQL syntax for `nested` queries are not supported.  Additionally, arrays of objects and primitive types return the first index of the array, while in `V1` they return the entire array as a json object. 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -94,6 +94,7 @@ Such queries are successfully executed by the `V2` engine unless they have `V1`-
 * `json` formatted output is supported in `V1` engine only. 
 * The `V2` engine does not track query execution time, so slow queries are not reported.
 * The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complex queries. Accordingly, the `explain` output is no longer OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
-* The `V2` query engine does not support aggregation queries (`histogram`, `date_histogram`, `percentiles`, `topHits`, `stats`, `extended_stats`, `terms`, `range`)
+Suggested change
+* The `V2` query engine does not support aggregation queries such as `histogram`, `date_histogram`, `percentiles`, `topHits`, `stats`, `extended_stats`, `terms`, or `range`.
 * JOINs and sub-queries are not supported, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).
 * PartiQL syntax for `nested` queries are not supported.  Additionally, arrays of objects and primitive types return the first index of the array, while in `V1` they return the entire array as a json object. 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -91,7 +91,7 @@ Such queries are successfully executed by the `V2` engine unless they have `V1`-
 
 * The [cursor feature](#pagination-only-supports-basic-queries) is supported by the `V1` engine only.
 For support of `cursor`/`pagination` in the `V2` engine, track [GitHub issue #656](https://github.com/opensearch-project/sql/issues/656).
-* `JSON` formatted output support is no longer supported. 
+* `json` formatted output is no longer supported. 
 * The `V2` engine does not track query execution time, so slow queries are not reported.
 * The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complicated queries. Accordingly, the explain output is no longer pure OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
 * The `V2` query engine does not support aggregation queries (historgram, date_histogram, percentiles, topHits, stats, extended_stats, terms, range)

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -93,7 +93,7 @@ Such queries are successfully executed by the `V2` engine unless they have `V1`-
   * For support of `cursor`/`pagination` in the `V2` engine, track [GitHub issue #656](https://github.com/opensearch-project/sql/issues/656).
 * `json` formatted output is supported in `V1` engine only. 
 * The `V2` engine does not track query execution time, so slow queries are not reported.
-* The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complicated queries. Accordingly, the `explain` output is no longer pure OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
+* The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complex queries. Accordingly, the `explain` output is no longer OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
 * The `V2` query engine does not support aggregation queries (`histogram`, `date_histogram`, `percentiles`, `topHits`, `stats`, `extended_stats`, `terms`, `range`)
 * JOINs and sub-queries are not supported, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).
 * PartiQL syntax for `nested` queries are not supported.  Additionally, arrays of objects and primitive types return the first index of the array, while in `V1` they return the entire array as a json object. 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -90,9 +90,10 @@ Such queries are successfully executed by the `V2` engine unless they have `V1`-
 ### V2 engine limitations
 
 * The [cursor feature](#pagination-only-supports-basic-queries) is supported by the `V1` engine only.
-For support of `cursor`/`pagination` in the `V2` engine, track [GitHub issue #656](https://github.com/opensearch-project/sql/issues/656).
-* `json` formatted output is no longer supported. 
+  * For support of `cursor`/`pagination` in the `V2` engine, track [GitHub issue #656](https://github.com/opensearch-project/sql/issues/656).
+* `json` formatted output is supported in `V1` engine only. 
 * The `V2` engine does not track query execution time, so slow queries are not reported.
-* The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complicated queries. Accordingly, the explain output is no longer pure OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
-* The `V2` query engine does not support aggregation queries (historgram, date_histogram, percentiles, topHits, stats, extended_stats, terms, range)
-* JOINs are sub-queries are not supported, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).
+* The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complicated queries. Accordingly, the `explain` output is no longer pure OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
+* The `V2` query engine does not support aggregation queries (`histogram`, `date_histogram`, `percentiles`, `topHits`, `stats`, `extended_stats`, `terms`, `range`)
+* JOINs and sub-queries are not supported, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).
+* PartiQL syntax for `nested` queries are not supported.  Additionally, arrays of objects and primitive types return the first index of the array, while in `V1` they return the entire array as a json object. 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -91,6 +91,8 @@ Such queries are successfully executed by the `V2` engine unless they have `V1`-
 
 * The [cursor feature](#pagination-only-supports-basic-queries) is supported by the `V1` engine only.
 For support of `cursor`/`pagination` in the `V2` engine, track [GitHub issue #656](https://github.com/opensearch-project/sql/issues/656).
+* `JSON` formatted output support is no longer supported. 
 * The `V2` engine does not track query execution time, so slow queries are not reported.
 * The `V2` query engine not only runs queries in the OpenSearch engine but also supports post-processing for complicated queries. Accordingly, the explain output is no longer pure OpenSearch domain-specific language (DSL) but also includes query plan information from the `V2` query engine.
-* The `V2` engine does not support [`SCORE_QUERY`]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql/functions#score-query) and [`WILDCARD_QUERY`]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql/functions#wildcard-query) functions.
+* The `V2` query engine does not support aggregation queries (historgram, date_histogram, percentiles, topHits, stats, extended_stats, terms, range)
+* JOINs are sub-queries are not supported, track [GitHub issue #1441](https://github.com/opensearch-project/sql/issues/1441) and [GitHub issue #892](https://github.com/opensearch-project/sql/issues/892).


### PR DESCRIPTION
### Description
Update the [SQL limitations](https://opensearch.org/docs/latest/search-plugins/sql/limitation/#query-processing-engines) page.  The V2 engine has been updated with various new features. 

### Issues Resolved
Update SQL limitations list, as release 2.7 and 2.8 have changed the limitations. 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
