### PR TITLE
Typo in convert_entry_type.md

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/convert_entry_type.md
+++ b/_data-prepper/pipelines/configuration/processors/convert_entry_type.md
@@ -29,7 +29,7 @@ type-conv-pipeline:
     ...
   ....  
   processor:
-    - convert_entry_type_type:
+    - convert_entry_type:
         key: "response_status"
         type: "integer"
 ```


### PR DESCRIPTION
Replaced "convert_entry_type_type" with "convert_entry_type".

### Description
Fix typo.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
