### PR TITLE
Update of Configure user section in Debian installation procedure

### DIFF
--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -404,7 +404,7 @@ TLS certificates provide additional security for your cluster by allowing client
 
 ### Configure a user
 
-Users are defined and authenticated by OpenSearch in a variety of ways. One method that does not require additional backend infrastructure is to manually configure users in `internal_users.yml`. See [YAML files]({{site.url}}{{site.baseurl}}/security-plugin/configuration/yaml/) for more information about configuring users. The following steps explain how to remove all demo users except for the `admin` user and how to replace the `admin` default password using a script.
+Users are defined and authenticated by OpenSearch in a variety of ways. One method that does not require additional backend infrastructure is to manually configure users in `internal_users.yml`. See [YAML files]({{site.url}}{{site.baseurl}}/security-plugin/configuration/yaml/) for more information about configuring users. The following steps explain how to add a new internal user and how to replace the `admin` default password using a script.
 
 1. Navigate to the Security plugins tools directory.
    ```bash
@@ -440,7 +440,7 @@ Users are defined and authenticated by OpenSearch in a variety of ways. One meth
    ```
    {% include copy.html %}
 
-1. Remove all demo users except for `admin` and replace the hash with the output provided by `hash.sh` in a previous step. The file should look similar to the following example:
+1. Add a new internal user and replace the hash with the output provided by `hash.sh` in a previous step. The file should look similar to the following example:
    ```bash
    ---
    # This is the internal user database
@@ -458,6 +458,15 @@ Users are defined and authenticated by OpenSearch in a variety of ways. One meth
       backend_roles:
       - "admin"
       description: "Admin user"
+
+   user1:
+      hash: "$2y$12$zoHpvTCRjjQr6h0PEaabueCaGam3/LDvT6rZZGDGMusD7oehQjw/O"
+      reserved: false
+      backend_roles: []
+      description: "New internal user"
+
+   # Other users 
+   ...
    ```
    {% include copy.html %}
 

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -440,7 +440,7 @@ Users are defined and authenticated by OpenSearch in a variety of ways. One meth
    ```
    {% include copy.html %}
 
-1. Add a new internal user and replace the hash with the output provided by `hash.sh` in a previous step. The file should look similar to the following example:
+1. Add a new internal user and replace the hash inside `internal_users.yml` with the output provided by `hash.sh` in step 2. The file should look similar to the following example:
    ```bash
    ---
    # This is the internal user database


### PR DESCRIPTION
### Description
In the current Debian installation procedure the `Configure user` tells to remove all the demo users from the internal_users.yml file except the `admin` user. 
I would avoid removing all the demo users during the installation process. For example, removing the `kibanaserver` user from internal_users.yml will prevent OpenSearch Dashboards with initial configuration from successful connection to OpenSearch nodes. 
Any additional changes to the internal_users.yml file (including removing demo users), should be done after the successful deployment of OpenSearch and OpenSearch Dashboards. 


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
