### PR TITLE
Add data prepper documentation for grok performance_metadata

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -20,7 +20,7 @@ Option | Required | Type | Description
 `grok_when` | No | String  | Specifies under what condition the `grok` processor should perform matching. Default is no condition.
 `keep_empty_captures` | No | Boolean | Enables the preservation of `null` captures from the processed output. Default is `false`.
 `keys_to_overwrite` | No | List | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default is `[]`.
-`match` | No | Map | Specifies which keys to should match specific patterns. Default is an empty response body.
+`match` | No | Map | Specifies which keys should match specific patterns. Default is an empty response body.
 `named_captures_only` | No | Boolean | Specifies whether to keep only named captures. Default is `true`.
 `pattern_definitions` | No | Map | Allows for a custom pattern that can be used inline inside the response body. Default is an empty response body.
 `patterns_directories` | No | List | Specifies which directory paths contain the custom pattern files. Default is an empty list.

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -16,8 +16,8 @@ The following table describes options you can use with the Grok processor to str
 
 Option | Required | Type | Description
 :--- | :--- |:--- | :---
-`break_on_match` | No | Boolean | Specifies whether to match all patterns (`true`) or stop once the first successful match is found (`false`). Defaultis `true`.
-`grok_when` | No | String  | Specifies under what condition the `Grok` processor should perform matching. Default is no condition.
+`break_on_match` | No | Boolean | Specifies whether to match all patterns (`true`) or stop once the first successful match is found (`false`). Default is `true`.
+`grok_when` | No | String  | Specifies under what condition the `grok` processor should perform matching. Default is no condition.
 `keep_empty_captures` | No | Boolean | Enables the preservation of `null` captures. Default is `false`.
 `keys_to_overwrite` | No | List | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default is `[]`.
 `match` | No | Map | Specifies which keys to match specific patterns against. Default is an empty response body.
@@ -27,7 +27,7 @@ Option | Required | Type | Description
 `pattern_files_glob` | No | String | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default is `*`.
 `target_key` | No | String | Specifies a parent-level key used to store all captures. Default value is `null`.
 `timeout_millis` | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` disables the timeout. Default is `30,000`.
-`performance_metadata` | No | Boolean | Whether or not to add performance metadata to Events. Defaults to `false`. For more information, see [Grok Performance Metadata](#grok-performance-metadata)
+`performance_metadata` | No | Boolean | Whether or not to add performance metadata to events. Default is `false`. For more information, see [Grok Performance Metadata](#grok-performance-metadata)
 
 
 ## Conditional grok
@@ -48,14 +48,13 @@ The `grok_when` option can take a conditional expression. This expression is det
 
 # Grok performance metadata
 
-When `performance_metadata` is set to true, the `grok` processor adds the following metadata keys to each event.
+When the `performance_metadata` option is set to true, the `grok` processor adds the following metadata keys to each event:
 
-* `_total_grok_processing_time` - The total time, in milliseconds, that the `grok` processor takes to match the event. This is the sum processing time for this event based on all of the grok processors that ran on this Event, and also have the `performance_metadata` enabled.
-* `_total_grok_patterns_attempted` - The total number `grok` pattern match attempts across all `grok` processors that have run on the event.
+* `_total_grok_processing_time` - The total time, in milliseconds, that the `grok` processor takes to match the event. This is the sum of the processing time for this event based on all of the grok processors that ran on this event that have the `performance_metadata` option enabled.
+* `_total_grok_patterns_attempted` - The total number of `grok` pattern match attempts across all `grok` processors that have run on the event.
 
-To include this metadata in the event that is sent to the sink of the pipeline, and `add_entries` processor can be used.
+To include this metadata in the event when the event is sent to the sink set inside the pipeline, use the `add_entries` processor tot describe the metadata you want to include, as shown in the following example:
 
-If you want to include grok performance metadata when the event is sent from the processor to the sink, use the `add_entries` processor to describe the metadata, as shown in the following example:
 
 ```yaml
 processor:

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -14,19 +14,20 @@ The Grok processor uses pattern matching to structure and extract important keys
 
 The following table describes options you can use with the Grok processor to structure your data and make your data easier to query.
 
