### PR TITLE
Update documentation for automatic model undeployment

### DIFF
--- a/_ml-commons-plugin/api/model-apis/undeploy-model.md
+++ b/_ml-commons-plugin/api/model-apis/undeploy-model.md
@@ -56,3 +56,13 @@ POST /_plugins/_ml/models/_undeploy
   }
 }
 ```
+### Automatically undeploy a model based on TTL
+
+Starting with OpenSearch version 2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that auto undeploys a model, include the following ModelDeploySetting in your ML mode.
+
+```json
+PUT /_plugins/_ml/models/COj7K48BZzNMh1sWedLK
+{
+    "deploy_setting": {"model_ttl_minutes" : 100}
+}
+```

--- a/_ml-commons-plugin/api/model-apis/undeploy-model.md
+++ b/_ml-commons-plugin/api/model-apis/undeploy-model.md
@@ -60,6 +60,19 @@ POST /_plugins/_ml/models/_undeploy
 
 Starting with OpenSearch version 2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that auto undeploys a model, include the following ModelDeploySetting in your ML mode.
 
+#### Example request: Creating a model with TTL
+```json
+POST /_plugins/_ml/models/_register
+ {
+   "name": "Sample Model Name",
+   "function_name": "remote",
+   "description": "test model",
+   "connector_id": "-g1nOo8BOaAC5MIJ3_4R",
+   "deploy_setting": {"model_ttl_minutes": 100}
+ }
+```
+
+#### Example request: Updating a model with TTL 
 ```json
 PUT /_plugins/_ml/models/COj7K48BZzNMh1sWedLK
 {

--- a/_ml-commons-plugin/api/model-apis/undeploy-model.md
+++ b/_ml-commons-plugin/api/model-apis/undeploy-model.md
@@ -58,7 +58,7 @@ POST /_plugins/_ml/models/_undeploy
 ```
 ### Automatically undeploy a model based on TTL
 
-Starting with OpenSearch  2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that auto undeploys a model, include the following `ModelDeploySetting` in your ML node. Note that model TTLs are checked periodically by a `syn_up` cron job, so the maximum time a model lives in the memory could be TTL + the `sync_up_job_` interval. The default cron job interval is 10 seconds. To update the cron job internally, use the following cluster setting:
+Starting with OpenSearch  2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that automatically undeploys a model, include the following `ModelDeploySetting` in your machine learning (ML) model. Note that model TTLs are checked periodically by a `syn_up` cron job, so the maximum time that a model lives in memory could be TTL + the `sync_up_job_` interval. The default cron job interval is 10 seconds. To update the cron job internally, use the following cluster setting:
 
 ```json
 PUT /_cluster/settings
@@ -69,7 +69,7 @@ PUT /_cluster/settings
 }
 ```
 
-#### Example request: Creating a model with TTL
+#### Example request: Creating a model with a TTL
 ```json
 POST /_plugins/_ml/models/_register
  {
@@ -81,7 +81,7 @@ POST /_plugins/_ml/models/_register
  }
 ```
 
-#### Example request: Updating a model with TTL when the model is undeployed
+#### Example request: Updating a model with a TTL when the model is undeployed
 ```json
 PUT /_plugins/_ml/models/COj7K48BZzNMh1sWedLK
 {

--- a/_ml-commons-plugin/api/model-apis/undeploy-model.md
+++ b/_ml-commons-plugin/api/model-apis/undeploy-model.md
@@ -58,7 +58,16 @@ POST /_plugins/_ml/models/_undeploy
 ```
 ### Automatically undeploy a model based on TTL
 
-Starting with OpenSearch version 2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that auto undeploys a model, include the following ModelDeploySetting in your ML mode.
+Starting with OpenSearch version 2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that auto undeploys a model, include the following ModelDeploySetting in your ML mode. Note that model TTLs are checked periodically by a syn_up cron job, so the maximum time a model lives in the memory could be TTL + sync_up_job_interval. The default cron job interval is 10 seconds. To update the cron job internal, use the following cluster setting.
+
+```json
+PUT /_cluster/settings
+{
+    "persistent": {
+        "plugins.ml_commons.sync_up_job_interval_in_seconds": 10
+    }
+}
+```
 
 #### Example request: Creating a model with TTL
 ```json
@@ -72,7 +81,7 @@ POST /_plugins/_ml/models/_register
  }
 ```
 
-#### Example request: Updating a model with TTL 
+#### Example request: Updating a model with TTL when the model is undeployed
 ```json
 PUT /_plugins/_ml/models/COj7K48BZzNMh1sWedLK
 {

--- a/_ml-commons-plugin/api/model-apis/undeploy-model.md
+++ b/_ml-commons-plugin/api/model-apis/undeploy-model.md
@@ -58,7 +58,7 @@ POST /_plugins/_ml/models/_undeploy
 ```
 ### Automatically undeploy a model based on TTL
 
-Starting with OpenSearch version 2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that auto undeploys a model, include the following ModelDeploySetting in your ML mode. Note that model TTLs are checked periodically by a syn_up cron job, so the maximum time a model lives in the memory could be TTL + sync_up_job_interval. The default cron job interval is 10 seconds. To update the cron job internal, use the following cluster setting.
+Starting with OpenSearch  2.14, models can be automatically undeployed from memory based on the predefined time-to-live (TTL) when the model was last accessed or used. To define a TTL that auto undeploys a model, include the following `ModelDeploySetting` in your ML node. Note that model TTLs are checked periodically by a `syn_up` cron job, so the maximum time a model lives in the memory could be TTL + the `sync_up_job_` interval. The default cron job interval is 10 seconds. To update the cron job internally, use the following cluster setting:
 
 ```json
 PUT /_cluster/settings

--- a/_ml-commons-plugin/remote-models/index.md
+++ b/_ml-commons-plugin/remote-models/index.md
@@ -324,7 +324,7 @@ To learn how to use the model for vector search, see [Using an ML model for neur
 
 ## Step 7 (Optional): Undeploy the model 
 
-Undeploy the model automatically by defining a TTL in the model settings or use the Undeploy API to undeploy the model manually. To learn more about model undeploy, see [Undeploy API]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/model-apis/undeploy-model/).
+You can undeploy the model automatically by defining a TTL in the model settings or by using the Undeploy API to undeploy the model manually. For more information, see [Undeploy API]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/model-apis/undeploy-model/).
 
 ## Next steps
 

--- a/_ml-commons-plugin/remote-models/index.md
+++ b/_ml-commons-plugin/remote-models/index.md
@@ -322,6 +322,10 @@ The response contains the inference results provided by the OpenAI model:
 
 To learn how to use the model for vector search, see [Using an ML model for neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/#using-an-ml-model-for-neural-search).
 
+## Step 7 (Optional): Undeploy the model 
+
+Undeploy the model automatically by defining a TTL in the model settings or use the Undeploy API to undeploy the model manually. To learn more about model undeploy, see [Undeploy API]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/model-apis/undeploy-model/).
+
 ## Next steps
 
 - For more information about connectors, including example connectors, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).


### PR DESCRIPTION
### Description
Update the Model Undeploy API to include the automatic undeploy feature based on TTL for all ML models in ML-Commons.

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/7061

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
