### PR TITLE
Remove steps for migrating cluster, targeted for later release

### DIFF
--- a/_tools/index.md
+++ b/_tools/index.md
@@ -117,10 +117,4 @@ The OpenSearch Kubernetes Operator is an open-source Kubernetes operator that he
 
 OpenSearch migration tools facilitate migrations to OpenSearch and upgrades to newer versions of OpenSearch. These can help you can set up a proof-of-concept environment locally using Docker containers or deploy to AWS using a one-click deployment script. This empowers you to fine-tune cluster configurations and manage workloads more effectively before migration. 
 
- After setup and deployment of the migration’s tools and test environment, you can perform the following steps to begin migrating your OpenSearch target cluster:
- 
-1. Redirect your production traffic from a source cluster to a provisioned OpenSearch target cluster, enabling a comparison of results between the two clusters. All traffic directed to the source cluster is stored for future replay. 
-
-2. Meanwhile, traffic to the target cluster is replayed at an identical rate to ensure a direct comparison between the source cluster and the target. 
-
 For more information about OpenSearch migration tools, see the documentation in the [OpenSearch Migration GitHub repository](https://github.com/opensearch-project/opensearch-migrations/tree/capture-and-replay-v0.1.0).


### PR DESCRIPTION
### Description
Omitting migrations documentation intended for a later release. 

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/4855


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
