### PR TITLE
Fix example code for temporary search pipelines

### DIFF
--- a/_search-plugins/search-pipelines/using-search-pipeline.md
+++ b/_search-plugins/search-pipelines/using-search-pipeline.md
@@ -38,7 +38,7 @@ POST /my-index/_search
       "text_field" : "some search text"
     }
   },
-  "pipeline" : {
+  "search_pipeline" : {
     "request_processors": [
       {
         "filter_query" : {


### PR DESCRIPTION


### Description
Fixes the example code for temporary search pipelines.

### Issues Resolved
The temporary pipeline has to be referenced with `search_pipeline` instead of `pipeline` in the JSON.

Otherwise, you get the error `{"error":{"root_cause":[{"type":"parsing_exception","reason":"Unknown key for a START_OBJECT in [pipeline].","line":8,"col":16}],"type":"parsing_exception","reason":"Unknown key for a START_OBJECT in [pipeline].","line":8,"col":16},"status":400}`.

Tested with Docker image `opensearchproject/opensearch:2.11.0`.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
