### PR TITLE
Roll back Vale to version 2.29.3

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -20,3 +20,4 @@ jobs:
           reporter: github-pr-check
           filter_mode: added
           vale_flags: "--no-exit"
+          version: 2.29.3


### PR DESCRIPTION
Roll back Vale to version 2.29.3 to prevent heading capitalization errors until further investigation.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
