### PR TITLE
[OSCI][DOC] Fixing broken link in 'PPL' documentation under 'Search' section

### DIFF
--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -16,7 +16,7 @@ redirect_from:
 
 # PPL
 
-Piped Processing Language (PPL) is a query language that focuses on processing data in a sequential, step-by-step manner. PPL uses the pipe (`|`) operator to combine commands to find and retrieve data. It is the primary language used with observability in OpenSearch and supports multi-data queries. 
+Piped Processing Language (PPL) is a query language that focuses on processing data in a sequential, step-by-step manner. PPL uses the pipe (`|`) operator to combine commands to find and retrieve data. It is the primary language used with observability in OpenSearch and supports multi-data queries.
 
 ## PPL syntax
 
@@ -31,9 +31,9 @@ See [Syntax]({{site.url}}{{site.baseurl}}/search-plugins/sql/ppl/syntax/) for sp
 
 ## PPL commands
 
-PPL filters, transforms, and aggregates data using a series of commands. See [Commands](/search-plugins/sql/ppl/functions/) for a description and an example of each command.  
+PPL filters, transforms, and aggregates data using a series of commands. See [Commands]({{site.url}}{{site.baseurl}}/search-plugins/sql/ppl/functions/) for a description and an example of each command.
 
-## Using PPL within OpenSearch 
+## Using PPL within OpenSearch
 
 To use PPL, you must have installed OpenSearch Dashboards. PPL is available within the [Query Workbench tool](https://playground.opensearch.org/app/opensearch-query-workbench#/). See the [Query Workbench]({{site.url}}{{site.baseurl}}/dashboards/query-workbench/) documentation for a tutorial on using PPL within OpenSearch.
 
@@ -41,7 +41,7 @@ To use PPL, you must have installed OpenSearch Dashboards. PPL is available with
 
 Developers can find information in the following resources:
 
-- [Piped Processing Language](https://github.com/opensearch-project/piped-processing-language) specification 
-- [OpenSearch PPL Reference Manual](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.rst) 
+- [Piped Processing Language](https://github.com/opensearch-project/piped-processing-language) specification
+- [OpenSearch PPL Reference Manual](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.rst)
 - [Observability](https://github.com/opensearch-project/dashboards-observability/) using [PPL-based visualizations](https://github.com/opensearch-project/dashboards-observability#event-analytics)
 - PPL [Data Types](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/general/datatypes.rst)


### PR DESCRIPTION
### Description
Fixing dead link `Commands` in `PPL commads` section. Prefix `{{site.url}}{{site.baseurl}}` included in link

### Issues Resolved
Solving issue #5527


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
