### PR TITLE
Improve list in search plugins index

### DIFF
--- a/_search-plugins/index.md
+++ b/_search-plugins/index.md
@@ -9,24 +9,15 @@ nav_exclude: true
 
 # Search
 
-OpenSearch provides several features for customizing your search use cases and improving search relevance. In OpenSearch, you can:
+OpenSearch provides the following features for customizing your search use cases and improving search relevance:
 
-- Use [SQL and Piped Processing Language (PPL)]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/) as alternatives to [query domain-specific language (DSL)]({{site.url}}{{site.baseurl}}/query-dsl/) to search data.
-
-- Run resource-intensive queries asynchronously with [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/).
-
-- Search for k-nearest neighbors with [k-NN search]({{site.url}}{{site.baseurl}}/search-plugins/knn/).
-
-- Abstract OpenSearch queries into [search templates]({{site.url}}{{site.baseurl}}/search-plugins/search-template/).
-
-- Integrate machine learning (ML) language models into your search workloads with [neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/).
-
-- [Compare search results]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/) to tune search relevance.
-
-- Use a dataset that is fixed in time to paginate results with [Point in Time]({{site.url}}{{site.baseurl}}/search-plugins/point-in-time/).
-
+- [SQL and Piped Processing Language (PPL)]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/): Alternative to [query domain-specific language (DSL)]({{site.url}}{{site.baseurl}}/query-dsl/) to search data.
+- [Asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/): Run resource-intensive queries asynchronously.
+- [k-NN search]({{site.url}}{{site.baseurl}}/search-plugins/knn/): Search for k-nearest neighbors.
+- [Search templates]({{site.url}}{{site.baseurl}}/search-plugins/search-template/): Abstract OpenSearch queries.
+- [neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/): Integrate machine learning (ML) language models into your search workloads.
+- [Compare search results]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/). Tune search relevance.
+- [Point in Time]({{site.url}}{{site.baseurl}}/search-plugins/point-in-time/): Use a dataset that is fixed in time to paginate results.
 - [Paginate]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/paginate/) and [sort]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/sort/) search results, [highlight]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/highlight/) search terms, and use the [autocomplete]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/autocomplete/) and [did-you-mean]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/did-you-mean/) functionality.
-
-- Rewrite queries with [Querqy]({{site.url}}{{site.baseurl}}/search-plugins/querqy/).
-
-- Process search queries and search results with [search pipelines]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/index/).
+- [Querqy]({{site.url}}{{site.baseurl}}/search-plugins/querqy/): Rewrite queries.
+- [Search pipelines]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/index/): Process search queries and search results.

--- a/_search-plugins/index.md
+++ b/_search-plugins/index.md
@@ -15,7 +15,7 @@ OpenSearch provides the following features for customizing your search use cases
 - [Asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/): Run resource-intensive queries asynchronously.
 - [k-NN search]({{site.url}}{{site.baseurl}}/search-plugins/knn/): Search for k-nearest neighbors.
 - [Search templates]({{site.url}}{{site.baseurl}}/search-plugins/search-template/): Abstract OpenSearch queries.
-- [neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/): Integrate machine learning (ML) language models into your search workloads.
+- [Neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/): Integrate machine learning (ML) language models into your search workloads.
 - [Compare search results]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/). Tune search relevance.
 - [Point in Time]({{site.url}}{{site.baseurl}}/search-plugins/point-in-time/): Use a dataset that is fixed in time to paginate results.
 - [Paginate]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/paginate/) and [sort]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/sort/) search results, [highlight]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/highlight/) search terms, and use the [autocomplete]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/autocomplete/) and [did-you-mean]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/did-you-mean/) functionality.


### PR DESCRIPTION
### Description

This PR improves the list in the search plugins index page.

The list in https://opensearch.org/docs/latest/search-plugins/index/ was not easy to digest.

The list is not completely parallel yet, See lines 14 and 21. Ideas on how to fix that are welcome. Maybe this doesn't matter at all though, as the list formatting has already been approved so much. Let me know. 

### Issues Resolved

none

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
