### PR TITLE
Add custom_return_attributes to LDAP documentation

### DIFF
--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -513,7 +513,7 @@ Name | Description
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.
 `custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
 `custom_attr_maxval_len`  | Integer. Specifies the maximum allowed length of each attribute. All attributes longer than this value are discarded. A value of `0` disables custom attributes altogether. Default is 36.
-`custom_return_attributes`  | String array. Allows specifying which attributes to request from the LDAP server.
+`custom_return_attributes`  | String array. Specifies which attributes to request from the LDAP server.
 
 
 ### Complete authorization example

--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -513,6 +513,7 @@ Name | Description
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.
 `custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.
 `custom_attr_maxval_len`  | Integer. Specifies the maximum allowed length of each attribute. All attributes longer than this value are discarded. A value of `0` disables custom attributes altogether. Default is 36.
+`custom_return_attributes`  | String array. Allows specifying which attributes to request from the LDAP server.
 
 
 ### Complete authorization example


### PR DESCRIPTION
### Description

Adds a setting to the LDAP documentation that was added in OpenSearch 2.4. This attribute allows an admin to specify which attributes to explicitly request from an LDAP server when authenticating a user to prevent the LDAP server from returning all attributes to OpenSearch.

Added in https://github.com/opensearch-project/security/pull/2093

### Issues Resolved

https://github.com/opensearch-project/documentation-website/issues/1248


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
