### PR TITLE
Update index.md

### DIFF
--- a/_observing-your-data/notifications/index.md
+++ b/_observing-your-data/notifications/index.md
@@ -123,8 +123,8 @@ To send or receive notifications with email, choose **Email** as the channel typ
 If your email provider requires SSL or TLS, you must authenticate each sender account before you can send an email. Enter the sender account credentials in the OpenSearch keystore using the command line interface (CLI). Run the following commands (in your OpenSearch directory) to enter your user name and password. The &lt;sender_name&gt; is the name you entered for **Sender** earlier.
 
 ```json
-opensearch.notifications.core.email.<sender_name>.username
-opensearch.notifications.core.email.<sender_name>.password
+/usr/share/opensearch/bin/opensearch-keystore add opensearch.notifications.core.email.<sender_name>.username
+/usr/share/opensearch/bin/opensearch-keystore add opensearch.notifications.core.email.<sender_name>.password
 ```
 
 To change or update your credentials (after you’ve added them to the keystore on every node), call the reload API to automatically update those credentials without restarting OpenSearch.


### PR DESCRIPTION
Missing command 
/usr/share/opensearch/bin/opensearch-keystore add

### Description
I was assisting with the case https://forum.opensearch.org/t/support-for-smtp-office365-com/9920 and the OpenSearch docs stated "Enter the sender account credentials in the OpenSearch keystore using the command line interface (CLI)." However, the example didn't contain the full command but only the keystore entry. 


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
