### PR TITLE
Add `bytes` into "Query parameters" for CAT Segment Replication API

### DIFF
--- a/_api-reference/cat/cat-segment-replication.md
+++ b/_api-reference/cat/cat-segment-replication.md
@@ -34,18 +34,18 @@ Parameter | Type | Description
 
 The CAT segment replication API operation supports the following optional query parameters.
 
-Parameter | Data type | Description
-:--- |:---| :---
-`active_only` | Boolean | If `true`, the response only includes active segment replications. Defaults to `false`. 
-[`detailed`](#additional-detailed-response-metrics) | String | If `true`, the response includes additional metrics for each stage of a segment replication event. Defaults to `false`.
-`shards` | String | A comma-separated list of shards to display.
-`bytes` | Byte size | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display byte size values.
-`format` | String | A short version of the HTTP accept header. Valid values include `JSON` and `YAML`.  
-`h` | String | A comma-separated list of column names to display. 
-`help` | Boolean | If `true`, the response includes help information. Defaults to `false`.
-`time` | Time | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display time values.
-`v` | Boolean | If `true`, the response includes column headings. Defaults to `false`.
-`s` | String | Specifies to sort the results. For example, `s=shardId:desc` sorts by shardId in descending order.
+Parameter | Data type  | Description
+:--- |:-----------| :---
+`active_only` | Boolean    | If `true`, the response only includes active segment replications. Defaults to `false`. 
+[`detailed`](#additional-detailed-response-metrics) | String     | If `true`, the response includes additional metrics for each stage of a segment replication event. Defaults to `false`.
+`shards` | String     | A comma-separated list of shards to display.
+`bytes` | Byte units | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display byte size values.
+`format` | String     | A short version of the HTTP accept header. Valid values include `JSON` and `YAML`.  
+`h` | String     | A comma-separated list of column names to display. 
+`help` | Boolean    | If `true`, the response includes help information. Defaults to `false`.
+`time` | Time units | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display time values.
+`v` | Boolean    | If `true`, the response includes column headings. Defaults to `false`.
+`s` | String     | Specifies to sort the results. For example, `s=shardId:desc` sorts by shardId in descending order.
 
 ## Examples 
 

--- a/_api-reference/cat/cat-segment-replication.md
+++ b/_api-reference/cat/cat-segment-replication.md
@@ -39,7 +39,7 @@ Parameter | Data type | Description
 `active_only` | Boolean | If `true`, the response only includes active segment replications. Defaults to `false`. 
 [`detailed`](#additional-detailed-response-metrics) | String | If `true`, the response includes additional metrics for each stage of a segment replication event. Defaults to `false`.
 `shards` | String | A comma-separated list of shards to display.
-`byte` | Byte size | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display byte size values.
+`bytes` | Byte size | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display byte size values.
 `format` | String | A short version of the HTTP accept header. Valid values include `JSON` and `YAML`.  
 `h` | String | A comma-separated list of column names to display. 
 `help` | Boolean | If `true`, the response includes help information. Defaults to `false`.

--- a/_api-reference/cat/cat-segment-replication.md
+++ b/_api-reference/cat/cat-segment-replication.md
@@ -39,11 +39,11 @@ Parameter | Data type | Description
 `active_only` | Boolean | If `true`, the response only includes active segment replications. Defaults to `false`. 
 [`detailed`](#additional-detailed-response-metrics) | String | If `true`, the response includes additional metrics for each stage of a segment replication event. Defaults to `false`.
 `shards` | String | A comma-separated list of shards to display.
-`byte` | Byte size | [Units]({{site.url}}{{site.baseurl}}/opensearch/units) used to display byte size values.
+`byte` | Byte size | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display byte size values.
 `format` | String | A short version of the HTTP accept header. Valid values include `JSON` and `YAML`.  
 `h` | String | A comma-separated list of column names to display. 
 `help` | Boolean | If `true`, the response includes help information. Defaults to `false`.
-`time` | Time | [Units]({{site.url}}{{site.baseurl}}/opensearch/units) used to display time values.
+`time` | Time | [Units]({{site.url}}{{site.baseurl}}/opensearch/units/) used to display time values.
 `v` | Boolean | If `true`, the response includes column headings. Defaults to `false`.
 `s` | String | Specifies to sort the results. For example, `s=shardId:desc` sorts by shardId in descending order.
 

--- a/_api-reference/cat/cat-segment-replication.md
+++ b/_api-reference/cat/cat-segment-replication.md
@@ -39,10 +39,11 @@ Parameter | Data type | Description
 `active_only` | Boolean | If `true`, the response only includes active segment replications. Defaults to `false`. 
 [`detailed`](#additional-detailed-response-metrics) | String | If `true`, the response includes additional metrics for each stage of a segment replication event. Defaults to `false`.
 `shards` | String | A comma-separated list of shards to display.
+`byte` | Byte size | [Units]({{site.url}}{{site.baseurl}}/opensearch/units) used to display byte size values.
 `format` | String | A short version of the HTTP accept header. Valid values include `JSON` and `YAML`.  
 `h` | String | A comma-separated list of column names to display. 
 `help` | Boolean | If `true`, the response includes help information. Defaults to `false`.
-`time` | Time value | [Units]({{site.url}}{{site.baseurl}}/opensearch/units) used to display time values. Defaults to `ms` (milliseconds).
+`time` | Time | [Units]({{site.url}}{{site.baseurl}}/opensearch/units) used to display time values.
 `v` | Boolean | If `true`, the response includes column headings. Defaults to `false`.
 `s` | String | Specifies to sort the results. For example, `s=shardId:desc` sorts by shardId in descending order.
 


### PR DESCRIPTION
### Description

- Add description for `bytes` parameter into "Query parameters" section for [CAT Segment Replication API](https://opensearch.org/docs/2.9/api-reference/cat/cat-segment-replication/) 
This is a common parameters for CAT API, and I think it's worth to mention here, because it's available for "cat-segment-replication" REST API.
- Correct the description for `time` parameter. The default value is not milliseconds, but no default value. By default, the response is human-formatted, for example, `1.2s` instead of `1209`. Besides, the "data type" is not Time "value", but Time "unit".

An example for the API response:
```
$ curl "opens-clust-xxx.elb.us-west-2.amazonaws.com/_cat/segment_replication?v&pretty"
shardId          target_node                              target_host checkpoints_behind bytes_behind current_lag last_completed_lag rejected_requests
[logs-221998][7] ip-10-0-4-86.us-west-2.compute.internal  10.0.4.86   1                  47.3kb       988ms       823ms              0
[logs-221998][7] ip-10-0-3-170.us-west-2.compute.internal 10.0.3.170  1                  39.2kb       988ms       1.2s               0
[logs-231998][0] ip-10-0-3-66.us-west-2.compute.internal  10.0.3.66   1                  31.6kb       791ms       699ms              0
[logs-231998][0] ip-10-0-4-187.us-west-2.compute.internal 10.0.4.187  1                  40kb         791ms       1.1s               0
[logs-231998][0] ip-10-0-3-170.us-west-2.compute.internal 10.0.3.170  1                  40kb         791ms       342ms              0
[logs-231998][0] ip-10-0-4-86.us-west-2.compute.internal  10.0.4.86   1                  31.6kb       791ms       343ms              0
```

In addition, the format and description in the [CAT Segment Replication API](https://opensearch.org/docs/2.9/api-reference/cat/cat-segment-replication/) is a bit distinct with other CAT APIs, such as [CAT Recovery](https://opensearch.org/docs/2.9/api-reference/cat/cat-recovery/).
1 There is no "code" (``) style for the parameter names for the other pages.
2 The descriptions for the parameters are different from other pages.
I didn't make changes to make "cat-segment-replication" align with other pages.

### Issues Resolved
n/a

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
