### PR TITLE
Add continue-on-error for vale checks to ignore inconsistent return status (temp fix)

### DIFF
--- a/.github/workflows/vale.yml
+++ b/.github/workflows/vale.yml
@@ -21,3 +21,4 @@ jobs:
           filter_mode: added
           vale_flags: "--no-exit"
           version: 2.28.0
+        continue-on-error: true


### PR DESCRIPTION

### Description
Add continue-on-error for vale checks to ignore inconsistent return status (temp fix)

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/6721


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
