### PR TITLE
Remove tiered cache docs from release notes

### DIFF
--- a/release-notes/opensearch-documentation-release-notes-2.13.0.md
+++ b/release-notes/opensearch-documentation-release-notes-2.13.0.md
@@ -25,7 +25,6 @@ The OpenSearch 2.13.0 documentation includes the following additions and updates
 - Add post_filter is supported in hybrid search [#6724](https://github.com/opensearch-project/documentation-website/pull/6724)
 - Update deb/rpm autorestart service after upgrade documentation [#6720](https://github.com/opensearch-project/documentation-website/pull/6720)
 - Add documentation page for Vega Visualizations [#6711](https://github.com/opensearch-project/documentation-website/pull/6711)
-- Add cache plugin and tiered cache documentation [#6708](https://github.com/opensearch-project/documentation-website/pull/6708)
 - Add documentation for text chunking processor [#6707](https://github.com/opensearch-project/documentation-website/pull/6707)
 - Update documentation to support InnerProduct with k-NN Lucene Engine [#6703](https://github.com/opensearch-project/documentation-website/pull/6703)
 - Add documentation for kuromoji_completion filter [#6699](https://github.com/opensearch-project/documentation-website/pull/6699)


### PR DESCRIPTION
Remove tiered cache docs from release notes


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
