### PR TITLE
Moves the generic sink options into the Sinks documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/sinks/sinks.md
+++ b/_data-prepper/pipelines/configuration/sinks/sinks.md
@@ -14,6 +14,9 @@ Sinks define where Data Prepper writes your data to.
 
 The following table describes options you can use to configure the `sinks` sink.
 
-Option | Required | Type | Description
-:--- | :--- | :--- | :---
-routes | No | List | List of routes that the sink accepts. If not specified, the sink accepts all upstream events.
+Option | Required | Type        | Description
+:--- | :--- |:------------| :---
+routes | No | String list | A list of routes for which this sink applies. If not provided, this sink receives all events. See [conditional routing]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/pipelines#conditional-routing) for more information.
+tags_target_key | No | String   | When specified, includes event tags in the output of the provided key.
+include_keys | No | String list | When specified, provides the keys in this list in the data sent to the sink.
+exclude_keys | No | String list | When specified, excludes the keys given from the data sent to the sink.

--- a/_data-prepper/pipelines/pipelines-configuration-options.md
+++ b/_data-prepper/pipelines/pipelines-configuration-options.md
@@ -16,15 +16,3 @@ Option | Required | Type | Description
 workers | No | Integer | Essentially the number of application threads. As a starting point for your use case, try setting this value to the number of CPU cores on the machine. Default is 1.
 delay | No | Integer | Amount of time in milliseconds workers wait between buffer read attempts. Default is `3000`.
 
-
-## General sink options
-
-The following options are available for all sinks.
-
-Option | Required | Type        | Description
-:--- | :--- |:------------| :---
-routes | No | String list | A list of routes for which this sink applies. If not provided, this sink receives all events. See [conditional routing]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/pipelines#conditional-routing) for more information.
-tags_target_key | No | String   | When specified, includes event tags in the output of the provided key.
-include_keys | No | String list | When specified, provides the keys in this list in the data sent to the sink.
-exclude_keys | No | String list | When specified, excludes the keys given from the data sent to the sink.
-


### PR DESCRIPTION
### Description

Both the Sink documentation and Pipeline Configuration documentation has sink configurations. This PR moves the sink options out of Pipeline Configuration and into Sink documentation exclusively.

### Issues Resolved

N/A


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
