### PR TITLE
Add documentation for parameter substitution when provisioning workflows

### DIFF
--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -64,7 +64,7 @@ The following table lists the available query parameters. All query parameters a
 | :--- | :--- | :--- |
 | `provision` | Boolean | Whether to provision the workflow as part of the request. Default is `false`. |
 | `validation` | String | Whether to validate the workflow. Valid values are `all` (validate the template) and `none` (do not validate the template). Default is `all`. |
-| User-provided substitution expressions | String | Parameters matching substitution expressions in the template. Only allowed if `provision` is set to `true`.  Optional. |
+| User-provided substitution expressions | String | Parameters matching substitution expressions in the template. Only allowed if `provision` is set to `true`. Optional. If `provision` is set to `false`, you can pass these parameters in the [Provision Workflow API query parameters]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/#query-parameters). |
 
 ## Request fields
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -16,6 +16,8 @@ Creating a workflow adds the content of a workflow template to the flow framewor
 
 To obtain the validation template for workflow steps, call the [Get Workflow Steps API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-steps/).
 
+You can include expresions in the value of workflow step fields which will be substituted with a user-provided value during provisioning, using the format `${{ <value> }}`. For example, you can specify a credential field in a template as `openAI_key: '${{ openai_key }}'`, and then pass the actual key as a parameter using the [Provision Workflow API]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/) or using this API with the `provision` parameter set to `true`.
+
 Once a workflow is created, provide its `workflow_id` to other APIs.
 
 The `POST` method creates a new workflow. The `PUT` method updates an existing workflow. 
@@ -56,12 +58,13 @@ POST /_plugins/_flow_framework/workflow?validation=none
 ```
 {% include copy-curl.html %}
 
-The following table lists the available query parameters. All query parameters are optional.
+The following table lists the available query parameters. All query parameters are optional. User-provided parameters are only allowed if the `provision` parameter is set to `true`.
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
 | `provision` | Boolean | Whether to provision the workflow as part of the request. Default is `false`. |
 | `validation` | String | Whether to validate the workflow. Valid values are `all` (validate the template) and `none` (do not validate the template). Default is `all`. |
+| User-provided | String | Parameters matching substitutions in the template. Optional. |
 
 ## Request fields
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -16,7 +16,7 @@ Creating a workflow adds the content of a workflow template to the flow framewor
 
 To obtain the validation template for workflow steps, call the [Get Workflow Steps API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-steps/).
 
-You can include expressions in the value of workflow step fields which will be substituted with a user-provided value during provisioning, using the format `${{ <value> }}`. For example, you can specify a credential field in a template as `openAI_key: '${{ openai_key }}'`, and then pass the actual key as a parameter using the [Provision Workflow API]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/) or using this API with the `provision` parameter set to `true`.
+You can include placeholder expressions in the value of workflow step fields. For example, you can specify a credential field in a template as `openAI_key: '${{ openai_key }}'`. The expression will be substituted with the user-provided value during provisioning, using the format `${{ <value> }}`. You can pass the actual key as a parameter using the [Provision Workflow API]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/) or using this API with the `provision` parameter set to `true`.
 
 Once a workflow is created, provide its `workflow_id` to other APIs.
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -64,7 +64,7 @@ The following table lists the available query parameters. All query parameters a
 | :--- | :--- | :--- |
 | `provision` | Boolean | Whether to provision the workflow as part of the request. Default is `false`. |
 | `validation` | String | Whether to validate the workflow. Valid values are `all` (validate the template) and `none` (do not validate the template). Default is `all`. |
-| User-provided | String | Parameters matching substitutions in the template. Optional. |
+| User-provided substitution expressions | String | Parameters matching substitution expressions in the template. Only allowed if `provision` is set to `true`.  Optional. |
 
 ## Request fields
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -16,7 +16,7 @@ Creating a workflow adds the content of a workflow template to the flow framewor
 
 To obtain the validation template for workflow steps, call the [Get Workflow Steps API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-steps/).
 
-You can include expresions in the value of workflow step fields which will be substituted with a user-provided value during provisioning, using the format `${{ <value> }}`. For example, you can specify a credential field in a template as `openAI_key: '${{ openai_key }}'`, and then pass the actual key as a parameter using the [Provision Workflow API]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/) or using this API with the `provision` parameter set to `true`.
+You can include expressions in the value of workflow step fields which will be substituted with a user-provided value during provisioning, using the format `${{ <value> }}`. For example, you can specify a credential field in a template as `openAI_key: '${{ openai_key }}'`, and then pass the actual key as a parameter using the [Provision Workflow API]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/) or using this API with the `provision` parameter set to `true`.
 
 Once a workflow is created, provide its `workflow_id` to other APIs.
 

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -38,7 +38,7 @@ POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision?<parameter>=<va
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
-| User-provided | String | Parameters matching substitutions in the template. Optional. |
+| User-provided | String | Parameters that match substitutions in the template. Optional. |
 
 #### Example requests
 

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -47,7 +47,7 @@ POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision
 ```
 {% include copy-curl.html %}
 
