### PR TITLE
Specify how to enable ssl hostname verification for python client

### DIFF
--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -123,6 +123,41 @@ client = OpenSearch(
 ```
 {% include copy.html %}
 
+If you need to verify ssl to a different hostname, specify it in `ssl_assert_hostname`: 
+
+```python
+host = 'localhost'
+port = 9200
+
+# Create the client with SSL/TLS and hostname verification disabled.
+client = OpenSearch(
+    hosts = [{'host': host, 'port': port}],
+    http_compress = True, # enables gzip compression for request bodies
+    use_ssl = True,
+    verify_certs = False,
+    ssl_assert_hostname = 'example.com',
+    ssl_show_warn = False
+)
+```
+{% include copy.html %}
+
+If you need to enable ssl hostname verification to the same host, specify None, or leave it to its default value.
+```python
+host = 'localhost'
+port = 9200
+
+# Create the client with SSL/TLS and hostname verification disabled.
+client = OpenSearch(
+    hosts = [{'host': host, 'port': port}],
+    http_compress = True, # enables gzip compression for request bodies
+    use_ssl = True,
+    verify_certs = False,
+    ssl_assert_hostname = None,
+    ssl_show_warn = False
+)
+```
+{% include copy.html %}
+
 ## Connecting to Amazon OpenSearch Serverless
 
 The following example illustrates connecting to Amazon OpenSearch Serverless Service:

--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -45,7 +45,7 @@ client = OpenSearch(
     http_auth = auth,
     use_ssl = True,
     verify_certs = True,
-    ssl_assert_hostname = False,
+    ssl_assert_hostname = False, # specify a different hostname, or None to use server_hostname
     ssl_show_warn = False,
     ca_certs = ca_certs_path
 )
@@ -73,7 +73,7 @@ client = OpenSearch(
     client_key = client_key_path,
     use_ssl = True,
     verify_certs = True,
-    ssl_assert_hostname = False,
+    ssl_assert_hostname = False, # specify a different hostname, or None to use server_hostname
     ssl_show_warn = False,
     ca_certs = ca_certs_path
 )

--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -45,7 +45,7 @@ client = OpenSearch(
     http_auth = auth,
     use_ssl = True,
     verify_certs = True,
-    ssl_assert_hostname = False, # specify a different hostname, or None to use server_hostname
+    ssl_assert_hostname = False,
     ssl_show_warn = False,
     ca_certs = ca_certs_path
 )
@@ -73,7 +73,7 @@ client = OpenSearch(
     client_key = client_key_path,
     use_ssl = True,
     verify_certs = True,
-    ssl_assert_hostname = False, # specify a different hostname, or None to use server_hostname
+    ssl_assert_hostname = False,
     ssl_show_warn = False,
     ca_certs = ca_certs_path
 )
@@ -94,31 +94,6 @@ client = OpenSearch(
     verify_certs = False,
     ssl_assert_hostname = False,
     ssl_show_warn = False
-)
-```
-{% include copy.html %}
-
-## Connecting to Amazon OpenSearch Service
-
-The following example illustrates connecting to Amazon OpenSearch Service:
-
-```python
-from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
-import boto3
-
-host = '' # cluster endpoint, for example: my-test-domain.us-east-1.es.amazonaws.com
-region = 'us-west-2'
-service = 'es'
-credentials = boto3.Session().get_credentials()
-auth = AWSV4SignerAuth(credentials, region, service)
-
-client = OpenSearch(
-    hosts = [{'host': host, 'port': 443}],
-    http_auth = auth,
-    use_ssl = True,
-    verify_certs = True,
-    connection_class = RequestsHttpConnection,
-    pool_maxsize = 20
 )
 ```
 {% include copy.html %}
@@ -154,6 +129,31 @@ client = OpenSearch(
     verify_certs = False,
     ssl_assert_hostname = None,
     ssl_show_warn = False
+)
+```
+{% include copy.html %}
+
+## Connecting to Amazon OpenSearch Service
+
+The following example illustrates connecting to Amazon OpenSearch Service:
+
+```python
+from opensearchpy import OpenSearch, RequestsHttpConnection, AWSV4SignerAuth
+import boto3
+
+host = '' # cluster endpoint, for example: my-test-domain.us-east-1.es.amazonaws.com
+region = 'us-west-2'
+service = 'es'
+credentials = boto3.Session().get_credentials()
+auth = AWSV4SignerAuth(credentials, region, service)
+
+client = OpenSearch(
+    hosts = [{'host': host, 'port': 443}],
+    http_auth = auth,
+    use_ssl = True,
+    verify_certs = True,
+    connection_class = RequestsHttpConnection,
+    pool_maxsize = 20
 )
 ```
 {% include copy.html %}


### PR DESCRIPTION
### Description
Python client documentation does not specify how to properly enable ssl hostname verification. The trick is that the `False` value when disabled needs to become a string when enabled, which is confusing.

### Issues Resolved
None


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
