### PR TITLE
Adding audit rest request method to audit log

### DIFF
--- a/_security/audit-logs/field-reference.md
+++ b/_security/audit-logs/field-reference.md
@@ -40,6 +40,7 @@ Name | Description
 `audit_rest_request_headers` | The HTTP headers, if any.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
+`audit_rest_request_method` | The HTTP request method.
 
 
 ## REST AUTHENTICATED attributes
@@ -52,6 +53,7 @@ Name | Description
 `audit_rest_request_params` | The HTTP request parameters, if any.
 `audit_rest_request_headers` | The HTTP headers, if any.
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
+`audit_rest_request_method` | The HTTP request method.
 
 
 ## REST SSL_EXCEPTION attributes

--- a/_security/audit-logs/field-reference.md
+++ b/_security/audit-logs/field-reference.md
@@ -40,7 +40,6 @@ Name | Description
 `audit_rest_request_headers` | The HTTP headers, if any.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
-`audit_rest_request_method` | The HTTP request method.
 
 
 ## REST AUTHENTICATED attributes
@@ -53,7 +52,6 @@ Name | Description
 `audit_rest_request_params` | The HTTP request parameters, if any.
 `audit_rest_request_headers` | The HTTP headers, if any.
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
-`audit_rest_request_method` | The HTTP request method.
 
 
 ## REST SSL_EXCEPTION attributes


### PR DESCRIPTION
### Description
Adding audit_rest_request_method field to audit log

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/6395


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
