### PR TITLE
Fix copy_values processor documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -19,7 +19,7 @@ You can configure the `copy_values` processor with the following options.
 | `entries` | Yes | A list of entries to be copied in an event. |
 | `from_key` | Yes | The key of the entry to be copied. |
 | `to_key` | Yes | The key of the new entry to be added. |
-| `overwrite_if_key_exists` | No | When set to `true`, the existing value is overwritten if `key` already exists in the event. The default value is `false`. |
+| `overwrite_if_to_key_exists` | No | When set to `true`, the existing value is overwritten if `key` already exists in the event. The default value is `false`. |
 
 ## Usage
 


### PR DESCRIPTION
The documentation of copy-values has a mistake, the property overwrite_if_to_key_exists used on example is different from the property in the table.

In the source code the correct value is `overwrite_if_to_key_exists`

### Description
Fix documentation mistake

### Issues Resolved
-


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
