### PR TITLE
Fixes the label on cluster API index page

### DIFF
--- a/_api-reference/cluster-api/index.md
+++ b/_api-reference/cluster-api/index.md
@@ -9,6 +9,6 @@ redirect_from:
 
 # Cluster APIs
 **Introduced 1.0**
-{: .label .label-purple }|
+{: .label .label-purple }
 
 The cluster APIs allow you to manage your cluster. You can use them to check cluster health, modify settings, retrieve statistics, and more.


### PR DESCRIPTION
Fixes the label on cluster API index page


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
