### PR TITLE
Update compatibility chart with Almalinux8 and remove CentOS8 since already deprecated

### DIFF
--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -19,7 +19,7 @@ This section details how to install OpenSearch on your host, including which ope
 
 OpenSearch and OpenSearch Dashboards are compatible with Red Hat Enterprise Linux (RHEL) and Debian-based Linux distributions that use [`systemd`](https://en.wikipedia.org/wiki/Systemd), such as Amazon Linux, and Ubuntu Long-Term Support (LTS). While OpenSearch and OpenSearch Dashboards should work on most Linux distributions, we only test a subset. 
 
-The following table lists the operating system versions that we currently tested on: 
+The following table lists the operating system versions that we are currently testing on: 
 
 OS | Version
 :---------- | :-------- 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -17,15 +17,17 @@ This section details how to install OpenSearch on your host, including which ope
 
 ## Operating system compatibility
 
-OpenSearch and OpenSearch Dashboards are compatible with Red Hat Enterprise Linux (RHEL) and Debian-based Linux distributions that use [`systemd`](https://en.wikipedia.org/wiki/Systemd), such as CentOS, Amazon Linux 2, and Ubuntu Long-Term Support (LTS). While OpenSearch and OpenSearch Dashboards should work on most Linux distributions, we only test a subset. 
+OpenSearch and OpenSearch Dashboards are compatible with Red Hat Enterprise Linux (RHEL) and Debian-based Linux distributions that use [`systemd`](https://en.wikipedia.org/wiki/Systemd), such as Amazon Linux, and Ubuntu Long-Term Support (LTS). While OpenSearch and OpenSearch Dashboards should work on most Linux distributions, we only test a subset. 
 
-The following table lists the operating system versions that we currently support. 
+The following table lists the operating system versions that we currently tested on: 
 
 OS | Version
 :---------- | :-------- 
-RHEL/CentOS |	7/8
-Rocky Linux |	8
-Ubuntu | 16.04/18.04/20.04
+CentOS | 7
+Rocky Linux | 8
+Alma Linux | 8
+Amazon Linux | 2/2023
+Ubuntu | 20.04
 Windows Server | 2019
 
 


### PR DESCRIPTION

### Description
Tweak compatibility chart with Almalinux8 and remove CentOS8 since already deprecated

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-build/issues/4573


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
