### PR TITLE
Add multimodal and benchmarked to Vale

### DIFF
--- a/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
@@ -5,6 +5,7 @@
 [Bb]ackporting
 [Bb]ackpressure
 [Bb]asemap
+[Bb]enchmarked
 [Bb]igram
 Boolean
 [Cc]allout
@@ -64,6 +65,7 @@ Levenshtein
 [Mm]isorder
 [Mm]ultifield
 [Mm]ultiline
+[Mm]ultimodal
 [Mm]ultipoint
 [Mm]ultipolygon
 [Mm]ultithreaded


### PR DESCRIPTION
Add 2 words to Vale:
- multimodal
- benchmarked


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
