### PR TITLE
Correct constant keyword example

### DIFF
--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -23,6 +23,7 @@ PUT romcom_movies
   "mappings" : {
     "properties" : {
       "genre" : {
+        "type": "constant_keyword",
         "value" : "Romantic comedy"
       }
     }


### PR DESCRIPTION
### Description
Corrects the example in the constant keyword document

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
