### PR TITLE
Clarifies that Data Prepper select_entries processor does not remove events

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/select-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/select-entries.md
@@ -9,8 +9,7 @@ nav_order: 59
 # select_entries
 
 The `select_entries` processor selects entries from a Data Prepper event.
-Only the selected entries will remain in the event, and all other entries will be removed from the event.
-This processor will not remove any events from the pipeline.
+Only the selected entries remain in the processed event and all other entries will be removed from the processed event. However, the processor does not remove any events from the Data Prepper pipeline.
 
 ## Configuration
 
@@ -19,7 +18,7 @@ You can configure the `select_entries` processor using the following options.
 | Option | Required | Description |
 | :--- | :--- | :--- |
 | `include_keys` | Yes | A list of keys to be selected from an event. |
-| `select_when` | No | A [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as `/some-key == "test"'`, that will be evaluated to determine whether the processor will be run on the event. If the condition is false, then the event will continue through the pipeline unmodified with all the original fields. |
+| `select_when` | No | A [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as `/some-key == "test"'`, that will be evaluated to determine whether the processor will be run on the event. If the condition is not met, then the event continues through the pipeline unmodified with all the original fields present. |
 
 ### Usage
 

--- a/_data-prepper/pipelines/configuration/processors/select-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/select-entries.md
@@ -9,7 +9,7 @@ nav_order: 59
 # select_entries
 
 The `select_entries` processor selects entries from a Data Prepper event.
-Only the selected entries remain in the processed event and all other entries will be removed from the processed event. However, the processor does not remove any events from the Data Prepper pipeline.
+Only the selected entries remain in the processed event and while all other entries are removed. However, the processor does not remove any events from the Data Prepper pipeline.
 
 ## Configuration
 

--- a/_data-prepper/pipelines/configuration/processors/select-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/select-entries.md
@@ -8,7 +8,9 @@ nav_order: 59
 
 # select_entries
 
-The `select_entries` processor selects entries from a Data Prepper event. Only the selected entries will remain in the event, and all other entries will be removed from the event.
+The `select_entries` processor selects entries from a Data Prepper event.
+Only the selected entries will remain in the event, and all other entries will be removed from the event.
+This processor will not remove any events from the pipeline.
 
 ## Configuration
 
@@ -17,7 +19,7 @@ You can configure the `select_entries` processor using the following options.
 | Option | Required | Description |
 | :--- | :--- | :--- |
 | `include_keys` | Yes | A list of keys to be selected from an event. |
-| `select_when` | No | A [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as `/some-key == "test"'`, that will be evaluated to determine whether the processor will be run on the event. |
+| `select_when` | No | A [conditional expression](https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/), such as `/some-key == "test"'`, that will be evaluated to determine whether the processor will be run on the event. If the condition is false, then the event will continue through the pipeline unmodified with all the original fields. |
 
 ### Usage
 


### PR DESCRIPTION
### Description

We recently had some customers expect that `select_entries` would also select events that match. This is not the case.

This PR attempts to clarify the behavior so that customers better understand what happens when `select_when` is false.

### Issues Resolved
N/A


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
