### PR TITLE
Add documentation for API rate limiting

### DIFF
--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -163,7 +163,7 @@ auth_failure_listeners:
 ```
 {% include copy.html %}
 
-The following table describes the settings for this type of configuration.
+The following table describes the individual settings for this type of configuration.
 
 | Setting | Description |
 | :--- | :--- |
@@ -178,7 +178,19 @@ The following table describes the settings for this type of configuration.
 
 ### IP address rate limiting
 
-This configuration limits login attempts by IP address. When a login fails, the IP address specific to the machine being used for login is blocked. The following example shows `config.yml` file settings configured for IP address rate limiting:
+This configuration limits login attempts by IP address. When a login fails, the IP address specific to the machine being used for login is blocked. 
+
+There are two steps for configuring IP address rate limiting. First, set the `challenge` setting to `false` in the `http_authenticator` section of the `config.yml` file.
+
+```yml
+http_authenticator:
+  type: basic
+  challenge: false
+```
+
+For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
+
+Second, configure the IP address rate limiting setttings. The following example shows a completed configuration:
 
 ```yml
 auth_failure_listeners:
@@ -192,10 +204,7 @@ auth_failure_listeners:
 ```
 {% include copy.html %}
 
-In addition to the IP rate limiting configuration shown here, make sure to set the `challenge` setting to `false` in the `http_authenticator` section of the `config.yml` file. For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
-{: .important }
-
-The following table describes the settings for this type of configuration.
+The following table describes the individual settings for this type of configuration.
 
 | Setting | Description |
 | :--- | :--- |

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -136,7 +136,7 @@ In most cases, you set the `challenge` flag to `true`. The flag defines the beha
 
 If `challenge` is set to `true`, the Security plugin sends a response with status `UNAUTHORIZED` (401) back to the client. If the client is accessing the cluster with a browser, this triggers the authentication dialog box, and the user is prompted to enter a user name and password.
 
-If `challenge` is set to `false` and no `Authorization` header field is set, the Security plugin does not send a `WWW-Authenticate` response back to the client, and authentication fails. Consider using this setting if you have more than one challenge `http_authenticator` key in your configured authentication domains. This might be the case, for example, when you plan to use basic authentication and OpenID Connect together.
+If `challenge` is set to `false` and no `Authorization` header field is set, the Security plugin does not send a `WWW-Authenticate` response back to the client, and authentication fails. Consider using this setting if you have more than one challenge `http_authenticator` keys in your configured authentication domains. This might be the case, for example, when you plan to use basic authentication and OpenID Connect together.
 
 
 ## API rate limiting

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -148,7 +148,7 @@ You have the option to configure the Security plugin for username rate limiting,
 
 ### Username rate limiting
 
-This configuration limits login attempts by username. The following example shows `config.yml` file settings configured for username rate limiting:
+This configuration limits login attempts by username. When a login fails, the username is blocked for any machine in the network. The following example shows `config.yml` file settings configured for username rate limiting:
 
 ```yml
 auth_failure_listeners:
@@ -168,7 +168,7 @@ The following table describes the settings for this type of configuration.
 | Setting | Description |
 | :--- | :--- |
 | `type` |  The type of rate limiting. In this case, `username`. |
-| `authentication_backend` | The backend used for authentication and authorization. |
+| `authentication_backend` | The internal backend. Enter `internal`. |
 | `allowed_tries` |  The number of login attempts allowed before login is blocked. Be aware that increasing the number increases heap usage. |
 | `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries` is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second time span before login is blocked. |
 | `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the username can attempt successful login again. |
@@ -178,7 +178,7 @@ The following table describes the settings for this type of configuration.
 
 ### IP address rate limiting
 
-This configuration limits login attempts by IP address. The following example shows `config.yml` file settings configured for IP address rate limiting:
+This configuration limits login attempts by IP address. When a login fails, the IP address specific to the machine being used for login is blocked. The following example shows `config.yml` file settings configured for IP address rate limiting:
 
 ```yml
 auth_failure_listeners:
@@ -191,6 +191,9 @@ auth_failure_listeners:
         max_tracked_clients: 100000
 ```
 {% include copy.html %}
+
+In addition to the IP rate limiting configuration, make sure to set the `challenge` setting to `false` in the `http_authenticator` section of the `config.yml` file.<br>```yml<br>http_authenticator:<br>&nbsp;&nbsp;&nbsp;type: basic<br>&nbsp;&nbsp;&nbsp;challenge: false<br>For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
+{: .important }
 
 The following table describes the settings for this type of configuration.
 

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -190,7 +190,7 @@ http_authenticator:
 
 For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
 
