### PR TITLE
Add documentation for exclude_roles settings for LDAP security config

### DIFF
--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -509,6 +509,7 @@ Name | Description
 `resolve_nested_roles`  | Boolean. Whether or not to resolve nested roles. Default is `false`.
 `max_nested_depth`  | Integer. When `resolve_nested_roles` is `true`, this defines the maximum number of nested roles to traverse. Setting smaller values can reduce the amount of data retrieved from LDAP and improve authentication times at the cost of failing to discover deeply nested roles. Default is `30`.
 `skip_users`  | Array of users that should be skipped when retrieving roles. Wildcards and regular expressions are supported.
+`exclude_roles`  | String array. Specifies which roles to filter out when extracting backend roles from LDAP. Wildcards are supported.
 `nested_role_filter`  | Array of role DNs that should be filtered before resolving nested roles. Wildcards and regular expressions are supported.
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.
 `custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.

--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -509,7 +509,7 @@ Name | Description
 `resolve_nested_roles`  | Boolean. Whether or not to resolve nested roles. Default is `false`.
 `max_nested_depth`  | Integer. When `resolve_nested_roles` is `true`, this defines the maximum number of nested roles to traverse. Setting smaller values can reduce the amount of data retrieved from LDAP and improve authentication times at the cost of failing to discover deeply nested roles. Default is `30`.
 `skip_users`  | Array of users that should be skipped when retrieving roles. Wildcards and regular expressions are supported.
-`exclude_roles`  | String array. Specifies which roles to filter out when extracting backend roles from LDAP. Wildcards are supported.
+`exclude_roles`  | Array of roles that should be excluded when retrieving roles. Wildcards are supported.
 `nested_role_filter`  | Array of role DNs that should be filtered before resolving nested roles. Wildcards and regular expressions are supported.
 `rolesearch_enabled`  | Boolean. Enable or disable the role search. Default is `true`.
 `custom_attr_allowlist`  | String array. Specifies the LDAP attributes that should be made available for variable substitution.


### PR DESCRIPTION
### Description

Adds `exclude_roles` setting description in the LDAP section of the security configuration. This setting allows a cluster administrator specify roles to ignore when extracting roles from a backend LDAP system which is useful if the roles are not pertinent to using OpenSearch.

### Issues Resolved

- Related PR in security plugin: https://github.com/opensearch-project/security/pull/4025

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
