### PR TITLE
Audit logging initial state description.

### DIFF
--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -26,7 +26,7 @@ redirect_from:
 
 Audit logs let you track access to your OpenSearch cluster and are useful for compliance purposes or in the aftermath of a security breach. You can configure the categories to be logged, the detail level of the logged messages, and where to store the logs.
 
-To enable audit logging:
+Audit logging is disabled by default. To enable audit logging:
 
 1. Add the following line to `opensearch.yml` on each node:
 

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -220,3 +220,7 @@ The default setting is `10`. Setting this value to `0` disables the thread pool,
 plugins.security.audit.config.threadpool.max_queue_len: 100000
 ```
 
+## Disabling audit logs
+
+To disable audit logs after they've been enabled, remove the `plugins.security.audit.type: internal_opensearch` setting from opensearch.yml, or switch off the **Enable audit logging** check box in Opensearch Dashboards.
+

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -222,5 +222,5 @@ plugins.security.audit.config.threadpool.max_queue_len: 100000
 
 ## Disabling audit logs
 
-To disable audit logs after they've been enabled, remove the `plugins.security.audit.type: internal_opensearch` setting from opensearch.yml, or switch off the **Enable audit logging** check box in Opensearch Dashboards.
+To disable audit logs after they've been enabled, remove the `plugins.security.audit.type: internal_opensearch` setting from `opensearch.yml`, or switch off the **Enable audit logging** check box in OpenSearch Dashboards.
 


### PR DESCRIPTION
### Description

I was working on https://forum.opensearch.org/t/disabling-audit-log/18235. The OpenSearch Documentation doesn't mention how to disable Audit logging. 
The Audit logging is by default disabled and should be enabled manually as per documentation. 



### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
