### PR TITLE
Add breaking changes documentation for ES 6.8 to OS 1.x migration issues- 1.1

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,2 @@
+# This should match the owning team set up in https://github.com/orgs/opensearch-project/teams
+*   @opensearch-project/docs

--- a/404.md
+++ b/404.md
@@ -1,3 +1,15 @@
 ---
 permalink: /404.html
 ---
+
+## Oops, this isn't the page you're looking for. 
+
+Maybe our [home page](https://opensearch.org/docs/latest) or one of the commonly visited pages below will help. If you need further support, please use the feedback feature on the right side of the screen to get in touch.
+
+- [Quickstart]({{site.url}}{{site.baseurl}}/quickstart/)
+- [Installing OpenSearch]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/index/)
+- [OpenSearch Dashboards]({{site.url}}{{site.baseurl}}/dashboards/index/)
+- [Query DSL]({{site.url}}{{site.baseurl}}/query-dsl/)
+- [API Reference]({{site.url}}{{site.baseurl}}/api-reference/index/)
+
+

--- a/_config.yml
+++ b/_config.yml
@@ -101,8 +101,15 @@ just_the_docs:
 
 
 # Enable or disable the site search
-# Supports true (default) or false
-search_enabled: true
+# By default, just-the-docs enables its JSON file-based search. We also have an OpenSearch-driven search functionality.
+# To disable any search from appearing, both `search_enabled` and `use_custom_search` need to be false.
+# To use the OpenSearch-driven search, `search_enabled` has to be false and `use_custom_search` needs to be true.
+# If `search_enabled` is true, irrespective of the value of `use_custom_search`, the JSON file-based search appears.
+#
+# `search_enabled` defaults to true
+# `use_custom_search` defaults to false
+search_enabled: false
+use_custom_search: true
 
 search:
   # Split pages into sections that can be searched individually

--- a/_includes/warning.html
+++ b/_includes/warning.html
@@ -1,0 +1,1 @@
+<p class="warning">This version of the OpenSearch documentation is no longer maintained. For the latest version, see the <a href="{{ site.url }}/docs{{ page.url }}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -142,6 +142,7 @@ layout: table_wrappers
           {% endif %}
         {% endunless %}
         <div id="main-content" class="main-content" role="main">
