### PR TITLE
[BUG] Cannot restore ES 6.x index into OpenSearch 2.x but the migration doc says it should work

### DIFF
--- a/_upgrade-to/snapshot-migrate.md
+++ b/_upgrade-to/snapshot-migrate.md
@@ -12,6 +12,6 @@ The snapshot approach can mean running two clusters in parallel, but lets you va
 
 Elasticsearch OSS version | Snapshot migration path
 :--- | :--- 
-5.x | Upgrade to 5.6, upgrade to 6.8, reindex all 5.x indexes, make snapshot and restore in OpenSearch 1.x.
+5.x | Upgrade to 5.6, then upgrade to 6.8. Reindex all 5.x indexes, make a snapshot, and restore in OpenSearch 1.x.
 6.x | Make a snapshot and restore in OpenSearch 1.x
 7.x | Make a snapshot and restore in OpenSearch 1.x or OpenSearch 2.x

--- a/_upgrade-to/snapshot-migrate.md
+++ b/_upgrade-to/snapshot-migrate.md
@@ -9,3 +9,9 @@ nav_order: 5
 One popular approach is to take a [snapshot]({{site.url}}{{site.baseurl}}/opensearch/snapshots/snapshot-restore) of your Elasticsearch OSS 6.x or 7.x indexes, [create an OpenSearch cluster]({{site.url}}{{site.baseurl}}/opensearch/install/), restore the snapshot on the new cluster, and point your clients to the new host.
 
 The snapshot approach can mean running two clusters in parallel, but lets you validate that the OpenSearch cluster is working in a way that meets your needs prior to modifying the Elasticsearch OSS cluster.
+
+Elasticsearch OSS version | Snapshot migration path
+:--- | :--- 
+5.x | Upgrade to 5.6, upgrade to 6.8, reindex all 5.x indexes, make snapshot and restore in OpenSearch 1.x.
+6.x | Make a snapshot and restore in OpenSearch 1.x
+7.x | Make a snapshot and restore in OpenSearch 1.x or OpenSearch 2.x


### PR DESCRIPTION
### Description
Clarifies with OSS ES version could be restored from snapshots in which OpenSearch version.

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/11737


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
