### PR TITLE
Toc keyboard navigation

### DIFF
--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -61,7 +61,7 @@
   {%- endfor -%}
 
   {%- assign pages_list = sorted_number_ordered_pages | concat: sorted_string_ordered_pages -%}
-
+  
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
       {%- unless node.nav_exclude -%}
@@ -71,7 +71,7 @@
           <a
             role="treeitem"
             aria-owns="{{ nested_owned_tree_id }}"
-            aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}"
+            aria-current="{% if page.url == node.url %}page{% endif %}"
             href="#" 
             class="nav-list-expander"
           ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
@@ -95,7 +95,7 @@
                 <a
                   role="treeitem"
                   aria-owns="{{ nested_nested_owned_tree_id }}"
-                  aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}" 
+                  aria-current="{% if page.url == child.url %}page{% endif %}"
                   href="#" 
                   class="nav-list-expander"
                 ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -1,4 +1,8 @@
-<ul class="nav-list">
+<ul 
+  role="tree" 
+  aria-expanded="{{ include.expanded | default: 'false' }}"
+  class="nav-list"
+>
   {%- assign titled_pages = include.pages
         | where_exp:"item", "item.title != nil" -%}
 
@@ -60,7 +64,7 @@
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
       {%- unless node.nav_exclude -%}
-      <li class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+      <li role="treeitem" class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
         {%- if node.has_children -%}
           <a 
             role="button"
@@ -78,10 +82,10 @@
         >{{ node.title }}</a>
         {%- if node.has_children -%}
           {%- assign children_list = pages_list | where: "parent", node.title -%}
-          <ul class="nav-list ">
+          <ul role="tree" class="nav-list ">
           {%- for child in children_list -%}
             {%- unless child.nav_exclude -%}
-            <li class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
+            <li role="treeitem" class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
               {%- if child.has_children -%}
                 <a
                   role="button"
@@ -99,10 +103,10 @@
               >{{ child.title }}</a>
               {%- if child.has_children -%}
                 {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
-                <ul class="nav-list">
+                <ul role="tree" class="nav-list">
                 {%- for grand_child in grand_children_list -%}
                   {%- unless grand_child.nav_exclude -%}
-                  <li class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
+                  <li role="treeitem" class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
                     <a 
                       aria-current="{% if page.url == grand_child.url %}page{% endif %}"
                       tabindex="{{ include.tab_index }}" 

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,7 +2,7 @@
   role="tree" 
   aria-expanded="{{ include.expanded | default: 'false' }}"
   class="nav-list"
-  id="{{ include.owned_tree_id }}"
+{%- if include.owned_tree_id -%}id="{{ include.owned_tree_id }}"{%- endif  -%}
 >
   {%- assign titled_pages = include.pages
         | where_exp:"item", "item.title != nil" -%}
@@ -65,13 +65,13 @@
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
       {%- unless node.nav_exclude -%}
-      {% assign nested_owned_tree_id = include.owned_tree_id | append: "-" | append: node.title | append: "-navitems" %}
+      {% assign nested_owned_tree_id = include.owned_tree_id | append: "_" | append: forloop.index | append: "_" | append: node.title | append: "_navitems" | replace: " ", "_" %}
       <li role="none" class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
         {%- if node.has_children -%}
           <a
             role="treeitem"
             aria-owns="{{ nested_owned_tree_id }}"
-            aria-current="{% if page.url == node.url %}page{% endif %}"
+            {%- if page.url == node.url -%}aria-current="page"{%- endif -%}
             href="#" 
             class="nav-list-expander"
           ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
@@ -79,8 +79,8 @@
         
         <a
           role="treeitem"
-          aria-owns="{{ nested_owned_tree_id }}"
-          aria-current="{% if page.url == node.url %}page{% endif %}"
+          {%- if node.has_children -%}aria-owns="{{ nested_owned_tree_id }}"{%- endif -%}
+          {%- if page.url == node.url -%}aria-current="page"{%- endif -%}
           href="{{ node.url | absolute_url }}" 
           class="nav-list-link{% if page.url == node.url %} active{% endif %}"
         >{{ node.title }}</a>
@@ -91,19 +91,19 @@
             {%- unless child.nav_exclude -%}
             <li role="none" class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
               {%- if child.has_children -%}
-                {% assign nested_nested_owned_tree_id = nested_owned_tree_id | append: "-" | append: child.title | append: "-navitems" %}
+                {% assign nested_nested_owned_tree_id = nested_owned_tree_id | append: "_" | append: forloop.index | append: "_" | append: child.title | append: "_navitems" | replace: " ", "_" %}
                 <a
                   role="treeitem"
                   aria-owns="{{ nested_nested_owned_tree_id }}"
-                  aria-current="{% if page.url == child.url %}page{% endif %}"
+                  {%- if page.url == node.url -%}aria-current="page"{%- endif -%}
                   href="#" 
                   class="nav-list-expander"
                 ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
               {%- endif -%}
               <a
                 role="treeitem"
-                aria-owns="{{ nested_nested_owned_tree_id }}"
-                aria-current="{% if page.url == child.url %}page{% endif %}"
+                {%- if child.has_children -%}aria-owns="{{ nested_nested_owned_tree_id }}"{%- endif -%}
+                {%- if page.url == node.url -%}aria-current="page"{%- endif -%}
                 href="{{ child.url | absolute_url }}" 
                 class="nav-list-link{% if page.url == child.url %} active{% endif %}"
               >{{ child.title }}</a>
@@ -115,7 +115,7 @@
                   <li role="none" class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
                     <a
                       role="treeitem"
-                      aria-current="{% if page.url == grand_child.url %}page{% endif %}"
+                      {%- if page.url == grand_child.url -%}aria-current="page"{%- endif -%}
                       href="{{ grand_child.url | absolute_url }}" 
                       class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}"
                     >{{ grand_child.title }}</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -62,9 +62,20 @@
       {%- unless node.nav_exclude -%}
       <li class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
         {%- if node.has_children -%}
-          <a tabindex="{{ include.tab_index }}" href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+          <a 
+            role="button"
+            aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}"
+            tabindex="{{ include.tab_index }}" 
+            href="#" 
+            class="nav-list-expander"
+          ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
         {%- endif -%}
