### PR TITLE
Adds data prepper decompress processor documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -8,18 +8,19 @@ nav_order: 40
 
 # decompress
 
-The `decompress` processor will decompress base64 encoded compressed fields of an Event.
+The `decompress` processor decompresses the `base64`-encoded compressed fields inside of an event.
 
 ## Configuration
 
-| Option            | Required | Type         | Description                                                                                                                                                                                                |
-|:------------------|:---------|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
-| `keys`            | Yes      | List<String> | The fields in the `event` that will be decompressed.                                                                                                                                                       |
-| `type`            | Yes      | Enum         | The type of decompression to use for the `keys` specified. Must be `gzip`                                                                                                                                  |
-| `decompress_when` | No       | String       | A [Data Prepper Conditional Expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) to determine which Events this processor should be run on. Defaults to no condition. |
-| `tags_on_failure` | No       | List<String> | A List of strings to tag Events with when the processor fails to decompress the `keys` on the Event. Defaults to [ `_decompression_failure` ]                                                              |
+Option | Required | Type | Description
+:--- | :--- | :--- | :---
+`keys` | Yes | List<String> | The fields in the event that will be decompressed.                                                                                          
+`type` | Yes | Enum | The type of decompression to use for the `keys` specified. As of Data Prepper 2.7, only `gzip` is supported.                                            `decompress_when` | No | String| A [Data Prepper conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) to determine which events to run the `decompress` processor. 
+`tags_on_failure` | No | List<String> | A list of strings to tag events with when the processor fails to decompress the `keys` on the event. Defaults to `_decompression_failure`.                               
 
-# Usage
+## Usage
+
+The following example shows the `decompress` processor when used in `pipelines.yaml`:
 
 ```yaml
 processor:
@@ -29,16 +30,15 @@ processor:
       type: gzip
 ```
 
-# Metrics 
+## Metrics 
 
 The following table describes common [Abstract processor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java) metrics.
 
 | Metric name | Type | Description |
 | ------------- | ---- | -----------|
-| `recordsIn` | Counter | Metric representing the ingress of records to a pipeline component. |
-| `recordsOut` | Counter | Metric representing the egress of records from a pipeline component. |
-| `timeElapsed` | Timer | Metric representing the time elapsed during execution of a pipeline component. |
-
+| `recordsIn` | Counter | The ingress of records to a pipeline component. |
+| `recordsOut` | Counter | The egress of records from a pipeline component. |
+| `timeElapsed` | Timer | The time elapsed during execution of a pipeline component. |
 
 The `decompress` processor includes the following custom metrics.
 

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -1,0 +1,48 @@
+---
+layout: default
+title: decompress
+parent: Processors
+grand_parent: Pipelines
+nav_order: 40
+---
+
+# decompress
+
+The `decompress` processor will decompress base64 encoded compressed fields of an Event.
+
+## Configuration
+
+| Option            | Required | Type         | Description                                                                                                                                                                                                |
+|:------------------|:---------|:-------------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| 
+| `keys`            | Yes      | List<String> | The fields in the `event` that will be decompressed.                                                                                                                                                       |
+| `type`            | Yes      | Enum         | The type of decompression to use for the `keys` specified. Must be `gzip`                                                                                                                                  |
+| `decompress_when` | No       | String       | A [Data Prepper Conditional Expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) to determine which Events this processor should be run on. Defaults to no condition. |
+| `tags_on_failure` | No       | List<String> | A List of strings to tag Events with when the processor fails to decompress the `keys` on the Event. Defaults to [ `_decompression_failure` ]                                                              |
+
+# Usage
+
+```yaml
+processor:
+  - decompress:
+      decompress_when: '/some_key == null'
+      keys: [ "base_64_gzip_key" ]
+      type: gzip
+```
+
+# Metrics 
+
+The following table describes common [Abstract processor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java) metrics.
+
+| Metric name | Type | Description |
+| ------------- | ---- | -----------|
+| `recordsIn` | Counter | Metric representing the ingress of records to a pipeline component. |
+| `recordsOut` | Counter | Metric representing the egress of records from a pipeline component. |
+| `timeElapsed` | Timer | Metric representing the time elapsed during execution of a pipeline component. |
+
+
+The `decompress` processor includes the following custom metrics.
+
+### Counter
+
+* `processingErrors`: The number of processing errors that have occurred in the `decompress` processor.
+

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -15,8 +15,9 @@ The `decompress` processor decompresses the `base64`-encoded compressed fields i
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
 `keys` | Yes | List<String> | The fields in the event that will be decompressed.                                                                                          
