### PR TITLE
Add breaking changes documentation for ES 6.8 to OS 1.x migration issues- 1.1

### DIFF
--- a/_upgrade-to/upgrade-to.md
+++ b/_upgrade-to/upgrade-to.md
@@ -8,7 +8,12 @@ nav_order: 15
 
 If you want to upgrade from an existing Elasticsearch OSS cluster to OpenSearch and find the [snapshot approach]({{site.url}}{{site.baseurl}}/upgrade-to/snapshot-migrate/) unappealing, you can upgrade your existing nodes from Elasticsearch OSS to OpenSearch.
 
-If your existing cluster runs an older version of Elasticsearch OSS, the first step is to upgrade to version 6.x or 7.x. Elasticsearch OSS supports two types of upgrades: rolling and cluster restart.
+If your existing cluster runs an older version of Elasticsearch OSS, the first step is to upgrade to version 6.x or 7.x.
+
+Before deciding on the version of Elasticsearch OSS for your upgrade, refer to the [Migrating to OpenSearch and limits on the number of nested JSON objects]({{site.url}}{{site.baseurl}}/breaking-changes/#migrating-to-opensearch-and-limits-on-the-number-of-nested-json-objects) documentation in Breaking changes to see whether the issue will have an impact on your cluster and, therefore, your decisions about upgrades and migration.
+{: .important }
+
+Elasticsearch OSS supports two types of upgrades: rolling and cluster restart.
 
 - Rolling upgrades let you shut down one node at a time for minimal disruption of service.
 

--- a/breaking-changes.md
+++ b/breaking-changes.md
@@ -1,0 +1,17 @@
+---
+layout: default
+title: Breaking changes
+nav_order: 3
+permalink: /breaking-changes/
+---
+
+## 1.x
+
+The following breaking changes are relevant to OpenSearch versions 1.x.
+
+### Migrating to OpenSearch and limits on the number of nested JSON objects
+
+Migrating from Elasticsearch OSS version 6.8 to OpenSearch version 1.x will fail when a cluster contains any document that includes more than 10,000 nested JSON objects across all fields. Elasticsearch version 7.0 introduced the `index.mapping.nested_objects.limit` setting to guard against out-of-memory errors and assigned the setting a default of `10000`. OpenSearch adopted this setting at its inception and enforces the limitation on nested JSON objects. However, because the setting is not present in Elasticsearch 6.8 and not recognized by this version, migration to OpenSearch 1.x can result in incompatibility issues that block shard relocation between Elasticsearch 6.8 and OpenSearch versions 1.x when the number of nested JSON objects in any document surpasses the default limit.
+
+Therefore, we recommend evaluating your data for these limits before attempting to migrate from Elasticsearch 6.8.
+


### PR DESCRIPTION
Adds breaking changes to 1.1.

### Description
The `index.mapping.nested_objects.limit` index level setting adopted in OpenSearch causes migration issues having to do with limitations to the number of nested JSON objects in a document and causes a migration to fail when these objects surpass the limitation.

### Issues Resolved
Fixes [#4831](https://github.com/opensearch-project/documentation-website/issues/4831) for the 1.1 branch.


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
