### PR TITLE
Updates the top navigation items to match that of the project website

### DIFF
--- a/_data/top_nav.yml
+++ b/_data/top_nav.yml
@@ -1,5 +1,14 @@
 items:
   -
+    label: OpenSearchCon
+    children:
+      -
+        label: Register for OpenSearchCon!
+        url: https://opensearchcon2023.splashthat.com
+      -
+        label: OpenSearchCon 2023 CFP!
+        url: /opensearchcon2023-cfp.html
+  -
     label: Download
     fragments:
       - downloads
@@ -28,6 +37,7 @@ items:
       - community_projects
       - blog
       - partners
+      - slack
     children:
       -
         label: Blog
@@ -35,6 +45,9 @@ items:
       -
         label: Forum
         url: https://forum.opensearch.org/
+      -
+        label: Slack
+        url: /slack.html
       -
         label: Events
         url: /events
@@ -48,3 +61,16 @@ items:
     label: Documentation
     fragment: docs
     url: /docs/
+  -
+    label: Platform
+    children:
+      -
+        label: Vector Database
+        url: /platform/search/vector-database.html
+      -
+        label: Live Demo
+        url: https://playground.opensearch.org/
+      -
+        label: Performance Benchmarks
+        url: /benchmarks
+  


### PR DESCRIPTION
### Description
Following the discussion with the team this updates the top navigation items to match that of the project website in a non-automated fashion. This manual update being a stop gap interim solution until something magical with GitHub actions or similar can be worked out to auto sync the navigation across repositories.

### Issues Resolved
N/A

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
