### PR TITLE
Remove extra tic mark from blueprint page

### DIFF
--- a/_ml-commons-plugin/extensibility/blueprints.md
+++ b/_ml-commons-plugin/extensibility/blueprints.md
@@ -129,7 +129,7 @@ POST /_plugins/_ml/connectors/_create
 ```
 {% include copy-curl.html %}
 
-The `request_body` template must be `${parameters.input}``. 
+The `request_body` template must be `${parameters.input}`. 
 {: .important}
 
 ### Preprocessing function 


### PR DESCRIPTION
Remove extra tic mark from blueprint page

### Checklist
- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
