### PR TITLE
Add missing list notification channels API

### DIFF
--- a/_observing-your-data/notifications/api.md
+++ b/_observing-your-data/notifications/api.md
@@ -49,6 +49,42 @@ GET /_plugins/_notifications/features
 }
 ```
 
+## List all notification channels
+
+To retrieve a list of all notification channels, send a GET request to the `channels` resource.
+
+#### Example request
+
+```json
+GET /_plugins/_notifications/channels
+```
+
+#### Example response
+
+```json
+{
+  "start_index" : 0,
+  "total_hits" : 2,
+  "total_hit_relation" : "eq",
+  "channel_list" : [
+    {
+      "config_id" : "sample-id",
+      "name" : "Sample Slack Channel",
+      "description" : "This is a Slack channel",
+      "config_type" : "slack",
+      "is_enabled" : true
+    },
+    {
+      "config_id" : "sample-id2",
+      "name" : "Test chime channel",
+      "description" : "A test chime channel",
+      "config_type" : "chime",
+      "is_enabled" : true
+    }
+  ]
+}
+```
+
 ## List all notification configurations
 
 To retrieve a list of all notification configurations, send a GET request to the `configs` resource.


### PR DESCRIPTION
GET /_plugins/_notifications/channels API is missing from the documentation

### Description
Adds the missing documentation for listing notification channels

### Issues Resolved
-

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
