### PR TITLE
Improve terms aggregation documentation and add concurrent segment search caveats

### DIFF
--- a/_aggregations/bucket/terms.md
+++ b/_aggregations/bucket/terms.md
@@ -87,7 +87,7 @@ If the `show_term_doc_count_error` parameter is set to `true`, then the `terms` 
 
 ## The `min_doc_count` and `shard_min_doc_count` parameters
 
-You can use the `min_doc_count` parameter to filter out any unique terms with fewer than `min_doc_count` results. The `min_doc_count` threshold is applied only after merging the results retrieved from all of the shards. Each shard is unaware of the global document count for a given term. If there is a significant difference in the top `shard_size` globally frequent terms and the top terms local to a shard, you may receive unexpected results when using the `min_doc_count` parameter.
+You can use the `min_doc_count` parameter to filter out any unique terms with fewer than `min_doc_count` results. The `min_doc_count` threshold is applied only after merging the results retrieved from all of the shards. Each shard is unaware of the global document count for a given term. If there is a significant difference between the top `shard_size` globally frequent terms and the top terms local to a shard, you may receive unexpected results when using the `min_doc_count` parameter.
 
 Separately, the `shard_min_doc_count` parameter is used to filter out the unique terms that a shard returns back to the coordinator with fewer than `shard_min_doc_count` results.
 

--- a/_aggregations/bucket/terms.md
+++ b/_aggregations/bucket/terms.md
@@ -63,45 +63,45 @@ The values are returned with the key `key`.
 
 The number of buckets returned by the `terms` aggregation is controlled by the `size` parameter, which is 10 by default.
 
-Additionally, the coordinating node that’s responsible for the aggregation prompts each shard for its top unique terms. The number of buckets returned by each shard is controlled by the `shard_size` parameter. This parameter is distinct from the `size` parameter and exists as a mechanism to increase the accuracy of the bucket document counts.
+Additionally, the coordinating node responsible for the aggregation will prompt each shard for its top unique terms. The number of buckets returned by each shard is controlled by the `shard_size` parameter. This parameter is distinct from the `size` parameter and exists as a mechanism to increase the accuracy of the bucket document counts.
 
-For example, imagine a scenario where the `size` and `shard_size` parameters are both 3. The `terms` aggregation requests each shard for its top 3 unique terms. The coordinating node takes each of the results and aggregates them to compute the final result. If a shard has an object that’s not part of the top 3, then it won't show up in the response. However, increasing the `shard_size` value for this request allows each shard to return a larger number of unique terms, increasing the likelihood that the coordinating node has the full picture of all results.
+For example, imagine a scenario in which the `size` and `shard_size` parameters both have a value of 3. The `terms` aggregation prompts each shard for its top three unique terms. The coordinating node aggregates the results to compute the final result. If a shard contains an object that is not included in the top three, then it won't show up in the response. However, increasing the `shard_size` value for this request will allow each shard to return a larger number of unique terms, increasing the likelihood that the coordinating node will receive all relevant results.
 
-By default the `shard_size` parameter is set to `size * 1.5 + 10`.
+By default, the `shard_size` parameter is set to `size * 1.5 + 10`.
 
 When using concurrent segment search, the `shard_size` parameter is also applied to each segment slice. 
 
-The `shard_size` parameter serves as a way to balance between performance and document count accuracy for terms aggregations. Higher `shard_size` values will ensure higher document count accuracy but with higher memory and compute usage. Lower `shard_size` values will be more performant but with lower document count accuracy.
+The `shard_size` parameter serves as a way to balance the performance and document count accuracy of the `terms` aggregation. Higher `shard_size` values will ensure higher document count accuracy but will result in higher memory and compute usage. Lower `shard_size` values will be more performant but will result in lower document count accuracy.
 
 ## Document count error
 
 The response also includes two keys named `doc_count_error_upper_bound` and `sum_other_doc_count`.
 
