### PR TITLE
ansible.md : add missing logstash_password variable

### DIFF
--- a/_install-and-configure/install-opensearch/ansible.md
+++ b/_install-and-configure/install-opensearch/ansible.md
@@ -55,11 +55,11 @@ Make sure you have direct SSH access into the root user of the target node.
 1. Run the Ansible playbook with root privileges:
 
    ```bash
-   ansible-playbook -i inventories/opensearch/hosts opensearch.yml --extra-vars "admin_password=Test@123 kibanaserver_password=Test@6789"
+   ansible-playbook -i inventories/opensearch/hosts opensearch.yml --extra-vars "admin_password=Test@123 kibanaserver_password=Test@6789 logstash_password=Test@456"
    ```
    {% include copy.html %}
 
-   You can set the passwords for reserved users (`admin` and `kibanaserver`) using the `admin_password` and `kibanaserver_password` variables.
+   You can set the passwords for reserved users (`admin`, `kibanaserver`, and `logstash`) using the `admin_password`, `kibanaserver_password`, and `logstash_password` variables.
 
 2. After the deployment process is complete, you can access OpenSearch and OpenSearch Dashboards with the username `admin` and the password that you set for the `admin_password` variable.
 


### PR DESCRIPTION
### Description

While executing the procedure dedicated to using the Ansible playbook [here](https://opensearch.org/docs/latest/install-and-configure/install-opensearch/ansible/#run-opensearch-and-opensearch-dashboards-using-ansible-playbook), I noticed that there is a missing consideration for the `logstash` user and, therefore, its password as indicated in the [README](https://github.com/opensearch-project/ansible-playbook/blob/29bc5280fcd5e62ecf5594dc8de7aec26ff3d3de/README.md?plain=1#L100) of the ansible-playbook project and this [PR](https://github.com/opensearch-project/ansible-playbook/pull/135) from three months ago.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
