### PR TITLE
configure Content Security Policy (CSP) rules in OpenSearch Dashboards dynamically

### DIFF
--- a/_dashboards/csp-configuration.md
+++ b/_dashboards/csp-configuration.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-title: Content Security Policy Configuration
+title: Content Security Policy (CSP) Rules Configuration
 nav_order: 110
 has_children: true
 ---
 
-# Content Security Policy
+# Content Security Policy Rules

--- a/_dashboards/csp-configuration.md
+++ b/_dashboards/csp-configuration.md
@@ -1,0 +1,8 @@
+---
+layout: default
+title: Content Security Policy Configuration
+nav_order: 110
+has_children: true
+---
+
+# Content Security Policy

--- a/_dashboards/csp-configuration.md
+++ b/_dashboards/csp-configuration.md
@@ -1,8 +1,0 @@
----
-layout: default
-title: Content Security Policy (CSP) Rules Configuration
-nav_order: 110
-has_children: true
----
-
-# Content Security Policy Rules

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -22,7 +22,7 @@ csp_handler.enabled: true
 
 ## Enable site embedding for OpenSearch Dashboards
 
-To enable site embedding for OpenSearch Dashboards, update the CSP rules using CURL. When using CURL commands with single quotation marks inside the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`. The configuration is shown in the following example. Refer to the `applicationConfig` plugin [README]([<insert-link>](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md)) for configuration details.
+To enable site embedding for OpenSearch Dashboards, update the CSP rules using CURL. When using CURL commands with single quotation marks inside the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`. The configuration is shown in the following example. Refer to the `applicationConfig` plugin [README](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md) for configuration details.
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"script-src '\''unsafe-eval'\'' '\''self'\''; worker-src blob: '\''self'\''; style-src '\''unsafe-inline'\'' '\''self'\''; frame-ancestors '\''self'\'' {new site}"}'

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -1,0 +1,44 @@
+---
+layout: default
+title: Content Security Policy (CSP) Rules Dynamic Configuration
+nav_order: 110
+has_children: false
+---
+
+# Content Security Policy Rules Dynamic Configuration
+
+Content Security Policy (CSP) is a security standard introduced to help prevent cross-site scripting (XSS), clickjacking, and other code injection attacks resulting from the execution of malicious content in the trusted web page context. OpenSearch Dashboards supports configuring CSP rules in OSD YML file with key `csp.rules`. A change in YML file requires a server restart which may interrupt service availability. This document introduces a dynamic way to configure the CSP rules through the plugin `applicationConfig` without restarting the server.
+
+## Configuration
+
+The plugin `applicationConfig` provides read and write APIs for OSD customers to manage their dynamic configurations as key value pairs in an index. Another plugin `cspHandler` registers a pre-response handler to `HttpServiceSetup` which can get CSP rules from the dependent plugin `applicationConfig` and then rewrite to CSP header. Customers who want to use this feature need to enable both plugins in OSD YML as follows.
+
+```
+application_config.enabled: true
+csp_handler.enabled: true
+
+```
+
+For OSD users who want to make changes to allow a new site to embed OSD pages, they can update CSP rules through CURL. (See the README of `applicationConfig` for more details about the APIs.) **Please note that use backslash as string wrapper for single quotes inside the `data-raw` parameter. E.g use `'\''` to represent `'`**
+s
+```
+curl '{osd endpoint}/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"script-src '\''unsafe-eval'\'' '\''self'\''; worker-src blob: '\''self'\''; style-src '\''unsafe-inline'\'' '\''self'\''; frame-ancestors '\''self'\'' {new site}"}'
+
+```
+
+Below is the CURL command to delete CSP rules.
+
+```
+curl '{osd endpoint}/api/appconfig/csp.rules' -X DELETE -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty'
+```
+
+Below is the CURL command to get the CSP rules.
+
+```
+curl '{osd endpoint}/api/appconfig/csp.rules'
+
+```
+
+## Precedence
+
+In general, the dynamic configurations will take precedence over the configurations in YML. Specifically, when there is non empty CSP rules configured in the index, the rules from the YML will be used. To prevent clickjacking, we will append the `frame-ancestors` directive with value `'self'` if the rules from YML will be used and do not already have the directive `frame-ancestors`.

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -22,7 +22,7 @@ csp_handler.enabled: true
 
 ## Enable site embedding for OpenSearch Dashboards
 
