### PR TITLE
Remove experimental feature warning for Flow Framework plugin docs

### DIFF
--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -7,9 +7,6 @@ nav_order: 10
 
 # Create or update a workflow
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 Creating a workflow adds the content of a workflow template to the flow framework system index. You can provide workflows in JSON format (by specifying `Content-Type: application/json`) or YAML format (by specifying `Content-Type: application/yaml`). By default, the workflow is validated to help identify invalid configurations, including:
 
 * Workflow steps requiring an OpenSearch plugin that is not installed.

--- a/_automating-configurations/api/delete-workflow.md
+++ b/_automating-configurations/api/delete-workflow.md
@@ -7,9 +7,6 @@ nav_order: 80
 
 # Delete a workflow
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 When you no longer need a workflow template, you can delete it by calling the Delete Workflow API. 
 
 Note that deleting a workflow only deletes the stored template but does not deprovision its resources.  

--- a/_automating-configurations/api/deprovision-workflow.md
+++ b/_automating-configurations/api/deprovision-workflow.md
@@ -7,9 +7,6 @@ nav_order: 70
 
 # Deprovision a workflow
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 When you no longer need a workflow, you can deprovision its resources. Most workflow steps that create a resource have corresponding workflow steps to reverse that action. To retrieve all resources currently created for a workflow, call the [Get Workflow Status API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/). When you call the Deprovision Workflow API, resources included in the `resources_created` field of the Get Workflow Status API response will be removed using a workflow step corresponding to the one that provisioned them.
 
 The workflow executes the provisioning workflow steps in reverse order. If failures occur because of resource dependencies, such as preventing deletion of a registered model if it is still deployed, the workflow attempts retries.

--- a/_automating-configurations/api/get-workflow-status.md
+++ b/_automating-configurations/api/get-workflow-status.md
@@ -7,9 +7,6 @@ nav_order: 40
 
 # Get a workflow status
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 [Provisioning a workflow]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/) may take a significant amount of time, particularly when the action is associated with OpenSearch indexing operations. The Get Workflow State API permits monitoring of the provisioning deployment status until it is complete.
 
 ## Path and HTTP methods

--- a/_automating-configurations/api/get-workflow-steps.md
+++ b/_automating-configurations/api/get-workflow-steps.md
@@ -7,9 +7,6 @@ nav_order: 50
 
 # Get workflow steps
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 OpenSearch validates workflows by using the validation template that lists the required inputs, generated outputs, and required plugins for all steps. For example, for the `register_remote_model` step, the validation template appears as follows:
 
 ```json

--- a/_automating-configurations/api/get-workflow.md
+++ b/_automating-configurations/api/get-workflow.md
@@ -7,9 +7,6 @@ nav_order: 20
 
 # Get a workflow
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 The Get Workflow API retrieves the workflow template.   
 
 ## Path and HTTP methods

--- a/_automating-configurations/api/index.md
+++ b/_automating-configurations/api/index.md
@@ -8,9 +8,6 @@ has_toc: false
 
 # Workflow APIs
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 OpenSearch supports the following workflow APIs:
 
 * [Create or update workflow]({{site.url}}{{site.baseurl}}/automating-configurations/api/create-workflow/)

--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -7,9 +7,6 @@ nav_order: 30
 
 # Provision a workflow
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 Provisioning a workflow is a one-time setup process usually performed by a cluster administrator to create resources that will be used by end users.  
 
 The `workflows` template field may contain multiple workflows. The workflow with the `provision` key can be executed with this API. This API is also executed when the [Create or Update Workflow API]({{site.url}}{{site.baseurl}}/automating-configurations/api/create-workflow/) is called with the `provision` parameter set to `true`.

--- a/_automating-configurations/api/search-workflow-state.md
+++ b/_automating-configurations/api/search-workflow-state.md
@@ -7,9 +7,6 @@ nav_order: 65
 
 # Search for a workflow
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 You can search for resources created by workflows by matching a query to a field. The fields you can search correspond to those returned by the [Get Workflow Status API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/).
 
 ## Path and HTTP methods

--- a/_automating-configurations/api/search-workflow.md
+++ b/_automating-configurations/api/search-workflow.md
@@ -7,9 +7,6 @@ nav_order: 60
 
 # Search for a workflow
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 You can retrieve created workflows with their `workflow_id` or search for workflows by using a query matching a field. You can use the `use_case` field to search for similar workflows.
 
 ## Path and HTTP methods

--- a/_automating-configurations/index.md
+++ b/_automating-configurations/index.md
@@ -11,9 +11,6 @@ redirect_from: /automating-configurations/
 **Introduced 2.12**
 {: .label .label-purple }
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 You can automate complex OpenSearch setup and preprocessing tasks by providing templates for common use cases. For example, automating machine learning (ML) setup tasks streamlines the use of OpenSearch ML offerings.
 
 In OpenSearch 2.12, configuration automation is limited to ML tasks.

--- a/_automating-configurations/workflow-settings.md
+++ b/_automating-configurations/workflow-settings.md
@@ -6,9 +6,6 @@ nav_order: 30
 
 # Workflow settings
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 The following keys represent configurable workflow settings.
 
 |Setting	|Data type	|Default value	|Description	|

--- a/_automating-configurations/workflow-steps.md
+++ b/_automating-configurations/workflow-steps.md
@@ -6,9 +6,6 @@ nav_order: 10
 
 # Workflow steps
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 _Workflow steps_ form basic "building blocks" for process automation. Most steps directly correspond to OpenSearch or plugin API operations, such as CRUD operations on machine learning (ML) connectors, models, and agents. Some steps simplify the configuration by reusing the body expected by these APIs across multiple steps. For example, once you configure a _tool_, you can use it with multiple _agents_.  
 
 ## Workflow step fields

--- a/_automating-configurations/workflow-tutorial.md
+++ b/_automating-configurations/workflow-tutorial.md
@@ -6,9 +6,6 @@ nav_order: 20
 
 # Workflow tutorial
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/flow-framework/issues/475).    
-{: .warning}
-
 You can automate the setup of common use cases, such as conversational chat, using a Chain-of-Thought (CoT) agent. An _agent_ orchestrates and runs ML models and tools. A _tool_ performs a set of specific tasks. This page presents a complete example of setting up a CoT agent. For more information about agents and tools, see [Agents and tools]({{site.url}}{{site.baseurl}}/ml-commons-plugin/)
 
 The setup requires the following sequence of API requests, with provisioned resources used in subsequent requests. The following list provides an overview of the steps required for this workflow. The step names correspond to the names in the template:


### PR DESCRIPTION
### Description

Removes the warning box for Flow Framework plugin (Automating Configurations docs section) experimental feature.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
