### PR TITLE
docs: update type of `version` in model register

### DIFF
--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -46,7 +46,7 @@ The following table lists the available request fields.
 Field | Data type | Required/Optional | Description
 :---  | :--- | :--- 
 `name`| String | Required | The model name. |
-`version` | Integer | Required | The model version number. |
+`version` | String | Required | The model version number. |
 `model_format` | String | Required | The portable format of the model file. Valid values are `TORCH_SCRIPT` and `ONNX`. |
 `description` | String | Optional| The model description. |
 `model_group_id` | String | Optional | The model group ID of the model group to register this model to. 
@@ -75,7 +75,7 @@ The following table lists the available request fields.
 Field | Data type | Required/Optional | Description
 :---  | :--- | :--- 
 `name`| String | Required | The model name. |
-`version` | Integer | Required | The model version number. |
+`version` | String | Required | The model version number. |
 `model_format` | String | Required | The portable format of the model file. Valid values are `TORCH_SCRIPT` and `ONNX`. |
 `function_name` | String | Required | Set this parameter to `SPARSE_ENCODING` or `SPARSE_TOKENIZE`.
 `model_content_hash_value` | String | Required | The model content hash generated using the SHA-256 hashing algorithm.
@@ -111,7 +111,7 @@ The following table lists the available request fields.
 Field | Data type | Required/Optional | Description
 :---  | :--- | :--- 
 `name`| String | Required | The model name. |
-`version` | Integer | Required | The model version number. |
+`version` | String | Required | The model version number. |
 `model_format` | String | Required | The portable format of the model file. Valid values are `TORCH_SCRIPT` and `ONNX`. |
 `function_name` | String | Required | Set this parameter to `SPARSE_ENCODING` or `SPARSE_TOKENIZE`.
 `model_content_hash_value` | String | Required | The model content hash generated using the SHA-256 hashing algorithm.

--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -46,7 +46,7 @@ The following table lists the available request fields.
 Field | Data type | Required/Optional | Description
 :---  | :--- | :--- 
 `name`| String | Required | The model name. |
-`version` | String | Required | The model version number. |
+`version` | String | Required | The model version. |
 `model_format` | String | Required | The portable format of the model file. Valid values are `TORCH_SCRIPT` and `ONNX`. |
 `description` | String | Optional| The model description. |
 `model_group_id` | String | Optional | The model group ID of the model group to register this model to. 
@@ -75,7 +75,7 @@ The following table lists the available request fields.
 Field | Data type | Required/Optional | Description
 :---  | :--- | :--- 
 `name`| String | Required | The model name. |
-`version` | String | Required | The model version number. |
+`version` | String | Required | The model version. |
 `model_format` | String | Required | The portable format of the model file. Valid values are `TORCH_SCRIPT` and `ONNX`. |
 `function_name` | String | Required | Set this parameter to `SPARSE_ENCODING` or `SPARSE_TOKENIZE`.
 `model_content_hash_value` | String | Required | The model content hash generated using the SHA-256 hashing algorithm.
@@ -111,7 +111,7 @@ The following table lists the available request fields.
 Field | Data type | Required/Optional | Description
 :---  | :--- | :--- 
 `name`| String | Required | The model name. |
-`version` | String | Required | The model version number. |
+`version` | String | Required | The model version. |
 `model_format` | String | Required | The portable format of the model file. Valid values are `TORCH_SCRIPT` and `ONNX`. |
 `function_name` | String | Required | Set this parameter to `SPARSE_ENCODING` or `SPARSE_TOKENIZE`.
 `model_content_hash_value` | String | Required | The model content hash generated using the SHA-256 hashing algorithm.


### PR DESCRIPTION
### Description
The docs for the [model register request](https://opensearch.org/docs/latest/ml-commons-plugin/api/model-apis/register-model/) say that the type of the `version` field is "integer". Based on the example requests provided in the same docs, and the following code..:

https://github.com/opensearch-project/ml-commons/blob/4d8d32e73845ead7574d9bac3ce77651c2158404/common/src/main/java/org/opensearch/ml/common/transport/register/MLRegisterModelInput.java#L386-L388

..I believe the correct type of this parameter is "string".

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
