### PR TITLE
update ML-commons profile API's path parameters documentation

### DIFF
--- a/_ml-commons-plugin/api/profile.md
+++ b/_ml-commons-plugin/api/profile.md
@@ -37,7 +37,7 @@ GET /_plugins/_ml/profile/tasks
 Parameter | Data type | Description
 :--- | :--- | :---
 `model_id` | String | Returns runtime data for a specific model. You can provide multiple model IDs as comma-separated values to retrieve multiple model profiles.
-`task_id`| String | Returns runtime data for a specific task. You can provide multiple `task_id`s as comma-separated values to retrieve multiple task profiles.
+`task_id`| String | Returns runtime data for a specific task. You can provide multiple task IDs as comma-separated values to retrieve multiple task profiles.
 
 ### Request fields
 

--- a/_ml-commons-plugin/api/profile.md
+++ b/_ml-commons-plugin/api/profile.md
@@ -29,7 +29,9 @@ To clear all monitoring requests, set `plugins.ml_commons.monitoring_request_cou
 ```json
 GET /_plugins/_ml/profile
 GET /_plugins/_ml/profile/models
+GET /_plugins/_ml/profile/models/<model_id>
 GET /_plugins/_ml/profile/tasks
+GET /_plugins/_ml/profile/tasks/<task_id>
 ```
 
 ## Path parameters

--- a/_ml-commons-plugin/api/profile.md
+++ b/_ml-commons-plugin/api/profile.md
@@ -36,8 +36,8 @@ GET /_plugins/_ml/profile/tasks
 
 Parameter | Data type | Description
 :--- | :--- | :---
-`model_id` | String | Returns runtime data for a specific model. You can string together multiple `model_id`s to return multiple model profiles.
-`tasks`| String | Returns runtime data for a specific task. You can string together multiple `task_id`s to return multiple task profiles.
+`model_id` | String | Returns runtime data for a specific model. You can provide multiple `model_id`s as comma-separated values to retrieve multiple model profiles.
+`task_id`| String | Returns runtime data for a specific task. You can provide multiple `task_id`s as comma-separated values to retrieve multiple task profiles..
 
 ### Request fields
 

--- a/_ml-commons-plugin/api/profile.md
+++ b/_ml-commons-plugin/api/profile.md
@@ -37,7 +37,7 @@ GET /_plugins/_ml/profile/tasks
 Parameter | Data type | Description
 :--- | :--- | :---
 `model_id` | String | Returns runtime data for a specific model. You can provide multiple `model_id`s as comma-separated values to retrieve multiple model profiles.
-`task_id`| String | Returns runtime data for a specific task. You can provide multiple `task_id`s as comma-separated values to retrieve multiple task profiles..
+`task_id`| String | Returns runtime data for a specific task. You can provide multiple `task_id`s as comma-separated values to retrieve multiple task profiles.
 
 ### Request fields
 

--- a/_ml-commons-plugin/api/profile.md
+++ b/_ml-commons-plugin/api/profile.md
@@ -36,7 +36,7 @@ GET /_plugins/_ml/profile/tasks
 
 Parameter | Data type | Description
 :--- | :--- | :---
-`model_id` | String | Returns runtime data for a specific model. You can provide multiple `model_id`s as comma-separated values to retrieve multiple model profiles.
+`model_id` | String | Returns runtime data for a specific model. You can provide multiple model IDs as comma-separated values to retrieve multiple model profiles.
 `task_id`| String | Returns runtime data for a specific task. You can provide multiple `task_id`s as comma-separated values to retrieve multiple task profiles.
 
 ### Request fields


### PR DESCRIPTION
### Description
path parameter is supposed to be `task_id`. but, it was mentioned as `tasks`. Also, several `model_id`'s can be given as comma-separated values. updated it to make it easier to understand.




### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
