### PR TITLE
Add Hadoop client to the clients list

### DIFF
--- a/_clients/index.md
+++ b/_clients/index.md
@@ -35,6 +35,9 @@ OpenSearch provides clients for the following programming languages and platform
   * [OpenSearch .NET clients]({{site.url}}{{site.baseurl}}/clients/dot-net/)
 * **Rust**
   * [OpenSearch Rust client]({{site.url}}{{site.baseurl}}/clients/rust/)
+* **Hadoop**
+  * [OpenSearch Hadoop client](https://github.com/opensearch-project/opensearch-hadoop) 
+
 
 For a client compatibility matrix, see the COMPATIBILITY.md file in the client's repository.
 {: .note}


### PR DESCRIPTION
### Description
This page is missing a reference to the hadoop client:
https://opensearch.org/docs/latest/clients/

### Issues Resolved
Addresses https://github.com/opensearch-project/documentation-website/issues/6638


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