-The `terms` aggregation returns the top unique terms. So, if the data has many unique terms, then some of them might not appear in the results. The `sum_other_doc_count` field is the sum of the documents that are left out of the response. In this case, the number is 0 because all the unique values appear in the response. 
+The `terms` aggregation returns the top unique terms. Therefore, if the data contains many unique terms, then some of them might not appear in the results. The `sum_other_doc_count` field represents the sum of the documents that are excluded from the response. In this case, the number is 0 because all of the unique values appear in the response. 
 
-The `doc_count_error_upper_bound` field represents the maximum possible count for a unique value that's left out of the final results. Use this field to estimate the error margin for the count. 
+The `doc_count_error_upper_bound` field represents the maximum possible count for a unique value that is excluded from the final results. Use this field to estimate the margin of error for the count. 
 
-The `doc_count_error_upper_bound` value and the entire notion of accuracy is only applicable to aggregations using the default sort order---by document count, descending. This is because when you sort by descending document count, any terms that were not returned are guaranteed to have equal or fewer documents than those terms which were returned. Based on this, you can compute the `doc_count_error_upper_bound`.
+The `doc_count_error_upper_bound` value and the concept of accuracy are only applicable to aggregations using the default sort order---by document count, descending. This is because when you sort by descending document count, any terms that were not returned are guaranteed to include equal or fewer documents than those terms that were returned. Based on this, you can compute the `doc_count_error_upper_bound`.
 
 If the `show_term_doc_count_error` parameter is set to `true`, then the `terms` aggregation will show the `doc_count_error_upper_bound` computed for each unique bucket in addition to the overall value.
 
 ## The `min_doc_count` and `shard_min_doc_count` parameters
 
-You can use the `min_doc_count` parameter to filter out any unique terms with less than `min_doc_count` results. The `min_doc_count` threshold is applied only after merging the results retrieved from all of the shards. Each shard does not know about the global document count for a given term. Thus, you may get unexpected results when using the `min_doc_count` parameter if there is a big difference between the list of top `shard_size` globally frequent terms and shard-locally frequent terms.
+You can use the `min_doc_count` parameter to filter out any unique terms with fewer than `min_doc_count` results. The `min_doc_count` threshold is applied only after merging the results retrieved from all of the shards. Each shard is unaware of the global document count for a given term. If there is a significant difference in the top `shard_size` globally frequent terms and the top terms local to a shard, you may receive unexpected results when using the `min_doc_count` parameter.
 
-Separately, the `shard_min_doc_count` parameter is used to filter out the unique terms a shard returns back to the coordinator with less than `shard_min_doc_count` results.
+Separately, the `shard_min_doc_count` parameter is used to filter out the unique terms that a shard returns back to the coordinator with fewer than `shard_min_doc_count` results.
 
-When using concurrent segment search, the `shard_min_doc_count` parameter is not applied to each segment slice.
+When using concurrent segment search, the `shard_min_doc_count` parameter is not applied to each segment slice. For more information, see the [related GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/11847).
 
 ## Collect mode
 
-There are two collect modes available: `depth_first` and `breadth_first`. The `depth_first` collection mode expands all branches of the aggregation tree in a depth-first manner and only does pruning after the expansion is done. 
+There are two collect modes available: `depth_first` and `breadth_first`. The `depth_first` collection mode expands all branches of the aggregation tree in a depth-first manner and only performs pruning after the expansion is complete. 
 
-However, when using nested terms aggregations, the cardinality of the number of buckets returned is multiplied by the cardinality of the field at each level of nesting, making it easy to see combinatorial explosion in the bucket count as you nest aggregations.
+However, when using nested `terms` aggregations, the cardinality of the number of buckets returned is multiplied by the cardinality of the field at each level of nesting, making it easy to see combinatorial explosion in the bucket count as you nest aggregations.
 
