### PR TITLE
Resolve liquid warning in data prepper document db file

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/documentdb.md
+++ b/_data-prepper/pipelines/configuration/sources/documentdb.md
@@ -25,8 +25,8 @@ documentdb-pipeline:
       host: "docdb-mycluster.cluster-random.us-west-2.docdb.amazonaws.com"
       port: 27017
       authentication:
-        username: ${{aws_secrets:secret:username}}
-        password: ${{aws_secrets:secret:password}}
+        {% raw %}username: ${{aws_secrets:secret:username}}
+        password: ${{aws_secrets:secret:password}}{% endraw %}
       aws:
         sts_role_arn: "arn:aws:iam::123456789012:role/MyRole"
       s3_bucket: my-bucket


### PR DESCRIPTION
Resolve liquid warning in data prepper document db file

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
