### PR TITLE
Add documentation for `constant_keyword` field type

### DIFF
--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -1,0 +1,45 @@
+---
+layout: default
+title: Constant Keyword
+nav_order: 46
+has_children: false
+parent: String field types
+grand_parent: Supported field types
+redirect_from:
+  - /opensearch/supported-field-types/constant-keyword/
+  - /field-types/constant-keyword/
+---
+
+# Constant keyword field type
+
+A constant keyword field uses the same value for documents in the index. 
+
+When a search request spans multiple indices, you can filter on a constant keyword field to match documents from indices with the given constant value, 
+but not indices with a different value.
+
+## Example
+
+The following query creates a mapping with a constant keyword field. 
+
+```json
+PUT romcom_movies
+{
+  "mappings" : {
+    "properties" : {
+      "genre" : {
+        "value" : "Romantic comedy"
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+## Parameters
+
+The following table lists the parameters accepted by constant keyword field types. All values are required.
+
+Parameter | Description 
+:--- | :--- 
+`value` | The string value for the field for all documents in the index.
+

--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -37,5 +37,5 @@ The following table lists the parameters accepted by constant keyword field type
 
 Parameter | Description 
 :--- | :--- 
-`value` | The string value for the field for all documents in the index.
+`value` | The string field value for all documents in the index.
 

--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Constant Keyword
-nav_order: 46
+nav_order: 71
 has_children: false
 parent: String field types
 grand_parent: Supported field types

--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -9,13 +9,13 @@ grand_parent: Supported field types
 
 # Constant keyword field type
 
-A constant keyword field uses the same value for documents in the index. 
+A constant keyword field uses the same value for all documents in the index. 
 
-When a search request spans multiple indexes, you can filter on a constant keyword field to match documents from indexes with the given constant value but not indexes with a different value.
+When a search request spans multiple indexes, you can filter on a constant keyword field to match documents from indexes with the given constant value but not from indexes with a different value.
 
 ## Example
 
-The following query creates a mapping with a constant keyword field. 
+The following query creates a mapping with a constant keyword field:
 
 ```json
 PUT romcom_movies

--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -1,21 +1,17 @@
 ---
 layout: default
-title: Constant Keyword
+title: Constant keyword
 nav_order: 71
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-redirect_from:
-  - /opensearch/supported-field-types/constant-keyword/
-  - /field-types/constant-keyword/
 ---
 
 # Constant keyword field type
 
 A constant keyword field uses the same value for documents in the index. 
 
-When a search request spans multiple indices, you can filter on a constant keyword field to match documents from indices with the given constant value, 
-but not indices with a different value.
+When a search request spans multiple indexes, you can filter on a constant keyword field to match documents from indexes with the given constant value but not indexes with a different value.
 
 ## Example
 

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -20,4 +20,4 @@ Field data type | Description
 [`text`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/text/) | A string that is analyzed. Useful for full-text search.
 [`match_only_text`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/match-only-text/) | A space-optimized version of a `text` field.
 [`token_count`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/token-count/)  | Counts the number of tokens in a string. 
-[`constant_keyword`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/constant-keyword/)  | Similar to `keyword` but uses a single value for all documents.
+[`constant_keyword`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/constant-keyword/)  | Similar to `keyword` but uses a single value for all documents.

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -20,4 +20,4 @@ Field data type | Description
 [`text`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/text/) | A string that is analyzed. Useful for full-text search.
 [`match_only_text`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/match-only-text/) | A space-optimized version of a `text` field.
 [`token_count`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/token-count/)  | Counts the number of tokens in a string. 
-[`token_count`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/constant-keyword/)  | Similar to `keyword`, but uses a single value for all documents.
+[`constant_keyword`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/constant-keyword/)  | Similar to `keyword`, but uses a single value for all documents.

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -20,4 +20,4 @@ Field data type | Description
 [`text`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/text/) | A string that is analyzed. Useful for full-text search.
 [`match_only_text`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/match-only-text/) | A space-optimized version of a `text` field.
 [`token_count`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/token-count/)  | Counts the number of tokens in a string. 
-[`constant_keyword`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/constant-keyword/)  | Similar to `keyword`, but uses a single value for all documents.
+[`constant_keyword`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/constant-keyword/)  | Similar to `keyword` but uses a single value for all documents.

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -20,3 +20,4 @@ Field data type | Description
 [`text`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/text/) | A string that is analyzed. Useful for full-text search.
 [`match_only_text`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/match-only-text/) | A space-optimized version of a `text` field.
 [`token_count`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/token-count/)  | Counts the number of tokens in a string. 
+[`token_count`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/constant-keyword/)  | Similar to `keyword`, but uses a single value for all documents.


### PR DESCRIPTION
### Description
Adds documentation for the `constant_keyword` field type added in https://github.com/opensearch-project/OpenSearch/pull/12285.

### Issues Resolved
Closes [ #7164](https://github.com/opensearch-project/documentation-website/issues/7164)


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
