### PR TITLE
Remove duplicate setting in dashboard tls

### DIFF
--- a/_install-and-configure/install-dashboards/tls.md
+++ b/_install-and-configure/install-dashboards/tls.md
@@ -19,7 +19,6 @@ server.ssl.enabled | This setting is for communications between OpenSearch Dashb
 server.ssl.certificate | If `server.ssl.enabled` is true, specify the full path to a valid client certificate for your OpenSearch cluster. You can [generate your own]({{site.url}}{{site.baseurl}}/security/configuration/generate-certificates/) or get one from a certificate authority.
 server.ssl.key | If `server.ssl.enabled` is true, specify the full path (e.g. `/usr/share/opensearch-dashboards-1.0.0/config/my-client-cert-key.pem` to the key for your client certificate. You can [generate your own]({{site.url}}{{site.baseurl}}/security/configuration/generate-certificates/) or get one from a certificate authority.
 server.ssl.certificateAuthorities | This setting adds the SSL certificate authority which issues SSL certificates for the Dashboard's server in a list format. 
-opensearch.ssl.certificateAuthorities | This setting adds the SSL certificate authority for OpenSearch.
 opensearch_security.cookie.secure | If you enable TLS for OpenSearch Dashboards, change this setting to `true`. For HTTP, set it to `false`.
 
 This `opensearch_dashboards.yml` configuration shows OpenSearch and OpenSearch Dashboards running on the same machine with the demo configuration:


### PR DESCRIPTION
### Description

![Screen Shot 2023-12-06 at 6 53 35 PM](https://github.com/opensearch-project/documentation-website/assets/24649991/828d8ca1-b572-4299-b91d-c3483958c4dd)

It has duplicate setting guide (`opensearch.ssl.certificateAuthorities`) 

### Issues Resolved

None

### Checklist

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
