### PR TITLE
Update example in SigV4 documentation for OpenSearch Benchmark

### DIFF
--- a/_benchmark/tutorials/sigv4.md
+++ b/_benchmark/tutorials/sigv4.md
@@ -21,7 +21,8 @@ OpenSearch Benchmark supports AWS Signature Version 4 authentication. To run Ben
    ```
    {% include copy.html %}
 
-   Note: For users testing against Amazon OpenSearch Serverless, set `OSB_SERVICE` to `aoss`.
+If you're testing against Amazon OpenSearch Serverless, set `OSB_SERVICE` to `aoss`.
+{: .note}
 
 3. Customize and run the following `execute-test` command with the ` --client-options=amazon_aws_log_in:environment` flag. This flag tells OpenSearch Benchmark the location of your exported credentials.
 

--- a/_benchmark/tutorials/sigv4.md
+++ b/_benchmark/tutorials/sigv4.md
@@ -17,9 +17,11 @@ OpenSearch Benchmark supports AWS Signature Version 4 authentication. To run Ben
    OSB_AWS_ACCESS_KEY_ID=<IAM USER AWS ACCESS KEY ID>
    OSB_AWS_SECRET_ACCESS_KEY=<IAM USER AWS SECRET ACCESS KEY>
    OSB_REGION=<YOUR REGION>
-   OSB_SERVICE=aos
+   OSB_SERVICE=es
    ```
    {% include copy.html %}
+
+   Note: For users testing against Amazon OpenSearch Serverless, set `OSB_SERVICE` to `aoss`.
 
 3. Customize and run the following `execute-test` command with the ` --client-options=amazon_aws_log_in:environment` flag. This flag tells OpenSearch Benchmark the location of your exported credentials.
 


### PR DESCRIPTION
### Description
OSB documentation currently suggests setting `OSB_SERVICE` to `aos` when users use SigV4. However, the only options that opensearch-py allows is either `es` or `aoss`. Thus, we should change the example to use `es` and also include additional information for users who are using `aoss`.

### Issues Resolved
N/A


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
