### PR TITLE
Fixing OpenSearch operator helm install

### DIFF
--- a/_tools/k8s-operator.md
+++ b/_tools/k8s-operator.md
@@ -22,7 +22,7 @@ If you use Helm to manage your Kubernetes cluster, you can use the OpenSearch Ku
 To begin, log in to your Kubernetes cluster and add the Helm repository (repo) from [Artifact Hub](https://artifacthub.io/packages/helm/opensearch-operator/opensearch-operator/). 
 
 ```
-helm repo add opensearch-operator https://opster.github.io/opensearch-k8s-operator/
+helm repo add opensearch-operator https://opensearch-project.github.io/opensearch-k8s-operator/
 ```
 
 Make sure that the repo is included in your Kubernetes cluster. 


### PR DESCRIPTION
### Description
With the move of the OpenSearch K8s Operator into the OpenSearch-Project org we need to update the artifact to point at the correct source. I have tested this on a cluster and confirmed it's working. 

### Issues Resolved
N/A


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
