### PR TITLE
Adjust Logstash example query quotes

### DIFF
--- a/_tools/logstash/read-from-opensearch.md
+++ b/_tools/logstash/read-from-opensearch.md
@@ -27,7 +27,7 @@ input {
     user        => "admin"
     password    => "admin"
     index       => "logstash-logs-%{+YYYY.MM.dd}"
-    query       => "{ "query": { "match_all": {}} }"
+    query       => '{ "query": { "match_all": {}} }'
   }
 }
 


### PR DESCRIPTION
### Description
The example for reading from Opensearch using Logstash specifies double quotes around a query containing double quotes. This causes the Ruby parser to complain with an error of the form:
```
message=>"Expected one of [ \\t\\r\\n], \"#\", \"{\", \"}\" at line 7, column 24 (byte 256) after input {\n  opensearch {\n    hosts       => \"https://myhost.com:443\"\n    user        => \"myuser\"\n    password    => \"password\"\n    index       => \"myindex\"\n    query       => \"{ \""
```

Swapping to single quotes resolves the issue. If this PR is accepted, an identical change should also be made to [the plugin README](https://github.com/opensearch-project/logstash-input-opensearch/blob/main/README.md) (I'm happy to open another PR).

Thanks!

### Issues Resolved
N/A


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
