### PR TITLE
[OSCI] Fixing documentation for Wildcard in term-level queries section for Q…

### DIFF
--- a/_query-dsl/term/wildcard.md
+++ b/_query-dsl/term/wildcard.md
@@ -14,7 +14,7 @@ Operator | Description
 :--- | :---
 `*` | Matches zero or more characters.
 `?` | Matches any single character.
-`case_insensitive` | If `true`, the wildcard query is case insensitive. If `false`, the wildcard query is case sensitive. Optional. Default is `true` (case insensitive).
+`case_insensitive` | If `true`, the wildcard query is case insensitive. If `false`, the wildcard query is case sensitive. Default is `false` (case sensitive).
 
 For a case-sensitive search for terms that start with `H` and end with `Y`, use the following request:
 
@@ -48,7 +48,7 @@ GET _search
     "wildcard": {
       "<field>": {
         "value": "patt*rn",
-        ... 
+        ...
       }
     }
   }
@@ -61,7 +61,7 @@ The `<field>` accepts the following parameters. All parameters except `value` ar
 Parameter | Data type | Description
 :--- | :--- | :---
 `value` | String | The wildcard pattern used for matching terms in the field specified in `<field>`.
-`boost` | Floating-point | Boosts the query by the given multiplier. Useful for searches that contain more than one query. Values in the [0, 1) range decrease relevance, and values greater than 1 increase relevance. Default is `1`. 
+`boost` | Floating-point | Boosts the query by the given multiplier. Useful for searches that contain more than one query. Values in the [0, 1) range decrease relevance, and values greater than 1 increase relevance. Default is `1`.
 `case_insensitive` | Boolean | If `true`, allows case-insensitive matching of the value with the indexed field values. Default is `false` (case sensitivity is determined by the field's mapping).
 `rewrite` | String | Determines how OpenSearch rewrites and scores multi-term queries. Valid values are `constant_score`, `scoring_boolean`, `constant_score_boolean`, `top_terms_N`, `top_terms_boost_N`, and `top_terms_blended_freqs_N`. Default is `constant_score`.
 


### PR DESCRIPTION
…uery DSL

### Description
Documentation for `Wildcards` in `term-level queries` subsection under `Query DSL` section has been fixed.

### Issues Resolved
- Fixing documentation related to the default value for `case_insensitive` feature in `Wilcards` from `true` to `false`


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
