### PR TITLE
Change syntax highlighting colors

### DIFF
--- a/_sass/color_schemes/opensearch.scss
+++ b/_sass/color_schemes/opensearch.scss
@@ -82,3 +82,212 @@ $media-queries: (
   lg: $content-width + $nav-width,
   xl: $content-width + $nav-width + $toc-width
 );
+
+// override the highlighting colors 
+
+.highlight .c {
+  color: $blue-dk-200;
+} // comment //
+.highlight .err {
+  color: $grey-dk-300;
+} // error //
+.highlight .g {
+  color: $grey-dk-300;
+} // generic //
+.highlight .k {
+  color: #990073;
+} // keyword //
+.highlight .l {
+  color: $grey-dk-300;
+} // literal //
+.highlight .n {
+  color: $grey-dk-300;
+} // name //
+.highlight .o {
+  color: $purple-100;
+} // operator //
+.highlight .x {
+  color: #cb4b16;
+} // other //
+.highlight .p {
+  color: $grey-dk-300;
+} // punctuation //
+.highlight .cm {
+  color: $blue-dk-200;
+} // comment.multiline //
+.highlight .cp {
+  color: $purple-000;
+} // comment.preproc //
+.highlight .c1 {
+  color: $blue-dk-200;
+} // comment.single //
+.highlight .cs {
+  color: $purple-000;
+} // comment.special //
+.highlight .gd {
+  color: #2aa198;
+} // generic.deleted //
+.highlight .ge {
+  font-style: italic;
+  color: $grey-dk-300;
+} // generic.emph //
+.highlight .gr {
+  color: #dc322f;
+} // generic.error //
+.highlight .gh {
+  color: #cb4b16;
+} // generic.heading //
+.highlight .gi {
+  color: $purple-000;
+} // generic.inserted //
+.highlight .go {
+  color: $grey-dk-300;
+} // generic.output //
+.highlight .gp {
+  color: $grey-dk-300;
+} // generic.prompt //
+.highlight .gs {
+  font-weight: bold;
+  color: $grey-dk-300;
+} // generic.strong //
+.highlight .gu {
+  color: #cb4b16;
+} // generic.subheading //
+.highlight .gt {
+  color: $grey-dk-300;
+} // generic.traceback //
+.highlight .kc {
+  color: #cb4b16;
+} // keyword.constant //
+.highlight .kd {
+  color: #268bd2;
+} // keyword.declaration //
+.highlight .kn {
+  color: $purple-000;
+} // keyword.namespace //
+.highlight .kp {
+  color: $purple-000;
+} // keyword.pseudo //
+.highlight .kr {
+  color: #268bd2;
+} // keyword.reserved //
+.highlight .kt {
+  color: #dc322f;
+} // keyword.type //
+.highlight .ld {
+  color: $grey-dk-300;
+} // literal.date //
+.highlight .m {
+  color: #2aa198;
+} // literal.number //
+.highlight .s {
+  color: #2aa198;
+} // literal.string //
+.highlight .na {
+  color: #555;
+} // name.attribute //
+.highlight .nb {
+  color: #b58900;
+} // name.builtin //
+.highlight .nc {
+  color: #268bd2;
+} // name.class //
+.highlight .no {
+  color: #cb4b16;
+} // name.constant //
+.highlight .nd {
+  color: #268bd2;
+} // name.decorator //
+.highlight .ni {
+  color: #cb4b16;
+} // name.entity //
+.highlight .ne {
+  color: #cb4b16;
+} // name.exception //
+.highlight .nf {
+  color: #268bd2;
+} // name.function //
+.highlight .nl {
+  color: #555;
+} // name.label //
+.highlight .nn {
+  color: $grey-dk-300;
+} // name.namespace //
+.highlight .nx {
+  color: #555;
+} // name.other //
+.highlight .py {
+  color: $grey-dk-300;
+} // name.property //
+.highlight .nt {
+  color: #268bd2;
+} // name.tag //
+.highlight .nv {
+  color: #268bd2;
+} // name.variable //
+.highlight .ow {
+  color: $purple-000;
+} // operator.word //
+.highlight .w {
+  color: $grey-dk-300;
+} // text.whitespace //
+.highlight .mf {
+  color: #2aa198;
+} // literal.number.float //
+.highlight .mh {
+  color: #2aa198;
+} // literal.number.hex //
+.highlight .mi {
+  color: #2aa198;
+} // literal.number.integer //
+.highlight .mo {
+  color: #2aa198;
+} // literal.number.oct //
+.highlight .sb {
+  color: $blue-dk-200;
+} // literal.string.backtick //
+.highlight .sc {
+  color: #2aa198;
+} // literal.string.char //
+.highlight .sd {
+  color: $grey-dk-300;
+} // literal.string.doc //
+.highlight .s2 {
+  color: #2aa198;
+} // literal.string.double //
+.highlight .se {
+  color: #cb4b16;
+} // literal.string.escape //
+.highlight .sh {
+  color: $grey-dk-300;
+} // literal.string.heredoc //
+.highlight .si {
+  color: #2aa198;
+} // literal.string.interpol //
+.highlight .sx {
+  color: #2aa198;
+} // literal.string.other //
+.highlight .sr {
+  color: #dc322f;
+} // literal.string.regex //
+.highlight .s1 {
+  color: #2aa198;
+} // literal.string.single //
+.highlight .ss {
+  color: #2aa198;
+} // literal.string.symbol //
+.highlight .bp {
+  color: #268bd2;
+} // name.builtin.pseudo //
+.highlight .vc {
+  color: #268bd2;
+} // name.variable.class //
+.highlight .vg {
+  color: #268bd2;
+} // name.variable.global //
+.highlight .vi {
+  color: #268bd2;
+} // name.variable.instance //
+.highlight .il {
+  color: #2aa198;
+} // literal.number.integer.long //


### PR DESCRIPTION
The default highlighting color scheme renders text illegible on the gray code block background. This PR changes the colors so the code is darker, the comments are lighter, and the keywords are a different color.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
