### PR TITLE
Fix debian installatation instructions in 1.3

### DIFF
--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -92,7 +92,7 @@ APT, the primary package management tool for Debian–based operating systems, a
     ```
 1. Create an APT repository for OpenSearch:
    ```bash
-   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-1x.list
+   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-1.x.list
    ```
 1. Verify that the repository was created successfully.
     ```bash

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -92,7 +92,7 @@ APT, the primary package management tool for Debian–based operating systems, a
     ```
 1. Create an APT repository for OpenSearch:
    ```bash
-   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/2.x/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-2.x.list
+   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/{{site.opensearch_version}}/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-{{site.opensearch_version}}.list
    ```
 1. Verify that the repository was created successfully.
     ```bash

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -92,7 +92,7 @@ APT, the primary package management tool for Debian–based operating systems, a
     ```
 1. Create an APT repository for OpenSearch:
    ```bash
-   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/{{site.opensearch_version}}/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-{{site.opensearch_version}}.list
+   echo "deb [signed-by=/usr/share/keyrings/opensearch-keyring] https://artifacts.opensearch.org/releases/bundle/opensearch/1.x/apt stable main" | sudo tee /etc/apt/sources.list.d/opensearch-1x.list
    ```
 1. Verify that the repository was created successfully.
     ```bash


### PR DESCRIPTION
### Description
Creates a variable for the version number so the version is correct in the APT repository section.

### Issues Resolved
Fixes https://github.com/opensearch-project/documentation-website/issues/4833


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
