### PR TITLE
Remove client and data prepper from navigation 1.2

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,3 +30,5 @@ gem "tzinfo-data", platforms: [:mingw, :mswin, :x64_mingw, :jruby]
 
 # Performance-booster for watching directories on Windows
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
+
+gem "webrick"

--- a/_clients/data-prepper/index.md
+++ b/_clients/data-prepper/index.md
@@ -4,6 +4,7 @@ title: Data Prepper
 nav_order: 120
 has_children: true
 has_toc: false
+nav_exclude: true
 ---
 
 # Data Prepper

--- a/_clients/go.md
+++ b/_clients/go.md
@@ -2,6 +2,8 @@
 layout: default
 title: Go client
 nav_order: 80
+nav_exclude: true
+redirect_to: https://opensearch.org/docs/latest/clients/go/
 ---
 
 # Go client

--- a/_clients/java-rest-high-level.md
+++ b/_clients/java-rest-high-level.md
@@ -2,6 +2,8 @@
 layout: default
 title: Java high-level REST client
 nav_order: 60
+nav_exclude: true
+redirect_to: https://opensearch.org/docs/latest/clients/java-rest-high-level/
 ---
 
 # Java high-level REST client

--- a/_clients/java.md
+++ b/_clients/java.md
@@ -2,6 +2,8 @@
 layout: default
 title: Java client
 nav_order: 65
+nav_exclude: true
+redirect_to: https://opensearch.org/docs/latest/clients/java/
 ---
 
 # Java client

--- a/_clients/javascript.md
+++ b/_clients/javascript.md
@@ -2,6 +2,8 @@
 layout: default
 title: JavaScript client
 nav_order: 100
+nav_exclude: true
+redirect_to: https://opensearch.org/docs/latest/clients/javascript/index/
 ---
 
 # JavaScript client

--- a/_clients/javascript.md
+++ b/_clients/javascript.md
@@ -3,7 +3,7 @@ layout: default
 title: JavaScript client
 nav_order: 100
 nav_exclude: true
-redirect_to: https://opensearch.org/docs/latest/clients/javascript/index/
+redirect_to: https://opensearch.org/docs/latest/clients/javascript/
 ---
 
 # JavaScript client

--- a/_clients/php.md
+++ b/_clients/php.md
@@ -2,6 +2,8 @@
 layout: default
 title: PHP client
 nav_order: 90
+nav_exclude: true
+redirect_to: https://opensearch.org/docs/latest/clients/php/
 ---
 
 # PHP client

--- a/_clients/python.md
+++ b/_clients/python.md
@@ -2,6 +2,8 @@
 layout: default
 title: Python client
 nav_order: 70
+nav_exclude: true
+redirect_to: https://opensearch.org/docs/latest/clients/python-low-level/
 ---
 
 # Python client

--- a/_config.yml
+++ b/_config.yml
@@ -98,7 +98,7 @@ just_the_docs:
       name: Monitoring plugins
       nav_fold: true
     clients:
-      name: Clients and tools
+      name: Tools
       nav_fold: true
     troubleshoot:
       name: Troubleshooting


### PR DESCRIPTION
Remove client and data prepper from navigation 1.2

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
