### PR TITLE
[DOC] Move Reporting to high-level section in nav menu

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -67,6 +67,9 @@ collections:
   observing-your-data:
     permalink: /:collection/:path/
     output: true
+  reporting:
+    permalink: /:collection/:path/
+    output: true
   query-dsl:
     permalink: /:collection/:path/
     output: true 
@@ -144,6 +147,9 @@ just_the_docs:
       nav_fold: true
     observing-your-data:
       name: Observability
+      nav_fold: true
+    reporting:
+      name: Reporting
       nav_fold: true
     clients:
       name: Clients

--- a/_reporting/index.md
+++ b/_reporting/index.md
@@ -11,4 +11,4 @@ nav_exclude: true
 Learn more about the following reporting features in OpenSearch:
 
 - [Reporting using OpenSearch Dashboards]({{site.url}}{{site.baseurl}}/reporting/report-dashboard-index/) 
-- [Reporting using the CLI]({{site.url}}{{site.baseurl}}/reporting/rep-cli-index/) to
+- [Reporting using the CLI]({{site.url}}{{site.baseurl}}/reporting/rep-cli-index/)

--- a/_reporting/index.md
+++ b/_reporting/index.md
@@ -8,4 +8,7 @@ nav_exclude: true
 
 # Reporting
 
-See [Reporting using OpenSearch Dashboards]({{site.url}}{{site.baseurl}}/reporting/report-dashboard-index/) or [Reporting using the CLI]({{site.url}}{{site.baseurl}}/reporting/rep-cli-index/) to learn more about the reporting features in OpenSearch. 
+Learn more about the following reporting features in OpenSearch:
+
+- [Reporting using OpenSearch Dashboards]({{site.url}}{{site.baseurl}}/reporting/report-dashboard-index/) 
+- [Reporting using the CLI]({{site.url}}{{site.baseurl}}/reporting/rep-cli-index/) to

--- a/_reporting/index.md
+++ b/_reporting/index.md
@@ -1,0 +1,11 @@
+---
+layout: default
+title: Reporting
+nav_order: 1
+has_children: false
+nav_exclude: true
+---
+
+# Reporting
+
+See [Reporting using OpenSearch Dashboards]({{site.url}}{{site.baseurl}}/reporting/report-dashboard-index/) or [Reporting using the CLI]({{site.url}}{{site.baseurl}}/reporting/rep-cli-index/) to learn more about the reporting features in OpenSearch. 

--- a/_reporting/rep-cli-create.md
+++ b/_reporting/rep-cli-create.md
@@ -1,12 +1,14 @@
 ---
 layout: default
-title: Creating and requesting a visualization report
+title: Create and request visualization reports
 nav_order: 15
-parent: Creating reports with the Reporting CLI
-
+parent: Reporting using the CLI
+grand_parent: Reporting
+redirect_from:
+  - /dashboards/reporting-cli/rep-cli-create/
 ---
 
-# Creating and requesting a visualization report
+# Create and request visualization reports
 
 First, you need to get the URL for the visualization that you want to download as an image file or PDF.
 

--- a/_reporting/rep-cli-cron.md
+++ b/_reporting/rep-cli-cron.md
@@ -1,12 +1,14 @@
 ---
 layout: default
-title: Scheduling reports with the cron utility
+title: Schedule reports with the cron utility
 nav_order: 20
-parent: Creating reports with the Reporting CLI
-
+parent: Reporting using the CLI
+grand_parent: Reporting
+redirect_from:
+  - /dashboards/reporting-cli/rep-cli-cron/
 ---
 
-# Scheduling reports with the cron utility
+# Schedule reports with the cron utility
 
 You can use the cron command-line utility to initiate a report request with the Reporting CLI that runs periodically at any date or time interval. Follow the cron expression syntax to specify the date and time that precedes the command that you want to initiate.
 

--- a/_reporting/rep-cli-env-var.md
+++ b/_reporting/rep-cli-env-var.md
@@ -1,12 +1,14 @@
 ---
 layout: default
-title: Using environment variables with the Reporting CLI
+title: Use environment variables with the Reporting CLI
 nav_order: 35
-parent: Creating reports with the Reporting CLI
-
+parent: Reporting using the CLI
+grand_parent: Reporting
+redirect_from:
+  - /dashboards/reporting-cli/rep-cli-env-var/
 ---
 
-# Using environment variables with the Reporting CLI
+# Use environment variables with the Reporting CLI
 
 Instead of explicitly providing values in the command line, you can save them as environment variables. The Reporting CLI reads environment variables from the current directory inside the project.
 

