### PR TITLE
Fixed bug in nav pane - paginate results

### DIFF
--- a/_search-plugins/searching-data/paginate.md
+++ b/_search-plugins/searching-data/paginate.md
@@ -2,7 +2,6 @@
 layout: default
 title: Paginate results
 parent: Searching data
-has_children: true
 nav_order: 10
 redirect_from:
   - /opensearch/search/paginate/


### PR DESCRIPTION
### Description
Paginate results had has_children = true, causing it to look like it could expand.
<img width="174" alt="image" src="https://github.com/opensearch-project/documentation-website/assets/104463754/552a2c5d-a468-456a-ba41-25d75c85dece">


### Issues Resolved
This fixes the issue: 
<img width="202" alt="image" src="https://github.com/opensearch-project/documentation-website/assets/104463754/0aa6ce31-2d51-4eaf-aa36-2f1fbad121ee">



### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