-To enable site embedding for OpenSearch Dashboards, update the CSP rules using CURL. When using CURL commands with single quotes inside the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`. The configuration is shown in the following example. Refer to the `applicationConfig` plugin [README]([<insert-link>](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md)) for configuration details.
+To enable site embedding for OpenSearch Dashboards, update the CSP rules using CURL. When using CURL commands with single quotation marks inside the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`. The configuration is shown in the following example. Refer to the `applicationConfig` plugin [README]([<insert-link>](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md)) for configuration details.
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"script-src '\''unsafe-eval'\'' '\''self'\''; worker-src blob: '\''self'\''; style-src '\''unsafe-inline'\'' '\''self'\''; frame-ancestors '\''self'\'' {new site}"}'

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -13,7 +13,7 @@ Content Security Policy (CSP) is a security standard intended to prevent cross-s
 
 ## Configuration
 
-The `applicationConfig` plugin provides read and write APIs for OpenSearch Dashboards users to manage dynamic configurations as key-value pairs in an index. The `cspHandler` plugin registers a pre-response handler to `HttpServiceSetup`, which gets CSP rules from the dependent `applicationConfig` plugin, and then rewrites to the CSP header. Enable both plugins within your `opensearch_dashboards.yml` file to use this feature. The configuration is shown in the following example. Refer to the `cspHandler` plugin [README](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/csp_handler/README.md) for configuration details.
+The `applicationConfig` plugin provides read and write APIs that allow OpenSearch Dashboards users to manage dynamic configurations as key-value pairs in an index. The `cspHandler` plugin registers a pre-response handler to `HttpServiceSetup`, which gets CSP rules from the dependent `applicationConfig` plugin and then rewrites to the CSP header. Enable both plugins within your `opensearch_dashboards.yml` file to use this feature. The configuration is shown in the following example. Refer to the `cspHandler` plugin [README](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/csp_handler/README.md) for configuration details.
 
 ```
 application_config.enabled: true

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -9,7 +9,7 @@ has_children: false
 Introduced 2.13
 {: .label .label-purple }
 
-Content Security Policy (CSP) is a security standard to prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in the `opensearch_dashboards.yml` file by using the `csp.rules` key. A change in the YAML file requires a server restart, which may interrupt service availability. You can, however, configure the CSP rules dynamically through the `applicationConfig` plugin without restarting the server.
+Content Security Policy (CSP) is a security standard intended to prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in the `opensearch_dashboards.yml` file by using the `csp.rules` key. A change in the YAML file requires a server restart, which may interrupt service availability. You can, however, configure the CSP rules dynamically through the `applicationConfig` plugin without restarting the server.
 
 ## Configuration
 

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Content Security Policy (CSP) rules dynamic configuration
+title: Configuring Content Security Policy rules dynamically
 nav_order: 110
 has_children: false
 ---
 
-# Configuring content security policy rules dynamically
+# Configuring Content Security Policy rules dynamically
 Introduced 2.13
 {: .label .label-purple }
 
@@ -47,4 +47,4 @@ curl '{osd endpoint}/api/appconfig/csp.rules'
 
 ## Precedence
 
-Dynamic configurations override YAML configurations, except for empty CSP rules. To prevent `clickjacking`, a `frame-ancestors: self` directive is automatically added to YAML-defined rules that lack it.
+Dynamic configurations override YAML configurations, except for empty CSP rules. To prevent `clickjacking`, a `frame-ancestors: self` directive is automatically added to YAML-defined rules when necessary.

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -6,27 +6,26 @@ has_children: false
 ---
 
 # Configuring content security policy rules dynamically
+Introduced 2.13
+{: .label .label-purple }
 
-Content Security Policy (CSP) is a security standard introduced to help prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in `opensearch_dashboards.yml` file by using the `csp.rules` key. A change in YAML file requires a server restart, which may interrupt service availability. You can, however, configure the CSP rules dynamically through the `applicationConfig` plugin without restarting the server.
+Content Security Policy (CSP) is a security standard to prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in the `opensearch_dashboards.yml` file by using the `csp.rules` key. A change in the YAML file requires a server restart, which may interrupt service availability. You can, however, configure the CSP rules dynamically through the `applicationConfig` plugin without restarting the server.
 
 ## Configuration
 
-The `applicationConfig` plugin provides read and write APIs for OpenSearch Dashboards users to manage dynamic configurations as key-value pairs in an index. The `cspHandler` plugin registers a pre-response handler to `HttpServiceSetup`, which can get CSP rules from the dependent `applicationConfig` plugin, and then rewrite to the CSP header. Enable both plugins within your `opensearch_dashboards.yml` file to use this feature. The configuration is shown in the following example:
+The `applicationConfig` plugin provides read and write APIs for OpenSearch Dashboards users to manage dynamic configurations as key-value pairs in an index. The `cspHandler` plugin registers a pre-response handler to `HttpServiceSetup`, which gets CSP rules from the dependent `applicationConfig` plugin, and then rewrites to the CSP header. Enable both plugins within your `opensearch_dashboards.yml` file to use this feature. The configuration is shown in the following example. Refer to the `cspHandler` plugin [README](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/csp_handler/README.md) for configuration details.
 
 ```
 application_config.enabled: true
 csp_handler.enabled: true