-Option | Required | Type | Description
-:--- | :--- | :--- | :---
+Option | Required | Type    | Description
+:--- | :--- |:--------| :---
 break_on_match | No | Boolean | Specifies whether to match all patterns or stop once the first successful match is found. Default value is `true`.
-grok_when | No | String | Specifies under what condition the `Grok` processor should perform matching. Default is no condition.
+grok_when | No | String  | Specifies under what condition the `Grok` processor should perform matching. Default is no condition.
 keep_empty_captures | No | Boolean | Enables the preservation of `null` captures. Default value is `false`.
-keys_to_overwrite | No | List | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default value is `[]`.
-match | No | Map | Specifies which keys to match specific patterns against. Default value is an empty body.
+keys_to_overwrite | No | List    | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default value is `[]`.
+match | No | Map     | Specifies which keys to match specific patterns against. Default value is an empty body.
 named_captures_only | No | Boolean | Specifies whether to keep only named captures. Default value is `true`.
-pattern_definitions | No | Map | Allows for custom pattern use inline. Default value is an empty body.
-patterns_directories | No | List | Specifies the path of directories that contain customer pattern files. Default value is an empty list.
-pattern_files_glob | No | String | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default value is `*`.
-target_key | No | String | Specifies a parent-level key used to store all captures. Default value is `null`.
+pattern_definitions | No | Map     | Allows for custom pattern use inline. Default value is an empty body.
+patterns_directories | No | List    | Specifies the path of directories that contain customer pattern files. Default value is an empty list.
+pattern_files_glob | No | String  | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default value is `*`.
+target_key | No | String  | Specifies a parent-level key used to store all captures. Default value is `null`.
 timeout_millis | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` disables the timeout. Default value is `30,000`.
+performance_metadata | No | Boolean | Whether or not to add performance metadata to Events. Defaults to `false`. For more information, see [Grok Performance Metadata](#grok_performance_metadata)
 
 <!---## Configuration
 
@@ -47,6 +48,31 @@ processor:
           message: ['%{IPV6:clientip} %{WORD:request} %{POSINT:bytes}']
 ```
 The `grok_when` option can take a conditional expression. This expression is detailed in the [Expression syntax](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) documentation.
+
+# Grok performance metadata <a id="grok_performance_metadata"></a>
+
+If `performance_metadata` is set to true, the grok processor will add the following metadata keys to each Event after it runs through that grok processor.
+
+* `_total_grok_processing_time` - The total time, in milliseconds, that this Event has taken to match in grok. Note that this is the sum for this Event based on all of the grok processors that ran on this Event, and also have the `performance_metadata` enabled.
+* `_total_grok_patterns_attempted` - The total number of grok patterns that this Event has attempted to match on, summed across all grok processors (with `performance_metadata` enabled) that have run on this Event.
+
+To include this metadata in the Event that is sent to the sink of the pipeline, and `add_entries` processor can be used.
+
+```yaml
+processor:
+    - grok:
+        performance_metadata: true
+        match:
+          log: "%{COMMONAPACHELOG"}
+    - add_entries:
+        entries:
+          - add_when: 'getMetadata("_total_grok_patterns_attempted") != null'
+            key: "grok_patterns_attempted"
+            value_expression: 'getMetadata("_total_grok_patterns_attempted")'
+          - add_when: 'getMetadata("_total_grok_processing_time") != null'
+            key: "grok_time_spent"
+            value_expression: 'getMetadata("_total_grok_processing_time")'
+```
 
 ## Metrics
 

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -14,24 +14,21 @@ The Grok processor uses pattern matching to structure and extract important keys
 
 The following table describes options you can use with the Grok processor to structure your data and make your data easier to query.
 
