### PR TITLE
Fix the width available to page content

### DIFF
--- a/_sass/_nested-nav.scss
+++ b/_sass/_nested-nav.scss
@@ -69,6 +69,13 @@
         }
       }
 
+      &:last-child {
+        > ul {
+          right: .5em;
+          left: auto;
+        }
+      }
+
       &:hover {
         > ul {
           display: block;

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -286,7 +286,8 @@ img {
   position: fixed;
   bottom: 30px;
   right: 16px;
-  z-index: 1;
+  z-index: 999;
+
   svg {
     transform: rotate(-90deg);
   }
@@ -515,6 +516,10 @@ p.label {
 // Adds TOC to right hand side in xl layout
 .main-content-wrap {
   width: 100%;
+
+  @include mq(xl) {
+    width: calc(100% - #{$toc-width});
+  }
 }
 
 .toc-wrap {


### PR DESCRIPTION
### Description
* Fixes the width bleeding out when ToC is visible
* Fixes the top nav bleeding out of the width



### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