--- a/_reporting/rep-cli-index.md
+++ b/_reporting/rep-cli-index.md
@@ -1,11 +1,13 @@
 ---
 layout: default
-title: Creating reports with the Reporting CLI
-nav_order: 75
+title: Reporting using the CLI
+nav_order: 10
 has_children: true
+redirect_from:
+  - /dashboards/reporting-cli/rep-cli-index/
 ---
 
-# Creating reports with the Reporting CLI
+# Reporting using the CLI
 
 You can programmatically create dashboard reports in PDF or PNG format with the Reporting CLI without using OpenSearch Dashboards or the Reporting plugin. This allows you to create reports automatically within your email workflows.
 

--- a/_reporting/rep-cli-install.md
+++ b/_reporting/rep-cli-install.md
@@ -1,12 +1,14 @@
 ---
 layout: default
-title: Downloading and installing the Reporting CLI tool
+title: Download and install the Reporting CLI tool
 nav_order: 10
-parent: Creating reports with the Reporting CLI
-
+parent: Reporting using the CLI
+grand_parent: Reporting
+redirect_from:
+  - /dashboards/reporting-cli/rep-cli-install/
 ---
 
-# Downloading and installing the Reporting CLI tool
+# Download and install the Reporting CLI tool
 
 You can download and install the Reporting CLI tool from either the npm software registry or the OpenSearch.org [Artifacts](https://opensearch.org/artifacts) hub. Refer to the following sections for instructions.
 

--- a/_reporting/rep-cli-lambda.md
+++ b/_reporting/rep-cli-lambda.md
@@ -1,9 +1,11 @@
 ---
 layout: default
-title: Scheduling reports with AWS Lambda
+title: Schedule reports with AWS Lambda
 nav_order: 30
-parent: Creating reports with the Reporting CLI
-
+parent: Reporting using the CLI
+grand_parent: Reporting
+redirect_from:
+  - /dashboards/reporting-cli/rep-cli-lambda/
 ---
 
 # Scheduling reports with AWS Lambda

--- a/_reporting/rep-cli-options.md
+++ b/_reporting/rep-cli-options.md
@@ -2,8 +2,10 @@
 layout: default
 title: Reporting CLI options
 nav_order: 30
-parent: Creating reports with the Reporting CLI
-
+parent: Reporting using the CLI
+grand_parent: Reporting
+redirect_from:
+  - /dashboards/reporting-cli/rep-cli-options/
 ---
 
 # Reporting CLI options

--- a/_reporting/report-dashboard-index.md
+++ b/_reporting/report-dashboard-index.md
@@ -1,18 +1,20 @@
 ---
 layout: default
-title: Creating reports with the Dashboards interface
-nav_order: 70
+title: Reporting using OpenSearch Dashboards
+nav_order: 5
+redirect_from:
+  - /dashboards/reporting/
 ---
 
 
-# Creating reports with the Dashboards interface
+# Reporting using OpenSearch Dashboards
 
 You can use OpenSearch Dashboards to create PNG, PDF, and CSV reports. To create reports, you must have the correct permissions. For a summary of the predefined roles and the permissions they grant, see the [Security plugin]({{site.url}}{{site.baseurl}}/security/access-control/users-roles#predefined-roles).
 
 CSV reports have a non-configurable 10,000 row limit. They have no explicit size limit (for example, MB), but extremely large documents could cause report generation to fail with an out of memory error from the V8 JavaScript engine.
 {: .tip }
 
-## Generating reports with the interface
+## Generating reports
 
 To generate a report from the interface:
 
@@ -43,6 +45,8 @@ Definitions let you generate reports on a periodic schedule.
 2. Choose **Create**.
 
 ## Troubleshooting
+
+You can use the following topics to troubleshoot and resolve issues with reporting.
 
 ### Chromium fails to launch with OpenSearch Dashboards
 


### PR DESCRIPTION
### Description
Reporting is used in Dashboards and the Reporting CLI (non-Dashboards). Documentation about both options need to be in a main section in the nav menu. Moved Reporting content from OpenSearch Dashboards to Reporting to make the content more user-friendly and easier to find. 
 
<img width="250" alt="Screenshot 2023-07-28 at 3 31 49 PM" src="https://github.com/opensearch-project/documentation-website/assets/105296784/42a58d08-018c-46df-9b75-43bb673b1aaf">

<img width="692" alt="Screenshot 2023-07-28 at 3 33 26 PM" src="https://github.com/opensearch-project/documentation-website/assets/105296784/253723ad-01a0-4f35-89f5-441898b26874">

### Issues Resolved


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
