### PR TITLE
Removes the Data Prepper csv sink codec

### DIFF
--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -109,18 +109,6 @@ Option | Required | Type | Description
 `schema` | Yes | String | The Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration). Not required if `auto_schema` is set to true.
 `auto_schema` | No | Boolean | When set to `true`, automatically generates the Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration) from the first event.
 
-
-### csv codec
-
-The `csv` codec writes events in comma-separated value (CSV) format.
-It also supports tab-separated value (TSV) and other delimited formats.
-
-
-Option | Required | Type | Description
-:--- | :--- | :--- | :---
-`delimiter` | No | String | The delimiter. By default, this is `,` to support CSV.
-`header` | No | String List | The header columns.
-
  
 ### ndjson codec
 


### PR DESCRIPTION
### Description

Data Prepper 2.4.0 will not include the `csv` sink codec. This PR removes that documentation.

### Issues Resolved

N/A


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
