### PR TITLE
Added the begin/end certificate and key comment lines

### DIFF
--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -175,10 +175,12 @@ config:
 ```yml
 config:
   pemtrustedcas_content: |-
+    -----BEGIN CERTIFICATE-----
     MIID/jCCAuagAwIBAgIBATANBgkqhkiG9w0BAQUFADCBjzETMBEGCgmSJomT8ixk
     ARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2V4YW1wbGUxGTAXBgNVBAoMEEV4YW1w
     bGUgQ29tIEluYy4xITAfBgNVBAsMGEV4YW1wbGUgQ29tIEluYy4gUm9vdCBDQTEh
     ...
+    -----END CERTIFICATE-----
 ```
 
 
@@ -204,16 +206,20 @@ or
 ```yml
 config:
   pemkey_content: |-
+    -----BEGIN PRIVATE KEY-----
     MIID2jCCAsKgAwIBAgIBBTANBgkqhkiG9w0BAQUFADCBlTETMBEGCgmSJomT8ixk
     ARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2V4YW1wbGUxGTAXBgNVBAoMEEV4YW1w
     bGUgQ29tIEluYy4xJDAiBgNVBAsMG0V4YW1wbGUgQ29tIEluYy4gU2lnbmluZyBD
     ...
+    -----END PRIVATE KEY-----
   pemkey_password: private_key_password
   pemcert_content: |-
+    -----BEGIN CERTIFICATE-----
     MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCHRZwzwGlP2FvL
     oEzNeDu2XnOF+ram7rWPT6fxI+JJr3SDz1mSzixTeHq82P5A7RLdMULfQFMfQPfr
     WXgB4qfisuDSt+CPocZRfUqqhGlMG2l8LgJMr58tn0AHvauvNTeiGlyXy0ShxHbD
     ...
+    -----END CERTIFICATE-----
 ```
 
 Name | Description

--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -201,10 +201,12 @@ config:
   openid_connect_idp:
     enable_ssl: true
     pemtrustedcas_content: |-
+      -----BEGIN CERTIFICATE-----
       MIID/jCCAuagAwIBAgIBATANBgkqhkiG9w0BAQUFADCBjzETMBEGCgmSJomT8ixk
       ARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2V4YW1wbGUxGTAXBgNVBAoMEEV4YW1w
       bGUgQ29tIEluYy4xITAfBgNVBAsMGEV4YW1wbGUgQ29tIEluYy4gUm9vdCBDQTEh
       ...
+      -----END CERTIFICATE-----
 ```
 
 
@@ -232,16 +234,20 @@ config:
   openid_connect_idp:
     enable_ssl: true
     pemkey_content: |-
+      -----BEGIN PRIVATE KEY-----
       MIID2jCCAsKgAwIBAgIBBTANBgkqhkiG9w0BAQUFADCBlTETMBEGCgmSJomT8ixk
       ARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2V4YW1wbGUxGTAXBgNVBAoMEEV4YW1w
       bGUgQ29tIEluYy4xJDAiBgNVBAsMG0V4YW1wbGUgQ29tIEluYy4gU2lnbmluZyBD
-    ...
+      ...
+      -----END PRIVATE KEY-----
     pemkey_password: private_key_password
     pemcert_content: |-
+      -----BEGIN CERTIFICATE-----
       MIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQCHRZwzwGlP2FvL
       oEzNeDu2XnOF+ram7rWPT6fxI+JJr3SDz1mSzixTeHq82P5A7RLdMULfQFMfQPfr
       WXgB4qfisuDSt+CPocZRfUqqhGlMG2l8LgJMr58tn0AHvauvNTeiGlyXy0ShxHbD
-    ...
+      ...
+      -----END CERTIFICATE-----
 ```
 
 Name | Description

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -282,10 +282,12 @@ config:
 config:
   idp:
     pemtrustedcas_content: |-
+      -----BEGIN CERTIFICATE-----
       MIID/jCCAuagAwIBAgIBATANBgkqhkiG9w0BAQUFADCBjzETMBEGCgmSJomT8ixk
       ARkWA2NvbTEXMBUGCgmSJomT8ixkARkWB2V4YW1wbGUxGTAXBgNVBAoMEEV4YW1w
       bGUgQ29tIEluYy4xITAfBgNVBAsMGEV4YW1wbGUgQ29tIEluYy4gUm9vdCBDQTEh
       ...
+      -----END CERTIFICATE-----
 ```
 
 Name | Description


### PR DESCRIPTION
### Description
The begin and end comment lines are necessary for OpenSearch Security. This should clarify the documentation that those should _not_ be removed.

### Issues Resolved
This will resolve issue #7014 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

Signed-off-by: Landon Lengyel <landon.lengyel@slcschools.org>