### PR TITLE
Remove -noopenssl from securityadmin documentation which was removed in 2.0

### DIFF
--- a/_security/configuration/security-admin.md
+++ b/_security/configuration/security-admin.md
@@ -208,7 +208,6 @@ Name | Description
 :--- | :---
 `-nhnv` | Do not validate hostname. Default is false.
 `-nrhn` | Do not resolve hostname. Only relevant if `-nhnv` is not set.
-`-noopenssl` | Do not use OpenSSL, even if available. Default is to use OpenSSL if it is available.
 
 
 ### Configuration files settings


### PR DESCRIPTION
### Description

Removes a setting from the securityadmin documentation that was removed in OpenSearch 2.0. 

### Issues Resolved

- Related https://github.com/opensearch-project/documentation-website/issues/913

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
