### PR TITLE
Fix typo in 'Update settings permission' link

### DIFF
--- a/_security/access-control/permissions.md
+++ b/_security/access-control/permissions.md
@@ -296,7 +296,7 @@ See [Script APIs]({{site.url}}{{site.baseurl}}/api-reference/script-apis/index/)
 
 ### Update settings permission
 
-See [Update settings]({{site.url}}{{site.baseurl}}api-reference/index-apis/update-settings/) on the Index APIs page.
+See [Update settings]({{site.url}}{{site.baseurl}}/api-reference/index-apis/update-settings/) on the Index APIs page.
 
 - cluster:admin/settings/update
 


### PR DESCRIPTION
### Description
It generates `https://opensearch.org/docs/latestapi-reference/index-apis/update-settings/`. It should be `https://opensearch.org/docs/latest/api-reference/index-apis/update-settings/`.

### Issues Resolved
None

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
