### PR TITLE
Fix stray `$` characters; fix some incorrect syntax rendering

### DIFF
--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -176,7 +176,7 @@ bin/opensearch-plugin install <groupId>:<artifactId>:<version>
 ```
 
 #### Example
-```bash
+```console
 $ sudo ./opensearch-plugin install org.opensearch.plugin:opensearch-anomaly-detection:2.2.0.0
 -> Installing org.opensearch.plugin:opensearch-anomaly-detection:2.2.0.0
 -> Downloading org.opensearch.plugin:opensearch-anomaly-detection:2.2.0.0 from maven central
@@ -214,8 +214,8 @@ bin/opensearch-plugin install <plugin-name> <plugin-name> ... <plugin-name>
 ```
 
 #### Example
-```bash
-$ sudo $ ./opensearch-plugin install analysis-nori repository-s3
+```console
+$ sudo ./opensearch-plugin install analysis-nori repository-s3
 ```
 
 ## Remove
@@ -228,8 +228,8 @@ bin/opensearch-plugin remove <plugin-name>
 ```
 
 #### Example
-```bash
-$ sudo $ ./opensearch-plugin remove opensearch-anomaly-detection
+```console
+$ sudo ./opensearch-plugin remove opensearch-anomaly-detection
 -> removing [opensearch-anomaly-detection]...
 ```
 


### PR DESCRIPTION
### Description

This fixes some incorrect example commands (`sudo $ ./opensearch-plugin ...`) and incorrect choice of syntax highlighting (`console` should be used for interactive shell examples, not `bash`, which incorrectly highlights keywords like `for` and characters like `[`, `*`, and `>`).

#### Before

![image](https://github.com/opensearch-project/documentation-website/assets/39996/3e20367e-dcf5-4988-9b4b-8e19fe9e7bc0)

#### After

![image](https://github.com/opensearch-project/documentation-website/assets/39996/88fb8332-d4fe-411a-8ba8-e5c2d2e788d5)


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