-You can use the `breadth_first` collection mode to address this issue. In this case, pruning will be applied to the first level of the aggregation tree before expanding it into the next level, potentially greatly reducing the number of buckets computed.
+You can use the `breadth_first` collection mode to address this issue. In this case, pruning will be applied to the first level of the aggregation tree before it is expanded to the next level, potentially greatly reducing the number of buckets computed.
 
-Additionally, there is memory overhead in performing `breadth_first` collection, which is linearly related to the number of matching documents. This is because `breadth_first` collection works by caching and replaying the pruned set of buckets from the parent level.
+Additionally, there is memory overhead associated with performing `breadth_first` collection, which is linearly related to the number of matching documents. This is because `breadth_first` collection works by caching and replaying the pruned set of buckets from the parent level.
 
 
 ## Account for pre-aggregated data

--- a/_aggregations/bucket/terms.md
+++ b/_aggregations/bucket/terms.md
@@ -59,21 +59,21 @@ The values are returned with the key `key`.
 `doc_count` specifies the number of documents in each bucket. By default, the buckets are sorted in descending order of `doc-count`.
 
 
-## Size & Shard Size
+## Size and shard size parameters
 
 The number of buckets returned by the `terms` aggregation is controlled by the `size` parameter, which is 10 by default.
 
-Additionally, the coordinating node that’s responsible for the aggregation prompts each shard for its top unique terms. The number of buckets returned by each shard is controlled by the `shard_sized` parameter. This is distinct from the `size` parameter and exists as a mechanism to increase the accuracy of the bucket document counts.
+Additionally, the coordinating node that’s responsible for the aggregation prompts each shard for its top unique terms. The number of buckets returned by each shard is controlled by the `shard_size` parameter. This parameter is distinct from the `size` parameter and exists as a mechanism to increase the accuracy of the bucket document counts.
 
-For example, imagine a scenario where the `size` and `shard_size` parameters are both 3. The `terms` aggregation requests each shard for its top 3 unique terms. The coordinating node takes each of the results and aggregates them to compute the final result. If a shard has an object that’s not part of the top 3, then it won't show up in the response. However, increasing the `shard_size` value for this request would allow each shard to return a larger number of unique terms, increasing the likelihood that the coordinating node has the full picture of all results.
+For example, imagine a scenario where the `size` and `shard_size` parameters are both 3. The `terms` aggregation requests each shard for its top 3 unique terms. The coordinating node takes each of the results and aggregates them to compute the final result. If a shard has an object that’s not part of the top 3, then it won't show up in the response. However, increasing the `shard_size` value for this request allows each shard to return a larger number of unique terms, increasing the likelihood that the coordinating node has the full picture of all results.
 
 By default the `shard_size` parameter is set to `size * 1.5 + 10`.
 
 When using concurrent segment search, the `shard_size` parameter is also applied to each segment slice. 
 
-The `shard_size` parameter serves as a way to balance between performance and document count accuracy for terms aggregations. Higher `shard_size` values will ensure higher document count accuracy but with higher memory and compute usage, while lower `shard_size` values will be more performant but with lower document count accuracy.
+The `shard_size` parameter serves as a way to balance between performance and document count accuracy for terms aggregations. Higher `shard_size` values will ensure higher document count accuracy but with higher memory and compute usage. Lower `shard_size` values will be more performant but with lower document count accuracy.
 
-## Document Count Error
+## Document count error
 
 The response also includes two keys named `doc_count_error_upper_bound` and `sum_other_doc_count`.
 
@@ -81,13 +81,13 @@ The `terms` aggregation returns the top unique terms. So, if the data has many u
 
 The `doc_count_error_upper_bound` field represents the maximum possible count for a unique value that's left out of the final results. Use this field to estimate the error margin for the count. 
 
