### PR TITLE
Exclude list scope from Vale dash spacing rule

### DIFF
--- a/.github/vale/styles/OpenSearch/DashSpacing.yml
+++ b/.github/vale/styles/OpenSearch/DashSpacing.yml
@@ -3,5 +3,7 @@ message: "There should be no spaces around the dash in '%s'."
 ignorecase: true
 nonword: true
 level: error
+scope:
+  - ~list
 tokens:
   - '\w+ +-{2,3} +\w+'

--- a/.github/vale/tests/test-style-neg.md
+++ b/.github/vale/tests/test-style-neg.md
@@ -6,6 +6,10 @@ This sentence tests cybersecurity.
 
 This sentence tests dash---spacing.
 
+This sentence tests:
+
+    - Dash --- spacing in a list.
+
 This sentence tests numbers above 1.2 in versions 1.2 and earlier.
 
 This sentence tests upper-right and lower left.


### PR DESCRIPTION
Exclude list scope from Vale dash spacing rule


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