-Second, configure the IP address rate limiting setttings. The following example shows a completed configuration:
+Second, configure the IP address rate limiting settings. The following example shows a completed configuration:
 
 ```yml
 auth_failure_listeners:

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -136,12 +136,12 @@ In most cases, you set the `challenge` flag to `true`. The flag defines the beha
 
 If `challenge` is set to `true`, the Security plugin sends a response with status `UNAUTHORIZED` (401) back to the client. If the client is accessing the cluster with a browser, this triggers the authentication dialog box, and the user is prompted to enter a user name and password.
 
-If `challenge` is set to `false` and no `Authorization` header field is set, the Security plugin does not send a `WWW-Authenticate` response back to the client, and authentication fails. You might want to use this setting if you have another challenge `http_authenticator` in your configured authentication domains. One such scenario is when you plan to use basic authentication and OpenID Connect together.
+If `challenge` is set to `false` and no `Authorization` header field is set, the Security plugin does not send a `WWW-Authenticate` response back to the client, and authentication fails. Consider using this setting if you have more than one challenge `http_authenticator` key in your configured authentication domains. This might be the case, for example, when you plan to use basic authentication and OpenID Connect together.
 
 
 ## API rate limiting
 
-API rate limiting is typically used to restrict the number of API calls that users can make in a set span of time, and it can thereby help manage the rate of API traffic. For security purposes, rate limiting features have the potential to defend against DoS attacks, or repeated login attempts to gain access through trial and error, by restricting failed login attempts.
+API rate limiting is typically used to restrict the number of API calls that users can make in a set span of time, thereby helping to manage the rate of API traffic. For security purposes, rate limiting features have the potential to defend against DoS attacks, or repeated login attempts to gain access through trial and error, by restricting failed login attempts.
 
 You have the option to configure the Security plugin for username rate limiting, IP address rate limiting, or both. These configurations are made in the `config.yml` file. See the following sections for information about each type of rate limiting configuration.
 
@@ -188,7 +188,7 @@ http_authenticator:
   challenge: false
 ```
 
