### PR TITLE
[DOC] Dump up java client version (2.6.0 -> 2.8.1)

### DIFF
--- a/_clients/java.md
+++ b/_clients/java.md
@@ -18,7 +18,7 @@ To start using the OpenSearch Java client, you need to provide a transport. The 
 <dependency>
   <groupId>org.opensearch.client</groupId>
   <artifactId>opensearch-java</artifactId>
-  <version>2.6.0</version>
+  <version>2.8.1</version>
 </dependency>
 
 <dependency>
@@ -33,7 +33,8 @@ If you're using Gradle, add the following dependencies to your project:
 
 ```
 dependencies {
-  implementation 'org.opensearch.client:opensearch-java:2.6.0'
+  implementation 'org.opensearch.client:opensearch-java:2.8.1'
+  implementation 'org.apache.httpcomponents.client5:httpclient5:5.2.1'
 }
 ```
 {% include copy.html %}


### PR DESCRIPTION
### Description

Bump up java client version to latest one (2.8.1)
[Java Client Releases](https://github.com/opensearch-project/opensearch-java/releases)

### Issues Resolved

None

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
