### PR TITLE
Update docker.md

### DIFF
--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -155,7 +155,12 @@ docker-compose -f /path/to/your-file.yml up
 
 If this is your first time launching an OpenSearch cluster using Docker Compose, use the following example `docker-compose.yml` file. Save it in the home directory of your host and name it `docker-compose.yml`. This file will create a cluster that contains three containers: two containers running the OpenSearch service and a single container running OpenSearch Dashboards. These containers will communicate over a bridge network called `opensearch-net` and use two volumes, one for each OpenSearch node. Because this file does not explicitly disable the demo security configuration, self-signed TLS certificates are installed and internal users with default names and passwords are created.
 
-Starting with OpenSearch 2.12.0, a custom admin password is required to set up a demo security configuration. For a Docker cluster-setup using `docker-compose.yml`, you can do either of the following: 1) export `OPENSEARCH_INITIAL_ADMIN_PASSWORD` with a value in the same terminal session before running `docker-compose up`, or 2) create an `.env` file in the same folder as your `docker-compose.yml` file with the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` and strong password values.
+### Setting a custom admin password
+
+Starting with OpenSearch 2.12, a custom admin password is required to set up a demo security configuration. For a docker cluster set up using a `docker-compose.yml` file, do either of the following:
+
+1. Export `OPENSEARCH_INITIAL_ADMIN_PASSWORD` with a value in the same terminal session before running `docker-compose up`.
+2. Create an `.env` file in the same folder as your `docker-compose.yml` file with the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` and strong password values.
 {: .note}
 
 ### Sample docker-compose.yml

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -155,6 +155,9 @@ docker-compose -f /path/to/your-file.yml up
 
 If this is your first time launching an OpenSearch cluster using Docker Compose, use the following example `docker-compose.yml` file. Save it in the home directory of your host and name it `docker-compose.yml`. This file will create a cluster that contains three containers: two containers running the OpenSearch service and a single container running OpenSearch Dashboards. These containers will communicate over a bridge network called `opensearch-net` and use two volumes, one for each OpenSearch node. Because this file does not explicitly disable the demo security configuration, self-signed TLS certificates are installed and internal users with default names and passwords are created.
 
+Starting with OpenSearch 2.12.0, a custom admin password is required to set up a demo security configuration. For a Docker cluster-setup using `docker-compose.yml`, you can do either of the following: 1) export `OPENSEARCH_INITIAL_ADMIN_PASSWORD` with a value in the same terminal session before running `docker-compose up`, or 2) create an `.env` file in the same folder as your `docker-compose.yml` file with the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` and strong password values.
+{: .note}
+
 ### Sample docker-compose.yml
 
 ```yml

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -161,7 +161,6 @@ Starting with OpenSearch 2.12, a custom admin password is required to set up a d
 
 1. Export `OPENSEARCH_INITIAL_ADMIN_PASSWORD` with a value in the same terminal session before running `docker-compose up`.
 2. Create an `.env` file in the same folder as your `docker-compose.yml` file with the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` and strong password values.
-{: .note}
 
 ### Sample docker-compose.yml
 

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -157,7 +157,7 @@ If this is your first time launching an OpenSearch cluster using Docker Compose,
 
 ### Setting a custom admin password
 
-Starting with OpenSearch 2.12, a custom admin password is required to set up a demo security configuration. For a docker cluster set up using a `docker-compose.yml` file, do either of the following:
+Starting with OpenSearch 2.12, a custom admin password is required to set up a demo security configuration. For a Docker cluster set up using a `docker-compose.yml` file, do either of the following:
 
 1. Export `OPENSEARCH_INITIAL_ADMIN_PASSWORD` with a value in the same terminal session before running `docker-compose up`.
 2. Create an `.env` file in the same folder as your `docker-compose.yml` file with the `OPENSEARCH_INITIAL_ADMIN_PASSWORD` and strong password values.

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -173,7 +173,7 @@ services:
       - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2 # Nodes eligible to serve as cluster manager
       - bootstrap.memory_lock=true # Disable JVM heap memory swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
-      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}    # Sets the demo admin user password when using demo configuration, required for OpenSearch 2.12 and higher
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}    # Sets the demo admin user password when using demo configuration, required for OpenSearch 2.12 and later
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -170,6 +170,7 @@ services:
       - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2 # Nodes eligible to serve as cluster manager
       - bootstrap.memory_lock=true # Disable JVM heap memory swapping
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m" # Set min and max JVM heap sizes to at least 50% of system RAM
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}    # Sets the demo admin user password when using demo configuration, required for OpenSearch 2.12 and higher
     ulimits:
       memlock:
         soft: -1 # Set memlock to unlimited (no soft or hard limit)
@@ -194,6 +195,7 @@ services:
       - cluster.initial_cluster_manager_nodes=opensearch-node1,opensearch-node2
       - bootstrap.memory_lock=true
       - "OPENSEARCH_JAVA_OPTS=-Xms512m -Xmx512m"
+      - OPENSEARCH_INITIAL_ADMIN_PASSWORD=${OPENSEARCH_INITIAL_ADMIN_PASSWORD}
     ulimits:
       memlock:
         soft: -1


### PR DESCRIPTION
Adding OPENSEARCH_INITIAL_ADMIN_PASSWORD variable to OpenSearch node for version 2.12.0.

### Description
Adding OPENSEARCH_INITIAL_ADMIN_PASSWORD variable to OpenSearch nodes in example docker-compose.yml file for version 2.12.0.



### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
