### PR TITLE
[DOC] Fixed converted date with time_zone

### DIFF
--- a/_query-dsl/term/range.md
+++ b/_query-dsl/term/range.md
@@ -182,7 +182,7 @@ GET /products/_search
 ```
 {% include copy-curl.html %}
 
-The preceding query specifies the `-04:00` offset, so the `gte` parameter is converted to `2022-04-17T10:00:00 UTC`.   
+The preceding query specifies the `-04:00` offset, so the `gte` parameter is converted to `2022-04-17T02:00:00 UTC`.   
 
 The `time_zone` parameter does not affect the `now` value.
 {: .note}


### PR DESCRIPTION
### Description

I fixed the `time_zone` example.
`2022-04-17T06:00:00 UTC` with `time_zone: -04:00` is `2022-04-17T02:00:00 UTC`, right?

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