-        <a tabindex="{{ include.tab_index }}" href="{{ node.url | absolute_url }}" class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+        <a 
+          aria-current="{% if page.url == node.url %}page{% endif %}"
+          tabindex="{{ include.tab_index }}" 
+          href="{{ node.url | absolute_url }}" 
+          class="nav-list-link{% if page.url == node.url %} active{% endif %}"
+        >{{ node.title }}</a>
         {%- if node.has_children -%}
           {%- assign children_list = pages_list | where: "parent", node.title -%}
           <ul class="nav-list ">
@@ -72,16 +83,32 @@
             {%- unless child.nav_exclude -%}
             <li class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
               {%- if child.has_children -%}
-                <a tabindex="{{ include.tab_index }}" href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+                <a
+                  role="button"
+                  aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}" 
+                  tabindex="{{ include.tab_index }}" 
+                  href="#" 
+                  class="nav-list-expander"
+                ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
               {%- endif -%}
-              <a tabindex="{{ include.tab_index }}" href="{{ child.url | absolute_url }}" class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+              <a 
+                aria-current="{% if page.url == child.url %}page{% endif %}"
+                tabindex="{{ include.tab_index }}" 
+                href="{{ child.url | absolute_url }}" 
+                class="nav-list-link{% if page.url == child.url %} active{% endif %}"
+              >{{ child.title }}</a>
               {%- if child.has_children -%}
                 {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
                 <ul class="nav-list">
                 {%- for grand_child in grand_children_list -%}
                   {%- unless grand_child.nav_exclude -%}
                   <li class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                    <a tabindex="{{ include.tab_index }}" href="{{ grand_child.url | absolute_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                    <a 
+                      aria-current="{% if page.url == grand_child.url %}page{% endif %}"
+                      tabindex="{{ include.tab_index }}" 
+                      href="{{ grand_child.url | absolute_url }}" 
+                      class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}"
+                    >{{ grand_child.title }}</a>
                   </li>
                   {%- endunless -%}
                 {%- endfor -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -62,9 +62,9 @@
       {%- unless node.nav_exclude -%}
       <li class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
         {%- if node.has_children -%}
-          <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+          <a tabindex="{{ include.tab_index }}" href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
         {%- endif -%}
-        <a href="{{ node.url | absolute_url }}" class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+        <a tabindex="{{ include.tab_index }}" href="{{ node.url | absolute_url }}" class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
         {%- if node.has_children -%}
           {%- assign children_list = pages_list | where: "parent", node.title -%}
           <ul class="nav-list ">
@@ -72,16 +72,16 @@
             {%- unless child.nav_exclude -%}
             <li class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
               {%- if child.has_children -%}
-                <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+                <a tabindex="{{ include.tab_index }}" href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
               {%- endif -%}
-              <a href="{{ child.url | absolute_url }}" class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+              <a tabindex="{{ include.tab_index }}" href="{{ child.url | absolute_url }}" class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
               {%- if child.has_children -%}
                 {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
                 <ul class="nav-list">
                 {%- for grand_child in grand_children_list -%}
                   {%- unless grand_child.nav_exclude -%}
                   <li class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                    <a href="{{ grand_child.url | absolute_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                    <a tabindex="{{ include.tab_index }}" href="{{ grand_child.url | absolute_url }}" class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
                   </li>
                   {%- endunless -%}
                 {%- endfor -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -69,14 +69,12 @@
           <a 
             role="button"
             aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}"
-            tabindex="{{ include.tab_index }}" 
             href="#" 
             class="nav-list-expander"
           ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
         {%- endif -%}
         <a 
           aria-current="{% if page.url == node.url %}page{% endif %}"
-          tabindex="{{ include.tab_index }}" 
           href="{{ node.url | absolute_url }}" 
           class="nav-list-link{% if page.url == node.url %} active{% endif %}"
         >{{ node.title }}</a>
@@ -90,14 +88,12 @@
                 <a
                   role="button"
                   aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}" 
-                  tabindex="{{ include.tab_index }}" 
                   href="#" 
                   class="nav-list-expander"
                 ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
               {%- endif -%}
               <a 
                 aria-current="{% if page.url == child.url %}page{% endif %}"
-                tabindex="{{ include.tab_index }}" 
                 href="{{ child.url | absolute_url }}" 
                 class="nav-list-link{% if page.url == child.url %} active{% endif %}"
               >{{ child.title }}</a>
@@ -109,7 +105,6 @@
                   <li role="treeitem" class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
                     <a 
                       aria-current="{% if page.url == grand_child.url %}page{% endif %}"
-                      tabindex="{{ include.tab_index }}" 
                       href="{{ grand_child.url | absolute_url }}" 
                       class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}"
                     >{{ grand_child.title }}</a>

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -2,6 +2,7 @@
   role="tree" 
   aria-expanded="{{ include.expanded | default: 'false' }}"
   class="nav-list"
+  id="{{ include.owned_tree_id }}"
 >
   {%- assign titled_pages = include.pages
         | where_exp:"item", "item.title != nil" -%}
@@ -64,48 +65,56 @@
   {%- for node in pages_list -%}
     {%- if node.parent == nil -%}
       {%- unless node.nav_exclude -%}
-      <li role="treeitem" class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
+      {% assign nested_owned_tree_id = include.owned_tree_id | append: "-" | append: node.title | append: "-navitems" %}
+      <li role="none" class="nav-list-item{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %} active{% endif %}">
         {%- if node.has_children -%}
-          <a 
-            role="button"
+          <a
+            role="treeitem"
+            aria-owns="{{ nested_owned_tree_id }}"
             aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}"
             href="#" 
             class="nav-list-expander"
-            tabindex="-1"
           ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
         {%- endif -%}
-        <a 
+        
+        <a
+          role="treeitem"
+          aria-owns="{{ nested_owned_tree_id }}"
           aria-current="{% if page.url == node.url %}page{% endif %}"
           href="{{ node.url | absolute_url }}" 
           class="nav-list-link{% if page.url == node.url %} active{% endif %}"
         >{{ node.title }}</a>
         {%- if node.has_children -%}
           {%- assign children_list = pages_list | where: "parent", node.title -%}
-          <ul role="tree" class="nav-list ">
+          <ul role="tree" class="nav-list" id="{{ nested_owned_tree_id }}">
           {%- for child in children_list -%}
             {%- unless child.nav_exclude -%}
