### PR TITLE
LDAP certificate validation wrong troststore_filepath setting

### DIFF
--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -72,7 +72,7 @@ Name | Description
 `plugins.security.ssl.http.keystore_alias` | Alias name. Optional. Default is the first alias.
 `plugins.security.ssl.http.keystore_password` | Keystore password. Default is `changeit`.
 `plugins.security.ssl.http.truststore_type` | The type of the truststore file, JKS or PKCS12/PFX. Default is JKS.
-`plugins.security.ssl.http.truststore_filepath` | Path to the truststore file, which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.http.transport.truststore_filepath` | Path to the truststore file, which must be under the `config` directory, specified using a relative path. Required.
 `plugins.security.ssl.http.truststore_alias` | Alias name. Optional. Default is all certificates.
 `plugins.security.ssl.http.truststore_password` | Truststore password. Default is `changeit`.
 


### PR DESCRIPTION


### Description
The docs about LDAP auth backend references to a wrong setting in the "Certificate validation" section.
Instead of plugins.security.ssl.http.truststore_filepath it should be plugins.security.ssl.transport.truststore_filepath.

### Issues Resolved
Addresses https://github.com/opensearch-project/documentation-website/issues/6522


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
