### PR TITLE
Add encoding check workflow to ensure all the files having utf-8 encoding

### DIFF
--- a/.github/workflows/encoding-check.yml
+++ b/.github/workflows/encoding-check.yml
@@ -1,0 +1,27 @@
+name: Encoding Checker
+
+on: [pull_request]
+
+jobs:
+  extendedAsciiAndBom:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+    - name: Check for possible file that does not follow utf-8 encoding
+      run: |
+          set +e
+          IFS=$(echo -en "\n\b")
+          COUNTER=0
+          for i in `find . -type f \( -name "*.txt" -o -name "*.md" -o -name "*.markdown" -o -name "*.html" \) | grep -vE "^./.git"`;
+          do
+              grep -axv '.*' "$i"
+              if [ "$?" -eq 0 ]; then
+                  echo -e "######################\n$i\n######################"
+                  COUNTER=$(( COUNTER + 1 ))
+              fi
+          done
+          if [ "$COUNTER" != 0 ]; then
+              echo "Found files that is not following utf-8 encoding, exit 1"
+              exit 1
+          fi


### PR DESCRIPTION


### Description
Add encoding check workflow to ensure all the files having utf-8 encoding

### Issues Resolved
Closes https://github.com/opensearch-project/project-website/issues/2699


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
