### PR TITLE
Fix typo from headdump to heapdump

### DIFF
--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -36,7 +36,7 @@ The `gc` telemetry device enables garbage collector (GC) logs for the benchmark 
 
 If the runtime JDK is Java 9 or higher, you can specify the `gc-log-config` parameter. The GC logging configuration consists of a list of tags and levels, such as the default value `gc*=info,safepoint=info,age*=trace`. Run `java -Xlog:help` to view a list of available levels and tags. 
 
-## headdump
+## heapdump
 
 The `heapdump` telemetry device captures a heap dump after a benchmark has finished and right before the node is shut down.
 


### PR DESCRIPTION
### Description
fix typo from headdump to heapdump at https://opensearch.org/docs/latest/benchmark/reference/telemetry/#headdump

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
