### PR TITLE
Fix default value for indices.breaker.total.use_real_memory

### DIFF
--- a/_install-and-configure/configuring-opensearch/circuit-breaker.md
+++ b/_install-and-configure/configuring-opensearch/circuit-breaker.md
@@ -15,7 +15,7 @@ To learn more about static and dynamic settings, see [Configuring OpenSearch]({{
 
 OpenSearch supports the following parent circuit breaker settings:
 
-- `indices.breaker.total.use_real_memory` (Static, Boolean): If `true`, the parent circuit breaker considers the actual memory usage. Otherwise, the parent circuit breaker considers the amount of memory reserved by the child circuit breakers. Default is `false`.
+- `indices.breaker.total.use_real_memory` (Static, Boolean): If `true`, the parent circuit breaker considers the actual memory usage. Otherwise, the parent circuit breaker considers the amount of memory reserved by the child circuit breakers. Default is `true`.
 
 - `indices.breaker.total.limit` (Dynamic, percentage): Specifies the initial memory limit for the parent circuit breaker. If `indices.breaker.total.use_real_memory` is `true`, defaults to 95% of the JVM heap. If `indices.breaker.total.use_real_memory` is `false`, defaults to 70% of the JVM heap.
 


### PR DESCRIPTION
### Description
Fix default value for indices.breaker.total.use_real_memory.

### Issues Resolved
#6269

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
