### PR TITLE
Fix model group creation in ml-commons->conversational-search

### DIFF
--- a/_ml-commons-plugin/conversational-search.md
+++ b/_ml-commons-plugin/conversational-search.md
@@ -280,7 +280,7 @@ Use the following steps to set up an HTTP connector using the OpenAI GPT 3.5 mod
 1. Create a new model group for the connected model. You'll use the `model_group_id` returned by the Register API to register the model:
 
     ```json
-    POST /_plugins/_ml/model_group/_register
+    POST /_plugins/_ml/model_groups/_register
     {
       "name": "public_model_group", 
       "description": "This is a public model group"


### PR DESCRIPTION
### Description
under [Conversational search](https://opensearch.org/docs/latest/ml-commons-plugin/conversational-search/#connecting-the-model), model group creation API call is wrong. This code fixes it.

Reference documentation for creating model groups: [Link](https://opensearch.org/docs/latest/ml-commons-plugin/model-access-control/#path-and-http-method)

### Issues Resolved
NA


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