-Option | Required | Type    | Description
-:--- | :--- |:--------| :---
-break_on_match | No | Boolean | Specifies whether to match all patterns or stop once the first successful match is found. Default value is `true`.
-grok_when | No | String  | Specifies under what condition the `Grok` processor should perform matching. Default is no condition.
-keep_empty_captures | No | Boolean | Enables the preservation of `null` captures. Default value is `false`.
-keys_to_overwrite | No | List    | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default value is `[]`.
-match | No | Map     | Specifies which keys to match specific patterns against. Default value is an empty body.
-named_captures_only | No | Boolean | Specifies whether to keep only named captures. Default value is `true`.
-pattern_definitions | No | Map     | Allows for custom pattern use inline. Default value is an empty body.
-patterns_directories | No | List    | Specifies the path of directories that contain customer pattern files. Default value is an empty list.
-pattern_files_glob | No | String  | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default value is `*`.
-target_key | No | String  | Specifies a parent-level key used to store all captures. Default value is `null`.
-timeout_millis | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` disables the timeout. Default value is `30,000`.
-performance_metadata | No | Boolean | Whether or not to add performance metadata to Events. Defaults to `false`. For more information, see [Grok Performance Metadata](#grok_performance_metadata)
+Option | Required | Type | Description
+:--- | :--- |:--- | :---
+`break_on_match` | No | Boolean | Specifies whether to match all patterns (`true`) or stop once the first successful match is found (`false`). Defaultis `true`.
+`grok_when` | No | String  | Specifies under what condition the `Grok` processor should perform matching. Default is no condition.
+`keep_empty_captures` | No | Boolean | Enables the preservation of `null` captures. Default is `false`.
+`keys_to_overwrite` | No | List | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default is `[]`.
+`match` | No | Map | Specifies which keys to match specific patterns against. Default is an empty response body.
+`named_captures_only` | No | Boolean | Specifies whether to keep only named captures. Default is `true`.
+`pattern_definitions` | No | Map | Allows for custom pattern which can be used inline. Dafault is an empty response body.
+`patterns_directories` | No | List | Specifies directory paths that contain the customer pattern files. Default is an empty list.
+`pattern_files_glob` | No | String | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default is `*`.
+`target_key` | No | String | Specifies a parent-level key used to store all captures. Default value is `null`.
+`timeout_millis` | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` disables the timeout. Default is `30,000`.
+`performance_metadata` | No | Boolean | Whether or not to add performance metadata to Events. Defaults to `false`. For more information, see [Grok Performance Metadata](#grok-performance-metadata)
 
-<!---## Configuration
-
-Content will be added to this section.--->
 
 ## Conditional grok
 
@@ -49,14 +46,16 @@ processor:
 ```
 The `grok_when` option can take a conditional expression. This expression is detailed in the [Expression syntax](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) documentation.
 
-# Grok performance metadata <a id="grok_performance_metadata"></a>
+# Grok performance metadata
 
-If `performance_metadata` is set to true, the grok processor will add the following metadata keys to each Event after it runs through that grok processor.
+When `performance_metadata` is set to true, the `grok` processor adds the following metadata keys to each event.
 
-* `_total_grok_processing_time` - The total time, in milliseconds, that this Event has taken to match in grok. Note that this is the sum for this Event based on all of the grok processors that ran on this Event, and also have the `performance_metadata` enabled.
-* `_total_grok_patterns_attempted` - The total number of grok patterns that this Event has attempted to match on, summed across all grok processors (with `performance_metadata` enabled) that have run on this Event.
+* `_total_grok_processing_time` - The total time, in milliseconds, that the `grok` processor takes to match the event. This is the sum processing time for this event based on all of the grok processors that ran on this Event, and also have the `performance_metadata` enabled.
+* `_total_grok_patterns_attempted` - The total number `grok` pattern match attempts across all `grok` processors that have run on the event.
 
-To include this metadata in the Event that is sent to the sink of the pipeline, and `add_entries` processor can be used.
+To include this metadata in the event that is sent to the sink of the pipeline, and `add_entries` processor can be used.
+
+If you want to include grok performance metadata when the event is sent from the processor to the sink, use the `add_entries` processor to describe the metadata, as shown in the following example:
 
 ```yaml
 processor:

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -18,21 +18,22 @@ Option | Required | Type | Description
 :--- | :--- |:--- | :---
 `break_on_match` | No | Boolean | Specifies whether to match all patterns (`true`) or stop once the first successful match is found (`false`). Default is `true`.
 `grok_when` | No | String  | Specifies under what condition the `grok` processor should perform matching. Default is no condition.
-`keep_empty_captures` | No | Boolean | Enables the preservation of `null` captures. Default is `false`.
+`keep_empty_captures` | No | Boolean | Enables the preservation of `null` captures from the processed output. Default is `false`.
 `keys_to_overwrite` | No | List | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default is `[]`.
-`match` | No | Map | Specifies which keys to match specific patterns against. Default is an empty response body.
+`match` | No | Map | Specifies which keys to should match specific patterns. Default is an empty response body.
 `named_captures_only` | No | Boolean | Specifies whether to keep only named captures. Default is `true`.
-`pattern_definitions` | No | Map | Allows for custom pattern which can be used inline. Default is an empty response body.
-`patterns_directories` | No | List | Specifies directory paths that contain the customer pattern files. Default is an empty list.
+`pattern_definitions` | No | Map | Allows fors custom pattern that can be used inline inside the response body. Default is an empty response body.
+`patterns_directories` | No | List | Specifies which directory paths contain the custom pattern files. Default is an empty list.
 `pattern_files_glob` | No | String | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default is `*`.
 `target_key` | No | String | Specifies a parent-level key used to store all captures. Default value is `null`.
-`timeout_millis` | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` disables the timeout. Default is `30,000`.
-`performance_metadata` | No | Boolean | Whether or not to add performance metadata to events. Default is `false`. For more information, see [Grok Performance Metadata](#grok-performance-metadata)
+`timeout_millis` | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` prevents any matching from occuring. Default is `30,000`.
+`performance_metadata` | No | Boolean | Whether or not to add the performance metadata to events. Default is `false`. For more information, see [Grok performance metadata](#grok-performance-metadata)
 
 
 ## Conditional grok
 
-The Grok processor can be configured to run conditionally by using the `grok_when` option. The following is an example Grok processor configuration that uses `grok_when`:
+The `grok` processor can be configured to run conditionally by using the `grok_when` option. The following is an example Grok processor configuration that uses `grok_when`:
+
 ```
 processor:
   - grok:
@@ -44,16 +45,18 @@ processor:
         match:
           message: ['%{IPV6:clientip} %{WORD:request} %{POSINT:bytes}']
 ```
+{% include copy.html %}
+
 The `grok_when` option can take a conditional expression. This expression is detailed in the [Expression syntax](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) documentation.
 
-# Grok performance metadata
+## Grok performance metadata
 
 When the `performance_metadata` option is set to true, the `grok` processor adds the following metadata keys to each event:
 
-* `_total_grok_processing_time` - The total time, in milliseconds, that the `grok` processor takes to match the event. This is the sum of the processing time for this event based on all of the grok processors that ran on this event that have the `performance_metadata` option enabled.
-* `_total_grok_patterns_attempted` - The total number of `grok` pattern match attempts across all `grok` processors that have run on the event.
+* `_total_grok_processing_time`: The total time, in milliseconds, that the `grok` processor takes to match the event. This is the sum of the processing time based on all of the `grok` processors which have the `performance_metadata` option enabled that ran on this event.
+* `_total_grok_patterns_attempted`: The total number of `grok` pattern match attempts across all `grok` processors that have run on the event.
 
-To include this metadata in the event when the event is sent to the sink set inside the pipeline, use the `add_entries` processor tot describe the metadata you want to include, as shown in the following example:
+To include Grok performance metadata when the event is sent to the sink set inside the pipeline, use the `add_entries` processor tot describe the metadata you want to include, as shown in the following example:
 
 
 ```yaml

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -22,12 +22,12 @@ Option | Required | Type | Description
 `keys_to_overwrite` | No | List | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default is `[]`.
 `match` | No | Map | Specifies which keys to should match specific patterns. Default is an empty response body.
 `named_captures_only` | No | Boolean | Specifies whether to keep only named captures. Default is `true`.
-`pattern_definitions` | No | Map | Allows fors custom pattern that can be used inline inside the response body. Default is an empty response body.
+`pattern_definitions` | No | Map | Allows for a custom pattern that can be used inline inside the response body. Default is an empty response body.
 `patterns_directories` | No | List | Specifies which directory paths contain the custom pattern files. Default is an empty list.
 `pattern_files_glob` | No | String | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default is `*`.
 `target_key` | No | String | Specifies a parent-level key used to store all captures. Default value is `null`.
-`timeout_millis` | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` prevents any matching from occuring. Default is `30,000`.
-`performance_metadata` | No | Boolean | Whether or not to add the performance metadata to events. Default is `false`. For more information, see [Grok performance metadata](#grok-performance-metadata)
+`timeout_millis` | No | Integer | The maximum amount of time during which matching occurs. Setting to `0` prevents any matching from occurring. Default is `30,000`.
+`performance_metadata` | No | Boolean | Whether or not to add the performance metadata to events. Default is `false`. For more information, see [Grok performance metadata](#grok-performance-metadata).
 
 
 ## Conditional grok
@@ -51,12 +51,12 @@ The `grok_when` option can take a conditional expression. This expression is det
 
 ## Grok performance metadata
 
-When the `performance_metadata` option is set to true, the `grok` processor adds the following metadata keys to each event:
+When the `performance_metadata` option is set to `true`, the `grok` processor adds the following metadata keys to each event:
 
-* `_total_grok_processing_time`: The total time, in milliseconds, that the `grok` processor takes to match the event. This is the sum of the processing time based on all of the `grok` processors which have the `performance_metadata` option enabled that ran on this event.
-* `_total_grok_patterns_attempted`: The total number of `grok` pattern match attempts across all `grok` processors that have run on the event.
+* `_total_grok_processing_time`: The total amount of time, in milliseconds, that the `grok` processor takes to match the event. This is the sum of the processing time based on all of the `grok` processors that ran on the event and have the `performance_metadata` option enabled.
+* `_total_grok_patterns_attempted`: The total number of `grok` pattern match attempts across all `grok` processors that ran on the event.
 
-To include Grok performance metadata when the event is sent to the sink set inside the pipeline, use the `add_entries` processor tot describe the metadata you want to include, as shown in the following example:
+To include Grok performance metadata when the event is sent to the sink inside the pipeline, use the `add_entries` processor to describe the metadata you want to include, as shown in the following example:
 
 
 ```yaml

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -22,7 +22,7 @@ Option | Required | Type | Description
 `keys_to_overwrite` | No | List | Specifies which existing keys will be overwritten if there is a capture with the same key value. Default is `[]`.
 `match` | No | Map | Specifies which keys to match specific patterns against. Default is an empty response body.
 `named_captures_only` | No | Boolean | Specifies whether to keep only named captures. Default is `true`.
-`pattern_definitions` | No | Map | Allows for custom pattern which can be used inline. Dafault is an empty response body.
+`pattern_definitions` | No | Map | Allows for custom pattern which can be used inline. Default is an empty response body.
 `patterns_directories` | No | List | Specifies directory paths that contain the customer pattern files. Default is an empty list.
 `pattern_files_glob` | No | String | Specifies which pattern files to use from the directories specified for `pattern_directories`. Default is `*`.
 `target_key` | No | String | Specifies a parent-level key used to store all captures. Default value is `null`.


### PR DESCRIPTION
### Description
Adds documentation for grok `performance_metadata` parameter

### Issues Resolved
Related to https://github.com/opensearch-project/data-prepper/pull/4230


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
