### PR TITLE
Fix example for Security backend configuration

### DIFF
--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -16,7 +16,7 @@ The main configuration file for authentication and authorization backends is `co
 `config.yml` has three main parts:
 
 ```yml
-opensearch_security:
+config:
   dynamic:
     http:
       ...


### PR DESCRIPTION
### Description
The example given in the _Configuring the Security backend_ documentation displays `opensearch_security:` as the root in the `config.yml` file, while it should be `config:`. 

### Issues Resolved
Changed the root in the example to `config:`.

Fixes #4315 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
