### PR TITLE
Add thread level details to _tasks API

### DIFF
--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -93,7 +93,7 @@ Parameter | Data type | Description |
 `wait_for_completion` | Boolean | Waits for the matching tasks to complete. (Default: false)
 `group_by` | Enum | Groups tasks by parent/child relationships or nodes. (Default: nodes)
 `timeout` | Time | An explicit operation timeout. (Default: 30 seconds)
-`master_timeout` | Time | The time to wait for a connection to the primary node. (Default: 30 seconds)
+`cluster_manager_timeout` | Time | The time to wait for a connection to the primary node. (Default: 30 seconds)
 
 For example, this request returns tasks currently running on a node named `opensearch-node1`:
 
@@ -231,7 +231,7 @@ Response field | Description |
 `total` | The sum of resource usages across all scheduled thread executions. |
 `min` | The minimum resource usage across all scheduled thread executions. |
 `max` | The maximum resource usage across all scheduled thread executions. |
-`thread_info` | Thread count-related stats.|
+`thread_info` | Thread-count-related stats.|
 `thread_info.active_threads` | The number of threads currently working on the task. |
 `thread_info.thread_executions` | The number of threads that have been scheduled to work on the task. |
 

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -28,7 +28,7 @@ GET _tasks/<task_id>
 
 Note that if a task finishes running, it won't be returned as part of your request. For an example of a task that takes a little longer to finish, you can run the [`_reindex`]({{site.url}}{{site.baseurl}}/opensearch/reindex-data) API operation on a larger document, and then run `tasks`.
 
-**Sample Response**
+#### Example response
 ```json
 {
   "nodes": {
@@ -97,14 +97,14 @@ Parameter | Data type | Description |
 
 For example, this request returns tasks currently running on a node named `opensearch-node1`:
 
-**Sample Request**
+#### Example request
 
-```
+```json
 GET /_tasks?nodes=opensearch-node1
 ```
 {% include copy-curl.html %}
 
-**Sample Response**
+#### Example response
 
 ```json
 {
@@ -150,14 +150,14 @@ GET /_tasks?nodes=opensearch-node1
 
 The following request returns detailed information about active search tasks:
 
-**Sample Request**
+#### Example request
 
 ```bash
 curl -XGET "localhost:9200/_tasks?actions=*search&detailed
 ```
 {% include copy.html %}
 
-**Sample Response**
+#### Example response
 
 ```json
 {
@@ -219,17 +219,21 @@ curl -XGET "localhost:9200/_tasks?actions=*search&detailed
 
 ```
 
-**`resource_stats` Response**
+### The `resource_stats` object
 
-Note that `resource_stats` values will only be updated for tasks that support resource tracking. Moreover, these stats are computed based on scheduled thread executions, which includes both threads that have finished working on the task and threads currently working on the task. Since the same thread may be scheduled to work on the same task multiple times, each time a given thread is scheduled to work on a given task that is considered a single thread execution.
+The `resource_stats` object is only updated for tasks that support resource tracking. These stats are computed based on scheduled thread executions, which includes both threads that have finished working on the task and threads currently working on the task. Because the same thread may be scheduled to work on the same task multiple times, each time a given thread is scheduled to work on a given task is considered a single thread execution.
 
-Response Field | Description |
+The following table lists all response fields in the `resource_stats` object. 
+
+Response field | Description |
 :--- | :--- |
 `average` | The average resource usage across all scheduled thread executions. |
-`total` | The sum of resource usage across all scheduled thread executions. |
+`total` | The sum of resource usages across all scheduled thread executions. |
 `min` | The minimum resource usage across all scheduled thread executions. |
 `max` | The maximum resource usage across all scheduled thread executions. |
-`thread_info` | Thread count related stats. `active_threads` refers to the number of threads currently working on the task while `thread_executions` refers to the number of threads that have been scheduled to work on the task. |
+`thread_info` | Thread count-related stats.|
+`thread_info.active_threads` | The number of threads currently working on the task. |
+`thread_info.thread_executions` | The number of threads that have been scheduled to work on the task. |
 
 ## Task canceling
 

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -221,7 +221,7 @@ curl -XGET "localhost:9200/_tasks?actions=*search&detailed
 
 ### The `resource_stats` object
 
-The `resource_stats` object is only updated for tasks that support resource tracking. These stats are computed based on scheduled thread executions, which includes both threads that have finished working on the task and threads currently working on the task. Because the same thread may be scheduled to work on the same task multiple times, each time a given thread is scheduled to work on a given task is considered a single thread execution.
+The `resource_stats` object is only updated for tasks that support resource tracking. These stats are computed based on scheduled thread executions, including both threads that have finished working on the task and threads currently working on the task. Because the same thread may be scheduled to work on the same task multiple times, each instance of a given thread being scheduled to work on a given task is considered to be a single thread execution.
 
 The following table lists all response fields in the `resource_stats` object. 
 

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -190,9 +190,25 @@ curl -XGET "localhost:9200/_tasks?actions=*search&detailed
           "cancelled" : false,
           "headers" : { },
           "resource_stats" : {
+            "average" : {
+              "cpu_time_in_nanos" : 0,
+              "memory_in_bytes" : 0
+            },
             "total" : {
               "cpu_time_in_nanos" : 0,
               "memory_in_bytes" : 0
+            },
+            "min" : {
+              "cpu_time_in_nanos" : 0,
+              "memory_in_bytes" : 0
+            },
+            "max" : {
+              "cpu_time_in_nanos" : 0,
+              "memory_in_bytes" : 0
+            },
+            "thread_info" : {
+              "thread_executions" : 0,
+              "active_threads" : 0
             }
           }
         }
@@ -202,6 +218,18 @@ curl -XGET "localhost:9200/_tasks?actions=*search&detailed
 }
 
 ```
+
+**`resource_stats` Response**
+
+Note that `resource_stats` values will only be updated for tasks that support resource tracking. Moreover, these stats are computed based on scheduled thread executions, which includes both threads that have finished working on the task and threads currently working on the task. Since the same thread may be scheduled to work on the same task multiple times, each time a given thread is scheduled to work on a given task that is considered a single thread execution.
+
+Response Field | Description |
+:--- | :--- |
+`average` | The average resource usage across all scheduled thread executions. |
+`total` | The sum of resource usage across all scheduled thread executions. |
+`min` | The minimum resource usage across all scheduled thread executions. |
+`max` | The maximum resource usage across all scheduled thread executions. |
+`thread_info` | Thread count related stats. `active_threads` refers to the number of threads currently working on the task while `thread_executions` refers to the number of threads that have been scheduled to work on the task. |
 
 ## Task canceling
 


### PR DESCRIPTION
### Description
Updates the sample response for `_tasks` API with detailed flag to include the new thread level response.

### Issues Resolved
Resolves #4206


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
