### PR TITLE
adding server.host to demo dashboards configuration #3884

### DIFF
--- a/_install-and-configure/install-dashboards/tls.md
+++ b/_install-and-configure/install-dashboards/tls.md
@@ -40,6 +40,7 @@ Setting | Description
 The following `opensearch_dashboards.yml` configuration shows OpenSearch and OpenSearch Dashboards running on the same machine with the demo configuration:
 
 ```yml
+server.host: '0.0.0.0'
 server.ssl.enabled: true
 server.ssl.certificate: /usr/share/opensearch-dashboards/config/client-cert.pem
 server.ssl.key: /usr/share/opensearch-dashboards/config/client-cert-key.pem


### PR DESCRIPTION
### Description
Adding missing server.host: '0.0.0.0' configuration in demo OpenSearch Dashboards config

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/3884


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
