### PR TITLE
Add unsupported warning to 2.10 and below

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -274,6 +274,11 @@ heading_anchors: false
 # Adds on-hover anchor links to h2-h6
 anchor_links: true
 
+# This setting governs including warning on every page
+# 'unsupported' produces red warning, 'supported' produces yellow warning
+# everything else produces no warning
+doc_version: unsupported
+
 footer_content:
 
 plugins:

--- a/_includes/warning.html
+++ b/_includes/warning.html
@@ -1,1 +1,0 @@
-<p class="warning">This version of the OpenSearch documentation is no longer maintained. For the latest version, see the <a href="{{ site.url }}/docs{{ page.url }}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -163,7 +163,13 @@ layout: table_wrappers
           {% endif %}
         {% endunless %}
         <div id="main-content" class="main-content" role="main">
-          {% include warning.html %}
+          {% if page.section == "opensearch" %}
+            {% if site.doc_version == "supported" %}            
+              <p class="supported-version-warning">This is an earlier version of the OpenSearch documentation. For the latest version, see the <a href="{{ site.url }}/docs{{ page.url }}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
+            {% elsif site.doc_version == "unsupported" %}
+              <p class="unsupported-version-warning">This version of the OpenSearch documentation is no longer maintained. For the latest version, see the <a href="{{ site.url }}/docs{{ page.url }}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
+            {% endif %}
+          {% endif %}
           {% if site.heading_anchors != false %}
             {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
           {% else %}

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -187,6 +187,27 @@ img {
   border-left: 5px solid $red-100;
 }
 
+@mixin version-warning ( $version: 'latest' ){
+  @extend %callout, .panel;
+  font-weight: 600;
+  @if $version == 'unsupported' {
+    border-left: 5px solid $red-100;
+    background-color: mix(white, $red-100, 80%);
+  }
+  @else if $version == 'supported' {
+    border-left: 5px solid $yellow-000;
+    background-color: mix(white, $yellow-000, 80%);
+  }
+}
+
+.supported-version-warning {
+  @include version-warning('supported');
+}
+
+.unsupported-version-warning {
+  @include version-warning('unsupported');
+}
+
 // Labels
 .label,
 .label-blue {


### PR DESCRIPTION
Add unsupported warning to 2.10 and below


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
