### PR TITLE
Improvements to the S3 sink documenation

### DIFF
--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -8,21 +8,21 @@ nav_order: 55
 
 # s3
 
-The `s3` sink saves batches of events to [Amazon Simple Storage Service (Amazon S3)](https://aws.amazon.com/s3/) objects.
+The `s3` sink saves batches of events to [Amazon Simple Storage Service (Amazon S3)](https://aws.amazon.com/s3/) objects and writes batches of Data Prepper events to S3 objects. The configured `codec` determines how the `s3` sink serializes the data into S3.
 
-It writes batches of Data Prepper events to S3 objects. You configure a `codec` which determines how the the sink serializes the data into S3.
 
-Each batch of objects is written to an S3 object. The format for each object will look somewhat like the following.
+The `s3` sink uses the following format when batching events:
+
+```
+${pathPrefix}events-%{yyyy-MM-dd'T'HH-mm-ss'Z'}-${currentTimeInNanos}-${uniquenessId}.${codecSuppliedExtension}
+```
+
+When a batch of objects is written to S3, the format of the object looks similar to the following:
 
 ```
 my-logs/2023/06/09/06/events-2023-06-09T06-00-01-1686290401871214927-ae15b8fa-512a-59c2-b917-295a0eff97c8.json
 ```
 
-The actual format is defined as:
-
-```
-${pathPrefix}events-%{yyyy-MM-dd'T'HH-mm-ss'Z'}-${currentTimeInNanos}-${uniquenessId}.${codecSuppliedExtension}
-```
 
 See the [Object key](#object-key-configuration) for more details on how to configure the key.
 
@@ -93,7 +93,7 @@ Option | Required | Type | Description
 `region` | No | String | The AWS Region to use for credentials. Defaults to [standard SDK behavior to determine the Region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 `sts_role_arn` | No | String | The AWS Security Token Service (AWS STS) role to assume for requests to Amazon SQS and Amazon S3. Defaults to `null`, which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).
 `sts_header_overrides` | No | Map | A map of header overrides that the IAM role assumes for the sink plugin.
-`sts_external_id` | No | String | An STS external Id to use when Data Prepper assumes the role. See the documentation for ExternalId in the [STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) reference for more details.
+`sts_external_id` | No | String | An STS external ID to use when Data Prepper assumes the role. For more information, see the documentation for `ExternalId` in the [STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) reference.
 
 
 
@@ -191,9 +191,9 @@ Option | Required | Type | Description
 `schema` | Yes | String | The Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration). Not required if `auto_schema` is set to true.
 `auto_schema` | No | Boolean | When set to `true`, automatically generates the Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration) from the first event.
 
-#### Setting a schema with Parquet
+### Setting a schema with Parquet
 
-The following example shows how you could configure the `s3` sink to write Parquet data with a schema for AWS VPC Flow logs.
+The following example shows how you can configure the `s3` sink to write Parquet data with a schema for the AWS VPC Flow logs.
 
 ```
 pipeline:

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -120,7 +120,7 @@ Option | Required | Type | Description
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
-`path_prefix` | No | String | The S3 key prefix path to use for objects written to S3. Accepts date-time formatting. For example, you can use `%{yyyy}/%{MM}/%{dd}/%{HH}/` to create hourly folders in S3. You should have this end with a `/`. By default, Data Prepper writes objects to the root of the S3 bucket.
+`path_prefix` | No | String | The S3 key prefix path to use for objects written to S3. Accepts date-time formatting. For example, you can use `%{yyyy}/%{MM}/%{dd}/%{HH}/` to create hourly folders in S3. The prefix path should end with `/`. By default, Data Prepper writes objects to the root of the S3 bucket.
 
 
 ## codec

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -22,19 +22,37 @@ pipeline:
         aws:
           region: us-east-1
           sts_role_arn: arn:aws:iam::123456789012:role/Data-Prepper
-          sts_header_overrides:
         max_retries: 5
-        bucket:
-          name: bucket_name
-          object_key:
-            path_prefix: my-elb/%{yyyy}/%{MM}/%{dd}/
+        bucket: mys3bucket
+        object_key:
+          path_prefix: my-elb/%{yyyy}/%{MM}/%{dd}/
         threshold:
-          event_count: 2000
+          event_count: 10000
           maximum_size: 50mb
           event_collect_timeout: 15s
         codec:
           ndjson:
         buffer_type: in_memory
+```
+
+## IAM permissions
+
+In order to use the `s3` sink, configure your AWS Identity and Access Management (IAM) permissions to grant Data Prepper access to write to Amazon S3. You can use a configuration similar to the following JSON configuration:
+
+```json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "s3-access",
+            "Effect": "Allow",
+            "Action": [
+              "s3:PutObject"
+            ],
+            "Resource": "arn:aws:s3:::<YOUR-BUCKET>/*"
+        }
+    ]
+}
 ```
 
 ## Configuration 
@@ -43,11 +61,11 @@ Use the following options when customizing the `s3` sink.
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
-`bucket` | Yes | String | The object from which the data is retrieved and then stored. The `name` must match the name of your object store.
-`codec` | Yes | [Buffer type](#buffer-type) | Determines the buffer type. 
+`bucket` | Yes | String | The name of the S3 bucket which this sink writes to.
+`codec` | Yes | [Codec](#codec) | The codec for how the data is serialized in the S3 object.
 `aws` | Yes | AWS | The AWS configuration. See [aws](#aws) for more information.
 `threshold` | Yes | [Threshold](#threshold-configuration) | Configures when to write an object to S3. 
-`object_key` | No | Sets the `path_prefix` and the `file_pattern` of the object store. Defaults to the S3 object `events-%{yyyy-MM-dd'T'hh-mm-ss}` found inside the root directory of the bucket.
+`object_key` | No | [Object key](#object-key-configuration) | Sets the `path_prefix` and the `file_pattern` of the object store. Defaults to the S3 object `events-%{yyyy-MM-dd'T'hh-mm-ss}` found inside the root directory of the bucket.
 `compression` | No | String | The compression algorithm to apply: `none`, `gzip`, or `snappy`. Default is `none`. 
 `buffer_type` | No | [Buffer type](#buffer-type) | Determines the buffer type. 
 `max_retries` | No | Integer | The maximum number of times a single request should retry when ingesting data to S3. Defaults to `5`.
@@ -59,33 +77,34 @@ Option | Required | Type | Description
 `region` | No | String | The AWS Region to use for credentials. Defaults to [standard SDK behavior to determine the Region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 `sts_role_arn` | No | String | The AWS Security Token Service (AWS STS) role to assume for requests to Amazon SQS and Amazon S3. Defaults to `null`, which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).
 `sts_header_overrides` | No | Map | A map of header overrides that the IAM role assumes for the sink plugin.
-`sts_external_id` | No | String | The external ID to attach to AssumeRole requests from AWS STS.
+`sts_external_id` | No | String | An STS external Id to use when Data Prepper assumes the role. See the documentation for ExternalId in the [STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) reference for more details.
+
 
 
 ## Threshold configuration
 
-Use the following options to set ingestion thresholds for the `s3` sink.
+Use the following options to set ingestion thresholds for the `s3` sink. When any of these conditions is met, Data Prepper will write events to an S3 object.
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
-`event_count` | Yes | Integer | The maximum number of events the S3 bucket can ingest. 
-`maximum_size` | Yes | String | The maximum number of bytes that the S3 bucket can ingest after compression. Defaults to `50mb`.
-`event_collect_timeout` | Yes | String | Sets the time period during which events are collected before ingestion. All values are strings that represent duration, either an ISO_8601 notation string, such as `PT20.345S`, or a simple notation, such as `60s` or `1500ms`.
+`event_count` | Yes | Integer | The number of Data Prepper events to accumulate before writing an object to S3.
+`maximum_size` | No | String | The maximum number of bytes to accumulate before writing an object to S3. Defaults to `50mb`.
+`event_collect_timeout` | Yes | String | The maximum timeout before Data Prepper writes an event to S3. The value should be either an ISO-8601 duration, such as `PT2M30S`, or a simple notation, such as `60s` or `1500ms`.
 
 
 ## Buffer type
 
-`buffer_type` is an optional configuration that records stored events temporarily before flushing them into an S3 bucket. The default value is `in_memory`. Use one of the following options: 
+`buffer_type` is an optional configuration that determines how Data Prepper temporarily holds data before writing an S3 object to S3. The default value is `in_memory`. Use one of the following options:
 
 - `in_memory`: Stores the record in memory.
-- `local_file`: Flushes the record into a file on your machine. 
+- `local_file`: Flushes the record into a file on your machine. This uses your local machine's temporary directory.
 - `multipart`: Writes using the [S3 multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html). Every 10 MB is written as a part.
 
 ## Object key configuration
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
-`path_prefix` | Yes | String | The S3 key prefix path to use. Accepts date-time formatting. For example, you can use `%{yyyy}/%{MM}/%{dd}/%{HH}/` to create hourly folders in S3. By default, events write to the root of the bucket. 
+`path_prefix` | No | String | The S3 key prefix path to use for objects written to S3. Accepts date-time formatting. For example, you can use `%{yyyy}/%{MM}/%{dd}/%{HH}/` to create hourly folders in S3. By default, Data Prepper writes objects to the root of the S3 bucket.
 
 
 ## codec
@@ -155,4 +174,50 @@ Option | Required | Type | Description
 :--- | :--- | :--- | :---
 `schema` | Yes | String | The Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration). Not required if `auto_schema` is set to true.
 `auto_schema` | No | Boolean | When set to `true`, automatically generates the Avro [schema declaration](https://avro.apache.org/docs/current/specification/#schema-declaration) from the first event.
+
+#### Setting a schema with Parquet
+
+The following example shows how you could configure the `s3` sink to write Parquet data with a schema for AWS VPC Flow logs.
+
+```
+pipeline:
+  ...
+  sink:
+    - s3:
+        aws:
+          region: us-east-1
+          sts_role_arn: arn:aws:iam::123456789012:role/Data-Prepper
+        bucket: mys3bucket
+        object_key:
+          path_prefix: vpc-flow-logs/%{yyyy}/%{MM}/%{dd}/%{HH}/
+        codec:
+          parquet:
+            schema: >
+              {
+                "type" : "record",
+                "namespace" : "org.opensearch.dataprepper.examples",
+                "name" : "VpcFlowLog",
+                "fields" : [
+                  { "name" : "version", "type" : ["null", "string"]},
+                  { "name" : "srcport", "type": ["null", "int"]},
+                  { "name" : "dstport", "type": ["null", "int"]},
+                  { "name" : "accountId", "type" : ["null", "string"]},
+                  { "name" : "interfaceId", "type" : ["null", "string"]},
+                  { "name" : "srcaddr", "type" : ["null", "string"]},
+                  { "name" : "dstaddr", "type" : ["null", "string"]},
+                  { "name" : "start", "type": ["null", "int"]},
+                  { "name" : "end", "type": ["null", "int"]},
+                  { "name" : "protocol", "type": ["null", "int"]},
+                  { "name" : "packets", "type": ["null", "int"]},
+                  { "name" : "bytes", "type": ["null", "int"]},
+                  { "name" : "action", "type": ["null", "string"]},
+                  { "name" : "logStatus", "type" : ["null", "string"]}
+                ]
+              }
+        threshold:
+          event_count: 500000000
+          maximum_size: 20mb
+          event_collect_timeout: PT15M
+        buffer_type: in_memory
+```
 

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -8,7 +8,7 @@ nav_order: 55
 
 # s3
 
-The `s3` sink saves batches of events to [Amazon Simple Storage Service (Amazon S3)](https://aws.amazon.com/s3/) objects and writes batches of Data Prepper events to S3 objects. The configured `codec` determines how the `s3` sink serializes the data into S3.
+The `s3` sink saves and writes batches of Data Prepper events to Amazon Simple Storage Service (Amazon S3) objects. The configured `codec` determines how the `s3` sink serializes the data into Amazon S3.
 
 
 The `s3` sink uses the following format when batching events:

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -10,7 +10,6 @@ nav_order: 55
 
 The `s3` sink saves and writes batches of Data Prepper events to Amazon Simple Storage Service (Amazon S3) objects. The configured `codec` determines how the `s3` sink serializes the data into Amazon S3.
 
-
 The `s3` sink uses the following format when batching events:
 
 ```

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -193,7 +193,7 @@ Option | Required | Type | Description
 
 ### Setting a schema with Parquet
 
-The following example shows you how to configure the `s3` sink to write Parquet data with a schema for VPC Flow Logs:
+The following example shows you how to configure the `s3` sink to write Parquet data into a Parquet file using a schema for VPC Flow Logs:
 
 ```
 pipeline:

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -10,6 +10,22 @@ nav_order: 55
 
 The `s3` sink saves batches of events to [Amazon Simple Storage Service (Amazon S3)](https://aws.amazon.com/s3/) objects.
 
+It writes batches of Data Prepper events to S3 objects. You configure a `codec` which determines how the the sink serializes the data into S3.
+
+Each batch of objects is written to an S3 object. The format for each object will look somewhat like the following.
+
+```
+my-logs/2023/06/09/06/events-2023-06-09T06-00-01-1686290401871214927-ae15b8fa-512a-59c2-b917-295a0eff97c8.json
+```
+
+The actual format is defined as:
+
+```
+${pathPrefix}events-%{yyyy-MM-dd'T'HH-mm-ss'Z'}-${currentTimeInNanos}-${uniquenessId}.${codecSuppliedExtension}
+```
+
+See the [Object key](#object-key-configuration) for more details on how to configure the key.
+
 ## Usage
 
 The following example creates a pipeline configured with an s3 sink. It contains additional options for customizing the event and size thresholds for which the pipeline sends record events and sets the codec type `ndjson`:
@@ -25,7 +41,7 @@ pipeline:
         max_retries: 5
         bucket: mys3bucket
         object_key:
-          path_prefix: my-elb/%{yyyy}/%{MM}/%{dd}/
+          path_prefix: my-logs/%{yyyy}/%{MM}/%{dd}/
         threshold:
           event_count: 10000
           maximum_size: 50mb
@@ -65,7 +81,7 @@ Option | Required | Type | Description
 `codec` | Yes | [Codec](#codec) | The codec for how the data is serialized in the S3 object.
 `aws` | Yes | AWS | The AWS configuration. See [aws](#aws) for more information.
 `threshold` | Yes | [Threshold](#threshold-configuration) | Configures when to write an object to S3. 
-`object_key` | No | [Object key](#object-key-configuration) | Sets the `path_prefix` and the `file_pattern` of the object store. Defaults to the S3 object `events-%{yyyy-MM-dd'T'hh-mm-ss}` found inside the root directory of the bucket.
+`object_key` | No | [Object key](#object-key-configuration) | Sets the `path_prefix` of the object in S3. Defaults to the S3 object `events-%{yyyy-MM-dd'T'hh-mm-ss}` found inside the root directory of the bucket.
 `compression` | No | String | The compression algorithm to apply: `none`, `gzip`, or `snappy`. Default is `none`. 
 `buffer_type` | No | [Buffer type](#buffer-type) | Determines the buffer type. 
 `max_retries` | No | Integer | The maximum number of times a single request should retry when ingesting data to S3. Defaults to `5`.
@@ -104,7 +120,7 @@ Option | Required | Type | Description
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
-`path_prefix` | No | String | The S3 key prefix path to use for objects written to S3. Accepts date-time formatting. For example, you can use `%{yyyy}/%{MM}/%{dd}/%{HH}/` to create hourly folders in S3. By default, Data Prepper writes objects to the root of the S3 bucket.
+`path_prefix` | No | String | The S3 key prefix path to use for objects written to S3. Accepts date-time formatting. For example, you can use `%{yyyy}/%{MM}/%{dd}/%{HH}/` to create hourly folders in S3. You should have this end with a `/`. By default, Data Prepper writes objects to the root of the S3 bucket.
 
 
 ## codec

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -24,7 +24,7 @@ my-logs/2023/06/09/06/events-2023-06-09T06-00-01-1686290401871214927-ae15b8fa-51
 ```
 
 
-For more information on how to configure an object, see the [Object key](#object-key-configuration) section.
+For more information about how to configure an object, see the [Object key](#object-key-configuration) section.
 
 ## Usage
 

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -192,7 +192,7 @@ Option | Required | Type | Description
 
 ### Setting a schema with Parquet
 
-The following example shows you how to configure the `s3` sink to write Parquet data into a Parquet file using a schema for VPC Flow Logs:
+The following example shows you how to configure the `s3` sink to write Parquet data into a Parquet file using a schema for [VPC Flow Logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html#flow-log-records):
 
 ```
 pipeline:

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -17,7 +17,7 @@ The `s3` sink uses the following format when batching events:
 ${pathPrefix}events-%{yyyy-MM-dd'T'HH-mm-ss'Z'}-${currentTimeInNanos}-${uniquenessId}.${codecSuppliedExtension}
 ```
 
-When a batch of objects is written to S3, the format of the object looks similar to the following:
+When a batch of objects is written to S3, the objects are formatted similarly to the following:
 
 ```
 my-logs/2023/06/09/06/events-2023-06-09T06-00-01-1686290401871214927-ae15b8fa-512a-59c2-b917-295a0eff97c8.json
@@ -53,7 +53,7 @@ pipeline:
 
 ## IAM permissions
 
-In order to use the `s3` sink, configure your AWS Identity and Access Management (IAM) permissions to grant Data Prepper access to write to Amazon S3. You can use a configuration similar to the following JSON configuration:
+In order to use the `s3` sink, configure AWS Identity and Access Management (IAM) to grant Data Prepper permissions to write to Amazon S3. You can use a configuration similar to the following JSON configuration:
 
 ```json
 {
@@ -77,11 +77,11 @@ Use the following options when customizing the `s3` sink.
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
-`bucket` | Yes | String | The name of the S3 bucket which this sink writes to.
-`codec` | Yes | [Codec](#codec) | The codec for how the data is serialized in the S3 object.
+`bucket` | Yes | String | The name of the S3 bucket to which the sink writes.
+`codec` | Yes | [Codec](#codec) | The codec that determines how the data is serialized in the S3 object.
 `aws` | Yes | AWS | The AWS configuration. See [aws](#aws) for more information.
 `threshold` | Yes | [Threshold](#threshold-configuration) | Configures when to write an object to S3. 
-`object_key` | No | [Object key](#object-key-configuration) | Sets the `path_prefix` of the object in S3. Defaults to the S3 object `events-%{yyyy-MM-dd'T'hh-mm-ss}` found inside the root directory of the bucket.
+`object_key` | No | [Object key](#object-key-configuration) | Sets the `path_prefix` of the object in S3. Defaults to the S3 object `events-%{yyyy-MM-dd'T'hh-mm-ss}` found in the root directory of the bucket.
 `compression` | No | String | The compression algorithm to apply: `none`, `gzip`, or `snappy`. Default is `none`. 
 `buffer_type` | No | [Buffer type](#buffer-type) | Determines the buffer type. 
 `max_retries` | No | Integer | The maximum number of times a single request should retry when ingesting data to S3. Defaults to `5`.
@@ -93,27 +93,27 @@ Option | Required | Type | Description
 `region` | No | String | The AWS Region to use for credentials. Defaults to [standard SDK behavior to determine the Region](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/region-selection.html).
 `sts_role_arn` | No | String | The AWS Security Token Service (AWS STS) role to assume for requests to Amazon SQS and Amazon S3. Defaults to `null`, which will use the [standard SDK behavior for credentials](https://docs.aws.amazon.com/sdk-for-java/latest/developer-guide/credentials.html).
 `sts_header_overrides` | No | Map | A map of header overrides that the IAM role assumes for the sink plugin.
-`sts_external_id` | No | String | An STS external ID to use when Data Prepper assumes the role. For more information, see the documentation for `ExternalId` in the [STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) reference.
+`sts_external_id` | No | String | An STS external ID used when Data Prepper assumes the role. For more information, see the `ExternalId` documentation in the [STS AssumeRole](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRole.html) API reference.
 
 
 
 ## Threshold configuration
 
-Use the following options to set ingestion thresholds for the `s3` sink. When any of these conditions is met, Data Prepper will write events to an S3 object.
+Use the following options to set ingestion thresholds for the `s3` sink. When any of these conditions are met, Data Prepper will write events to an S3 object.
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
 `event_count` | Yes | Integer | The number of Data Prepper events to accumulate before writing an object to S3.
-`maximum_size` | No | String | The maximum number of bytes to accumulate before writing an object to S3. Defaults to `50mb`.
+`maximum_size` | No | String | The maximum number of bytes to accumulate before writing an object to S3. Default is `50mb`.
 `event_collect_timeout` | Yes | String | The maximum timeout before Data Prepper writes an event to S3. The value should be either an ISO-8601 duration, such as `PT2M30S`, or a simple notation, such as `60s` or `1500ms`.
 
 
 ## Buffer type
 
-`buffer_type` is an optional configuration that determines how Data Prepper temporarily holds data before writing an S3 object to S3. The default value is `in_memory`. Use one of the following options:
+`buffer_type` is an optional configuration that determines how Data Prepper temporarily stores data before writing an object to S3. The default value is `in_memory`. Use one of the following options:
 
 - `in_memory`: Stores the record in memory.
-- `local_file`: Flushes the record into a file on your machine. This uses your local machine's temporary directory.
+- `local_file`: Flushes the record into a file on your local machine. This uses your machine's temporary directory.
 - `multipart`: Writes using the [S3 multipart upload](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpuoverview.html). Every 10 MB is written as a part.
 
 ## Object key configuration
@@ -193,7 +193,7 @@ Option | Required | Type | Description
 
 ### Setting a schema with Parquet
 
-The following example shows how you can configure the `s3` sink to write Parquet data with a schema for the AWS VPC Flow logs.
+The following example shows you how to configure the `s3` sink to write Parquet data with a schema for VPC Flow Logs:
 
 ```
 pipeline:

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -105,7 +105,7 @@ Option | Required | Type | Description
 :--- | :--- | :--- | :---
 `event_count` | Yes | Integer | The number of Data Prepper events to accumulate before writing an object to S3.
 `maximum_size` | No | String | The maximum number of bytes to accumulate before writing an object to S3. Default is `50mb`.
-`event_collect_timeout` | Yes | String | The maximum timeout before Data Prepper writes an event to S3. The value should be either an ISO-8601 duration, such as `PT2M30S`, or a simple notation, such as `60s` or `1500ms`.
+`event_collect_timeout` | Yes | String | The maximum amount of time before Data Prepper writes an event to S3. The value should be either an ISO-8601 duration, such as `PT2M30S`, or a simple notation, such as `60s` or `1500ms`.
 
 
 ## Buffer type

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -24,7 +24,7 @@ my-logs/2023/06/09/06/events-2023-06-09T06-00-01-1686290401871214927-ae15b8fa-51
 ```
 
 
-See the [Object key](#object-key-configuration) for more details on how to configure the key.
+For more information on how to configure an object, see the [Object key](#object-key-configuration) section.
 
 ## Usage
 


### PR DESCRIPTION
### Description

* Clarifies some configurations and corrects others.
* Adds an example IAM policy
* Adds an example inline Avro schema for Parquet

### Issues Resolved

N/A


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