-            <li role="treeitem" class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
+            <li role="none" class="nav-list-item {% if page.url == child.url or page.parent == child.title %} active{% endif %}">
               {%- if child.has_children -%}
+                {% assign nested_nested_owned_tree_id = nested_owned_tree_id | append: "-" | append: child.title | append: "-navitems" %}
                 <a
-                  role="button"
+                  role="treeitem"
+                  aria-owns="{{ nested_nested_owned_tree_id }}"
                   aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}" 
                   href="#" 
                   class="nav-list-expander"
-                  tabindex="-1"
                 ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
               {%- endif -%}
-              <a 
+              <a
+                role="treeitem"
+                aria-owns="{{ nested_nested_owned_tree_id }}"
                 aria-current="{% if page.url == child.url %}page{% endif %}"
                 href="{{ child.url | absolute_url }}" 
                 class="nav-list-link{% if page.url == child.url %} active{% endif %}"
               >{{ child.title }}</a>
               {%- if child.has_children -%}
                 {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
-                <ul role="tree" class="nav-list">
+                <ul role="tree" class="nav-list" id="{{ nested_nested_owned_tree_id }}">
                 {%- for grand_child in grand_children_list -%}
                   {%- unless grand_child.nav_exclude -%}
-                  <li role="treeitem" class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
-                    <a 
+                  <li role="none" class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
+                    <a
+                      role="treeitem"
                       aria-current="{% if page.url == grand_child.url %}page{% endif %}"
                       href="{{ grand_child.url | absolute_url }}" 
                       class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}"

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -71,6 +71,7 @@
             aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}"
             href="#" 
             class="nav-list-expander"
+            tabindex="-1"
           ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
         {%- endif -%}
         <a 
@@ -90,6 +91,7 @@
                   aria-expanded="{% if page.collection == include.key and page.url == node.url or page.parent == node.title or page.grand_parent == node.title %}true{% else %}false{% endif %}" 
                   href="#" 
                   class="nav-list-expander"
+                  tabindex="-1"
                 ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
               {%- endif -%}
               <a 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -80,7 +80,6 @@ layout: table_wrappers
                 {% if collection_value.nav_fold == true %}
                   <ul
                     role="tree" 
-                    aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
                     class="nav-list nav-category-list"
                   >
                     <li role="none" class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
@@ -91,7 +90,7 @@ layout: table_wrappers
                         <a 
                           role="treeitem"
                           aria-owns="{{ owned_tree_id }}"
-                          aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
+                          aria-current="{% if page.collection == collection_key %}page{% endif %}"
                           href="#" 
                           class="nav-list-expander"
                         ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
@@ -99,6 +98,7 @@ layout: table_wrappers
                       <a 
                         role="treeitem"
                         aria-owns="{{ owned_tree_id }}"
+                        aria-current="{% if page.collection == collection_key %}page{% endif %}"
                         class="nav-category{% if category_comparison_url == page.url %} active{% endif %}" 
                         href="{{ collection_url_path | relative_url  }}"
                       >{{ collection_value.name }}</a>
@@ -110,7 +110,6 @@ layout: table_wrappers
                   <a 
                     role="treeitem"
                     aria-owns="{{ owned_tree_id }}"
-                    aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
                     aria-current="{% if page.collection == collection_key %}page{% endif %}"
                     class="nav-category{% if category_comparison_url == page.url %} active{% endif %}"
                     href="{{ collection_url_path | relative_url }}"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,7 @@ layout: table_wrappers
             | where_exp:"item", "item.nav_exclude != true"
             | size %}
         {% if pages_top_size > 0 %}
-          {% include nav.html pages=site.html_pages key=nil tab_index="1" %}
+          {% include nav.html pages=site.html_pages key=nil tab_index="1" expanded=true %}
         {% endif %}
         {% if site.just_the_docs.collections %}
           {% assign collections_size = site.just_the_docs.collections | size %}
@@ -78,8 +78,12 @@ layout: table_wrappers
             {% if collection_value.nav_exclude != true %}
               {% if collections_size > 1 or pages_top_size > 0 %}
                 {% if collection_value.nav_fold == true %}
-                  <ul class="nav-list nav-category-list">
-                    <li class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
+                  <ul 
+                    role="tree" 
+                    aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
+                    class="nav-list nav-category-list"
+                  >
+                    <li role="treeitem" class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
                       {%- if collection.size > 0 -%}
                       <a 
                         role="button"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -102,7 +102,7 @@ layout: table_wrappers
                         class="nav-category{% if category_comparison_url == page.url %} active{% endif %}" 
                         href="{{ collection_url_path | relative_url  }}"
                       >{{ collection_value.name }}</a>
-                      {% include nav.html pages=collection key=collection_key owned_tree_id="{{ owned_tree_id }}" %}
+                      {% include nav.html pages=collection key=collection_key owned_tree_id=owned_tree_id %}
                     </li>
                   </ul>
                 {% else %}
@@ -115,10 +115,10 @@ layout: table_wrappers
                     class="nav-category{% if category_comparison_url == page.url %} active{% endif %}"
                     href="{{ collection_url_path | relative_url }}"
                   >{{ collection_value.name }}</a>
-                  {% include nav.html pages=collection key=collection_key %}
+                  {% include nav.html pages=collection key=collection_key owned_tree_id=owned_tree_id %}
                 {% endif %}
               {% else %}
