### PR TITLE
Deprecate max_token_score in neural sparse search

### DIFF
--- a/_query-dsl/specialized/neural-sparse.md
+++ b/_query-dsl/specialized/neural-sparse.md
@@ -20,8 +20,7 @@ Include the following request fields in the `neural_sparse` query:
 "neural_sparse": {
   "<vector_field>": {
     "query_text": "<query_text>",
-    "model_id": "<model_id>",
-    "max_token_score": "<max_token_score>"
+    "model_id": "<model_id>"
   }
 }
 ```
@@ -32,7 +31,7 @@ Field | Data type | Required/Optional | Description
 :--- | :--- | :--- 
 `query_text` | String | Required | The query text from which to generate vector embeddings. 
 `model_id` | String | Required | The ID of the sparse encoding model or tokenizer model that will be used to generate vector embeddings from the query text. The model must be deployed in OpenSearch before it can be used in sparse neural search. For more information, see [Using custom models within OpenSearch]({{site.url}}{{site.baseurl}}/ml-commons-plugin/using-ml-models/) and [Neural sparse search]({{site.url}}{{site.baseurl}}/search-plugins/neural-sparse-search/).
-`max_token_score` | Float | Optional | The theoretical upper bound of the score for all tokens in the vocabulary (required for performance optimization). For OpenSearch-provided [pretrained sparse embedding models]({{site.url}}{{site.baseurl}}/ml-commons-plugin/pretrained-models/#sparse-encoding-models), we recommend setting `max_token_score` to 2 for `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v1` and to 3.5 for `amazon/neural-sparse/opensearch-neural-sparse-encoding-v1`.
+`max_token_score` | Float | Optional | (Deprecated) The theoretical upper bound of the score for all tokens in the vocabulary (required for performance optimization). For OpenSearch-provided [pretrained sparse embedding models]({{site.url}}{{site.baseurl}}/ml-commons-plugin/pretrained-models/#sparse-encoding-models), we recommend setting `max_token_score` to 2 for `amazon/neural-sparse/opensearch-neural-sparse-encoding-doc-v1` and to 3.5 for `amazon/neural-sparse/opensearch-neural-sparse-encoding-v1`. This field has been deprecated from 2.12 release.
 
 #### Example request
 
@@ -43,8 +42,7 @@ GET my-nlp-index/_search
     "neural_sparse": {
       "passage_embedding": {
         "query_text": "Hi world",
-        "model_id": "aP2Q8ooBpBj3wT4HVS8a",
-        "max_token_score": 2
+        "model_id": "aP2Q8ooBpBj3wT4HVS8a"
       }
     }
   }

--- a/_search-plugins/neural-sparse-search.md
+++ b/_search-plugins/neural-sparse-search.md
@@ -154,8 +154,7 @@ GET my-nlp-index/_search
     "neural_sparse": {
       "passage_embedding": {
         "query_text": "Hi world",
-        "model_id": "aP2Q8ooBpBj3wT4HVS8a",
-        "max_token_score": 2
+        "model_id": "aP2Q8ooBpBj3wT4HVS8a"
       }
     }
   }


### PR DESCRIPTION
### Description
The `max_token_score` field in neural sparse search was deprecated in 2.12 release. ([ref PR](https://github.com/opensearch-project/neural-search/pull/478)). To avoid causing confusion for users, we should also update the information in documentation.

### Issues Resolved
[_List any issues this PR will resolve, e.g. Closes [...]._](https://github.com/opensearch-project/neural-search/pull/478)


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