-`doc_count_error_upper_bound` as well as the entire notion of accuracy is only applicable to aggregations using the default sort order -- by document count descending. This is because when we sort by descending document count we know that any terms that were not returned are guaranteed to have equal or fewer documents than those terms which were returned and from this we are able to compute the `doc_count_error_upper_bound`.
+The `doc_count_error_upper_bound` value and the entire notion of accuracy is only applicable to aggregations using the default sort order---by document count, descending. This is because when you sort by descending document count, any terms that were not returned are guaranteed to have equal or fewer documents than those terms which were returned. Based on this, you can compute the `doc_count_error_upper_bound`.
 
-If the `show_term_doc_count_error` parameter is set to `true`, then the `terms` aggregation will show the `doc_count_error_upper_bound` computer for each unique bucket as well.
+If the `show_term_doc_count_error` parameter is set to `true`, then the `terms` aggregation will show the `doc_count_error_upper_bound` computed for each unique bucket in addition to the overall value.
 
-## `min_doc_count` and `shard_min_doc_count`
+## The `min_doc_count` and `shard_min_doc_count` parameters
 
-The `min_doc_count` parameter can be used to filter out any unique terms with less than `min_doc_count` results. The `min_doc_count` threshold is applied only after merging the results retrieved from all of the shards. Each shard does not know about the global document count for a given term, so means that you may get unexpected results when using the `min_doc_count` parameter if there is a big difference between the list of top `shard_size` globally frequent terms and shard-locally frequent terms.
+You can use the `min_doc_count` parameter to filter out any unique terms with less than `min_doc_count` results. The `min_doc_count` threshold is applied only after merging the results retrieved from all of the shards. Each shard does not know about the global document count for a given term. Thus, you may get unexpected results when using the `min_doc_count` parameter if there is a big difference between the list of top `shard_size` globally frequent terms and shard-locally frequent terms.
 
 Separately, the `shard_min_doc_count` parameter is used to filter out the unique terms a shard returns back to the coordinator with less than `shard_min_doc_count` results.
 
@@ -95,13 +95,13 @@ When using concurrent segment search, the `shard_min_doc_count` parameter is not
 
 ## Collect mode
 
-There are 2 collect modes available: `depth_first` and `breadth_first`. `depth_first` collection mode expands all branches of the aggregation tree in a depth-first manner and only does pruning after the expansion is done. 
+There are two collect modes available: `depth_first` and `breadth_first`. The `depth_first` collection mode expands all branches of the aggregation tree in a depth-first manner and only does pruning after the expansion is done. 
 
-However, when using nested terms aggregations, the cardinality of the number of buckets returned is multiplied by the cardinality of the field at each level of nesting, making it easy to see combinatorial explosion in the bucket count as we nest aggregations.
+However, when using nested terms aggregations, the cardinality of the number of buckets returned is multiplied by the cardinality of the field at each level of nesting, making it easy to see combinatorial explosion in the bucket count as you nest aggregations.
 
-`breadth_first` collection mode can be used to address this issue, where pruning will be applied to the first level of the aggregation tree before expanding it into the next level, potentially greatly reducing the number of buckets computed.
+You can use the `breadth_first` collection mode to address this issue. In this case, pruning will be applied to the first level of the aggregation tree before expanding it into the next level, potentially greatly reducing the number of buckets computed.
 
-There is memory overhead in doing breadth_first collect mode as well which is linearly related to the number of matching documents as `breadth_first` collection works by cacheing and replaying the pruned set of buckets from the parent level.
+Additionally, there is memory overhead in performing `breadth_first` collection, which is linearly related to the number of matching documents. This is because `breadth_first` collection works by caching and replaying the pruned set of buckets from the parent level.
 
 
 ## Account for pre-aggregated data


### PR DESCRIPTION
### Description
Improve terms aggregation documentation by adding details for missing parameters as well as add caveats for concurrent segment search.

### Issues Resolved
Resolves: #6129
Resolves: #5046

Relates:
- https://github.com/opensearch-project/documentation-website/issues/3662


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
