### PR TITLE
Fix ambiguity with settings for search_backpressure

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/search-backpressure.md
+++ b/_tuning-your-cluster/availability-and-recovery/search-backpressure.md
@@ -10,7 +10,7 @@ redirect_from:
 
 # Search backpressure
 
-Search backpressure is a mechanism used to identify resource-intensive search requests and cancel them when the node is under duress. If a search request on a node or shard has breached the resource limits and does not recover within a certain threshold, it is rejected. These thresholds are dynamic and configurable through [cluster settings](#search-backpressure-settings). 
+Search backpressure is a mechanism used to identify resource-intensive search requests and cancel them when the node is under duress. If a search request on a node or shard has breached the resource limits and does not recover within a certain threshold, it is rejected. These thresholds are dynamic and configurable through [cluster settings](#search-backpressure-settings) using the `/_cluster/settings` API endpoint. 
 
 ## Measuring resource consumption
 
@@ -77,6 +77,20 @@ Search backpressure runs in `monitor_only` (default), `enforced`, or `disabled` 
 ## Search backpressure settings
 
 Search backpressure adds several settings to the standard OpenSearch cluster settings. These settings are dynamic, so you can change the default behavior of this feature without restarting your cluster.
+
+To configure these settings, send a PUT request to `/_cluster/settings`
+
+For example:
+
+```bash
+curl -X PUT "http://127.0.0.1:9200/_cluster/settings" -H 'Content-Type: application/json' -d '{
+    "persistent": {
+        "search_backpressure": {
+            "mode": "monitor_only"
+      }
+    }
+}'
+```
 
 Setting | Default | Description
 :--- | :--- | :---


### PR DESCRIPTION


### Description
This addresses issues with the search_backpressure documentation page:

1. no explicit mention of HOW to set settings for search_backpressure
2. no examples that can be used either as is or as a reference

While it may be domain knowledge that cluster settings always use `_cluster/settings`, many people that administrate or use OpenSearch are not full time OpenSearch admins and this info is very helpful to document.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