-                {% include nav.html pages=collection key=collection_key %}
+                {% include nav.html pages=collection key=collection_key owned_tree_id=owned_tree_id %}
               {% endif %}
             {% endif %}
           {% endfor %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -84,13 +84,14 @@ layout: table_wrappers
                       <a tabindex="{{ next_tab_index }}" href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
                       {%- endif -%}
                       {% assign collection_url_path = collection_key | append: "/index/" %}
-                      <div class="nav-category"><a tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url  }}">{{ collection_value.name }}</a></div>
+                      {% assign category_comparison_url = "/" | append: collection_url_path %}
+                      <div class="nav-category"><a class="{% if category_comparison_url == page.url %}active{% endif %}" tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url  }}">{{ collection_value.name }}</a></div>
                       {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
                     </li>
                   </ul>
                 {% else %}
                   {% assign collection_url_path = collection_key | append: "/index/" %}
-                  <div class="nav-category"><a tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url }}">{{ collection_value.name }}</a></div>
+                  <div class="nav-category"><a class="{% if category_comparison_url == page.url %}active{% endif %}" tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url }}">{{ collection_value.name }}</a></div>
                   {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
                 {% endif %}
               {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,7 @@ layout: table_wrappers
             | where_exp:"item", "item.nav_exclude != true"
             | size %}
         {% if pages_top_size > 0 %}
-          {% include nav.html pages=site.html_pages key=nil tab_index="1" expanded=true %}
+          {% include nav.html pages=site.html_pages key=nil expanded=true %}
         {% endif %}
         {% if site.just_the_docs.collections %}
           {% assign collections_size = site.just_the_docs.collections | size %}
@@ -74,7 +74,6 @@ layout: table_wrappers
             {% assign collection_key = collection_entry[0] %}
             {% assign collection_value = collection_entry[1] %}
             {% assign collection = site[collection_key] %}
-            {% assign next_tab_index = forloop.index | plus: 1 %}
             {% if collection_value.nav_exclude != true %}
               {% if collections_size > 1 or pages_top_size > 0 %}
                 {% if collection_value.nav_fold == true %}
@@ -88,15 +87,14 @@ layout: table_wrappers
                       <a 
                         role="button"
                         aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
-                        tabindex="{{ next_tab_index }}" 
                         href="#" 
                         class="nav-list-expander"
                       ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
                       {%- endif -%}
                       {% assign collection_url_path = collection_key | append: "/index/" %}
                       {% assign category_comparison_url = "/" | append: collection_url_path %}
-                      <div class="nav-category"><a class="{% if category_comparison_url == page.url %}active{% endif %}" tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url  }}">{{ collection_value.name }}</a></div>
-                      {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
+                      <div class="nav-category"><a class="{% if category_comparison_url == page.url %}active{% endif %}" href="{{ collection_url_path | relative_url  }}">{{ collection_value.name }}</a></div>
+                      {% include nav.html pages=collection key=collection_key %}
                     </li>
                   </ul>
                 {% else %}
@@ -107,13 +105,12 @@ layout: table_wrappers
                       aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
                       aria-current="{% if page.collection == collection_key %}page{% endif %}"
                       class="{% if category_comparison_url == page.url %}active{% endif %}"
-                      tabindex="{{ next_tab_index }}" 
                       href="{{ collection_url_path | relative_url }}"
                     >{{ collection_value.name }}</a></div>
-                  {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
+                  {% include nav.html pages=collection key=collection_key %}
                 {% endif %}
               {% else %}
-                {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
+                {% include nav.html pages=collection key=collection_key %}
               {% endif %}
             {% endif %}
           {% endfor %}
@@ -131,8 +128,8 @@ layout: table_wrappers
               {% assign docs_version = "latest" %}
             {% endif %}
             <input type="text" id="search-input" class="search-input"
-                   tabindex="0" placeholder="Search..." aria-label="Search {{ site.title }}"
-                   data-docs-version="{{ docs_version }}" autocomplete="off">
+              placeholder="Search..." aria-label="Search {{ site.title }}"
+              data-docs-version="{{ docs_version }}" autocomplete="off">
             <div class="search-spinner"><i></i></div>
             <label for="search-input" class="search-label"><svg viewBox="0 0 24 24" class="search-icon"><use xlink:href="#svg-search"></use></svg></label>
           </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -75,42 +75,45 @@ layout: table_wrappers
             {% assign collection_value = collection_entry[1] %}
             {% assign collection = site[collection_key] %}
             {% if collection_value.nav_exclude != true %}
+              {% assign owned_tree_id = collection_key | append: "-navitems" %}
               {% if collections_size > 1 or pages_top_size > 0 %}
                 {% if collection_value.nav_fold == true %}
-                  <ul 
+                  <ul
                     role="tree" 
                     aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
                     class="nav-list nav-category-list"
                   >
-                    <li role="treeitem" class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
+                    <li role="none" class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
                       
                       {% assign collection_url_path = collection_key | append: "/index/" %}
                       {% assign category_comparison_url = "/" | append: collection_url_path %}
                       {%- if collection.size > 0 -%}
                         <a 
-                          role="button"
+                          role="treeitem"
+                          aria-owns="{{ owned_tree_id }}"
                           aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
                           href="#" 
                           class="nav-list-expander"
-                          tabindex="-1"
                         ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
                       {%- endif -%}
                       <a 
+                        role="treeitem"
+                        aria-owns="{{ owned_tree_id }}"
                         class="nav-category{% if category_comparison_url == page.url %} active{% endif %}" 
                         href="{{ collection_url_path | relative_url  }}"
                       >{{ collection_value.name }}</a>
-                      {% include nav.html pages=collection key=collection_key %}
+                      {% include nav.html pages=collection key=collection_key owned_tree_id="{{ owned_tree_id }}" %}
                     </li>
                   </ul>
                 {% else %}
                   {% assign collection_url_path = collection_key | append: "/index/" %}
                   <a 
-                    role="button"
+                    role="treeitem"
+                    aria-owns="{{ owned_tree_id }}"
                     aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
                     aria-current="{% if page.collection == collection_key %}page{% endif %}"
                     class="nav-category{% if category_comparison_url == page.url %} active{% endif %}"
                     href="{{ collection_url_path | relative_url }}"
-                    tabindex="-1"
                   >{{ collection_value.name }}</a>
                   {% include nav.html pages=collection key=collection_key %}
                 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -92,6 +92,7 @@ layout: table_wrappers
                           aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
                           href="#" 
                           class="nav-list-expander"
+                          tabindex="-1"
                         ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
                       {%- endif -%}
                       <a 
@@ -109,6 +110,7 @@ layout: table_wrappers
                     aria-current="{% if page.collection == collection_key %}page{% endif %}"
                     class="nav-category{% if category_comparison_url == page.url %} active{% endif %}"
                     href="{{ collection_url_path | relative_url }}"
+                    tabindex="-1"
                   >{{ collection_value.name }}</a>
                   {% include nav.html pages=collection key=collection_key %}
                 {% endif %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -81,7 +81,13 @@ layout: table_wrappers
                   <ul class="nav-list nav-category-list">
                     <li class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
                       {%- if collection.size > 0 -%}
-                      <a tabindex="{{ next_tab_index }}" href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+                      <a 
+                        role="button"
+                        aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
+                        tabindex="{{ next_tab_index }}" 
+                        href="#" 
+                        class="nav-list-expander"
+                      ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
                       {%- endif -%}
                       {% assign collection_url_path = collection_key | append: "/index/" %}
                       {% assign category_comparison_url = "/" | append: collection_url_path %}
@@ -91,7 +97,15 @@ layout: table_wrappers
                   </ul>
                 {% else %}
                   {% assign collection_url_path = collection_key | append: "/index/" %}
-                  <div class="nav-category"><a class="{% if category_comparison_url == page.url %}active{% endif %}" tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url }}">{{ collection_value.name }}</a></div>
+                  <div class="nav-category">
+                    <a 
+                      role="button"
+                      aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
+                      aria-current="{% if page.collection == collection_key %}page{% endif %}"
+                      class="{% if category_comparison_url == page.url %}active{% endif %}"
+                      tabindex="{{ next_tab_index }}" 
+                      href="{{ collection_url_path | relative_url }}"
+                    >{{ collection_value.name }}</a></div>
                   {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
                 {% endif %}
               {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -75,7 +75,7 @@ layout: table_wrappers
             {% assign collection_value = collection_entry[1] %}
             {% assign collection = site[collection_key] %}
             {% if collection_value.nav_exclude != true %}
-              {% assign owned_tree_id = collection_key | append: "-navitems" %}
+              {% assign owned_tree_id = collection_key | append: "_" | append: forloop.index | append: "_navitems" | replace: " ", "_" %}
               {% if collections_size > 1 or pages_top_size > 0 %}
                 {% if collection_value.nav_fold == true %}
                   <ul

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -83,30 +83,33 @@ layout: table_wrappers
                     class="nav-list nav-category-list"
                   >
                     <li role="treeitem" class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
-                      {%- if collection.size > 0 -%}
-                      <a 
-                        role="button"
-                        aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
-                        href="#" 
-                        class="nav-list-expander"
-                      ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
-                      {%- endif -%}
+                      
                       {% assign collection_url_path = collection_key | append: "/index/" %}
                       {% assign category_comparison_url = "/" | append: collection_url_path %}
-                      <div class="nav-category"><a class="{% if category_comparison_url == page.url %}active{% endif %}" href="{{ collection_url_path | relative_url  }}">{{ collection_value.name }}</a></div>
+                      {%- if collection.size > 0 -%}
+                        <a 
+                          role="button"
+                          aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
+                          href="#" 
+                          class="nav-list-expander"
+                        ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+                      {%- endif -%}
+                      <a 
+                        class="nav-category{% if category_comparison_url == page.url %} active{% endif %}" 
+                        href="{{ collection_url_path | relative_url  }}"
+                      >{{ collection_value.name }}</a>
                       {% include nav.html pages=collection key=collection_key %}
                     </li>
                   </ul>
                 {% else %}
                   {% assign collection_url_path = collection_key | append: "/index/" %}
-                  <div class="nav-category">
-                    <a 
-                      role="button"
-                      aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
-                      aria-current="{% if page.collection == collection_key %}page{% endif %}"
-                      class="{% if category_comparison_url == page.url %}active{% endif %}"
-                      href="{{ collection_url_path | relative_url }}"
-                    >{{ collection_value.name }}</a></div>
+                  <a 
+                    role="button"
+                    aria-expanded="{% if page.collection == collection_key %}true{% else %}false{% endif %}"
+                    aria-current="{% if page.collection == collection_key %}page{% endif %}"
+                    class="nav-category{% if category_comparison_url == page.url %} active{% endif %}"
+                    href="{{ collection_url_path | relative_url }}"
+                  >{{ collection_value.name }}</a>
                   {% include nav.html pages=collection key=collection_key %}
                 {% endif %}
               {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,7 +66,7 @@ layout: table_wrappers
             | where_exp:"item", "item.nav_exclude != true"
             | size %}
         {% if pages_top_size > 0 %}
-          {% include nav.html pages=site.html_pages key=nil %}
+          {% include nav.html pages=site.html_pages key=nil tab_index="1" %}
         {% endif %}
         {% if site.just_the_docs.collections %}
           {% assign collections_size = site.just_the_docs.collections | size %}
@@ -74,26 +74,27 @@ layout: table_wrappers
             {% assign collection_key = collection_entry[0] %}
             {% assign collection_value = collection_entry[1] %}
             {% assign collection = site[collection_key] %}
+            {% assign next_tab_index = forloop.index | plus: 1 %}
             {% if collection_value.nav_exclude != true %}
               {% if collections_size > 1 or pages_top_size > 0 %}
                 {% if collection_value.nav_fold == true %}
                   <ul class="nav-list nav-category-list">
                     <li class="nav-list-item{% if page.collection == collection_key %} active{% endif %}">
                       {%- if collection.size > 0 -%}
-                      <a href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+                      <a tabindex="{{ next_tab_index }}" href="#" class="nav-list-expander"><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
                       {%- endif -%}
                       {% assign collection_url_path = collection_key | append: "/index/" %}
-                      <div class="nav-category"><a href="{{ collection_url_path | relative_url  }}">{{ collection_value.name }}</a></div>
-                      {% include nav.html pages=collection key=collection_key %}
+                      <div class="nav-category"><a tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url  }}">{{ collection_value.name }}</a></div>
+                      {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
                     </li>
                   </ul>
                 {% else %}
                   {% assign collection_url_path = collection_key | append: "/index/" %}
-                  <div class="nav-category"><a href="{{ collection_url_path | relative_url }}">{{ collection_value.name }}</a></div>
-                  {% include nav.html pages=collection key=collection_key %}
+                  <div class="nav-category"><a tabindex="{{ next_tab_index }}" href="{{ collection_url_path | relative_url }}">{{ collection_value.name }}</a></div>
+                  {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
                 {% endif %}
               {% else %}
-                {% include nav.html pages=collection key=collection_key %}
+                {% include nav.html pages=collection key=collection_key tab_index=next_tab_index %}
               {% endif %}
             {% endif %}
           {% endfor %}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -54,6 +54,11 @@ code {
   max-height: 100vh;
   overflow-x: hidden;
   min-width: 14rem;
+  padding-right: 1px;
+}
+
+.nav-list:nth-of-type(1) {
+  padding: 1px;
 }
 
 .nav-category {

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -60,9 +60,14 @@ code {
 .nav-list:nth-of-type(1) {
   padding: 1px;
 }
+.nav-list .nav-list-item .nav-list-expander {
+  right: 1px;
+}
 
 .nav-category {
   text-align: start;
+  display: block;
+  margin-left: -1px;
 }
 
 .main-content {

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -55,19 +55,17 @@ code {
   overflow-x: hidden;
   min-width: 14rem;
   padding-right: 1px;
+  padding-left: 1px;
+  padding-bottom: 1px;
 }
 
-.nav-list:nth-of-type(1) {
-  padding: 1px;
-}
-.nav-list .nav-list-item .nav-list-expander {
-  right: 1px;
+nav#site-nav > .nav-list:nth-of-type(1) {
+  padding-top: 2px;
 }
 
 .nav-category {
   text-align: start;
   display: block;
-  margin-left: -1px;
 }
 
 .main-content {

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -63,6 +63,10 @@ nav#site-nav > .nav-list:nth-of-type(1) {
   padding-top: 2px;
 }
 
+.nav-list {
+  margin-top: 1px;
+}
+
 .nav-category {
   text-align: start;
   display: block;

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -16,6 +16,12 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
     
+    /**
+     * This function configures the aria-expanded attributes on the navigation items.
+     * Liquid's limited features make this challenging to do cleanly at build time
+     * requiring searching forward through the tree to determine if something in the
+     * depth of the currently rendering tree node has a descendant that is active.
+     */
     function configureAriaAttributes() {
 
       const setSubTreeAriaExpanded = (listItem, isExpanded) => {
@@ -77,56 +83,13 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
     
-    function toggleAriaAttributes(event) {
-      const findParentLI = (element) => {
-        if (!element) {
-          return null;
-        }
-        if (element.tagName === 'LI') {
-          return element;
-        } else {
-          return findParentLI(element.parentElement);
-        }
-      };
-      const findChildUL = (element) => {
-        if (!element) {
-          return null;
-        }
-        if (element.tagName === 'UL') {
-          return element;
-        } else {
-          return findChildUL(element.nextElementSibling);
-        }
-      };
-      const { currentTarget } = event;
-      const currentlyExpanded = currentTarget.getAttribute('aria-expanded');
-      let expanded = 'false';
-      if (currentlyExpanded === 'true') {
-        expanded = 'false';
-      } else {
-        expanded = 'true';
-      }
-      currentTarget.setAttribute('aria-expanded', expanded);
-      const parentLi = findParentLI(currentTarget.parentElement);
-      if (parentLi) {
-        const toggledUL = findChildUL(parentLi.firstElementChild);
-        if (toggledUL) {
-          toggledUL.setAttribute('aria-expanded', expanded);
-        }
-      }
-    }
-
-    navParent.querySelectorAll('a[role="button"]').forEach((element) => {
-      element.addEventListener('click', toggleAriaAttributes);
-    });
-
     navParent.addEventListener('keydown', (event) => {
 
       const handleSpaceKey = () => {
 
         //
         // Space key functionality
-        // For reference: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid/
+        // For reference: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/examples/treeview-navigation/
         //
 
         const expandCollapse = (element) => {
@@ -157,8 +120,6 @@ document.addEventListener('DOMContentLoaded', () => {
           // If no item is focused then do nothing.
           return;
         }
-
-        
 
         // Preventing the default action prevents jankiness in the default scrolling
         // of the navigation panel, and is left to the browser to handle it when

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -27,4 +27,17 @@ document.addEventListener('DOMContentLoaded', () => {
         firstNavItem.focus();
       }
     }
+    
+    navParent.addEventListener('keydown', (event) => {
+      // Check that the target element has a the class name of nav-list-expander.
+      if (event.target.classList.contains('nav-list-expander')) {
+        // Check that the key pressed was the space key.
+        if (event.key === ' ') {
+          event.preventDefault();
+          event.target.click();
+          event.stopImmediatePropagation();
+          event.stopPropagation();
+        }
+      }
+    });
 });

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -4,9 +4,9 @@ document.addEventListener('DOMContentLoaded', () => {
       return;
     }
 
-    // The business logic on navigation items in _includes/nav.html is much too complex
-    // to reliably make this determination correctly without overly complicating something
-    // that is already overly complicated. So, this will make the corrections at runtime.
+    // The business logic on navigation items in layouts/default.html and _includes/nav.html 
+    // is much too complex to reliably make this determination correctly without overly complicating 
+    // something that is already overly complicated. So, this will make the corrections at runtime.
     navParent.querySelectorAll('ul').forEach((element) => {
       const hasNestedList = element.querySelector('ul');
       if (hasNestedList) {
@@ -16,6 +16,8 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
 
+    // Give keyboard focus to the active navigation item, and ensure
+    // it is scrolled into view.
     const activeNavItem = navParent.querySelector('a.active');
     if (activeNavItem) {
       const activeItemTop = activeNavItem.getBoundingClientRect().y;
@@ -32,6 +34,7 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     }
     
+
     function toggleAriaAttributes(event) {
       const findParentLI = (element) => {
         if (!element) {
@@ -101,6 +104,11 @@ document.addEventListener('DOMContentLoaded', () => {
       };
 
       const handleArrowKey = () => {
+        // Preventing the default action prevents jankiness in the default scrolling
+        // of the navigation panel, and is left to the browser to handle it when
+        // .focus() is invoked instead.
+        event.preventDefault();
+
         let currentlyFocusedNavItem = navParent.querySelector('a:focus');
         if (!currentlyFocusedNavItem) {
           const activeNavItem = navParent.querySelector('a.active');
@@ -112,9 +120,12 @@ document.addEventListener('DOMContentLoaded', () => {
             return;
           }
         }
-        const allNavItems = Array.from(navParent.querySelectorAll('a'));
+        const allNavItems = Array.from(
+          navParent.querySelectorAll('a')
+        ).filter(element => element.getBoundingClientRect().height > 0);
+
         const currentlyFocusedNavItemIndex = allNavItems.indexOf(currentlyFocusedNavItem);
-        if (event.key === 'ArrowUp') {
+        if (event.key === 'ArrowUp' || event.key === 'ArrowLeft') {
           if (currentlyFocusedNavItemIndex > 0) {
             allNavItems[currentlyFocusedNavItemIndex - 1].focus();
           }
@@ -125,11 +136,16 @@ document.addEventListener('DOMContentLoaded', () => {
         }
       };
 
-      
-      if (event.key === ' ') {
-        handleSpaceKey();
-      } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
-        handleArrowKey();
+      switch (event.key) {
+        case 'ArrowUp':
+        case 'ArrowDown':
+        case 'ArrowLeft':
+        case 'ArrowRight':
+          handleArrowKey();
+          break;
+        case ' ':
+          handleSpaceKey();
+          break;
       }
     });
 });

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -20,13 +20,16 @@ document.addEventListener('DOMContentLoaded', () => {
     // it is scrolled into view.
     const activeNavItem = navParent.querySelector('a.active');
     if (activeNavItem) {
+      // If the active item is not in view, then scroll it into view.
       const VERSION_WRAPPER_HEIGHT = 80;
       const parentRect = navParent.getBoundingClientRect();
       const activeRect = activeNavItem.getBoundingClientRect();
 
-      if (activeRect.top < (parentRect.top + VERSION_WRAPPER_HEIGHT) || activeRect.bottom > parentRect.bottom) {
-        // The active item is not in view, so scroll it into view.
-        const distanceToScroll = activeRect.top - parentRect.top + VERSION_WRAPPER_HEIGHT;
+      if (activeRect.top < (parentRect.top + VERSION_WRAPPER_HEIGHT)) {
+        const distanceToScroll = activeRect.top - parentRect.top - VERSION_WRAPPER_HEIGHT;
+        navParent.scrollTo(0, distanceToScroll);
+      } else if (activeRect.bottom > window.visualViewport.height) {
+        const distanceToScroll = activeRect.bottom - window.visualViewport.height + VERSION_WRAPPER_HEIGHT;
         navParent.scrollTo(0, distanceToScroll);
       }
     }

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -20,35 +20,27 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     navParent.addEventListener('keydown', (event) => {
+      //
+      // Space key functionality
+      // For reference: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid/
+      //
       if (event.key !== ' ') {
         return;
       }
+
       const expandCollapse = (element) => {
         event.preventDefault();
         event.stopImmediatePropagation();
         event.stopPropagation();
         element.click();
       };
-      const findCorrespondingExpandButton = (element) => {
-        return Array.from(element.children).find(
-          (child) => child.classList.contains('nav-list-expander')
-        );
-      };
+
       if (event.target.classList.contains('nav-list-expander')) {
+        // If the event target is the expand/collapse arrow then toggle the state of the sub tree.
         expandCollapse(event.target);
       } else if (event.target.tagName === 'A') {
-        const { parentElement } = event.target;
-        let correspondingExpandButton;
-        if (parentElement.classList.contains('nav-category')) {
-          correspondingExpandButton = findCorrespondingExpandButton(parentElement.parentElement)
-        } else if (parentElement.classList.contains('nav-list-item')) {
-          correspondingExpandButton = findCorrespondingExpandButton(parentElement);
-        } else {
-          return;
-        }
-        if (correspondingExpandButton) {
-          expandCollapse(correspondingExpandButton);
-        }
+        // If the event target is a link then follow the link.
+        event.target.click();
       }
     });
 });

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -1,18 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
-    const findParentNavElement = (element) => {
-        if (element === null) {
-            return null;
-        } else if (element.tagName === 'NAV') {
-            return element;
-        } else {
-            return findParentNavElement(element.parentElement);
-        }
-    };
-    const navParent = document.querySelector('body main .side-bar nav#site-nav');
+    const navParent = document.getElementById('site-nav');
     if (!navParent) {
       return;
     }
-    const activeNavItem = document.querySelector('.nav-list-item.active a.nav-list-link.active');
+    const activeNavItem = navParent.querySelector('a.active');
     if (activeNavItem) {
       const activeItemTop = activeNavItem.getBoundingClientRect().y;
       if (activeItemTop < 0) {
@@ -29,14 +20,34 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     navParent.addEventListener('keydown', (event) => {
-      // Check that the target element has a the class name of nav-list-expander.
+      if (event.key !== ' ') {
+        return;
+      }
+      const expandCollapse = (element) => {
+        event.preventDefault();
+        event.stopImmediatePropagation();
+        event.stopPropagation();
+        element.click();
+      };
+      const findCorrespondingExpandButton = (element) => {
+        return Array.from(element.children).find(
+          (child) => child.classList.contains('nav-list-expander')
+        );
+      };
       if (event.target.classList.contains('nav-list-expander')) {
-        // Check that the key pressed was the space key.
-        if (event.key === ' ') {
-          event.preventDefault();
-          event.target.click();
-          event.stopImmediatePropagation();
-          event.stopPropagation();
+        expandCollapse(event.target);
+      } else if (event.target.tagName === 'A') {
+        const { parentElement } = event.target;
+        let correspondingExpandButton;
+        if (parentElement.classList.contains('nav-category')) {
+          correspondingExpandButton = findCorrespondingExpandButton(parentElement.parentElement)
+        } else if (parentElement.classList.contains('nav-list-item')) {
+          correspondingExpandButton = findCorrespondingExpandButton(parentElement);
+        } else {
+          return;
+        }
+        if (correspondingExpandButton) {
+          expandCollapse(correspondingExpandButton);
         }
       }
     });

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -15,26 +15,22 @@ document.addEventListener('DOMContentLoaded', () => {
         element.setAttribute('role', 'group');
       }
     });
-
+    
     // Give keyboard focus to the active navigation item, and ensure
     // it is scrolled into view.
     const activeNavItem = navParent.querySelector('a.active');
     if (activeNavItem) {
-      const activeItemTop = activeNavItem.getBoundingClientRect().y;
-      if (activeItemTop < 0) {
-        navParent.scrollTo(0, activeItemTop);
-        activeNavItem.focus();
-      } else {
-        activeNavItem.focus();
-      }
-    } else {
-      const firstNavItem = navParent.querySelector('ul.nav-list > li.nav-list-item:nth-of-type(1) > a.nav-list-link');
-      if (firstNavItem) {
-        firstNavItem.focus();
+      const VERSION_WRAPPER_HEIGHT = 80;
+      const parentRect = navParent.getBoundingClientRect();
+      const activeRect = activeNavItem.getBoundingClientRect();
+
+      if (activeRect.top < (parentRect.top + VERSION_WRAPPER_HEIGHT) || activeRect.bottom > parentRect.bottom) {
+        // The active item is not in view, so scroll it into view.
+        const distanceToScroll = activeRect.top - parentRect.top + VERSION_WRAPPER_HEIGHT;
+        navParent.scrollTo(0, distanceToScroll);
       }
     }
     
-
     function toggleAriaAttributes(event) {
       const findParentLI = (element) => {
         if (!element) {

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -20,27 +20,60 @@ document.addEventListener('DOMContentLoaded', () => {
     }
     
     navParent.addEventListener('keydown', (event) => {
-      //
-      // Space key functionality
-      // For reference: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid/
-      //
-      if (event.key !== ' ') {
-        return;
-      }
 
-      const expandCollapse = (element) => {
-        event.preventDefault();
-        event.stopImmediatePropagation();
-        event.stopPropagation();
-        element.click();
+      const handleSpaceKey = () => {
+
+        //
+        // Space key functionality
+        // For reference: https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/examples/disclosure-navigation-hybrid/
+        //
+
+        const expandCollapse = (element) => {
+          event.preventDefault();
+          event.stopImmediatePropagation();
+          event.stopPropagation();
+          element.click();
+        };
+
+        if (event.target.classList.contains('nav-list-expander')) {
+          // If the event target is the expand/collapse arrow then toggle the state of the sub tree.
+          expandCollapse(event.target);
+        } else if (event.target.tagName === 'A') {
+          // If the event target is a link then follow the link.
+          event.target.click();
+        }
       };
 
-      if (event.target.classList.contains('nav-list-expander')) {
-        // If the event target is the expand/collapse arrow then toggle the state of the sub tree.
-        expandCollapse(event.target);
-      } else if (event.target.tagName === 'A') {
-        // If the event target is a link then follow the link.
-        event.target.click();
+      const handleArrowKey = () => {
+        let currentlyFocusedNavItem = navParent.querySelector('a:focus');
+        if (!currentlyFocusedNavItem) {
+          const activeNavItem = navParent.querySelector('a.active');
+          if (activeNavItem) {
+            currentlyFocusedNavItem = activeNavItem;
+          } else {
+            // Nothing is focused, nor active. Default to the first item.
+            navParent.querySelector('a.nav-list-link').focus();
+            return;
+          }
+        }
+        const allNavItems = Array.from(navParent.querySelectorAll('a'));
+        const currentlyFocusedNavItemIndex = allNavItems.indexOf(currentlyFocusedNavItem);
+        if (event.key === 'ArrowUp') {
+          if (currentlyFocusedNavItemIndex > 0) {
+            allNavItems[currentlyFocusedNavItemIndex - 1].focus();
+          }
+        } else {
+          if (currentlyFocusedNavItemIndex < allNavItems.length - 1) {
+            allNavItems[currentlyFocusedNavItemIndex + 1].focus();
+          }
+        }
+      };
+
+      
+      if (event.key === ' ') {
+        handleSpaceKey();
+      } else if (event.key === 'ArrowUp' || event.key === 'ArrowDown') {
+        handleArrowKey();
       }
     });
 });

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -1,27 +1,30 @@
-let siteNav = document.querySelector('.site-nav');
-const key = 'scroll';
-
 document.addEventListener('DOMContentLoaded', () => {
-    const scroll = JSON.parse(sessionStorage.getItem(key));
-
-    const currentDate = new Date();
-    
-    if (scroll !== null && currentDate.getTime() < scroll.expiry) {
-      siteNav.scrollTop = parseInt(scroll.value);
+    const findParentNavElement = (element) => {
+        if (element === null) {
+            return null;
+        } else if (element.tagName === 'NAV') {
+            return element;
+        } else {
+            return findParentNavElement(element.parentElement);
+        }
+    };
+    const navParent = document.querySelector('body main .side-bar nav#site-nav');
+    if (!navParent) {
+      return;
     }
-    else {
-      sessionStorage.removeItem(key);
+    const activeNavItem = document.querySelector('.nav-list-item.active a.nav-list-link.active');
+    if (activeNavItem) {
+      const activeItemTop = activeNavItem.getBoundingClientRect().y;
+      if (activeItemTop < 0) {
+        navParent.scrollTo(0, activeItemTop);
+        activeNavItem.focus();
+      } else {
+        activeNavItem.focus();
+      }
+    } else {
+      const firstNavItem = navParent.querySelector('ul.nav-list > li.nav-list-item:nth-of-type(1) > a.nav-list-link');
+      if (firstNavItem) {
+        firstNavItem.focus();
+      }
     }
-});
-
-window.addEventListener('beforeunload', () => {
-  const currentDate = new Date();
-
-  // add the scroll value that expires after one day
-  const scroll = {
-    value: siteNav.scrollTop,
-    expiry: currentDate.getTime() + 24 * 60 * 60 * 1000,
-  }
-  
-  sessionStorage.setItem(key, JSON.stringify(scroll));
 });

--- a/assets/js/nav-scroll.js
+++ b/assets/js/nav-scroll.js
@@ -100,6 +100,12 @@ document.addEventListener('DOMContentLoaded', () => {
       };
 
       const handleArrowKey = () => {
+
+        //
+        // Arrow key navigation implementation.
+        // For reference: https://www.w3.org/WAI/ARIA/apg/patterns/treeview/examples/treeview-navigation/
+        //
+        
         const currentlyFocusedNavItem = navParent.querySelector('a:focus');
         if (!currentlyFocusedNavItem) {
           // If no item is focused then do nothing.

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -45,12 +45,6 @@
                 e.preventDefault();
                 navToHighlightedResult();
                 break;
-
-            case 'Tab':
-                e.preventDefault();
-                highlightNextResult(!e.shiftKey);
-                break;
-
         }
     });
 


### PR DESCRIPTION
### Description
Adds keyboard navigation to the left navigation TOC using tab, space, enter / return, and arrow keys in accordance with the W3C ARIA Authroing Practices Guide definition of the Tree View Pattern 


Adds missing role,  aria-expanded, aria-current, aria-owned, corresponding ID attributes to the left navigation TOC tree in accordance with the W3C specification and working example.

Includes style fixes for focus rectangles.

Reference documentation
https://www.w3.org/WAI/ARIA/apg/patterns/treeview/
https://www.w3.org/WAI/ARIA/apg/patterns/treeview/examples/treeview-navigation/

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/518


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
