### PR TITLE
Update neural search documentation to include filters

### DIFF
--- a/_query-dsl/specialized/neural.md
+++ b/_query-dsl/specialized/neural.md
@@ -33,7 +33,7 @@ Field | Data type | Required/Optional | Description
 `query_image` | String | Optional | A base-64 encoded string that corresponds to the query image from which to generate vector embeddings. You must specify at least one `query_text` or `query_image`.
 `model_id` | String | Required if the default model ID is not set. For more information, see [Setting a default model on an index or field]({{site.url}}{{site.baseurl}}/search-plugins/neural-text-search/#setting-a-default-model-on-an-index-or-field). | The ID of the model that will be used to generate vector embeddings from the query text. The model must be deployed in OpenSearch before it can be used in neural search. For more information, see [Using custom models within OpenSearch]({{site.url}}{{site.baseurl}}/ml-commons-plugin/using-ml-models/) and [Neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/).
 `k` | Integer | Optional | The number of results returned by the k-NN search. Default is 10.
-`filter` | Object | Optional | A query that can be used to reduce the number of documents considered. For more information about filter usage, see [k-NN search with filters]({{site.url}}{{site.baseurl}}/search-plugins/knn/filter-search-knn). **Important** Filter can only be used with the `faiss` or `lucene` engines.
+`filter` | Object | Optional | A query that can be used to reduce the number of documents considered. For more information about filter usage, see [k-NN search with filters]({{site.url}}{{site.baseurl}}/search-plugins/knn/filter-search-knn/). **Important**: Filter can only be used with the `faiss` or `lucene` engines.
 
 #### Example request
 

--- a/_query-dsl/specialized/neural.md
+++ b/_query-dsl/specialized/neural.md
@@ -33,7 +33,7 @@ Field | Data type | Required/Optional | Description
 `query_image` | String | Optional | A base-64 encoded string that corresponds to the query image from which to generate vector embeddings. You must specify at least one `query_text` or `query_image`.
 `model_id` | String | Required if the default model ID is not set. For more information, see [Setting a default model on an index or field]({{site.url}}{{site.baseurl}}/search-plugins/neural-text-search/#setting-a-default-model-on-an-index-or-field). | The ID of the model that will be used to generate vector embeddings from the query text. The model must be deployed in OpenSearch before it can be used in neural search. For more information, see [Using custom models within OpenSearch]({{site.url}}{{site.baseurl}}/ml-commons-plugin/using-ml-models/) and [Neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/).
 `k` | Integer | Optional | The number of results returned by the k-NN search. Default is 10.
-`filter` | Object | Optional | A query that can be used to reduce the number of documents considered. For more information about filter usage, see [k-NN search with filters]({{site.url}}{{site.baseurl}}/search-plugins/knn/filter-search-knn). **Important** Filter can only be used with the `faiss` or `nmslib` engines.
+`filter` | Object | Optional | A query that can be used to reduce the number of documents considered. For more information about filter usage, see [k-NN search with filters]({{site.url}}{{site.baseurl}}/search-plugins/knn/filter-search-knn). **Important** Filter can only be used with the `faiss` or `lucene` engines.
 
 #### Example request
 

--- a/_query-dsl/specialized/neural.md
+++ b/_query-dsl/specialized/neural.md
@@ -33,6 +33,7 @@ Field | Data type | Required/Optional | Description
 `query_image` | String | Optional | A base-64 encoded string that corresponds to the query image from which to generate vector embeddings. You must specify at least one `query_text` or `query_image`.
 `model_id` | String | Required if the default model ID is not set. For more information, see [Setting a default model on an index or field]({{site.url}}{{site.baseurl}}/search-plugins/neural-text-search/#setting-a-default-model-on-an-index-or-field). | The ID of the model that will be used to generate vector embeddings from the query text. The model must be deployed in OpenSearch before it can be used in neural search. For more information, see [Using custom models within OpenSearch]({{site.url}}{{site.baseurl}}/ml-commons-plugin/using-ml-models/) and [Neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/).
 `k` | Integer | Optional | The number of results returned by the k-NN search. Default is 10.
+`filter` | Object | Optional | A query that can be used to reduce the number of documents considered. For more information about filter usage, see [k-NN search with filters]({{site.url}}{{site.baseurl}}/search-plugins/knn/filter-search-knn). **Important** Filter can only be used with the `faiss` or `nmslib` engines.
 
 #### Example request
 
@@ -44,7 +45,26 @@ GET /my-nlp-index/_search
       "passage_embedding": {
         "query_text": "Hi world",
         "query_image": "iVBORw0KGgoAAAAN...",
-        "k": 100
+        "k": 100,
+        "filter": {
+          "bool": {
+            "must": [
+              {
+                "range": {
+                  "rating": {
+                    "gte": 8,
+                    "lte": 10
+                  }
+                }
+              },
+              {
+                "term": {
+                  "parking": "true"
+                }
+              }
+            ]
+          }
+        }
       }
     }
   }


### PR DESCRIPTION
### Description
Adds filter information to neural query documentation. Confirmed that the server works:
![image](https://github.com/opensearch-project/documentation-website/assets/19438237/34290a9f-8d41-4647-9260-ef0c0db77939)

Note - in the image above it says "faiss" or "nmslib". I have updated this to "faiss" or "lucene"

### Issues Resolved
Fixes #6012 


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
