### PR TITLE
Update MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -12,3 +12,4 @@ This document contains a list of maintainers in this repo. See [opensearch-proje
 | Nate Bower       | [natebower](https://github.com/natebower)       | Amazon      |
 | Melissa Vagi     | [vagimeli](https://github.com/vagimeli)         | Amazon      |
 | Miki Barahmand   | [AMoo-Miki](https://github.com/AMoo-Miki)       | Amazon      |
+| David Venable    | [dlvenable](https://github.com/dlvenable)       | Amazon      | 


### PR DESCRIPTION
Add David Venable as a maintainer.

### Description
Four maintainers have approved David to be a maintainer in the documentation-website repo, and David has accepted.

### Issues Resolved
n/a

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