+          {% include warning.html %}
           {% if site.heading_anchors != false %}
             {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
           {% else %}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -105,13 +105,20 @@ layout: table_wrappers
     <div class="copy-banner">
       <div class="container">
         <h1><a href="#">Documentation</a></h1>
-        {% if site.search_enabled != false %}
+        {% if site.search_enabled != false or site.use_custom_search == true %}
         <div class="search">
           <div class="search-input-wrap">
-            <input type="text" id="search-input" class="search-input" tabindex="0" placeholder="Search..." aria-label="Search {{ site.title }}" autocomplete="off">
+            <input type="text" id="search-input" class="search-input"
+                   tabindex="0" placeholder="Search..." aria-label="Search {{ site.title }}"
+                   data-docs-version="{{ site.data.versions.current }}" autocomplete="off">
+            <div class="search-spinner"><i></i></div>
             <label for="search-input" class="search-label"><svg viewBox="0 0 24 24" class="search-icon"><use xlink:href="#svg-search"></use></svg></label>
           </div>
+          {% if site.search_enabled != false %}
           <div id="search-results" class="search-results"></div>
+          {% elsif site.use_custom_search == true %}
+          <div id="search-results" class="search-results custom-search-results"></div>
+          {% endif %}
         </div>
         {% endif %}
       </div>
@@ -213,5 +220,8 @@ layout: table_wrappers
     </script>
   {% endif %}
   <script src="{{ '/assets/js/header-nav.js' | relative_url }}"></script>
+  {% if site.search_enabled == false and site.use_custom_search == true %}
+  <script src="{{ '/assets/js/search.js' | relative_url }}"></script>
+  {% endif %}
 </body>
 </html>

--- a/_plugins/search-indexer.rb
+++ b/_plugins/search-indexer.rb
@@ -1,0 +1,118 @@
+# frozen_string_literal: true
+
+require "jekyll/hooks"
+require "jekyll/document"
+require "json"
+
+##
+# This singleton facilitates production of an indexable JSON representation of the content to populate a data source
+# to provide search functionality.
+
+module Jekyll::ContentIndexer
+
+  ##
+  # The collection that will get stores as the output
+
+  @data = []
+
+  ##
+  # Pattern to identify documents that should be excluded based on their URL
+
+  @excluded_paths = /\.(css|js|json|map|xml|txt|yml)$/i.freeze
+
+  ##
+  # Pattern to identify block HTML tags (not comprehensive)
+
+  @html_block_tags = /\s*<[?\/]?(article|blockquote|d[dlt]|div|fieldset|form|h|li|main|nav|[ou]l|p|section|table|t[rd]).*?>\s*/im.freeze
+
+  ##
+  # Pattern to identify certain HTML tags whose content should be excluded from indexing
+
+  @html_excluded_tags = /\s*<(head|style|script|h1).*?>.*?<\/\1>/im.freeze
+
+  ##
+  # Initializes the singleton by recording the site
+
+  def self.init(site)
+    @site = site
+  end
+
+  ##
+  # Processes a Document or Page and adds it to the collection
+
+  def self.add(page)
+    return if @excluded_paths.match(page.url)
+
+    content = page.content
+                  .gsub(@html_excluded_tags, ' ')             # Strip certain HTML blocks
+                  .gsub(@html_block_tags, "\n")               # Strip some block HTML tags, replacing with newline
+                  .gsub(/\s*<[?\/!]?[a-z]+.*?>\s*/im, ' ')    # Strip all remaining HTML tags
+                  .gsub(/\s*[\r\n]+\s*/, "\n")                # Clean line-breaks
+                  .gsub(/\s{2,}/, ' ')                        # Trim long spaces
+                  .gsub(/\s+([.:;,)!\]?])/, '\1')             # Remove spaces before some punctuations
+                  .strip                                      # Trim leading and tailing whitespaces
+
+    return if content.empty?
+
+    url = @site.config["baseurl"] + page.url
+
+    # Produce a breadcrumb
+    ancestors = []
+    if page.instance_of?(Jekyll::Document)
+      ancestors.push(@site.config.dig("just_the_docs", "collections", page.collection&.label, "name"))
+    end
+
+    ancestors.push(page.data["grand_parent"]) unless
+      page.data["grand_parent"].nil? ||
+      page.data["grand_parent"]&.empty? ||
+      ancestors.include?(page.data["grand_parent"])     # Make sure collection name is not added
+
+    ancestors.push(page.data["parent"]) unless
+      page.data["parent"].nil? ||
+      page.data["parent"]&.empty? ||
+      ancestors.include?(page.data["parent"])         # Make sure collection name is not added
+
+    data = {
+      url: url,
+      title: page.data["title"],
+      content: content,
+      ancestors: ancestors,
+      type: "DOCS"
+    }
+
+    @data.push(data)
+  end
+
+  ##
+  # Saves the collection as a JSON file
+
+  def self.save
+    File.open(File.join(@site.config["destination"], "search-index.json"), 'w') do |f|
+      f.puts JSON.pretty_generate(@data)
+    end
+  end
+end
+
+# Before any Document or Page is processed, initialize the ContentIndexer
+
+Jekyll::Hooks.register :site, :pre_render do |site|
+  Jekyll::ContentIndexer.init(site)
+end
+
+# Process a Page as soon as its content is ready
+
+Jekyll::Hooks.register :pages, :post_convert do |page|
+  Jekyll::ContentIndexer.add(page)
+end
+
+# Process a Document as soon as its content is ready
+
+Jekyll::Hooks.register :documents, :post_convert do |document|
+  Jekyll::ContentIndexer.add(document)
+end
+
+# Save the produced collection after Jekyll is done writing all its stuff
+
+Jekyll::Hooks.register :site, :post_write do |_|
+  Jekyll::ContentIndexer.save()
+end

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1130,3 +1130,104 @@ version-selector {
   --hover-bg: linear-gradient(#{lighten($blue-300, 2%)}, #{darken($blue-300, 4%)});
   --link-color: #{$blue-300};
 }
+.custom-search-results {
+  & > div {
+    padding: 1rem;
+  }
+
+  cite {
+    @include font-size(12);
+    @include sans-serif;
+    color: $grey-dk-300;
+    text-decoration: none;
+    font-style: normal;
+    display: block;
+    line-height: 1;
+    font-weight: normal;
+  }
+
+  a {
+    @include font-size(20);
+    @include heading-sans-serif;
+    line-height: 1.6;
+    font-weight: bold;
+    outline: none;
+  }
+
+  span {
+    @include font-size(14);
+    color: $grey-dk-200;
+    line-height: 1.4;
+    display: block;
+    overflow-wrap: break-word;
+
+    &:only-child {
+      text-align: center;
+      padding: 1rem;
+    }
+  }
+
+  .highlighted {
+    background: #EAF4F9;
+  }
+}
+
+.banner-alert ~ main .custom-search-results {
+  max-height: calc(100vh - 200% - 60px - 3.6rem) !important;
+}
+
+.search-spinner {
+  display: none;
+  font-weight: 700;
+  outline: 0;
+  user-select: none;
+
+  position: absolute;
+  padding-left: 0.6rem;
+  height: 100%;
+
+  &.spinning {
+    display: flex;
+
+    & ~ .search-label {
+      display: none;
+    }
+  }
+}
+
+.search-spinner > i {
+  border-color: rgba($grey-dk-000, 0.2);
+  position: relative;
+  animation: spin 0.6s infinite linear;
+  border-width: 3px;
+  border-style: solid;
+  border-radius: 100%;
+  display: inline-block;
+  width: 18px;
+  height: 18px;
+  vertical-align: middle;
+  align-self: center;
+
+  &:before {
+    content: "";
+    border: 3px solid rgba($grey-dk-000, 0);
+    border-top-color: rgba($grey-dk-000, 0.8);
+    border-radius: 100%;
+    display: block;
+    left: -3px;
+    position: absolute;
+    top: -3px;
+    height: 100%;
+    width: 100%;
+    box-sizing: content-box;
+  }
+}
+
+@keyframes spin {
+  from {
+    transform: rotate(0deg)
+  }
+  to {
+    transform: rotate(359deg)
+  }
+}

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -313,7 +313,7 @@ A space corresponds to the function used to measure the distance between two poi
   </tr>
   <tr>
     <td>innerproduct</td>
-    <td>\[ Distance(X, Y) = \sum_{i=1}^n (X_i - Y_i) \]</td>
+    <td>\[ Distance(X, Y) = \sum_{i=1}^n X_iY_i \]</td>
     <td>1 / (1 + Distance Function)</td>
   </tr>
   <tr>

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,0 +1,251 @@
+(() => {
+    const elInput = document.getElementById('search-input');
+    const elResults = document.getElementById('search-results');
+    const elOverlay = document.querySelector('.search-overlay');
+    const elSpinner = document.querySelector('.search-spinner');
+    if (!elInput || !elResults || !elOverlay) return;
+
+    const CLASSNAME_SPINNING = 'spinning';
+    const CLASSNAME_HIGHLIGHTED = 'highlighted';
+
+    const canSmoothScroll = 'scrollBehavior' in document.documentElement.style;
+
+    const docsVersion = elInput.getAttribute('data-docs-version');
+
+    let _showingResults = false,
+        animationFrame,
+        debounceTimer,
+        lastQuery;
+
+    const abortControllers = [];
+
+    elInput.addEventListener('input', e => {
+        debounceInput();
+    });
+
+    elInput.addEventListener('keydown', e => {
+        switch (e.key) {
+            case 'Esc':
+            case 'Escape':
+                hideResults(true);
+                elInput.value = '';
+                break;
+
+            case 'ArrowUp':
+                e.preventDefault();
+                highlightNextResult(false);
+                break;
+
+            case 'ArrowDown':
+                e.preventDefault();
+                highlightNextResult();
+                break;
+
+            case 'Enter':
+                e.preventDefault();
+                navToHighlightedResult();
+                break;
+
+            case 'Tab':
+                e.preventDefault();
+                highlightNextResult(!e.shiftKey);
+                break;
+
+        }
+    });
+
+    elInput.addEventListener('focus', e => {
+        if (!_showingResults && elResults.textContent) showResults();
+    });
+
+    elResults.addEventListener('pointerenter', e => {
+        cancelAnimationFrame(animationFrame);
+        animationFrame = requestAnimationFrame(() => {
+            highlightResult(e.target?.closest('.custom-search-result'));
+        });
+    }, true);
+
+    elResults.addEventListener('focus', e => {
+        highlightResult(e.target?.closest('.custom-search-result'));
+    }, true);
+
+    const debounceInput = () => {
+        clearTimeout(debounceTimer);
+        debounceTimer = setTimeout(doSearch, 300);
+    };
+
+    function abortPreviousCalls() {
+        while (abortControllers.length) abortControllers.pop()?.abort?.();
+    }
+
+    const doSearch = async () => {
+        const query = elInput.value.replace(/[^a-z0-9-_. ]+/ig, ' ');
+        if (query.length < 3) return hideResults(true);
+        if (query === lastQuery) return;
+
+        recordEvent('search', {
+            search_term: query,
+            docs_version: docsVersion
+        });
+
+        lastQuery = query;
+
+        abortPreviousCalls();
+
+        elSpinner?.classList.add(CLASSNAME_SPINNING);
+        if (!_showingResults) document.documentElement.classList.add('search-active');
+
+        try {
+            const controller = new AbortController();
+            abortControllers.unshift(abortControllers);
+            const startTime = Date.now();
+            const response = await fetch(`https://search-api.opensearch.org/search?q=${query}&v=${docsVersion}`, {signal: controller.signal});
+            const data = await response.json();
+
+            recordEvent('view_search_results', {
+                search_term: query,
+                docs_version: docsVersion,
+                duration: Date.now() - startTime,
+                results_num: data?.results?.length || 0
+            });
+
+            if (!Array.isArray(data?.results) || data.results.length === 0) {
+                return showNoResults();
+            }
+            const chunks = data.results.map(result => result
+                ? `
+                <div class="custom-search-result">
+                    <a href="${sanitizeAttribute(result.url)}">
+                        <cite>
+                            ${result.type === 'DOCS' ? `OpenSearch ${sanitizeText(result.version)} › ` : ''}
+                            ${sanitizeText(result.ancestors?.join?.(' › '))}
+                        </cite>
+                        ${sanitizeText(result.title)}
+                    </a>
+                    <span>${sanitizeText(result.content?.replace?.(/\n/g, '&hellip; '))}</span>
+                </div>
+                `
+                : ''
+            );
+
+            emptyResults();
+            elResults.appendChild(document.createRange().createContextualFragment(chunks.join('')));
+            showResults();
+        } catch (ex) {
+            showNoResults();
+        }
+
+        elSpinner?.classList.remove(CLASSNAME_SPINNING);
+    }
+
+    const hideResults = destroy => {
+        _showingResults = false;
+
+        elSpinner?.classList.remove(CLASSNAME_SPINNING);
+        document.documentElement.classList.remove('search-active');
+        elResults.setAttribute('aria-expanded', 'false');
+        document.body.removeEventListener('pointerdown', handlePointerDown, false);
+
+        if (destroy) {
+            abortPreviousCalls();
+            emptyResults();
+            lastQuery = '';
+        }
+    };
+
+    const showResults = () => {
+        if (!_showingResults) {
+            _showingResults = true;
+            document.documentElement.classList.add('search-active');
+            elResults.setAttribute('aria-expanded', 'true');
+            document.body.addEventListener('pointerdown', handlePointerDown, false);
+        }
+
+        elResults.scrollTo(0, 0);
+    };
+
+    const showNoResults = () => {
+        emptyResults();
+        elResults.appendChild(document.createRange().createContextualFragment('<span>No results found!</span>'));
+        showResults();
+        elSpinner?.classList.remove(CLASSNAME_SPINNING);
+    };
+
+    const emptyResults = () => {
+        //ToDo: Replace with `elResults.replaceChildren();` when https://caniuse.com/?search=replaceChildren shows above 90% can use it
+        while (elResults.firstChild) elResults.firstChild.remove();
+    };
+
+    const sanitizeText = text => {
+        return text?.replace?.(/</g, '&lt;');
+    };
+
+    const sanitizeAttribute = text => {
+        return text?.replace?.(/[>"]+/g, '');
+    };
+
+    const handlePointerDown = e => {
+        if (e.target.matches('.search-input-wrap, .search-input-wrap *, .search-results, .search-results *')) return;
+
+        e.preventDefault();
+
+        elInput.blur();
+        hideResults();
+    };
+
+    const highlightResult = node => {
+        if (!node || !_showingResults || node.classList.contains(CLASSNAME_HIGHLIGHTED)) return;
+
+        elResults.querySelectorAll('.custom-search-result.highlighted').forEach(el => {
+            el.classList.remove(CLASSNAME_HIGHLIGHTED);
+        });
+        node.classList.add(CLASSNAME_HIGHLIGHTED);
+        elInput.focus();
+    };
+
+    const highlightNextResult = (down = true) => {
+        const highlighted = elResults.querySelector('.custom-search-result.highlighted');
+        let nextResult;
+        if (highlighted) {
+            highlighted.classList.remove(CLASSNAME_HIGHLIGHTED);
+            nextResult = highlighted[down ? 'nextElementSibling' : 'previousElementSibling']
+        } else {
+            nextResult = elResults.querySelector(`.custom-search-result:${down ? 'first' : 'last'}-child`);
+        }
+
+        if (nextResult) {
+            nextResult.classList.add(CLASSNAME_HIGHLIGHTED);
+            if (down) {
+                if (canSmoothScroll) {
+                    nextResult.scrollIntoView({behavior: "smooth", block: "end"});
+                } else {
+                    nextResult.scrollIntoView(false)
+                }
+            } else if (
+                nextResult.offsetTop < elResults.scrollTop ||
+                nextResult.offsetTop + nextResult.clientHeight > elResults.scrollTop + elResults.clientHeight
+            ) {
+                if (canSmoothScroll) {
+                    elResults.scrollTo({behavior: "smooth", top: nextResult.offsetTop, left: 0});
+                } else {
+                    elResults.scrollTo(0, nextResult.offsetTop);
+                }
+            }
+        } else {
+            elResults.scrollTo(0, 0);
+        }
+    };
+
+    const navToHighlightedResult = () => {
+        elResults.querySelector('.custom-search-result.highlighted a[href]')?.click?.();
+    };
+
+    const recordEvent = (name, data) => {
+        try {
+            gtag?.('event', name, data);
+        } catch (e) {
+            // Do nothing
+        }
+
+    }
+})();

--- a/breaking-changes.md
+++ b/breaking-changes.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Breaking changes
+nav_order: 3
+permalink: /breaking-changes/
+---
+
+## 1.x
+
+The following breaking changes are relevant to OpenSearch versions 1.x.
+
+### Migrating to OpenSearch and limits on the number of nested JSON objects
+
+Migrating from Elasticsearch OSS version 6.8 to OpenSearch version 1.x will fail when a cluster contains any document that includes more than 10,000 nested JSON objects across all fields. Elasticsearch version 7.0 introduced the `index.mapping.nested_objects.limit` setting to guard against out-of-memory errors and assigned the setting a default of `10000`. OpenSearch adopted this setting at its inception and enforces the limitation on nested JSON objects. However, because the setting is not present in Elasticsearch 6.8 and not recognized by this version, migration to OpenSearch 1.x can result in incompatibility issues that block shard relocation between Elasticsearch 6.8 and OpenSearch versions 1.x when the number of nested JSON objects in any document surpasses the default limit.
+
+Therefore, we recommend evaluating your data for these limits before attempting to migrate from Elasticsearch 6.8.
+


### PR DESCRIPTION
### Description
The `index.mapping.nested_objects.limit` index level setting adopted in OpenSearch causes migration issues having to do with limitations to the number of nested JSON objects in a document and causes a migration to fail when these objects surpass the limitation.

### Issues Resolved
Fixes [#4831](https://github.com/opensearch-project/documentation-website/issues/4831) for the 1.1 branch.


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
