### PR TITLE
Removed forced options, cleaned up link checker args.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -39,3 +39,4 @@ gem "webrick", "~> 1.7"
 # Link checker
 gem "typhoeus"
 gem "ruby-link-checker"
+gem "ruby-enum"


### PR DESCRIPTION
### Description

It seems like the `@check_forced_external` option was added to enable checking internal links marked as external e.g. `/docs`, however the forced external matcher `@forced_external_matcher = %r{^https?://.*(?=opensearch\.org/)}.freeze` seems to just say "anything on opensearch.org". Jekyll renders all URLs using the base URL, so everything would match that now. I don't think this option is useful in its current state at all. 

@AMoo-Miki correct me if I am wrong.

This PR also makes passing arguments a bit easier to read, removing the magical `[1..3]` check in incremental options in favor of using `Ruby::Enum`, and renames `should_build_fatally` to `fail_on_error` which is more intentional.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
