### PR TITLE
Add breaking changes documentation for ES 6.8 to OS 1.x migration issues

### DIFF
--- a/breaking-changes.md
+++ b/breaking-changes.md
@@ -6,6 +6,15 @@ parent: OpenSearch documentation
 permalink: /breaking-changes/
 ---
 
+## 1.x
+
+### Migrating to OpenSearch and limits on the number of nested JSON objects
+
+Migrating from Elasticsearch version 6.8 to OpenSearch version 1.x will fail when a cluster contains any document that includes more than 10,000 nested JSON objects across all fields. Elasticsearch version 7.0 introduced the "index.mapping.nested_objects.limit" setting to guard against out-of-memory errors and assigned a default of `10000`. OpenSearch adopted this setting at its inception and recognizes the limitation on nested JSON objects. However, because the setting is not present in Elasticsearch 6.8 and not recognized by this version, migration to OpenSearch 1.x can result in incompatibility issues that block shard relocation between Elasticsearch 6.8 and OpenSearch versions 1.x when the number of nested objects in any document is surpassed. 
+
+Therefore, we recommend evaluating your data for these limitations before attempting to migrate from Elasticsearch 6.8.
+
+
 ## 2.0.0
 
 ### Remove mapping types parameter


### PR DESCRIPTION
### Description
The `index.mapping.nested_objects.limit` index level setting adopted in OpenSearch causes migration issues having to do with limitations to the number of nested JSON objects in a document and causes a migration to fail when these objects surpass the limitation. 

### Issues Resolved
Added documentation in "Breaking changes" and "Migrating from Elasticsearch OSS to OpenSearch" documentation to point this out.

Fixes #4831 


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