-For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
+For more information about this setting, see [HTTP basic authentication](#http-basic-authentication).
 
 Second, configure the IP address rate limiting settings. The following example shows a completed configuration:
 

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -198,8 +198,8 @@ The following table describes the settings for this type of configuration.
 | :--- | :--- |
 | `type` |  The type of rate limiting. In this case, `ip`. |
 | `allowed_tries` |  The number of login attempts allowed before login is blocked. Be aware that increasing the number increases heap usage. |
-| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second time span before login is blocked.  |
-| `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the username can attempt successful login again. |
+| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, an IP address has three attempts to log in successfully within a 60-second time span before login is blocked.  |
+| `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the IP address can attempt successful login again. |
 | `max_blocked_clients` |  The maximum number of blocked IP addresses. This limits heap usage to avoid a potential DoS. |
 | `max_tracked_clients` | The maximum number of tracked IP addresses that have failed login. This limits heap usage to avoid a potential DoS. |
 

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -192,7 +192,7 @@ auth_failure_listeners:
 ```
 {% include copy.html %}
 
-In addition to the IP rate limiting configuration, make sure to set the `challenge` setting to `false` in the `http_authenticator` section of the `config.yml` file.<br>```yml<br>http_authenticator:<br>&nbsp;&nbsp;&nbsp;type: basic<br>&nbsp;&nbsp;&nbsp;challenge: false<br>For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
+In addition to the IP rate limiting configuration, make sure to set the `challenge` setting to `false` in the `http_authenticator` section of the `config.yml` file.<br>`challenge: false`<br>For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
 {: .important }
 
 The following table describes the settings for this type of configuration.

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -139,18 +139,34 @@ If `challenge` is set to `true`, the Security plugin sends a response with statu
 If `challenge` is set to `false` and no `Authorization` header field is set, the Security plugin does not send a `WWW-Authenticate` response back to the client, and authentication fails. You might want to use this setting if you have another challenge `http_authenticator` in your configured authentication domains. One such scenario is when you plan to use basic authentication and OpenID Connect together.
 
 
-## Rate limiting
+## API rate limiting
+
+API rate limiting is a way of restricting the number of API calls that users can make in a set span of time; it can help manage the rate of API traffic. For security purposes, rate limiting has the potential to defend against DoS attacks or repeated login attempts to gain access by trial and error.
+
+You have the option to configure the Security plugin for username rate limiting, IP address rate limiting, or both. These configurations are made in the `config.yml` file. See the following sections for information about each type of rate-limiting configuration.
+
+### Username rate limiting
+
+This configuration limits the rate of API usage by username. The following table describes the settings for this configuration.
 
 | Setting | Description |
 | :--- | :--- |
-| `opensearch_security.ui.openid.login.buttonname` |  Display name for the login button. "Log in with single sign-on" by default. |
+| `type` |  The type of rate limiting. In this case, `username`. |
+| `authentication_backend` | The backend used for authentication and authorization. |
+| `allowed_tries` |  The number of login attempts allowed before login is blocked. |
+| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second timespan before login is blocked.  |
+| `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the username can attempt successful login again. |
+| `max_blocked_clients` |  The maximum number of blocked usernames. This limits heap usage to avoid a potential DoS. |
+| `max_tracked_clients` | The maximum number of tracked usernames that have failed login. This limits heap usage to avoid a potential DoS. |
+
+
 
 
 ```yml
 auth_failure_listeners:
       internal_authentication_backend_limiting:
         type: username
-        authentication_backend: intern
+        authentication_backend: internal
         allowed_tries: 3
         time_window_seconds: 60
         block_expiry_seconds: 60

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -192,7 +192,7 @@ auth_failure_listeners:
 ```
 {% include copy.html %}
 
-In addition to the IP rate limiting configuration, make sure to set the `challenge` setting to `false` in the `http_authenticator` section of the `config.yml` file.<br>`challenge: false`<br>For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
+In addition to the IP rate limiting configuration shown here, make sure to set the `challenge` setting to `false` in the `http_authenticator` section of the `config.yml` file. For more information about this setting, see [HTTP basic authentication](/security/configuration/configuration/#http-basic-authentication).
 {: .important }
 
 The following table describes the settings for this type of configuration.

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -139,6 +139,37 @@ If `challenge` is set to `true`, the Security plugin sends a response with statu
 If `challenge` is set to `false` and no `Authorization` header field is set, the Security plugin does not send a `WWW-Authenticate` response back to the client, and authentication fails. You might want to use this setting if you have another challenge `http_authenticator` in your configured authentication domains. One such scenario is when you plan to use basic authentication and OpenID Connect together.
 
 
+## Rate limiting
+
+| Setting | Description |
+| :--- | :--- |
+| `opensearch_security.ui.openid.login.buttonname` |  Display name for the login button. "Log in with single sign-on" by default. |
+
+
+```yml
+auth_failure_listeners:
+      internal_authentication_backend_limiting:
+        type: username
+        authentication_backend: intern
+        allowed_tries: 3
+        time_window_seconds: 60
+        block_expiry_seconds: 60
+        max_blocked_clients: 100000
+        max_tracked_clients: 100000
+```
+
+```yml
+auth_failure_listeners:
+      ip_rate_limiting:
+        type: ip
+        allowed_tries: 1
+        time_window_seconds: 20
+        block_expiry_seconds: 180
+        max_blocked_clients: 100000
+        max_tracked_clients: 100000
+```
+
+
 ## Backend configuration examples
 
 The default `config/opensearch-security/config.yml` file included in your OpenSearch distribution contains many configuration examples. Use these examples as a starting point and customize them to your needs. 

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -170,7 +170,7 @@ The following table describes the settings for this type of configuration.
 | `type` |  The type of rate limiting. In this case, `username`. |
 | `authentication_backend` | The backend used for authentication and authorization. |
 | `allowed_tries` |  The number of login attempts allowed before login is blocked. Be aware that increasing the number increases heap usage. |
-| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second time span before login is blocked.  |
+| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries` is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second time span before login is blocked. |
 | `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the username can attempt successful login again. |
 | `max_blocked_clients` |  The maximum number of blocked usernames. This limits heap usage to avoid a potential DoS. |
 | `max_tracked_clients` | The maximum number of tracked usernames that have failed login. This limits heap usage to avoid a potential DoS. |
@@ -198,7 +198,7 @@ The following table describes the settings for this type of configuration.
 | :--- | :--- |
 | `type` |  The type of rate limiting. In this case, `ip`. |
 | `allowed_tries` |  The number of login attempts allowed before login is blocked. Be aware that increasing the number increases heap usage. |
-| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, an IP address has three attempts to log in successfully within a 60-second time span before login is blocked.  |
+| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries` is `3` and `time_window_seconds` is `60`, an IP address has three attempts to log in successfully within a 60-second time span before login is blocked. |
 | `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the IP address can attempt successful login again. |
 | `max_blocked_clients` |  The maximum number of blocked IP addresses. This limits heap usage to avoid a potential DoS. |
 | `max_tracked_clients` | The maximum number of tracked IP addresses that have failed login. This limits heap usage to avoid a potential DoS. |

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -141,26 +141,14 @@ If `challenge` is set to `false` and no `Authorization` header field is set, the
 
 ## API rate limiting
 
-API rate limiting is a way of restricting the number of API calls that users can make in a set span of time; it can help manage the rate of API traffic. For security purposes, rate limiting has the potential to defend against DoS attacks or repeated login attempts to gain access by trial and error.
+API rate limiting is typically used to restrict the number of API calls that users can make in a set span of time and thereby help manage the rate of API traffic. For security purposes, rate limiting features have the potential to defend against DoS attacks, or repeated login attempts to gain access through trial and error, by restricting failed login attempts.
 
-You have the option to configure the Security plugin for username rate limiting, IP address rate limiting, or both. These configurations are made in the `config.yml` file. See the following sections for information about each type of rate-limiting configuration.
+You have the option to configure the Security plugin for username rate limiting, IP address rate limiting, or both. These configurations are made in the `config.yml` file. See the following sections for information about each type of rate limiting configuration.
+
 
 ### Username rate limiting
 
-This configuration limits the rate of API usage by username. The following table describes the settings for this configuration.
-
-| Setting | Description |
-| :--- | :--- |
-| `type` |  The type of rate limiting. In this case, `username`. |
-| `authentication_backend` | The backend used for authentication and authorization. |
-| `allowed_tries` |  The number of login attempts allowed before login is blocked. |
-| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second timespan before login is blocked.  |
-| `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the username can attempt successful login again. |
-| `max_blocked_clients` |  The maximum number of blocked usernames. This limits heap usage to avoid a potential DoS. |
-| `max_tracked_clients` | The maximum number of tracked usernames that have failed login. This limits heap usage to avoid a potential DoS. |
-
-
-
+This configuration limits login attempts by username. The following example shows `config.yml` file settings configured for username rate limiting:
 
 ```yml
 auth_failure_listeners:
@@ -173,6 +161,24 @@ auth_failure_listeners:
         max_blocked_clients: 100000
         max_tracked_clients: 100000
 ```
+{% include copy.html %}
+
+The following table describes the settings for this type of configuration.
+
+| Setting | Description |
+| :--- | :--- |
+| `type` |  The type of rate limiting. In this case, `username`. |
+| `authentication_backend` | The backend used for authentication and authorization. |
+| `allowed_tries` |  The number of login attempts allowed before login is blocked. Be aware that increasing the number increases heap usage. |
+| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second time span before login is blocked.  |
+| `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the username can attempt successful login again. |
+| `max_blocked_clients` |  The maximum number of blocked usernames. This limits heap usage to avoid a potential DoS. |
+| `max_tracked_clients` | The maximum number of tracked usernames that have failed login. This limits heap usage to avoid a potential DoS. |
+
+
+### IP address rate limiting
+
+This configuration limits login attempts by IP address. The following example shows `config.yml` file settings configured for IP address rate limiting:
 
 ```yml
 auth_failure_listeners:
@@ -184,6 +190,18 @@ auth_failure_listeners:
         max_blocked_clients: 100000
         max_tracked_clients: 100000
 ```
+{% include copy.html %}
+
+The following table describes the settings for this type of configuration.
+
+| Setting | Description |
+| :--- | :--- |
+| `type` |  The type of rate limiting. In this case, `ip`. |
+| `allowed_tries` |  The number of login attempts allowed before login is blocked. Be aware that increasing the number increases heap usage. |
+| `time_window_seconds` | The window of time in which the value for `allowed_tries` is enforced. For example, if `allowed_tries is `3` and `time_window_seconds` is `60`, a username has three attempts to log in successfully within a 60-second time span before login is blocked.  |
+| `block_expiry_seconds` | The duration of time that login remains blocked after a failed login. After this time elapses, login is reset and the username can attempt successful login again. |
+| `max_blocked_clients` |  The maximum number of blocked IP addresses. This limits heap usage to avoid a potential DoS. |
+| `max_tracked_clients` | The maximum number of tracked IP addresses that have failed login. This limits heap usage to avoid a potential DoS. |
 
 
 ## Backend configuration examples

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -141,7 +141,7 @@ If `challenge` is set to `false` and no `Authorization` header field is set, the
 
 ## API rate limiting
 
-API rate limiting is typically used to restrict the number of API calls that users can make in a set span of time and thereby help manage the rate of API traffic. For security purposes, rate limiting features have the potential to defend against DoS attacks, or repeated login attempts to gain access through trial and error, by restricting failed login attempts.
+API rate limiting is typically used to restrict the number of API calls that users can make in a set span of time, and it can thereby help manage the rate of API traffic. For security purposes, rate limiting features have the potential to defend against DoS attacks, or repeated login attempts to gain access through trial and error, by restricting failed login attempts.
 
 You have the option to configure the Security plugin for username rate limiting, IP address rate limiting, or both. These configurations are made in the `config.yml` file. See the following sections for information about each type of rate limiting configuration.
 


### PR DESCRIPTION
### Description
Rate limiting is configured in the `config.yml` file for security. This configuration needs to be documented.

### Issues Resolved
Did the above.

Fixes #4171 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
