### PR TITLE
Add note about configuring root CA for ldap in both authc and authz

### DIFF
--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -160,7 +160,12 @@ plugins.security.ssl.http.truststore_filepath: ...
 
 If your server uses a certificate signed by a different CA, import this CA into your truststore or add it to your trusted CA file on each node.
 
-You can also use a separate root CA in PEM format by setting one of the following configuration options:
+You can also use a separate root CA in PEM format.
+
+When configuring a separate root CA for LDAP, make sure to include the setting in all instances of the ldap `config:` including instances in the `authc` and `authz` portions of the configuration.
+{: .note}
+
+To configure a separate root CA, use one of the following configuration options:
 
 ```yml
 config:

--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -162,7 +162,7 @@ If your server uses a certificate signed by a different CA, import this CA into 
 
 You can also use a separate root CA in PEM format.
 
-When configuring a separate root CA for LDAP, make sure to include the setting in all instances of the ldap `config:` including instances in the `authc` and `authz` portions of the configuration.
+When configuring a separate root CA for LDAP, make sure to include the setting in all instances of the LDAP `config:` settings, including in both the `authc` and `authz` options of the configuration.
 {: .note}
 
 To configure a separate root CA, use one of the following configuration options:


### PR DESCRIPTION
### Description

Addresses an issue with documentation for configuring a cluster with LDAP authentication where SSL needs to be configured in multiple places for a full integration. 

### Issues Resolved

- https://github.com/opensearch-project/security/issues/2548

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
