### PR TITLE
Correct error in SpacingWords

### DIFF
--- a/.github/vale/styles/OpenSearch/SpacingWords.yml
+++ b/.github/vale/styles/OpenSearch/SpacingWords.yml
@@ -1,5 +1,5 @@
 extends: existence
-message: "There should be once space between words in '%s'."
+message: "There should be one space between words in '%s'."
 level: error
 nonword: true
 tokens:


### PR DESCRIPTION
### Description
Changes "once" to "one" in SpacingWords.yml.

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
