### PR TITLE
Data Prepper's s3 source: visibility_duplication_protection

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -112,7 +112,7 @@ Option | Required | Type | Description
 `visibility_timeout` | No | Duration | The visibility timeout to apply to messages read from the Amazon SQS queue. This should be set to the amount of time that Data Prepper may take to read all the S3 objects in a batch. Default is `30s`.
 `wait_time` | No | Duration | The amount of time to wait for long polling on the Amazon SQS API. Default is `20s`.
 `poll_delay` | No | Duration | A delay placed between the reading and processing of a batch of Amazon SQS messages and making a subsequent request. Default is `0s`.
-`visibility_duplication_protection` | No | Boolean | If set to `true`, Data Prepper will attempt to avoid duplicate processing by extending the visibility timeout of SQS messages. Until the data reaches the sink, Data Prepper will regularly call `ChangeMessageVisibility` to avoid reading the S3 object again. You must grant permissions to `ChangeMessageVisibility` on the IAM role to use this feature. Default is `false`.
+`visibility_duplication_protection` | No | Boolean | If set to `true`, Data Prepper attempts to avoid duplicate processing by extending the visibility timeout of SQS messages. Until the data reaches the sink, Data Prepper will regularly call `ChangeMessageVisibility` to avoid reading the S3 object again. To use this feature, you need to grant permissions to `ChangeMessageVisibility` on the IAM role. Default is `false`.
 `visibility_duplicate_protection_timeout` | No | Duration | Sets the maximum total length of time that a message will not be processed when using `visibility_duplication_protection`. Defaults to two hours.
 
 

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -50,7 +50,7 @@ In order to use the `s3` source, configure your AWS Identity and Access Manageme
 
 If your S3 objects or Amazon SQS queues do not use [AWS Key Management Service (AWS KMS)](https://aws.amazon.com/kms/), remove the `kms:Decrypt` permission.
 
-If you do not enable `visibility_duplication_protection`, you may also remove the `sqs:ChangeMessageVisibility` permission from the SQS queue access.
+If you do not enable `visibility_duplication_protection`, you can remove the `sqs:ChangeMessageVisibility` permission from the SQS queue's access.
 
 ## Cross-account S3 access<a name="s3_bucket_ownership"></a>
 

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -32,6 +32,7 @@ In order to use the `s3` source, configure your AWS Identity and Access Manageme
             "Sid": "sqs-access",
             "Effect": "Allow",
             "Action": [
+                "sqs:ChangeMessageVisibility",
                 "sqs:DeleteMessage",
                 "sqs:ReceiveMessage"
             ],
@@ -48,6 +49,8 @@ In order to use the `s3` source, configure your AWS Identity and Access Manageme
 ```
 
 If your S3 objects or Amazon SQS queues do not use [AWS Key Management Service (AWS KMS)](https://aws.amazon.com/kms/), remove the `kms:Decrypt` permission.
+
+If you do not enable `visibility_duplication_protection`, you may also remove the `sqs:ChangeMessageVisibility` permission from the SQS queue access.
 
 ## Cross-account S3 access<a name="s3_bucket_ownership"></a>
 
@@ -109,6 +112,8 @@ Option | Required | Type | Description
 `visibility_timeout` | No | Duration | The visibility timeout to apply to messages read from the Amazon SQS queue. This should be set to the amount of time that Data Prepper may take to read all the S3 objects in a batch. Default is `30s`.
 `wait_time` | No | Duration | The amount of time to wait for long polling on the Amazon SQS API. Default is `20s`.
 `poll_delay` | No | Duration | A delay placed between the reading and processing of a batch of Amazon SQS messages and making a subsequent request. Default is `0s`.
+`visibility_duplication_protection` | No | Boolean | If set to `true`, Data Prepper will attempt to avoid duplicate processing by extending the visibility timeout of SQS messages. Until the data reaches the sink, Data Prepper will regularly call `ChangeMessageVisibility` to avoid reading the S3 object again. You must grant permissions to `ChangeMessageVisibility` on the IAM role to use this feature. Default is `false`.
+`visibility_duplicate_protection_timeout` | No | Duration | Sets the maximum total length of time that a message will not be processed when using `visibility_duplication_protection`. Defaults to two hours.
 
 
 ## aws


### PR DESCRIPTION
### Description

Adds documentation for Data Prepper's s3 source `visibility_duplication_protection` configuration. Includes the necessary permissions.

### Issues Resolved

N/A


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
