### PR TITLE
Removes the Data Prepper csv sink codec. This is not ready for use an…

### DIFF
--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -65,6 +65,75 @@ Option | Required | Type | Description
 `buffer_type` is an optional configuration that records stored events temporarily before flushing them into an S3 bucket. Use of one of the following options: 
 
 - `local_file`: Flushes the record into a file on your machine. 
+<<<<<<< HEAD
 - `in_memory`: Stores the record in memory.
+=======
+- `multipart`: Writes using the [S3 multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html). Every 10 MB is written as a part.
+
+## Object key configuration
+
+Option | Required | Type | Description
+:--- | :--- | :--- | :---
+`path_prefix` | Yes | String | The S3 key prefix path to use. Accepts date-time formatting. For example, you can use `%{yyyy}/%{MM}/%{dd}/%{HH}/` to create hourly folders in S3. By default, events write to the root of the bucket. 
+
+
+## codec
+
+The `codec` determines how the `s3` source formats data written to each S3 object.
+
+### avro codec
+
+The `avro` codec writes an event as an [Apache Avro](https://avro.apache.org/) document.
+
+Because Avro requires a schema, you may either define the schema yourself, or Data Prepper will automatically generate a schema.
+In general, you should define your own schema because it will most accurately reflect your needs.
+In cases where your data is uniform, you may be able to automatically generate a schema.
+Automatically generated schemas are based on the first event received by the codec.
+The schema will only contain keys from this event. Therefore, you must have all keys present in all events in order for the automatically generated schema to produce a working schema.
+Automatically generated schemas make all fields nullable.
+
+
+Option | Required | Type | Description
+:--- | :--- | :--- | :---
+`schema` | Yes | String | The Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration). Not required if `auto_schema` is set to true.
+`auto_schema` | No | Boolean | When set to `true`, automatically generates the Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration) from the first event.
+
+ 
+### ndjson codec
+
+The `ndjson` codec writes each line as a JSON object.
+
+The `ndjson` codec does not take any configurations.
+
+
+### json codec
+
+The `json` codec writes events in a single large JSON file.
+Each event is written into an object within a JSON array.
+
+
+Option | Required | Type | Description
+:--- | :--- | :--- | :---
+`key_name` | No | String | The name of the key for the JSON array. By default this is `events`.
+
+
+### parquet codec
+
+The `parquet` codec writes events into a Parquet file.
+You must set the `buffer_type` to `multipart` when using Parquet.
+
+The Parquet codec writes data using the Avro schema.
+In general, you should define your own schema because it will most accurately reflect your needs.
+In cases where your data is uniform, you may be able to automatically generate a schema.
+Automatically generated schemas are based on the first event received by the codec.
+The schema will only have keys from this event, so you must have all keys present in all events for the auto-schema generation to produce a working schema.
+Auto-generated schemas make all fields nullable.
+
+
+Option | Required | Type | Description
+:--- | :--- | :--- | :---
+`schema` | Yes | String | The Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration). Not required if `auto_schema` is set to true.
+`auto_schema` | No | Boolean | When set to `true`, automatically generates the Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration) from the first event.
+>>>>>>> ed21ec74 (Removes the Data Prepper csv sink codec. This is not ready for use and should not be documented. (#4859))
 
  


### PR DESCRIPTION
…d should not be documented. (#4859)

Signed-off-by: David Venable <dlv@amazon.com>
(cherry picked from commit ed21ec74cf3534ebf6fe3e21662c38ccc901a6e5)

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
