### PR TITLE
Document optional clear_status query parameter for Delete Workflow API

### DIFF
--- a/_automating-configurations/api/delete-workflow.md
+++ b/_automating-configurations/api/delete-workflow.md
@@ -33,7 +33,7 @@ The following table lists the available query parameters. All query parameters a
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
-| `clear_status` | Boolean | Whether to delete the workflow state (without deprovisioning resources) after deleting the template, if the provisioning status is any state other than `IN_PROGRESS`. Default is false. |
+| `clear_status` | Boolean | Determines whether to delete the workflow state (without deprovisioning resources) after deleting the template, if the provisioning status is in any state other than IN_PROGRESS. The default value is false. |
 
 #### Example request
 

--- a/_automating-configurations/api/delete-workflow.md
+++ b/_automating-configurations/api/delete-workflow.md
@@ -67,4 +67,4 @@ If the workflow exists, a delete response contains the status of the deletion, w
 }
 ```
 
-If the `clear_status` parameter was `true`, also deletes the Workflow State if the provisioning status is any state other than `IN_PROGRESS`.
+Note: If the `clear_status` parameter was `true`, also deletes the Workflow State if the provisioning status is any state other than `IN_PROGRESS`.

--- a/_automating-configurations/api/delete-workflow.md
+++ b/_automating-configurations/api/delete-workflow.md
@@ -7,9 +7,11 @@ nav_order: 80
 
 # Delete a workflow
 
-When you no longer need a workflow template, you can delete it by calling the Delete Workflow API. 
+When you no longer need a workflow template, you can delete it by calling the Delete Workflow API.
 
-Note that deleting a workflow only deletes the stored template but does not deprovision its resources.  
+Note that deleting a workflow only deletes the stored template but does not deprovision its resources.
+
+When a workflow is deleted, its corresponding status (returned by the [Workflow State API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/) is also deleted unless either the provisioning status is `IN_PROGRESS` or resources have been provisioned.
 
 ## Path and HTTP methods
 
@@ -25,10 +27,23 @@ The following table lists the available path parameters.
 | :--- | :--- | :--- |
 | `workflow_id` | String | The ID of the workflow to be retrieved. Required. |
 
+## Query parameters
+
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description |
+| :--- | :--- | :--- |
+| `clear_status` | Boolean | Whether to delete the workflow state (without deprovisioning resources) after deleting the template, if the provisioning status is any state other than `IN_PROGRESS`. Default is false. |
+
 #### Example request
 
 ```
 DELETE /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50
+```
+{% include copy-curl.html %}
+
+```
+DELETE /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50?clear_status=true
 ```
 {% include copy-curl.html %}
 
@@ -51,3 +66,5 @@ If the workflow exists, a delete response contains the status of the deletion, w
   "_primary_term": 1
 }
 ```
+
+If the `clear_status` parameter was `true`, also deletes the Workflow State if the provisioning status is any state other than `IN_PROGRESS`.

--- a/_automating-configurations/api/delete-workflow.md
+++ b/_automating-configurations/api/delete-workflow.md
@@ -9,7 +9,7 @@ nav_order: 80
 
 When you no longer need a workflow template, you can delete it by calling the Delete Workflow API.
 
-Note that deleting a workflow only deletes the stored template but does not deprovision its resources.
+Note that deleting a workflow only deletes the stored template---it does not deprovision its resources.
 
 When a workflow is deleted, its corresponding status (returned by the [Workflow State API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/)) is also deleted unless either the provisioning status is `IN_PROGRESS` or resources have been provisioned.
 

--- a/_automating-configurations/api/delete-workflow.md
+++ b/_automating-configurations/api/delete-workflow.md
@@ -11,7 +11,7 @@ When you no longer need a workflow template, you can delete it by calling the De
 
 Note that deleting a workflow only deletes the stored template but does not deprovision its resources.
 
-When a workflow is deleted, its corresponding status (returned by the [Workflow State API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/) is also deleted unless either the provisioning status is `IN_PROGRESS` or resources have been provisioned.
+When a workflow is deleted, its corresponding status (returned by the [Workflow State API]({{site.url}}{{site.baseurl}}/automating-configurations/api/get-workflow-status/)) is also deleted unless either the provisioning status is `IN_PROGRESS` or resources have been provisioned.
 
 ## Path and HTTP methods
 
@@ -33,16 +33,16 @@ The following table lists the available query parameters. All query parameters a
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
-| `clear_status` | Boolean | Determines whether to delete the workflow state (without deprovisioning resources) after deleting the template, if the provisioning status is in any state other than IN_PROGRESS. The default value is false. |
+| `clear_status` | Boolean | Determines whether to delete the workflow state (without deprovisioning resources) after deleting the template. OpenSearch deletes the workflow state only if the provisioning status is not `IN_PROGRESS`. Default is `false`. |
 
 #### Example request
 
-```
+```json
 DELETE /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50
 ```
 {% include copy-curl.html %}
 
-```
+```json
 DELETE /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50?clear_status=true
 ```
 {% include copy-curl.html %}
@@ -66,5 +66,3 @@ If the workflow exists, a delete response contains the status of the deletion, w
   "_primary_term": 1
 }
 ```
-
-Note: If the `clear_status` parameter was `true`, also deletes the Workflow State if the provisioning status is any state other than `IN_PROGRESS`.


### PR DESCRIPTION
### Description

https://github.com/opensearch-project/flow-framework/pull/719 adds a `clear_status` parameter to the Delete Workflow API to also delete the corresponding workflow state document.

Targeted for 2.15 release.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
