### PR TITLE
Remove useless dco.yml as it has been already replace with dco app

### DIFF
--- a/.github/dco.yml
+++ b/.github/dco.yml
@@ -1,2 +1,0 @@
-require:
-  members: false


### PR DESCRIPTION
### Description
Remove useless dco.yml as it has been already replace with dco app

### Issues Resolved
#6400


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
