### PR TITLE
Updated tls.md with 2 different CA settings

### DIFF
--- a/_install-and-configure/install-dashboards/tls.md
+++ b/_install-and-configure/install-dashboards/tls.md
@@ -18,8 +18,8 @@ opensearch.ssl.certificateAuthorities | If `opensearch.ssl.verificationMode` is 
 server.ssl.enabled | This setting is for communications between OpenSearch Dashboards and the web browser. Set to true for HTTPS, false for HTTP.
 server.ssl.certificate | If `server.ssl.enabled` is true, specify the full path to a valid client certificate for your OpenSearch cluster. You can [generate your own]({{site.url}}{{site.baseurl}}/security/configuration/generate-certificates/) or get one from a certificate authority.
 server.ssl.key | If `server.ssl.enabled` is true, specify the full path (e.g. `/usr/share/opensearch-dashboards-1.0.0/config/my-client-cert-key.pem` to the key for your client certificate. You can [generate your own]({{site.url}}{{site.baseurl}}/security/configuration/generate-certificates/) or get one from a certificate authority.
-server.ssl.certificateAuthorities | Certificate Authorities that issued the dashbords server certificate in list format.
-opensearch.ssl.certificateAuthorities| Certificate Authorities that issued Opensearch certificate. 
+server.ssl.certificateAuthorities | This setting adds the SSL certificate authority which issues SSL certificates for the Dashboard's server in a list format. 
+opensearch.ssl.certificateAuthorities | This setting adds the SSL certificate authority for OpenSearch.
 opensearch_security.cookie.secure | If you enable TLS for OpenSearch Dashboards, change this setting to `true`. For HTTP, set it to `false`.
 
 This `opensearch_dashboards.yml` configuration shows OpenSearch and OpenSearch Dashboards running on the same machine with the demo configuration:

--- a/_install-and-configure/install-dashboards/tls.md
+++ b/_install-and-configure/install-dashboards/tls.md
@@ -18,6 +18,8 @@ opensearch.ssl.certificateAuthorities | If `opensearch.ssl.verificationMode` is 
 server.ssl.enabled | This setting is for communications between OpenSearch Dashboards and the web browser. Set to true for HTTPS, false for HTTP.
 server.ssl.certificate | If `server.ssl.enabled` is true, specify the full path to a valid client certificate for your OpenSearch cluster. You can [generate your own]({{site.url}}{{site.baseurl}}/security/configuration/generate-certificates/) or get one from a certificate authority.
 server.ssl.key | If `server.ssl.enabled` is true, specify the full path (e.g. `/usr/share/opensearch-dashboards-1.0.0/config/my-client-cert-key.pem` to the key for your client certificate. You can [generate your own]({{site.url}}{{site.baseurl}}/security/configuration/generate-certificates/) or get one from a certificate authority.
+server.ssl.certificateAuthorities | Certificate Authorities that issued the dashbords server certificate in list format.
+opensearch.ssl.certificateAuthorities| Certificate Authorities that issued Opensearch certificate. 
 opensearch_security.cookie.secure | If you enable TLS for OpenSearch Dashboards, change this setting to `true`. For HTTP, set it to `false`.
 
 This `opensearch_dashboards.yml` configuration shows OpenSearch and OpenSearch Dashboards running on the same machine with the demo configuration:
@@ -31,6 +33,7 @@ opensearch.requestHeadersAllowlist: [ authorization,securitytenant ]
 server.ssl.enabled: true
 server.ssl.certificate: /usr/share/opensearch-dashboards/config/client-cert.pem
 server.ssl.key: /usr/share/opensearch-dashboards/config/client-cert-key.pem
+server.ssl.certificateAuthorities: [ "/usr/share/opensearch-dashboards/config/root-ca.pem", "/usr/share/opensearch-dashboards/config/intermediate-ca.pem" ]
 opensearch.ssl.certificateAuthorities: [ "/usr/share/opensearch-dashboards/config/root-ca.pem", "/usr/share/opensearch-dashboards/config/intermediate-ca.pem" ]
 opensearch_security.multitenancy.enabled: true
 opensearch_security.multitenancy.tenants.preferred: ["Private", "Global"]


### PR DESCRIPTION
Updated tls.md with 2 different CA settings.
One is used to for the dashboards server and the other one when it's dashboards is a TLS client connecting to opensearch

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
