### PR TITLE
Add notification_source option for S3

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -53,6 +53,7 @@ You can use the following options to configure the `s3` source.
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
 notification_type | Yes | String | Must be `sqs`.
+notification_source | No | String | Determines how to notifications are received by SQS. Must be `s3` or `eventbridge`. `s3` represents notifications which are directly sent from Amazon S3 to Amazon SQS or fanout notifications from Amazon S3 to Amazon SNS to Amazon SQS. `eventbridge` represents notifcations from [Amazon EventBridge](https://aws.amazon.com/eventbridge/) and [Amazon Security Lake](Amazon Security Lake). Default value is `s3`. 
 compression | No | String | The compression algorithm to apply: `none`, `gzip`, or `automatic`. Default value is `none`.
 codec | Yes | Codec | The [codec](#codec) to apply. 
 sqs | Yes | sqs | The SQS configuration. See [sqs](#sqs) for details.


### PR DESCRIPTION
### Description
Adds new `notification_source` option for S3 source.

### Issues Resolved



### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
