### PR TITLE
Update URL to fix Jekyll error

### DIFF
--- a/_includes/cards.html
+++ b/_includes/cards.html
@@ -25,7 +25,7 @@
   
     
     <div class="card">
-      <a href="{{site.url}}/docs/latest/benchmark/" class='card-link'></a>
+      <a href="https://opensearch.org/docs/latest/benchmark/" class='card-link'></a>
         <p class="heading">OpenSearch Benchmark</p>
         <p class="description">Measure performance metrics for your OpenSearch cluster</p>
         <p class="last-link">Documentation &#x2192;</p>


### PR DESCRIPTION
`{{Site-base}}` for benchmark does not seem to pass Jekyll link checks. Updating to the absolute link to prevent this error


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
