### PR TITLE
demonstrate fluent queries to exclude fields with empty values

### DIFF
--- a/_clients/OSC-dot-net.md
+++ b/_clients/OSC-dot-net.md
@@ -299,6 +299,19 @@ internal class Program
         PrintResponse(searchResponse);
     }
 
+    private static void SearchForAllStudentsWithANonEmptyLastName()
+    {
+        var searchResponse = osClient.Search<Student>(s => s
+                                .Index("students")
+                                .Query(q => q
+                        						.Bool(b => b
+                        							.Must(m => m.Exists(fld => fld.LastName))
+                        							.MustNot(m => m.Term(t => t.Verbatim().Field(fld => fld.LastName).Value(string.Empty)))
+                        						)));
+
+        PrintResponse(searchResponse);
+    }
+
     private static void SearchLowLevel()
     {
         // Search for the student using the low-level client


### PR DESCRIPTION
a `TermQuery` with an empty string `Value` is considered by the .NET client to be "conditionless" and is removed from the search request body by default.

for those times that you want to use a `TermQuery` with an empty string `Value` (e.g. show me all documents with a non-empty last_name property) you need to use the `.Verbatim()` method to tell the client library to include the `TermQuery` as written even though it is considered to be "conditionless".

in other words, while a "conditionless" query may not make sense in the positive it can make sense in the negative

```
GET /my-index/_search
{
     "query": {
        "bool": {
          "must": [{
            "exists": { "field": "last_name"}
          }],
          "must_not": [{
            "term": {"last_name.keyword": { "value": "" }}
          }]
        }
      },
}
```

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
