### PR TITLE
Clarify concurrent segment search index setting

### DIFF
--- a/_search-plugins/concurrent-segment-search.md
+++ b/_search-plugins/concurrent-segment-search.md
@@ -27,7 +27,7 @@ By default, concurrent segment search is disabled on the cluster. You can enable
 - Cluster level
 - Index level
 
-The index-level setting takes priority over the cluster-level setting. Thus, if the cluster setting is enabled but the index setting is disabled, then concurrent segment search will be disabled for that index.
+The index-level setting takes priority over the cluster-level setting. Thus, if the cluster setting is enabled but the index setting is disabled, then concurrent segment search will be disabled for that index. Because of this, the index-level setting is also not evaluated unless it is explicitly set regardless of the default value configured for the setting. The currently set value of the index-level setting can be retrieved with the index settings API without using the `?include_defaults` parameter.
 {: .note}
 
 To enable concurrent segment search for all indexes in the cluster, set the following dynamic cluster setting:


### PR DESCRIPTION
### Description
Clarifies the meaning of the default value of the concurrent segment search setting.

### Issues Resolved
Resolves #6670


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