-`type` | Yes | Enum | The type of decompression to use for the `keys` specified. As of Data Prepper 2.7, only `gzip` is supported.                                            `decompress_when` | No | String| A [Data Prepper conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) to determine which events to run the `decompress` processor. 
-`tags_on_failure` | No | List<String> | A list of strings to tag events with when the processor fails to decompress the `keys` on the event. Defaults to `_decompression_failure`.                               
+`type` | Yes | Enum | The type of decompression to use for the `keys` in the event. Only `gzip` is supported.                                           
+`decompress_when` | No | String| A [Data Prepper conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) that determines when the `decompress` processor will run on certain events.
+`tags_on_failure` | No | List<String> | A list of strings to tag events with when the processor fails to decompress the `keys` inside the event. Defaults to `_decompression_failure`.                               
 
 ## Usage
 
@@ -40,9 +41,9 @@ The following table describes common [Abstract processor](https://github.com/ope
 | `recordsOut` | Counter | The egress of records from a pipeline component. |
 | `timeElapsed` | Timer | The time elapsed during execution of a pipeline component. |
 
-The `decompress` processor includes the following custom metrics.
-
 ### Counter
+
+The `decompress` processor accounts for the following metrics:
 
 * `processingErrors`: The number of processing errors that have occurred in the `decompress` processor.
 

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -17,7 +17,7 @@ Option | Required | Type | Description
 `keys` | Yes | List<String> | The fields in the event that will be decompressed.                                                                                          
 `type` | Yes | Enum | The type of decompression to use for the `keys` in the event. Only `gzip` is supported.                                           
 `decompress_when` | No | String| A [Data Prepper conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/) that determines when the `decompress` processor will run on certain events.
-`tags_on_failure` | No | List<String> | A list of strings to tag events with when the processor fails to decompress the `keys` inside the event. Defaults to `_decompression_failure`.                               
+`tags_on_failure` | No | List<String> | A list of strings with which to tag events when the processor fails to decompress the `keys` inside an event. Defaults to `_decompression_failure`.                               
 
 ## Usage
 

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -8,7 +8,7 @@ nav_order: 40
 
 # decompress
 
-The `decompress` processor decompresses any base64-encoded compressed fields inside of an event.
+The `decompress` processor decompresses any Base64-encoded compressed fields inside of an event.
 
 ## Configuration
 
@@ -21,7 +21,7 @@ Option | Required | Type | Description
 
 ## Usage
 
-The following example shows the `decompress` processor when used in `pipelines.yaml`:
+The following example shows the `decompress` processor used in `pipelines.yaml`:
 
 ```yaml
 processor:
@@ -33,7 +33,7 @@ processor:
 
 ## Metrics 
 
-The following table describes common [Abstract processor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java) metrics.
+The following table describes common [abstract processor](https://github.com/opensearch-project/data-prepper/blob/main/data-prepper-api/src/main/java/org/opensearch/dataprepper/model/processor/AbstractProcessor.java) metrics.
 
 | Metric name | Type | Description |
 | ------------- | ---- | -----------|

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -8,7 +8,7 @@ nav_order: 40
 
 # decompress
 
-The `decompress` processor decompresses the `base64`-encoded compressed fields inside of an event.
+The `decompress` processor decompresses any base64-encoded compressed fields inside of an event.
 
 ## Configuration
 


### PR DESCRIPTION
### Description
Adds documentations for data prepper's new `decompress` processor.

### Issues Resolved
Closes [#6407 ](https://github.com/opensearch-project/documentation-website/issues/6407)


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
