### PR TITLE
Fix typo in query-dsl doc page

### DIFF
--- a/_query-dsl/full-text/query-string.md
+++ b/_query-dsl/full-text/query-string.md
@@ -50,7 +50,7 @@ You can use query string syntax in the following cases:
     GET _search?q=wind
   ```
 
-A query string consists of _terms_ and _operators_. A term is a single word (for example, in the query `wind rises`, the terms are `wind` and `rises`). If several terms are surrounded by quotation marks, they are treated as one phrase where words are marched in the order they appear (for example, `"wind rises"`). Operators (such as `OR`, `AND`, and `NOT`) specify the Boolean logic used to interpret text in the query string. 
+A query string consists of _terms_ and _operators_. A term is a single word (for example, in the query `wind rises`, the terms are `wind` and `rises`). If several terms are surrounded by quotation marks, they are treated as one phrase where words are matched in the order they appear (for example, `"wind rises"`). Operators (such as `OR`, `AND`, and `NOT`) specify the Boolean logic used to interpret text in the query string. 
 
 The examples in this section use an index containing the following mapping and documents:
 


### PR DESCRIPTION
### Description

Fix typo in query-dsl doc page here https://opensearch.org/docs/latest/query-dsl/full-text/query-string/#query-string-syntax

The word `matched` is written as `marched`

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
