### PR TITLE
Fix typo in jwt authentication guide

### DIFF
--- a/_security/authentication-backends/jwt.md
+++ b/_security/authentication-backends/jwt.md
@@ -108,7 +108,7 @@ jwt_auth_domain:
       roles_key: null
       jwt_clock_skew_tolerance_seconds: 20
   authentication_backend:
-I    type: noop
+    type: noop
 ```
 
 The following table lists the configuration parameters.


### PR DESCRIPTION
### Description

Fix type (remove `I`)

### Issues Resolved

None


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
