### PR TITLE
Correct nested.md example

### DIFF
--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -172,11 +172,115 @@ PUT testindex1/_doc/100
 ```
 {% include copy-curl.html %}
 
-Now if you run the same query to search for patients older than 75 AND smokers, nothing is returned, which is correct.
+We can update our query to use a nested query to sucessfully search for patient results. To search for patients older than 75 OR smokers:
 
 ```json
+GET testindex1/_search
 {
-  "took" : 3,
+  "query": {
+    "nested": {
+      "path": "patients",
+      "query": {
+        "bool": {
+          "should": [
+            {
+              "term": {
+                "patients.smoker": true
+              }
+            },
+            {
+              "range": {
+                "patients.age": {
+                  "gte": 75
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+The above will return:
+```json
+{
+  "took" : 7,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 1,
+      "relation" : "eq"
+    },
+    "max_score" : 0.8465736,
+    "hits" : [
+      {
+        "_index" : "testindex1",
+        "_id" : "100",
+        "_score" : 0.8465736,
+        "_source" : {
+          "patients" : [
+            {
+              "name" : "John Doe",
+              "age" : 56,
+              "smoker" : true
+            },
+            {
+              "name" : "Mary Major",
+              "age" : 85,
+              "smoker" : false
+            }
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+
+Searching for patients older than 75 AND smokers:
+```json
+GET testindex1/_search
+{
+  "query": {
+    "nested": {
+      "path": "patients",
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "term": {
+                "patients.smoker": true
+              }
+            },
+            {
+              "range": {
+                "patients.age": {
+                  "gte": 75
+                }
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Will return no results as expected.
+```json
+{
+  "took" : 7,
   "timed_out" : false,
   "_shards" : {
     "total" : 1,

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -172,7 +172,7 @@ PUT testindex1/_doc/100
 ```
 {% include copy-curl.html %}
 
-We can update our query to use a nested query to sucessfully search for patient results. To search for patients older than 75 OR smokers:
+You can use the following nested query to search for patients older than 75 OR smokers:
 
 ```json
 GET testindex1/_search
@@ -204,7 +204,8 @@ GET testindex1/_search
 ```
 {% include copy-curl.html %}
 
-The above will return:
+The query correctly returns both patients:
+
 ```json
 {
   "took" : 7,
@@ -246,7 +247,8 @@ The above will return:
 }
 ```
 
-Searching for patients older than 75 AND smokers:
+You can use the following nested query to search for patients older than 75 AND smokers:
+
 ```json
 GET testindex1/_search
 {
@@ -277,7 +279,8 @@ GET testindex1/_search
 ```
 {% include copy-curl.html %}
 
-Will return no results as expected.
+The previous query returns no results, as expected:
+
 ```json
 {
   "took" : 7,


### PR DESCRIPTION
### Description
Running through the current example for nested docs, rerunning the queries for "smokers AND older than 75" vs "smokers OR older than 75" both do not display results when using a nested mapping, which I don't believe is the intention of this demo. Modifying the query using a nested query seems to make this work ("smokers AND older than 75" returns nothing, "smokers OR older than 75" returns a hit).

Please let me know if I can improve the queries as I've only recently started dealing with nested queries.

### Issues Resolved
None that I know of.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