-
 ```
+
 ## Enable site embedding for OpenSearch Dashboards
 
-To enable site embedding for OpenSearch Dashboards, update CSP rules using CURL. Refer to the `applicationConfig` [README](<insert-link>) for more details.
-When using CURL commands with single quotes inside the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`.
-{: .note}
+To enable site embedding for OpenSearch Dashboards, update the CSP rules using CURL. When using CURL commands with single quotes inside the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`. The configuration is shown in the following example. Refer to the `applicationConfig` plugin [README]([<insert-link>](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md)) for configuration details.
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"script-src '\''unsafe-eval'\'' '\''self'\''; worker-src blob: '\''self'\''; style-src '\''unsafe-inline'\'' '\''self'\''; frame-ancestors '\''self'\'' {new site}"}'
-
 ```
 
 ## Delete CSP rules

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -5,9 +5,9 @@ nav_order: 110
 has_children: false
 ---
 
-# Content Security Policy Rules Dynamic Configuration
+# Configuring Content Security Policy Rules Dynamically
 
-Content Security Policy (CSP) is a security standard introduced to help prevent cross-site scripting (XSS), clickjacking, and other code injection attacks resulting from the execution of malicious content in the trusted web page context. OpenSearch Dashboards supports configuring CSP rules in OSD YML file with key `csp.rules`. A change in YML file requires a server restart which may interrupt service availability. This document introduces a dynamic way to configure the CSP rules through the plugin `applicationConfig` without restarting the server.
+Content Security Policy (CSP) is a security standard introduced to help prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in OSD YML file with key `csp.rules`. A change in YML file requires a server restart which may interrupt service availability. This document introduces a dynamic way to configure the CSP rules through the plugin `applicationConfig` without restarting the server.
 
 ## Configuration
 
@@ -19,20 +19,20 @@ csp_handler.enabled: true
 
 ```
 
-For OSD users who want to make changes to allow a new site to embed OSD pages, they can update CSP rules through CURL. (See the README of `applicationConfig` for more details about the APIs.) **Please note that use backslash as string wrapper for single quotes inside the `data-raw` parameter. E.g use `'\''` to represent `'`**
+For OSD users who want to make changes to allow a new site to embed OSD pages, they can update CSP rules through CURL. (See the README of `applicationConfig` for more details about the APIs.) **Note that use backslash as string wrapper for single quotes inside the `data-raw` parameter. E.g use `'\''` to represent `'`**
 s
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"script-src '\''unsafe-eval'\'' '\''self'\''; worker-src blob: '\''self'\''; style-src '\''unsafe-inline'\'' '\''self'\''; frame-ancestors '\''self'\'' {new site}"}'
 
 ```
 
-Below is the CURL command to delete CSP rules.
+Following is the CURL command to delete CSP rules.
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules' -X DELETE -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty'
 ```
 
-Below is the CURL command to get the CSP rules.
+Following is the CURL command to get the CSP rules.
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules'
@@ -41,4 +41,4 @@ curl '{osd endpoint}/api/appconfig/csp.rules'
 
 ## Precedence
 
-In general, the dynamic configurations will take precedence over the configurations in YML. Specifically, when there is non empty CSP rules configured in the index, the rules from the YML will be used. To prevent clickjacking, we will append the `frame-ancestors` directive with value `'self'` if the rules from YML will be used and do not already have the directive `frame-ancestors`.
+In general, the dynamic configurations will take precedence over the configurations in YML. Specifically, when there is non empty CSP rules configured in the index, the rules from the YML will be used. To prevent `clickjacking`, we will append the `frame-ancestors` directive with value `'self'` if the rules from YML will be used and do not already have the directive `frame-ancestors`.

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -5,7 +5,7 @@ nav_order: 110
 has_children: false
 ---
 
