### PR TITLE
Updates the text for Data Prepper on the landing page

### DIFF
--- a/_includes/cards.html
+++ b/_includes/cards.html
@@ -12,7 +12,7 @@
     <div class="card">
       <a href="{{site.url}}/docs/latest/data-prepper/" class='card-link'></a>
         <p class="heading">Data Prepper</p>
-        <p class="description">Prepare your data for OpenSearch</p>
+        <p class="description">Filter, mutate, and sample your data for ingestion into OpenSearch</p>
         <p class="last-link" >Documentation &#x2192;</p>
       </div>
   
@@ -26,7 +26,7 @@
     
     <div class="card">
       <a href="{{site.url}}/docs/latest/benchmark/" class='card-link'></a>
-        <p class="heading">Benchmark</p>
+        <p class="heading">OpenSearch Benchmark</p>
         <p class="description">Track OpenSearch performance</p>
         <p class="last-link">Documentation &#x2192;</p>
       </div>  


### PR DESCRIPTION
### Description
This PR updates the text on the documentation landing page to more accurately represent Data Prepper. It also adds "OpenSearch" to the Benchmark tile.

### Issues Resolved
n/a


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
