### PR TITLE
Introduce the relationship between geohash precision and the approximte grid cell dimensions

### DIFF
--- a/_aggregations/bucket/geohash-grid.md
+++ b/_aggregations/bucket/geohash-grid.md
@@ -264,7 +264,7 @@ shard_size | Integer | The maximum number of buckets to return from each shard. 
 
 The relationship between geohash precision and the approximate grid cell dimensions is described in the following table.
 
-Percision /<br>geohash length | Latitude bits | Longitude bits | Latitude error | Longitude error | Cell height | Cell width
+Precision /<br>geohash length | Latitude bits | Longitude bits | Latitude error | Longitude error | Cell height | Cell width
 :---:|:-------------:|:--------------:|:--------------:|:---------------:|:-----------:|:----------:
   1  |       2       |       3        |      ±23       |       ±23       |  4992.6 km  | 5009.4 km  
   2  |       5       |       5        |      ±2.8      |      ±5.6       |  624.1 km   | 1252.3 km  


### PR DESCRIPTION
### Description
Introduce the relationship between geohash precision and the approximte grid cell dimensions

I am not sure if the _bits_ columns are really needed but might be of help for those who want to understand the precision. On the other hand, I think without the _error_ columns, the precision of _dimensions_ would be incomplete.

Related to https://github.com/opensearch-project/OpenSearch-Dashboards/issues/5865

![Geohash grid](https://github.com/opensearch-project/documentation-website/assets/3527403/ea3533b5-d4b6-4e4c-b87c-704d54f13e9d)



### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
