### PR TITLE
Correct the release version for the upgrade API feature

### DIFF
--- a/_security/access-control/api.md
+++ b/_security/access-control/api.md
@@ -1299,7 +1299,7 @@ PATCH _plugins/_security/api/securityconfig
 
 ### Configuration upgrade check
 
-Introduced 2.13
+Introduced 2.14
 {: .label .label-purple }
 
 Checks the current configuration bundled with the host's Security plugin and compares it to the version of the OpenSearch Security plugin the user downloaded. Then, the API responds indicating whether or not an upgrade can be performed and what resources can be updated.
@@ -1337,7 +1337,7 @@ GET _plugins/_security/api/_upgrade_check
 
 ### Configuration upgrade
 
-Introduced 2.13
+Introduced 2.14
 {: .label .label-purple }
 
 Adds and updates resources on a host's existing security configuration from the configuration bundled with the latest version of the Security plugin.


### PR DESCRIPTION
### Description
Correct the release version for the upgrade API feature, it was accidentally not included in 2.13, but it will be present in 2.14

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