-A request substituting the expression `${{ openai_key }}` with the value "12345":
+The following request substitutes the expression `${{ openai_key }}` with the value "12345" using a query parameter:
 
 ```json
 POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision?openai_key=12345

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -30,7 +30,7 @@ The following table lists the available path parameters.
 
 ## Query parameters
 
-If you have included substitution expressions in the template, you may pass them as parameters on the path or in the body as a string field value. For example, if you specified a credential field in a template as `openAI_key: '${{ openai_key }}'`, then you can include the `openai_key` parameter on the path or in the body, to substitute during provisioning.
+If you have included a substitution expression in the template, you may pass it as a query parameter or as a string value of a request body field. For example, if you specified a credential field in a template as `openAI_key: '${{ openai_key }}'`, then you can include the `openai_key` parameter as a query parameter or body field so it can be substituted during provisioning.
 
 ```json
 POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision?<parameter>=<value>

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -30,7 +30,7 @@ The following table lists the available path parameters.
 
 ## Query parameters
 
-If you have included a substitution expression in the template, you may pass it as a query parameter or as a string value of a request body field. For example, if you specified a credential field in a template as `openAI_key: '${{ openai_key }}'`, then you can include the `openai_key` parameter as a query parameter or body field so it can be substituted during provisioning.
+If you have included a substitution expression in the template, you may pass it as a query parameter or as a string value of a request body field. For example, if you specified a credential field in a template as `openAI_key: '${{ openai_key }}'`, then you can include the `openai_key` parameter as a query parameter or body field so it can be substituted during provisioning. For example, the following request provides a query parameter:
 
 ```json
 POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision?<parameter>=<value>

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -54,7 +54,7 @@ POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision?openai_k
 ```
 {% include copy-curl.html %}
 
-A request substituting the expression `${{ openai_key }}` with the value "12345" using the request body:
+The following request substitutes the expression `${{ openai_key }}` with the value "12345" using the request body:
 
 ```json
 POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -28,10 +28,39 @@ The following table lists the available path parameters.
 | :--- | :--- | :--- |
 | `workflow_id` | String | The ID of the workflow to be provisioned. Required. |
 
-#### Example request
+## Query parameters
+
+If you have included substitution expressions in the template, you may pass them as parameters on the path or in the body as a string field value. For example, if you specified a credential field in a template as `openAI_key: '${{ openai_key }}'`, then you can include the `openai_key` parameter on the path or in the body, to substitute during provisioning.
+
+```json
+POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision?<parameter>=<value>
+```
+
+| Parameter | Data type | Description |
+| :--- | :--- | :--- |
+| User-provided | String | Parameters matching substitutions in the template. Optional. |
+
+#### Example requests
 
 ```json
 POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision
+```
+{% include copy-curl.html %}
+
+A request substituting the expression `${{ openai_key }}` with the value "12345":
+
+```json
+POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision?openai_key=12345
+```
+{% include copy-curl.html %}
+
+A request substituting the expression `${{ openai_key }}` with the value "12345" using the request body:
+
+```json
+POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision
+{
+  "openai_key" : "12345"
+}
 ```
 {% include copy-curl.html %}
 

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -38,7 +38,7 @@ POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision?<parameter>=<va
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
-| User-provided | String | Parameters that match substitutions in the template. Optional. |
+| User-provided substitution expressions | String | Parameters matching substitution expressions in the template. Optional. |
 
 #### Example requests
 


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/flow-framework/pull/525 added the ability to substitute expressions with API parameters during workflow provisioning.  

This PR updates the documentation for this new feature.

This will be part of the 2.13 release.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
