### PR TITLE
Adds documentation for permission that provides access to system indexes

### DIFF
--- a/_security/access-control/permissions.md
+++ b/_security/access-control/permissions.md
@@ -65,6 +65,16 @@ Rather than individual permissions, you can often achieve your desired security 
 {: .tip }
 
 
+### System permission
+
+The system permission `system:admin/system_index` is unique compared to other permissions. To extend some traditional admin-only accessibility to non-admin users, this permission gives normal users the ability to modify system indexes for the cluster; this excludes, however, access to the security system index `.opendistro_security`, which is used to store the configuration YAML files and remains accessible only to admins with an admin certificate.
+
+Admin users that have the permission `restapi:admin/roles` are able to map the `system:admin/system_index` permission to users just as they would for a cluster or index permission. However, to preserve some control over this permission, the configuration setting `plugins.security.system_indices.additional_control.enabled` allows administrators to disable this permission by setting it to `false`. For more information about this setting, see [opensearch.yml]({{site.url}}{{site.baseurl}}/security/configuration/yaml/#enabling-user-access-to-system-indexes).
+
+Keep in mind that an admin user who enables this feature necessarily accepts the risks involved with giving normal users access to system indexes, which may contain sensitive information.
+{: .warning }
+
+
 ## Cluster permissions
 
 These permissions are for the cluster and can't be applied granularly. For example, you either have permissions to take snapshots (`cluster:admin/snapshot/create`) or you don't. The cluster permission, therefore, cannot grant a user privileges to take snapshots of a select set of indexes while preventing the user from taking snapshots of others.

--- a/_security/configuration/yaml.md
+++ b/_security/configuration/yaml.md
@@ -134,6 +134,18 @@ An authentication cache for the Security plugin exists to help speed up authenti
 plugins.security.cache.ttl_minutes: 60
 ```
 
+### Enabling user access to system indexes
+
+Mapping the `system:admin/system_index` permission to a user allows that user to modify system indexes, with the exception of the Security plugin's [system index]({{site.url}}{{site.baseurl}}/security/configuration/system-indices/). The `plugins.security.system_indices.additional_control.enabled` setting provides a way for administrators to make this permission available for or hidden from role mapping.
+
+When set to `true`, the feature is enabled and administrators can add the `system:admin/system_index` permission for a user.
+
+```yml
+plugins.security.system_indices.additional_control.enabled: true
+```
+When set to `false`, the permission is disabled and only admins with an admin certificate can make changes to system indexes. To learn more about this permission, see [System permissions]({{site.url}}{{site.baseurl}}).
+
+
 ### Password settings
 
 If you want to run your users' passwords against some validation, specify a regular expression (regex) in this file. You can also include an error message that loads when passwords don't pass validation. The following example demonstrates how to include a regex so OpenSearch requires new passwords to be a minimum of eight characters with at least one uppercase, one lowercase, one digit, and one special character.


### PR DESCRIPTION
### Description
Document a new permission that allows normal users to modify system indexes.

### Issues Resolved
Documents the new permission and the setting that enables or disables its functionality.

Fixes #4736 


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
