### PR TITLE
Add permissions, metrics, and metadata attributes to Data Prepper dyn…

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -88,8 +88,96 @@ Option | Required | Type | Description
 :--- | :--- | :--- | :---
 `start_position` | No | String | The position from where the source starts reading stream events when the DynamoDB stream option is enabled. `LATEST` starts reading events from the most recent stream record. 
 
+## Exposed metadata attributes
+
+The following metadata will be added to each Event that is processed by the DynamoDB source. These metadata attributes can be accessed with
+the [expression syntax getMetadata function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
+
+* `primary_key` - The primary key of the DynamoDB item. For tables that only contain a partition key, this value will give the partition key. For tables that contain both a partition and sort key, the primary_key attribute will be equal to the partition and sort key, separated by a `|` (i.e. `partition_key|sort_key`)
+* `partition_key` - The partition key of the DynamoDB item
+* `sort_key` - The sort key of the DynamoDB item. This will be null if the table does not have a sort key
+* `dynamodb_timestamp` - The timestamp of the DynamoDB item. This will be the export time for export items, and the DDB stream Event time for stream items. This timestamp is used by sinks to emit an `EndtoEndLatency` metric for DDB stream Events, which tracks the latency between a change in the DDB table, and that change getting applied to the sink.
+* `document_version` - Based off the `dynamodb_timestamp`, and modified to break ties between stream items that are received in the same second. Recommend for use with the `opensearch` sink `document_version` setting.
+* `opensearch_action` - A default value for mapping DDB Event actions to OpenSearch actions. This action will be `index` for export items, and INSERT or MODIFY stream events. This action will be `delete` for REMOVE stream events.
+* `dynamodb_event_name` - The exact event type for the item. Will be `null` for export items, and either `INSERT`, `MODIFY`, or `REMOVE` for stream events.
+* `table_name` - The DynamoDB table name that an event came from.
 
 
+## Permissions
+
+The following shows the minimum required permissions for running DDB as a source
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "allowRunExportJob",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:DescribeTable",
+                "dynamodb:DescribeContinuousBackups",
+                "dynamodb:ExportTableToPointInTime"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-east-1:{account-id}:table/my-table"
+            ]
+        },
+        {
+            "Sid": "allowCheckExportjob",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:DescribeExport"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-east-1:{account-id}:table/my-table/export/*"
+            ]
+        },
+        {
+            "Sid": "allowReadFromStream",
+            "Effect": "Allow",
+            "Action": [
+                "dynamodb:DescribeStream",
+                "dynamodb:GetRecords",
+                "dynamodb:GetShardIterator"
+            ],
+            "Resource": [
+                "arn:aws:dynamodb:us-east-1:{account-id}:table/my-table/stream/*"
+            ]
+        },
+        {
+            "Sid": "allowReadAndWriteToS3ForExport",
+            "Effect": "Allow",
+            "Action": [
+                "s3:GetObject",
+                "s3:AbortMultipartUpload",
+                "s3:PutObject",
+                "s3:PutObjectAcl"
+            ],
+            "Resource": [
+                "arn:aws:s3:::my-bucket/*"
+            ]
+        }
+    ]
+}
+```
+
+## Metrics
+
+The `dynamodb` source includes the following metrics
+
+### Counters
+
+* `exportJobSuccess` - The number of export jobs that have been submitted successfully
+* `exportJobFailure` - The number of export job submission attempts that have failed
+* `exportS3ObjectsTotal` - The total number of export data files found in S3 for an export
+* `exportS3ObjectsProcessed` - The total number of export data files that have been processed successfully from S3
+* `exportRecordsTotal` - The total number of records found the entire export
+* `exportRecordsProcessed` - The total number of export records that have been processed successfully
+* `exportRecordsProcessingErrors` - The number of export record processing errors
+* `changeEventsProcessed` - The number of change events processed from DDB streams
+* `changeEventsProcessingErrors` - The number of processing errors for change events from DDB streams
+* `shardProgress` - Incremented when DDB streams is being read from correctly. If this is 0 for a certain period of time, then there is a problem with the pipeline if it has streams enabled
 
 
 

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -92,14 +92,14 @@ Option | Required | Type | Description
 
 The following metadata will be added to each event that is processed by the `dynamodb` source. These metadata attributes can be accessed using the [expression syntax `getMetadata` function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
 
-* `primary_key` - The primary key of the DynamoDB item. For tables that only contain a partition key, this value provides the partition key. For tables that contain both a partition and sort key, the `primary_key` attribute will be equal to the partition and sort key, separated by a `|`, for example, `partition_key|sort_key`.
-* `partition_key` - The partition key of the DynamoDB item.
-* `sort_key` - The sort key of the DynamoDB item. This will be null if the table does not contain a sort key.
-* `dynamodb_timestamp` - The timestamp of the DynamoDB item. This will be the export time for export items and the DynamoDB stream event time for stream items. This timestamp is used by sinks to emit an `EndtoEndLatency` metric for DynamoDB stream events that tracks the latency between a change occurring in the DynamoDB table and that change being applied to the sink.
-* `document_version` - Uses the `dynamodb_timestamp` to modify break ties between stream items that are received in the same second. Recommend for use with the `opensearch` sink's `document_version` setting.
-* `opensearch_action` - A default value for mapping DynamoDB event actions to OpenSearch actions. This action will be `index` for export items, and `INSERT` or `MODIFY` for stream events, and `REMOVE` stream events when the OpenSearch action is `delete`.
-* `dynamodb_event_name` - The exact event type for the item. Will be `null` for export items and either `INSERT`, `MODIFY`, or `REMOVE` for stream events.
-* `table_name` - The name of the DynamoDB table that an event came from.
+* `primary_key`: The primary key of the DynamoDB item. For tables that only contain a partition key, this value provides the partition key. For tables that contain both a partition and sort key, the `primary_key` attribute will be equal to the partition and sort key, separated by a `|`, for example, `partition_key|sort_key`.
+* `partition_key`: The partition key of the DynamoDB item.
+* `sort_key`: The sort key of the DynamoDB item. This will be null if the table does not contain a sort key.
+* `dynamodb_timestamp`: The timestamp of the DynamoDB item. This will be the export time for export items and the DynamoDB stream event time for stream items. This timestamp is used by sinks to emit an `EndtoEndLatency` metric for DynamoDB stream events that tracks the latency between a change occurring in the DynamoDB table and that change being applied to the sink.
+* `document_version`: Uses the `dynamodb_timestamp` to modify break ties between stream items that are received in the same second. Recommend for use with the `opensearch` sink's `document_version` setting.
+* `opensearch_action`: A default value for mapping DynamoDB event actions to OpenSearch actions. This action will be `index` for export items, and `INSERT` or `MODIFY` for stream events, and `REMOVE` stream events when the OpenSearch action is `delete`.
+* `dynamodb_event_name`: The exact event type for the item. Will be `null` for export items and either `INSERT`, `MODIFY`, or `REMOVE` for stream events.
+* `table_name`: The name of the DynamoDB table that an event came from.
 
 
 ## Permissions
@@ -179,16 +179,16 @@ The `dynamodb` source includes the following metrics.
 
 ### Counters
 
-* `exportJobSuccess` - The number of export jobs that have been submitted successfully.
-* `exportJobFailure` - The number of export job submission attempts that have failed.
-* `exportS3ObjectsTotal` - The total number of export data files found in S3.
-* `exportS3ObjectsProcessed` - The total number of export data files that have been processed successfully from S3.
-* `exportRecordsTotal` - The total number of records found in the export.
-* `exportRecordsProcessed` - The total number of export records that have been processed successfully.
-* `exportRecordsProcessingErrors` - The number of export record processing errors.
-* `changeEventsProcessed` - The number of change events processed from DynamoDB streams.
-* `changeEventsProcessingErrors` - The number of processing errors for change events from DynamoDB streams.
-* `shardProgress` - The incremented shard progress when DynamoDB streams are being read correctly. If this is `0` for a certain period of time, then there is a problem with the pipeline that has streams enabled.
+* `exportJobSuccess`: The number of export jobs that have been submitted successfully.
+* `exportJobFailure`: The number of export job submission attempts that have failed.
+* `exportS3ObjectsTotal`: The total number of export data files found in S3.
+* `exportS3ObjectsProcessed`: The total number of export data files that have been processed successfully from S3.
+* `exportRecordsTotal`: The total number of records found in the export.
+* `exportRecordsProcessed`: The total number of export records that have been processed successfully.
+* `exportRecordsProcessingErrors`: The number of export record processing errors.
+* `changeEventsProcessed`: The number of change events processed from DynamoDB streams.
+* `changeEventsProcessingErrors`: The number of processing errors for change events from DynamoDB streams.
+* `shardProgress`: The incremented shard progress when DynamoDB streams are being read correctly. If this is `0` for a certain period of time, then there is a problem with the pipeline that has streams enabled.
 
 
 

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -90,21 +90,21 @@ Option | Required | Type | Description
 
 ## Exposed metadata attributes
 
-The following metadata will be added to each event that is processed by the `dynamodb` source. These metadata attributes can be accessed with the [expression syntax `getMetadata` function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
+The following metadata will be added to each event that is processed by the `dynamodb` source. These metadata attributes can be accessed using the [expression syntax `getMetadata` function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
 
-* `primary_key` - The primary key of the DynamoDB item. For tables that only contain a partition key, this value gives the partition key. For tables that contain both a partition and sort key, the` primary_key` attribute will be equal to the partition and sort key, separated by a `|`, for example `partition_key|sort_key`.
+* `primary_key` - The primary key of the DynamoDB item. For tables that only contain a partition key, this value provides the partition key. For tables that contain both a partition and sort key, the `primary_key` attribute will be equal to the partition and sort key, separated by a `|`, for example, `partition_key|sort_key`.
 * `partition_key` - The partition key of the DynamoDB item.
-* `sort_key` - The sort key of the DynamoDB item. This will be null if the table does not have a sort key.
-* `dynamodb_timestamp` - The timestamp of the DynamoDB item. This will be the export time for export items and the DynamoDB stream event time for stream items. This timestamp is used by sinks to emit an `EndtoEndLatency` metric for DynamoDB stream events, which tracks the latency between a change in the DynamoDB table and that change getting applied to the sink.
+* `sort_key` - The sort key of the DynamoDB item. This will be null if the table does not contain a sort key.
+* `dynamodb_timestamp` - The timestamp of the DynamoDB item. This will be the export time for export items and the DynamoDB stream event time for stream items. This timestamp is used by sinks to emit an `EndtoEndLatency` metric for DynamoDB stream events that tracks the latency between a change occurring in the DynamoDB table and that change being applied to the sink.
 * `document_version` - Uses the `dynamodb_timestamp` to modify break ties between stream items that are received in the same second. Recommend for use with the `opensearch` sink's `document_version` setting.
 * `opensearch_action` - A default value for mapping DynamoDB event actions to OpenSearch actions. This action will be `index` for export items, and `INSERT` or `MODIFY` for stream events, and `REMOVE` stream events when the OpenSearch action is `delete`.
-* `dynamodb_event_name` - The exact event type for the item. Will be `null` for export items, and either `INSERT`, `MODIFY`, or `REMOVE` for stream events.
-* `table_name` - The DynamoDB table name that an event came from.
+* `dynamodb_event_name` - The exact event type for the item. Will be `null` for export items and either `INSERT`, `MODIFY`, or `REMOVE` for stream events.
+* `table_name` - The name of the DynamoDB table that an event came from.
 
 
 ## Permissions
 
-The following shows the minimum required permissions for running DynamoDB as a source:
+The following are the minimum required permissions for running DynamoDB as a source:
 
 ```json
 {
@@ -170,20 +170,20 @@ The following shows the minimum required permissions for running DynamoDB as a s
 }
 ```
 
-When performing an export, `"Sid": "allowReadFromStream"` section is not required. If only reading from DynamoDB streams, the 
-`"Sid": "allowReadAndWriteToS3ForExport"`, `"Sid": "allowCheckExportjob"`, ` "Sid": "allowRunExportJob"` sections are not required.
+When performing an export, the `"Sid": "allowReadFromStream"` section is not required. If only reading from DynamoDB streams, the 
+`"Sid": "allowReadAndWriteToS3ForExport"`, `"Sid": "allowCheckExportjob"`, and ` "Sid": "allowRunExportJob"` sections are not required.
 
 ## Metrics
 
-The `dynamodb` source includes the following metrics:
+The `dynamodb` source includes the following metrics.
 
 ### Counters
 
 * `exportJobSuccess` - The number of export jobs that have been submitted successfully.
 * `exportJobFailure` - The number of export job submission attempts that have failed.
-* `exportS3ObjectsTotal` - The total number of export data files found in S3 for an export.
+* `exportS3ObjectsTotal` - The total number of export data files found in S3.
 * `exportS3ObjectsProcessed` - The total number of export data files that have been processed successfully from S3.
-* `exportRecordsTotal` - The total number of records found in the entire export.
+* `exportRecordsTotal` - The total number of records found in the export.
 * `exportRecordsProcessed` - The total number of export records that have been processed successfully.
 * `exportRecordsProcessingErrors` - The number of export record processing errors.
 * `changeEventsProcessed` - The number of change events processed from DynamoDB streams.

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -90,22 +90,21 @@ Option | Required | Type | Description
 
 ## Exposed metadata attributes
 
-The following metadata will be added to each Event that is processed by the DynamoDB source. These metadata attributes can be accessed with
-the [expression syntax `getMetadata` function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
+The following metadata will be added to each rvent that is processed by the `dynamodb` source. These metadata attributes can be accessed with the [expression syntax `getMetadata` function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
 
-* `primary_key` - The primary key of the DynamoDB item. For tables that only contain a partition key, this value will give the partition key. For tables that contain both a partition and sort key, the primary_key attribute will be equal to the partition and sort key, separated by a `|` (i.e. `partition_key|sort_key`)
-* `partition_key` - The partition key of the DynamoDB item
-* `sort_key` - The sort key of the DynamoDB item. This will be null if the table does not have a sort key
-* `dynamodb_timestamp` - The timestamp of the DynamoDB item. This will be the export time for export items, and the DynamoDB stream Event time for stream items. This timestamp is used by sinks to emit an `EndtoEndLatency` metric for DynamoDB stream Events, which tracks the latency between a change in the DynamoDB table, and that change getting applied to the sink.
-* `document_version` - Based off the `dynamodb_timestamp`, and modified to break ties between stream items that are received in the same second. Recommend for use with the `opensearch` sink `document_version` setting.
-* `opensearch_action` - A default value for mapping DynamoDB Event actions to OpenSearch actions. This action will be `index` for export items, and INSERT or MODIFY stream events. This action will be `delete` for REMOVE stream events.
+* `primary_key` - The primary key of the DynamoDB item. For tables that only contain a partition key, this value gives the partition key. For tables that contain both a partition and sort key, the` primary_key` attribute will be equal to the partition and sort key, separated by a `|`, for example `partition_key|sort_key`.
+* `partition_key` - The partition key of the DynamoDB item.
+* `sort_key` - The sort key of the DynamoDB item. This will be null if the table does not have a sort key.
+* `dynamodb_timestamp` - The timestamp of the DynamoDB item. This will be the export time for export items and the DynamoDB stream event time for stream items. This timestamp is used by sinks to emit an `EndtoEndLatency` metric for DynamoDB stream events, which tracks the latency between a change in the DynamoDB table and that change getting applied to the sink.
+* `document_version` - Uses the `dynamodb_timestamp` to modify break ties between stream items that are received in the same second. Recommend for use with the `opensearch` sink's `document_version` setting.
+* `opensearch_action` - A default value for mapping DynamoDB event actions to OpenSearch actions. This action will be `index` for export items, and `INSERT` or `MODIFY` for stream events, and `REMOVE` stream events when the OpenSearch action is `delete`.
 * `dynamodb_event_name` - The exact event type for the item. Will be `null` for export items, and either `INSERT`, `MODIFY`, or `REMOVE` for stream events.
 * `table_name` - The DynamoDB table name that an event came from.
 
 
 ## Permissions
 
-The following shows the minimum required permissions for running DynamoDB as a source
+The following shows the minimum required permissions for running DynamoDB as a source:
 
 ```json
 {
@@ -171,25 +170,25 @@ The following shows the minimum required permissions for running DynamoDB as a s
 }
 ```
 
-If only doing an export, `"Sid": "allowReadFromStream"` section is not required. If only reading from DynamoDB streams, the 
+When performing an export, `"Sid": "allowReadFromStream"` section is not required. If only reading from DynamoDB streams, the 
 `"Sid": "allowReadAndWriteToS3ForExport"`, `"Sid": "allowCheckExportjob"`, ` "Sid": "allowRunExportJob"` sections are not required.
 
 ## Metrics
 
-The `dynamodb` source includes the following metrics
+The `dynamodb` source includes the following metrics:
 
 ### Counters
 
-* `exportJobSuccess` - The number of export jobs that have been submitted successfully
-* `exportJobFailure` - The number of export job submission attempts that have failed
-* `exportS3ObjectsTotal` - The total number of export data files found in S3 for an export
-* `exportS3ObjectsProcessed` - The total number of export data files that have been processed successfully from S3
-* `exportRecordsTotal` - The total number of records found the entire export
-* `exportRecordsProcessed` - The total number of export records that have been processed successfully
-* `exportRecordsProcessingErrors` - The number of export record processing errors
-* `changeEventsProcessed` - The number of change events processed from DynamoDB streams
-* `changeEventsProcessingErrors` - The number of processing errors for change events from DynamoDB streams
-* `shardProgress` - Incremented when DynamoDB streams is being read from correctly. If this is 0 for a certain period of time, then there is a problem with the pipeline if it has streams enabled
+* `exportJobSuccess` - The number of export jobs that have been submitted successfully.
+* `exportJobFailure` - The number of export job submission attempts that have failed.
+* `exportS3ObjectsTotal` - The total number of export data files found in S3 for an export.
+* `exportS3ObjectsProcessed` - The total number of export data files that have been processed successfully from S3.
+* `exportRecordsTotal` - The total number of records found in the entire export.
+* `exportRecordsProcessed` - The total number of export records that have been processed successfully.
+* `exportRecordsProcessingErrors` - The number of export record processing errors.
+* `changeEventsProcessed` - The number of change events processed from DynamoDB streams.
+* `changeEventsProcessingErrors` - The number of processing errors for change events from DynamoDB streams.
+* `shardProgress` - The incremented shard progress when DynamoDB streams are being read correctly. If this is `0` for a certain period of time, then there is a problem with the pipeline that has streams enabled.
 
 
 

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -90,7 +90,7 @@ Option | Required | Type | Description
 
 ## Exposed metadata attributes
 
-The following metadata will be added to each rvent that is processed by the `dynamodb` source. These metadata attributes can be accessed with the [expression syntax `getMetadata` function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
+The following metadata will be added to each event that is processed by the `dynamodb` source. These metadata attributes can be accessed with the [expression syntax `getMetadata` function](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/#getmetadata).
 
 * `primary_key` - The primary key of the DynamoDB item. For tables that only contain a partition key, this value gives the partition key. For tables that contain both a partition and sort key, the` primary_key` attribute will be equal to the partition and sort key, separated by a `|`, for example `partition_key|sort_key`.
 * `partition_key` - The partition key of the DynamoDB item.

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -188,7 +188,7 @@ The `dynamodb` source includes the following metrics.
 * `exportRecordsProcessingErrors`: The number of export record processing errors.
 * `changeEventsProcessed`: The number of change events processed from DynamoDB streams.
 * `changeEventsProcessingErrors`: The number of processing errors for change events from DynamoDB streams.
-* `shardProgress`: The incremented shard progress when DynamoDB streams are being read correctly. If this is `0` for a certain period of time, then there is a problem with the pipeline that has streams enabled.
+* `shardProgress`: The incremented shard progress when DynamoDB streams are being read correctly. This being`0` for any significant amount of time means there is a problem with the pipeline that has streams enabled.
 
 
 


### PR DESCRIPTION
…amodb source documentation

### Description
This change adds some important information for using the `dynamodb` source in Data Prepper, including metadata attributes that are added to Events, a minimum permissions policy, and metrics that the dynamodb source emits.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
