### PR TITLE
Add opensearch-java version description on version 1.3

### DIFF
--- a/_clients/java.md
+++ b/_clients/java.md
@@ -34,6 +34,8 @@ dependencies {
 
 You can now start your OpenSearch cluster.
 
+Note that if your OpenSearch version is 1.3.2 or lower, consider using opensearch-java version 1.0 ([refer](https://github.com/opensearch-project/opensearch-java/blob/main/COMPATIBILITY.md)).
+
 ## Installing the client using RestClient Transport
 
 Alternatively, you can create a Java client by using the `RestClient`-based transport. In this case, make sure that you have the following dependencies in your project's `pom.xml` file:
@@ -64,6 +66,8 @@ dependencies {
 {% include copy.html %}
 
 You can now start your OpenSearch cluster.
+
+Note that if your OpenSearch version is 1.3.2 or lower, consider using opensearch-java version 1.0 ([refer](https://github.com/opensearch-project/opensearch-java/blob/main/COMPATIBILITY.md)).
 
 ## Security
 

--- a/_clients/java.md
+++ b/_clients/java.md
@@ -34,7 +34,8 @@ dependencies {
 
 You can now start your OpenSearch cluster.
 
-Note that if your OpenSearch version is 1.3.2 or lower, consider using opensearch-java version 1.0 ([refer](https://github.com/opensearch-project/opensearch-java/blob/main/COMPATIBILITY.md)).
+If you're running OpenSearch version 1.3.2 or earlier, consider using opensearch-java version 1.0. See the developer documentation [Compatibility with OpenSearch](https://github.com/opensearch-project/opensearch-java/blob/main/COMPATIBILITY.md) for more detailed information.
+{: .note}
 
 ## Installing the client using RestClient Transport
 
@@ -67,7 +68,8 @@ dependencies {
 
 You can now start your OpenSearch cluster.
 
-Note that if your OpenSearch version is 1.3.2 or lower, consider using opensearch-java version 1.0 ([refer](https://github.com/opensearch-project/opensearch-java/blob/main/COMPATIBILITY.md)).
+If you're running OpenSearch version 1.3.2 or earlier, consider using opensearch-java version 1.0. See the developer documentation [Compatibility with OpenSearch](https://github.com/opensearch-project/opensearch-java/blob/main/COMPATIBILITY.md) for more detailed information.
+{: .note}
 
 ## Security
 


### PR DESCRIPTION
### Description
- Even if opensearch version is 1.3, if the patch version is 2, you should not install it with the version in the guide document.
- For version 1.3.2 or lower, an explanatory text is added to guide installation in version 1.0.

### Issues Resolved
- https://github.com/opensearch-project/opensearch-java/issues/719


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
