### PR TITLE
Fix permission name

### DIFF
--- a/_security/access-control/permissions.md
+++ b/_security/access-control/permissions.md
@@ -361,7 +361,7 @@ See [REST API reference]({{site.url}}{{site.baseurl}}/api-reference/index/).
 - cluster:monitor/stats
 - cluster:monitor/task
 - cluster:monitor/task/get
-- cluster:monitor/tasks/list
+- cluster:monitor/tasks/lists
 
 ### Index templates
 


### PR DESCRIPTION
### Description

Fix permission name ('cluster:monitor/tasks/list' -> 'cluster:monitor/tasks/lists').
No `cluster:monitor/tasks/list` in OpenSearch repository. It seems typo in representing [ListTasksAction](https://github.com/opensearch-project/OpenSearch/blob/f92f846a1f9b30a055dde846fd12d987a511723a/server/src/main/java/org/opensearch/action/admin/cluster/node/tasks/list/ListTasksAction.java#L45).

### Issues Resolved

None

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
