### PR TITLE
Add note about not passing 0 vector for cosine sim in k-NN

### DIFF
--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -297,3 +297,8 @@ The cosine similarity formula does not include the `1 -` prefix. However, becaus
 smaller scores with closer results, they return `1 - cosineSimilarity` for cosine similarity space---that's why `1 -` is
 included in the distance function.
 {: .note }
+
+With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...`]) as input. This is because the magnitude of
+such a vector is 0, which would lead to the dreaded `divide by 0` exception in the corresponding formula. Requests
+containing the 0 vector will be rejected and a corresponding exception will be thrown.
+{: .note }

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -299,6 +299,6 @@ included in the distance function.
 {: .note }
 
 With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...]`) as input. This is because the magnitude of
-such a vector is 0, which would lead to the dreaded `divide by 0` exception in the corresponding formula. Requests
+such a vector is 0, which raises a `divide by 0` exception in the corresponding formula. Requests
 containing the 0 vector will be rejected and a corresponding exception will be thrown.
 {: .note }

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -298,7 +298,7 @@ smaller scores with closer results, they return `1 - cosineSimilarity` for cosin
 included in the distance function.
 {: .note }
 
-With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...`]) as input. This is because the magnitude of
+With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...]`) as input. This is because the magnitude of
 such a vector is 0, which would lead to the dreaded `divide by 0` exception in the corresponding formula. Requests
 containing the 0 vector will be rejected and a corresponding exception will be thrown.
 {: .note }

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -300,5 +300,5 @@ included in the distance function.
 
 With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...]`) as input. This is because the magnitude of
 such a vector is 0, which raises a `divide by 0` exception in the corresponding formula. Requests
-containing the 0 vector will be rejected and a corresponding exception will be thrown.
+containing the zero vector will be rejected and a corresponding exception will be thrown.
 {: .note }

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -326,3 +326,8 @@ A space corresponds to the function used to measure the distance between two poi
 
 
 Cosine similarity returns a number between -1 and 1, and because OpenSearch relevance scores can't be below 0, the k-NN plugin adds 1 to get the final score.
+
+With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...`]) as input. This is because the magnitude of
+such a vector is 0, which would lead to the dreaded `divide by 0` exception in the corresponding formula. Requests 
+containing the 0 vector will be rejected and a corresponding exception will be thrown.
+{: .note }

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -328,6 +328,6 @@ A space corresponds to the function used to measure the distance between two poi
 Cosine similarity returns a number between -1 and 1, and because OpenSearch relevance scores can't be below 0, the k-NN plugin adds 1 to get the final score.
 
 With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...`]) as input. This is because the magnitude of
-such a vector is 0, which would lead to the dreaded `divide by 0` exception in the corresponding formula. Requests 
-containing the 0 vector will be rejected and a corresponding exception will be thrown.
+such a vector is 0, which raises a `divide by 0` exception in the corresponding formula. Requests 
+containing the zero vector will be rejected and a corresponding exception will be thrown.
 {: .note }

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -67,3 +67,8 @@ cosineSimilarity | `float cosineSimilarity (float[] queryVector, doc['vector fie
    ```
 
    Because scores can only be positive, this script ranks documents with vector fields higher than those without.
+
+With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...`]) as input. This is because the magnitude of
+such a vector is 0, which would lead to the dreaded `divide by 0` when computing the value. Requests
+containing the 0 vector will be rejected and a corresponding exception will be thrown.
+{: .note }

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -70,5 +70,5 @@ cosineSimilarity | `float cosineSimilarity (float[] queryVector, doc['vector fie
 
 With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...`]) as input. This is because the magnitude of
 such a vector is 0, which raises a `divide by 0` exception when computing the value. Requests
-containing the 0 vector will be rejected and a corresponding exception will be thrown.
+containing the zero vector will be rejected and a corresponding exception will be thrown.
 {: .note }

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -69,6 +69,6 @@ cosineSimilarity | `float cosineSimilarity (float[] queryVector, doc['vector fie
    Because scores can only be positive, this script ranks documents with vector fields higher than those without.
 
 With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...`]) as input. This is because the magnitude of
-such a vector is 0, which would lead to the dreaded `divide by 0` when computing the value. Requests
+such a vector is 0, which raises a `divide by 0` exception when computing the value. Requests
 containing the 0 vector will be rejected and a corresponding exception will be thrown.
 {: .note }


### PR DESCRIPTION
### Description
Add a note indicating that 0 vector is not valid for cosine similarity in k-NN.

Related issue: https://github.com/opensearch-project/k-NN/issues/1461

### Issues Resolved
Closes #6678 


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
