### PR TITLE
Use a different user-agent for the link checker.

### DIFF
--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -104,7 +104,8 @@ module Jekyll::LinkChecker
       @external_link_checker = LinkChecker::Typhoeus::Hydra::Checker.new(
         logger: Jekyll.logger,
         hydra: { max_concurrency: 2 },
-        retries: 3
+        retries: 3,
+        user_agent: 'OpenSearch Documentation Website Link Checker/1.0'
       )
 
       @external_link_checker.on :failure, :error do |result|


### PR DESCRIPTION
### Description

This works around https://github.com/dblock/ruby-link-checker/issues/9, looks like https://repost.aws/knowledge-center/ses-554-400-message-rejected-error is explicitly denying the link checker's user-agent, which was likely added by hand on that website.

```
$ curl -I https://repost.aws/knowledge-center/ses-554-400-message-rejected-error  
HTTP/2 403 

$ curl -H "User-agent: Ruby Link Checker/1.0" -I https://repost.aws/knowledge-center/ses-554-400-message-rejected-error  
HTTP/2 403 

$ curl -H "User-agent: Something Else/1.0" -I https://repost.aws/knowledge-center/ses-554-400-message-rejected-error  
HTTP/2 200 
```

If this comes back we can start generating user-agents randomly 🤷‍♂️ 

### Issues Resolved

Closes https://github.com/opensearch-project/documentation-website/issues/4301

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
