### PR TITLE
fix semantic search docs search request

### DIFF
--- a/_ml-commons-plugin/semantic-search.md
+++ b/_ml-commons-plugin/semantic-search.md
@@ -598,7 +598,7 @@ PUT /my-nlp-index/_doc/5
 When the documents are ingested into the index, the `text_embedding` processor creates an additional field that contains vector embeddings and adds that field to the document. To see an example document that is indexed, search for document 1:
 
 ```json
-GET /my-nlp-index/_search/1
+GET /my-nlp-index/_doc/1
 ```
 {% include copy-curl.html %}
 


### PR DESCRIPTION
### Description
I was going through semantic search docs and this request didn't work, it's not a valid search request. Since id is `1`, it should have been `_doc/1` instead of `_search/1`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
