### PR TITLE
Add openai.com to domains excluded by link checker

### DIFF
--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -63,6 +63,7 @@ module Jekyll::LinkChecker
     'playground.opensearch.org', # inifite redirect, https://github.com/opensearch-project/dashboards-anywhere/issues/172
     'crates.io', # 404s on bots
     'www.cloudflare.com', # 403s on bots
+    'openai.com', # 403s on bots
     'example.issue.link' # a fake example link from the template
   ]
 


### PR DESCRIPTION
Add openai.com to domains excluded by link checker because of 403 on bots.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
