### PR TITLE
[DOC] Add missing plugins.security.ssl.http.enabled for PEM paragraph

### DIFF
--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -34,7 +34,7 @@ Name | Description
 
 Name | Description
 :--- | :---
-`plugins.security.ssl.http.enabled` | Whether to enable TLS on the REST layer. If enabled, only HTTPS is allowed. Optional. Default is false.
+`plugins.security.ssl.http.enabled` | Whether to enable TLS on the REST layer. If enabled, only HTTPS is allowed. Optional. Default is `false`.
 `plugins.security.ssl.http.pemkey_filepath` | Path to the certificate's key file (PKCS \#8), which must be under the `config` directory, specified using a relative path. Required.
 `plugins.security.ssl.http.pemkey_password` | Key password. Omit this setting if the key has no password. Optional.
 `plugins.security.ssl.http.pemcert_filepath` | Path to the X.509 node certificate chain (PEM format), which must be under the `config` directory, specified using a relative path. Required.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -34,6 +34,7 @@ Name | Description
 
 Name | Description
 :--- | :---
+`plugins.security.ssl.http.enabled` | Whether to enable TLS on the REST layer. If enabled, only HTTPS is allowed. Optional. Default is false.
 `plugins.security.ssl.http.pemkey_filepath` | Path to the certificate's key file (PKCS \#8), which must be under the `config` directory, specified using a relative path. Required.
 `plugins.security.ssl.http.pemkey_password` | Key password. Omit this setting if the key has no password. Optional.
 `plugins.security.ssl.http.pemcert_filepath` | Path to the X.509 node certificate chain (PEM format), which must be under the `config` directory, specified using a relative path. Required.


### PR DESCRIPTION
### Description
TLS is not enabled when this parameter is missing in a X.509/PEM configuration... It's only mentioned in the key/trust-store paragraph.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
