### PR TITLE
Wrong link reference in ML-Commons -> Model Access Control -> updating-a-model-group

### DIFF
--- a/_ml-commons-plugin/model-access-control.md
+++ b/_ml-commons-plugin/model-access-control.md
@@ -266,7 +266,7 @@ PUT /_plugins/_ml/model_groups/<model_group_id>
 
 ### Request fields
 
-Refer to [Request fields](#request-fields-1) for request field descriptions. 
+Refer to [Request fields](#request-fields) for request field descriptions. 
 
 #### Example request
 


### PR DESCRIPTION
### Description
When clicking link on [Request Fields](https://opensearch.org/docs/latest/ml-commons-plugin/model-access-control/#request-fields-1) under updating a model group, it was redirecting to the same header

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
