### PR TITLE
Add documentation for Search Workflow State API

### DIFF
--- a/_automating-configurations/api/get-workflow-status.md
+++ b/_automating-configurations/api/get-workflow-status.md
@@ -83,7 +83,8 @@ While provisioning is in progress, OpenSearch returns a partial resource list:
     {
       "workflow_step_name": "create_connector",
       "workflow_step_id": "create_connector_1",
-      "connector_id": "NdjCQYwBLmvn802B0IwE"
+      "resource_type": "connector_id",
+      "resource_id": "NdjCQYwBLmvn802B0IwE"
     }
   ]
 }
@@ -99,12 +100,14 @@ Upon provisioning completion, OpenSearch returns the full resource list:
     {
       "workflow_step_name": "create_connector",
       "workflow_step_id": "create_connector_1",
-      "connector_id": "NdjCQYwBLmvn802B0IwE"
+      "resource_type": "connector_id",
+      "resource_id": "NdjCQYwBLmvn802B0IwE"
     },
     {
       "workflow_step_name": "register_remote_model",
       "workflow_step_id": "register_model_2",
-      "model_id": "N9jCQYwBLmvn802B0oyh"
+      "resource_type": "model_id",
+      "resource_id": "N9jCQYwBLmvn802B0oyh"
     }
   ]
 }

--- a/_automating-configurations/api/index.md
+++ b/_automating-configurations/api/index.md
@@ -19,5 +19,6 @@ OpenSearch supports the following workflow APIs:
 * [Get workflow status]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/)
 * [Get workflow steps]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-steps/)
 * [Search workflow]({{site.url}}{{site.baseurl}}/automating-configurations/api/search-workflow/)
+* [Search workflow state]({{site.url}}{{site.baseurl}}/automating-configurations/api/search-workflow-state/)
 * [Deprovision workflow]({{site.url}}{{site.baseurl}}/automating-configurations/api/deprovision-workflow/)
 * [Delete workflow]({{site.url}}{{site.baseurl}}/automating-configurations/api/delete-workflow/)

--- a/_automating-configurations/api/search-workflow-state.md
+++ b/_automating-configurations/api/search-workflow-state.md
@@ -10,7 +10,7 @@ nav_order: 65
 This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
 {: .warning}
 
-You can search for resources created by workflows using a query matching a field. The fields you can search correspond to those returned by the [Get Workflow Status API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/).
+You can search for resources created by workflows by matching a query to a field. The fields you can search correspond to those returned by the [Get Workflow Status API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/).
 
 ## Path and HTTP methods
 
@@ -33,7 +33,7 @@ GET /_plugins/_flow_framework/workflow/state/_search
 ```
 {% include copy-curl.html %}
 
-#### Example request: All workflows which have a `resources_created` field with a `workflow_step_id` of `register_model_2`
+#### Example request: All workflows that have a `resources_created` field with a `workflow_step_id` of `register_model_2`
 
 ```json
 GET /_plugins/_flow_framework/workflow/state/_search
@@ -60,4 +60,4 @@ GET /_plugins/_flow_framework/workflow/state/_search
 
 #### Example response
 
-OpenSearch responds with a search response with hits matching the search parameters.
+The response contains documents matching the search parameters.

--- a/_automating-configurations/api/search-workflow-state.md
+++ b/_automating-configurations/api/search-workflow-state.md
@@ -38,22 +38,22 @@ GET /_plugins/_flow_framework/workflow/state/_search
 ```json
 GET /_plugins/_flow_framework/workflow/state/_search
 {
-    "query": {
-        "nested": {
-            "path": "resources_created",
-            "query": {
-                "bool": {
-                    "must": [
-                        {
-                            "match": {
-                                "resources_created.workflow_step_id": "register_model_2"
-                            }
-                        }
-                    ]
-                }
+  "query": {
+    "nested": {
+      "path": "resources_created",
+      "query": {
+        "bool": {
+          "must": [
+            {
+              "match": {
+                "resources_created.workflow_step_id": "register_model_2"
+              }
             }
+          ]
         }
+      }
     }
+  }
 }
 ```
 {% include copy-curl.html %}

--- a/_automating-configurations/api/search-workflow-state.md
+++ b/_automating-configurations/api/search-workflow-state.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Search for a workflow state
+parent: Workflow APIs
+nav_order: 65
+---
+
+# Search for a workflow
+
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
+{: .warning}
+
+You can search for resources created by workflows using a query matching a field. The fields you can search correspond to those returned by the [Get Workflow Status API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/).
+
+## Path and HTTP methods
+
+```json
+GET /_plugins/_flow_framework/workflow/state/_search
+POST /_plugins/_flow_framework/workflow/state/_search
+``` 
+
+#### Example request: All workflows with a state of `NOT_STARTED`
+
+```json
+GET /_plugins/_flow_framework/workflow/state/_search
+{
+  "query": {
+    "match": {
+      "state": "NOT_STARTED"
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+#### Example request: All workflows which have a `resources_created` field with a `workflow_step_id` of `register_model_2`
+
+```json
+GET /_plugins/_flow_framework/workflow/state/_search
+{
+    "query": {
+        "nested": {
+            "path": "resources_created",
+            "query": {
+                "bool": {
+                    "must": [
+                        {
+                            "match": {
+                                "resources_created.workflow_step_id": "register_model_2"
+                            }
+                        }
+                    ]
+                }
+            }
+        }
+    }
+}
+```
+{% include copy-curl.html %}
+
+#### Example response
+
+OpenSearch responds with a search response with hits matching the search parameters.

--- a/_automating-configurations/api/search-workflow.md
+++ b/_automating-configurations/api/search-workflow.md
@@ -24,7 +24,7 @@ POST /_plugins/_flow_framework/workflow/_search
 ```json
 GET /_plugins/_flow_framework/workflow/_search
 {
-    "query": {
+  "query": {
     "match_all": {}
   }
 }
@@ -36,7 +36,7 @@ GET /_plugins/_flow_framework/workflow/_search
 ```json
 GET /_plugins/_flow_framework/workflow/_search
 {
-    "query": {
+  "query": {
     "match": {
       "use_case": "REMOTE_MODEL_DEPLOYMENT"
     }


### PR DESCRIPTION
### Description

The Search Workflow State API was missed when providing documentation for the 2.12 release.  Here it is!

Please backport to 2.12 docs.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
