### PR TITLE
Updates navigation header background color

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -82,7 +82,7 @@
 {% endif %}
 <div role="banner" id="top">
   <div class="navigation-container">
-    <a class="navigation-container--logo" href="{{ '/' | relative_url }}">
+    <a class="navigation-container--logo" href="{{ '/' }}">
       OpenSearch
       <svg width="200" height="39" viewBox="0 0 200 39" fill="none" xmlns="http://www.w3.org/2000/svg">
         <g clip-path="url(#clip0_723_1352)">

--- a/_sass/_navigation-header.scss
+++ b/_sass/_navigation-header.scss
@@ -51,6 +51,8 @@ $max-container: 1440px;
             text-decoration: none;
             text-indent: 100%;
             position: relative;
+            // NOTE: The min() function name is deliberatedly misspelled with an upercase M to workaround an outdated SCSS compiler
+            // dependency used by the Just the Docs theme 0.3.3.
             left: Min(80px, calc(100% - $header-banner-min-width));
             box-sizing: content-box;
             @media screen and (max-width: 1339px) {

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -1025,7 +1025,7 @@ body {
   }
 }
 
-$light-theme-navigation-background: rgba(0, 163, 224, 0.05);
+$light-theme-navigation-background: #F1FBFF;
 $primary-deep-blue-sea-s3: #001E30;
 $primary-deep-blue-sea-t1: #2C5E7A;
 $primary-open-sky: #00A3E0;


### PR DESCRIPTION
### Description

Updates the background color of the header navigation. The same change is going to be made for the 1.3 branch as well as in the project website. This change uses a solid color instead of one with transparency, because the background colors of the body elements are different in the project website and the documentation site which makes a slightly darker tint in the header in the project website than the documentation site.

This also adds a kludge to get around outdated SCSS compilers not liking the `min` function with mixed units which has already been pushed to 1.3.

Corrects header logo link URL.

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
