### PR TITLE
Add documentation to provide a link from detector creation to detection rule creation in using rules docs

### DIFF
--- a/_security-analytics/sec-analytics-config/detectors-config.md
+++ b/_security-analytics/sec-analytics-config/detectors-config.md
@@ -21,7 +21,11 @@ You can define a new detector by naming the detector, selecting a data source an
     When multiple data sources are selected, the logs must be of the same type. We recommend creating separate detectors for different log types.
     {: .note }
     
-1. In the **Log types and rules** section, select the log type for the data source. The system automatically populates the Sigma security rules associated with the log type. The following image shows the number of associated rules populated in the **Detection rules** section.
+1. In the **Log types and rules** section, select the log type for the data source. The system automatically populates the Sigma security rules associated with the log type.
+
+For information about creating custom detection rules, see 
+
+The following image shows the number of associated rules populated in the **Detection rules** section.
 
     <img src="{{site.url}}{{site.baseurl}}/images/Security/detector_rules.png" alt="Selecting threat detector type to auto-populate rules" width="85%">
 

--- a/_security-analytics/sec-analytics-config/detectors-config.md
+++ b/_security-analytics/sec-analytics-config/detectors-config.md
@@ -29,12 +29,12 @@ You can define a new detector by naming the detector, selecting a data source an
    The following image shows the number of associated rules populated in the **Detection rules** section.
 
     <img src="{{site.url}}{{site.baseurl}}/images/Security/detector_rules.png" alt="Selecting threat detector type to auto-populate rules" width="85%">
-
+    
     When you select **Network events**, **CloudTrail logs**, or **S3 access logs** as the log type, the system automatically creates a detector dashboard. The dashboard offers visualizations for the detector and can provide security-related insight into log source data. For more information about visualizations, see [Building data visualizations]({{site.url}}{{site.baseurl}}/dashboards/visualize/viz-index/).
     
     You can skip the next step for applying select rules if you are satisfied with those automatically populated by the system. Otherwise, go to the next step to select rules individually.
     {: .note }
-
+    
 1. Expand **Detection rules** to show the list of available detection rules for the selected log type. Initially, all rules are selected by default. The following image illustrates this.
 
     <img src="{{site.url}}{{site.baseurl}}/images/Security/select_rules.png" alt="Select or deselect rules that the detector will use for findings" width="85%">

--- a/_security-analytics/sec-analytics-config/detectors-config.md
+++ b/_security-analytics/sec-analytics-config/detectors-config.md
@@ -23,7 +23,8 @@ You can define a new detector by naming the detector, selecting a data source an
     
 1. In the **Log types and rules** section, select the log type for the data source. The system automatically populates the Sigma security rules associated with the log type.
 
-For information about creating custom detection rules, see 
+For information about creating your own detection rules, see [Creating detection rules](/security-analytics/usage/rules/#creating-detection-rules).
+{: .note }
 
 The following image shows the number of associated rules populated in the **Detection rules** section.
 

--- a/_security-analytics/sec-analytics-config/detectors-config.md
+++ b/_security-analytics/sec-analytics-config/detectors-config.md
@@ -22,11 +22,11 @@ You can define a new detector by naming the detector, selecting a data source an
     {: .note }
     
 1. In the **Log types and rules** section, select the log type for the data source. The system automatically populates the Sigma security rules associated with the log type.
-
-For information about creating your own detection rules, see [Creating detection rules](/security-analytics/usage/rules/#creating-detection-rules).
-{: .note }
-
-The following image shows the number of associated rules populated in the **Detection rules** section.
+   
+   For information about creating your own detection rules, see [Creating detection rules]({{site.url}}{{site.baseurl}}/security-analytics/usage/rules/#creating-detection-rules).
+   {: .note }
+   
+   The following image shows the number of associated rules populated in the **Detection rules** section.
 
     <img src="{{site.url}}{{site.baseurl}}/images/Security/detector_rules.png" alt="Selecting threat detector type to auto-populate rules" width="85%">
 

--- a/_security-analytics/usage/rules.md
+++ b/_security-analytics/usage/rules.md
@@ -34,7 +34,7 @@ In Visual view, rule details are arranged in fields, and the links are active. S
 * To copy the rule, select the copy icon in the upper-right corner of the rule. To quickly create a new, customized rule, you can paste the rule into the YAML editor and make any modifications before saving it. See [Customizing rules](#customizing-rules) for more information.
 
 ---
-## Creating rules
+## Creating detection rules
 
 There are multiple ways to create rules on the **Detection rules** page. These methods include manually creating a custom rule, importing a rule, and duplicating an existing rule to customize it. The following sections discuss these methods in detail.  
 


### PR DESCRIPTION
### Description
Provide a link from detector creation steps to creating detection rules section in "Working with detection rules" section so users know the option to create custom detection rules exists at the detector creation stage.

### Issues Resolved
Should help users know custom rule creation is available at the right time in setup.
Fixes #4828 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
