### PR TITLE
[OSCI][DOC] Fixing documentation in  v1.3.x for Cluster Creation.md

### DIFF
--- a/_tuning-your-cluster/index.md
+++ b/_tuning-your-cluster/index.md
@@ -81,7 +81,7 @@ node.name: opensearch-cluster_manager
 You can also explicitly specify that this node is a cluster manager node, even though it is already set to true by default. Set the node role to `cluster_manager` to make it easier to identify the cluster manager node.
 
 ```yml
-node.roles: [ cluster_manager ]
+node.roles: [ master ]
 ```
 
 #### Data nodes


### PR DESCRIPTION
Changing configuration reference for cluster creation

### Description
Fixing documentation for configuration reference for `Creating a cluster` in version 1.3.x. Changing line 84 in `_tuning-your-cluster/index.md` from `node.roles: [ cluster_manager]` to `node.roles : [ master ]`

### Issues Resolved
Solving issue #4936

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
