### PR TITLE
Remove link list on script API index duplicated in related articles

### DIFF
--- a/_api-reference/script-apis/index.md
+++ b/_api-reference/script-apis/index.md
@@ -10,11 +10,3 @@ redirect_from:
 # Script APIs
 
 The script APIs allow you to work with stored scripts. Stored scripts are part of the cluster state and reduce compilation time and enhance search speed. The default scripting language is Painless.
-
-You can perform the following operations on stored scripts:
-* [Create or update stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/create-stored-script/)
-* [Execute Painless stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/exec-stored-script/)
-* [Get stored script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/get-stored-script/)
-* [Delete script]({{site.url}}{{site.baseurl}}/api-reference/script-apis/delete-script/)
-* [Get stored script contexts]({{site.url}}{{site.baseurl}}/api-reference/script-apis/get-script-contexts/).
-* [Get script language]({{site.url}}{{site.baseurl}}/api-reference/script-apis/get-script-language/)


### PR DESCRIPTION
### Description
This PR removes the link list that is duplicated in the related articles at the bottom of the article.

Not sure how related articles are added but you can check out the current state here:
https://opensearch.org/docs/latest/api-reference/script-apis/index/

### Issues Resolved

none

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
