### PR TITLE
Update concurrent search docs with dynamic slice count setting

### DIFF
--- a/_search-plugins/concurrent-segment-search.md
+++ b/_search-plugins/concurrent-segment-search.md
@@ -62,16 +62,21 @@ By default, Lucene assigns a maximum of 250K documents or 5 segments (whichever 
 
 ### The max slice count mechanism
 
-The _max slice count_ mechanism is an alternative slicing mechanism that uses a statically configured maximum number of slices and divides segments among the slices in a round-robin fashion. This is useful when there are already too many top-level shard requests and you want to limit the number of slices per request in order to reduce competition between the slices.
+The _max slice count_ mechanism is an alternative slicing mechanism that uses a dynamically configurable maximum number of slices and divides segments among the slices in a round-robin fashion. This is useful when there are already too many top-level shard requests and you want to limit the number of slices per request in order to reduce competition between the slices.
 
 ### Setting the slicing mechanism
 
-By default, concurrent segment search uses the Lucene mechanism to calculate the number of slices for each shard-level request. To use the max slice count mechanism instead, configure the `search.concurrent.max_slice_count` static setting in the `opensearch.yml` config file:
+By default, concurrent segment search uses the Lucene mechanism to calculate the number of slices for each shard-level request. To use the max slice count mechanism instead, configure the `search.concurrent.max_slice_count` cluster setting:
 
-```yaml
-search.concurrent.max_slice_count: 2
+```json
+PUT _cluster/settings
+{
+   "persistent":{
+      "search.concurrent.max_slice_count": 2
+   }
+}
 ```
-{% include copy.html %}
+{% include copy-curl.html %}
 
 The `search.concurrent.max_slice_count` setting can take the following valid values:
 - `0`: Use the default Lucene mechanism.


### PR DESCRIPTION
### Description
Fix concurrent search docs with dynamic setting info for slice count.
I also called out in #6953 that we should move this page out of `search-plugins` but I wasn't sure where to move it to, I could use some advice on that here.

### Issues Resolved
Resolves #6953


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
