### PR TITLE
Documents general sink options

### DIFF
--- a/_data-prepper/pipelines/pipelines-configuration-options.md
+++ b/_data-prepper/pipelines/pipelines-configuration-options.md
@@ -14,4 +14,17 @@ This page provides information about pipeline configuration options in Data Prep
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
 workers | No | Integer | Essentially the number of application threads. As a starting point for your use case, try setting this value to the number of CPU cores on the machine. Default is 1.
-delay | No | Integer | Amount of time in milliseconds workers wait between buffer read attempts. Default is 3,000. 
+delay | No | Integer | Amount of time in milliseconds workers wait between buffer read attempts. Default is 3,000.
+
+
+## General sink options
+
+The following options are available for all sinks.
+
+Option | Required | Type        | Description
+:--- | :--- |:------------| :---
+routes | No | String list | A list of routes for which this sink applies. If not provided, this sink receives all events. See [conditional routing]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/pipelines#conditional_routing) for more information.
+tags_target_key | No | String      | If supplied, then the event tags will be included in the output in the provided key.
+include_keys | No | String list | If specified, only the keys provided in this list will be included in the data sent to the sink.
+exclude_keys | No | String list | If specified, the following keys will be excluded from the data sent to the sink.
+

--- a/_data-prepper/pipelines/pipelines.md
+++ b/_data-prepper/pipelines/pipelines.md
@@ -58,7 +58,7 @@ When any component of a pipeline fails and is unable to send an event, the sourc
 
 As of Data Prepper 2.2, only the `s3` source and `opensearch` sink support E2E acknowledgments. 
 
-## Conditional routing
+## Conditional routing<a name="conditional_routing"></a>
 
 Pipelines also support **conditional routing**  which allows you to route events to different sinks based on specific conditions. To add conditional routing to a pipeline, specify a list of named routes under the `route` component and add specific routes to sinks under the `routes` property. Any sink with the `routes` property will only accept events that match at least one of the routing conditions. 
 


### PR DESCRIPTION
### Description

New documentation for general sink options:

* routes
* tags_target_key
* include_keys
* exclude_keys.

Also, creates a link to the Conditional routing section in the general Pipelines documentation.

### Issues Resolved

Resolves #4757


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
