### PR TITLE
Updates based on feedback in Slack and doc website

### DIFF
--- a/_tuning-your-cluster/index.md
+++ b/_tuning-your-cluster/index.md
@@ -120,16 +120,16 @@ node.roles: []
 
 ## Step 3: Bind a cluster to specific IP addresses
 
-`network_host` defines the IP address used to bind the node. By default, OpenSearch listens on a local host, which limits the cluster to a single node. You can also use `_local_` and `_site_` to bind to any loopback or site-local address, whether IPv4 or IPv6:
+`network.bind_host` defines the IP address used to bind the node. By default, OpenSearch listens on a local host, which limits the cluster to a single node. You can also use `_local_` and `_site_` to bind to any loopback or site-local address, whether IPv4 or IPv6:
 
 ```yml
-network.host: [_local_, _site_]
+network.bind_host: [_local_, _site_]
 ```
 
 To form a multi-node cluster, specify the IP address of the node:
 
 ```yml
-network.host: <IP address of the node>
+network.bind_host: <IP address of the node>
 ```
 
 Make sure to configure these settings on all of your nodes.


### PR DESCRIPTION
### Description
There was a comment about this being incorrect in the public slack and we also got a comment in our documentation feedback mechanism. 

Changed 'network.host' to 'network.bind_host'

### Issues Resolved
na


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
