### PR TITLE
Fix Java client example

### DIFF
--- a/_clients/java.md
+++ b/_clients/java.md
@@ -222,10 +222,10 @@ public class OpenSearchClientExample {
     System.setProperty("javax.net.ssl.trustStore", "/full/path/to/keystore");
     System.setProperty("javax.net.ssl.trustStorePassword", "password-to-keystore");
 
-    final HttpHost host = new HttpHost("https", 9200, "localhost");
+    final HttpHost host = new HttpHost("https", "localhost", 9200);
     final BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
     //Only for demo purposes. Don't specify your credentials in code.
-    credentialsProvider.setCredentials(new AuthScope(host), new UsernamePasswordCredentials("admin", "admin"));
+    credentialsProvider.setCredentials(new AuthScope(host), new UsernamePasswordCredentials("admin", "admin".toCharArray()));
 
     //Initialize the client with SSL and TLS enabled
     final RestClient restClient = RestClient.builder(host).


### PR DESCRIPTION
### Description

The syntax provided for the second example at https://opensearch.org/docs/latest/clients/java/#initializing-the-client-with-ssl-and-tls-enabled-using-restclient-transport is invalid:
 - hostname and port order are reversed
 - the password field is a character array

The correct syntax is used earlier on the page for the Apache HTTP client version.

### Issues Resolved

Typo fix.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
