### PR TITLE
[OSCI][DOC] Fixing error in java client documentation for creating indexes

### DIFF
--- a/_clients/java.md
+++ b/_clients/java.md
@@ -295,9 +295,8 @@ CreateIndexRequest createIndexRequest = new CreateIndexRequest.Builder().index(i
 client.indices().create(createIndexRequest);
 
 IndexSettings indexSettings = new IndexSettings.Builder().autoExpandReplicas("0-all").build();
-IndexSettingsBody settingsBody = new IndexSettingsBody.Builder().settings(indexSettings).build();
-PutSettingsRequest putSettingsRequest = new PutSettingsRequest.Builder().index(index).value(settingsBody).build();
-client.indices().putSettings(putSettingsRequest);
+PutIndicesSettingsRequest putIndicesSettingsRequest = new PutIndicesSettingsRequest.Builder().index(index).value(indexSettings).build();
+client.indices().putSettings(PutIndicesSettingsRequest);
 ```
 {% include copy.html %}
 


### PR DESCRIPTION
### Description
Fixing error in java client documentation for creating indexes. Update in code base does not consider any more the classes `IndexSettingsBody` and `PutSettingsRequest`. Classes `IndexSettings` and `PutIndicesSettingsRequest` are the ones used instead.

### Issues Resolved
Fixing issue #4072 


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