-# Configuring Content Security Policy Rules Dynamically
+# Configuring content security policy rules dynamically
 
 Content Security Policy (CSP) is a security standard introduced to help prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in OSD YML file with key `csp.rules`. A change in YML file requires a server restart which may interrupt service availability. This document introduces a dynamic way to configure the CSP rules through the plugin `applicationConfig` without restarting the server.
 

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -1,38 +1,45 @@
 ---
 layout: default
-title: Content Security Policy (CSP) Rules Dynamic Configuration
+title: Content Security Policy (CSP) rules dynamic configuration
 nav_order: 110
 has_children: false
 ---
 
 # Configuring content security policy rules dynamically
 
-Content Security Policy (CSP) is a security standard introduced to help prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in OSD YML file with key `csp.rules`. A change in YML file requires a server restart which may interrupt service availability. This document introduces a dynamic way to configure the CSP rules through the plugin `applicationConfig` without restarting the server.
+Content Security Policy (CSP) is a security standard introduced to help prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the execution of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in `opensearch_dashboards.yml` file by using the `csp.rules` key. A change in YAML file requires a server restart, which may interrupt service availability. You can, however, configure the CSP rules dynamically through the `applicationConfig` plugin without restarting the server.
 
 ## Configuration
 
-The plugin `applicationConfig` provides read and write APIs for OSD customers to manage their dynamic configurations as key value pairs in an index. Another plugin `cspHandler` registers a pre-response handler to `HttpServiceSetup` which can get CSP rules from the dependent plugin `applicationConfig` and then rewrite to CSP header. Customers who want to use this feature need to enable both plugins in OSD YML as follows.
+The `applicationConfig` plugin provides read and write APIs for OpenSearch Dashboards users to manage dynamic configurations as key-value pairs in an index. The `cspHandler` plugin registers a pre-response handler to `HttpServiceSetup`, which can get CSP rules from the dependent `applicationConfig` plugin, and then rewrite to the CSP header. Enable both plugins within your `opensearch_dashboards.yml` file to use this feature. The configuration is shown in the following example:
 
 ```
 application_config.enabled: true
 csp_handler.enabled: true
 
 ```
+## Enable site embedding for OpenSearch Dashboards
 
-For OSD users who want to make changes to allow a new site to embed OSD pages, they can update CSP rules through CURL. (See the README of `applicationConfig` for more details about the APIs.) **Note that use backslash as string wrapper for single quotes inside the `data-raw` parameter. E.g use `'\''` to represent `'`**
-s
+To enable site embedding for OpenSearch Dashboards, update CSP rules using CURL. Refer to the `applicationConfig` [README](<insert-link>) for more details.
+When using CURL commands with single quotes inside the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`.
+{: .note}
+
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"script-src '\''unsafe-eval'\'' '\''self'\''; worker-src blob: '\''self'\''; style-src '\''unsafe-inline'\'' '\''self'\''; frame-ancestors '\''self'\'' {new site}"}'
 
 ```
 
-Following is the CURL command to delete CSP rules.
+## Delete CSP rules
+
+Use the following CURL command to delete CSP rules:
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules' -X DELETE -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty'
 ```
 
-Following is the CURL command to get the CSP rules.
+## Get CSP rules
+
+Use the following CURL command to get CSP rules.
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules'
@@ -41,4 +48,4 @@ curl '{osd endpoint}/api/appconfig/csp.rules'
 
 ## Precedence
 
-In general, the dynamic configurations will take precedence over the configurations in YML. Specifically, when there is non empty CSP rules configured in the index, the rules from the YML will be used. To prevent `clickjacking`, we will append the `frame-ancestors` directive with value `'self'` if the rules from YML will be used and do not already have the directive `frame-ancestors`.
+Dynamic configurations override YAML configurations, except for empty CSP rules. To prevent `clickjacking`, a `frame-ancestors: self` directive is automatically added to YAML-defined rules that lack it.

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -38,7 +38,7 @@ curl '{osd endpoint}/api/appconfig/csp.rules' -X DELETE -H 'osd-xsrf: osd-fetch'
 
 ## Get CSP rules
 
-Use the following CURL command to get CSP rules.
+Use the following CURL command to get CSP rules:
 
 ```
 curl '{osd endpoint}/api/appconfig/csp.rules'


### PR DESCRIPTION
### Description
This PR is to add instructions to configure CSP rules in OSD.

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/6139

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
