### PR TITLE
Adds a configuration for the Data Prepper S3 source workers field.

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -104,7 +104,7 @@ Option | Required | Type | Description
 `s3_select` | No | [s3_select](#s3_select) | The Amazon S3 Select configuration.
 `scan` | No | [scan](#scan) | The S3 scan configuration.
 `delete_s3_objects_on_read` | No | Boolean | When `true`, the S3 scan attempts to delete S3 objects after all events from the S3 object are successfully acknowledged by all sinks. `acknowledgments` should be enabled when deleting S3 objects. Default is `false`.
-`workers` | No | Integer | Configures the number of worker threads that the source uses to read data from S3. We recommend leaving this value at the default unless your S3 objects are all very small (less than 1MB). Performance may decrease for larger S3 objects. This currently only affects SQS-based sources. Defaults to 1.
+`workers` | No | Integer | Configures the number of worker threads that the source uses to read data from S3.  Leaving this value at the default unless your S3 objects are less than 1MB. Performance may decrease for larger S3 objects. This setting only affects SQS-based sources. Default is `1`.
 
 
 ## sqs

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -104,6 +104,7 @@ Option | Required | Type | Description
 `s3_select` | No | [s3_select](#s3_select) | The Amazon S3 Select configuration.
 `scan` | No | [scan](#scan) | The S3 scan configuration.
 `delete_s3_objects_on_read` | No | Boolean | When `true`, the S3 scan attempts to delete S3 objects after all events from the S3 object are successfully acknowledged by all sinks. `acknowledgments` should be enabled when deleting S3 objects. Default is `false`.
+`workers` | No | Integer | Configures the number of worker threads that the source uses to read data from S3. We recommend leaving this value at the default unless your S3 objects are all very small (less than 1MB). Performance may decrease for larger S3 objects. This currently only affects SQS-based sources. Defaults to 1.
 
 
 ## sqs


### PR DESCRIPTION
### Description

Data Prepper 2.7 includes a new `workers` configuration for the `s3` source. This includes documentation for it.

### Issues Resolved

N/A


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
