### PR TITLE
Fix the minimum width of the main section of the page

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -501,6 +501,8 @@ p.label {
 }
 
 .main {
+  flex-grow: 1;
+
   @include mq(lg) {
     max-width: calc(100% - #{$nav-width + $top-button-margin});
   }
@@ -512,8 +514,7 @@ p.label {
 
 // Adds TOC to right hand side in xl layout
 .main-content-wrap {
-  max-width: 100%;
-  min-width: 0;
+  width: 100%;
 }
 
 .toc-wrap {


### PR DESCRIPTION
Fix the minimum width of the main section of the page so it's the same regardless of the length of text on the page.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
