### PR TITLE
Add remote guardrails model support

### DIFF
--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -269,7 +269,7 @@ Field | Data type | Description
 `regex`| Object |  A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected. 
 `model_id`| String  | The guardrail model used to validate user input and LLM output. 
 `response_filter`| String | The dot path of the field containing the guardrail model response. 
-`resonse_validation_regex`| String | The regular expression used to validate the guardrail model response.     
+`response_validation_regex`| String | The regular expression used to validate the guardrail model response.     
 
 ## Examples
 
@@ -329,11 +329,11 @@ POST /_plugins/_ml/models/_register?deploy=true
     "guardrails": {
         "input_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
+            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "output_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
+            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "type": "model"
     }

--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -269,7 +269,7 @@ Field | Data type | Description
 `regex`| Object |  A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected. 
 `model_id`| String  | The guardrail model used to validate user input and LLM output. 
 `response_filter`| String | The dot path of the field containing the guardrail model response. 
-`response_accept`| String | The regular expression used to validate the guardrail model response.     
+`resonse_validation_regex`| String | The regular expression used to validate the guardrail model response.     
 
 ## Examples
 
@@ -329,11 +329,11 @@ POST /_plugins/_ml/models/_register?deploy=true
     "guardrails": {
         "input_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
+            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "output_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
+            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "type": "model"
     }

--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -258,20 +258,26 @@ Guardrails are safety measures for large language models (LLMs). They provide a 
 
 To register an externally hosted model with guardrails, provide the `guardrails` parameter, which supports the following fields. All fields are optional.
 
-Field | Data type | Description                                                                                                                                                                                                           
-:---  |:----------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
-`type` | String    | The guardrail type. Currently, we have `local_regex` and `model` types.                                                                                                                                               
-`input_guardrail`| Object    | The guardrail for the model input.                                                                                                                                                                                    |
-`output_guardrail`| Object    | The guardrail for the model output.                                                                                                                                                                                   |
-`stop_words`| Object    | The list of indexes containing stopwords used for the model input/output validation. If the model prompt/response contains a stopword contained in any of the indexes, the predict request on this model is rejected. |
-`index_name`| Object    | The name of the index storing the stopwords.                                                                                                                                                                          |
-`source_fields`| Object    | The name of the field storing the stopwords.                                                                                                                                                                          |
-`regex`| Object    | A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected.                                                    |
-`model_id`| String    | The guardrails model to validate user input and LLM output.                                                                                                                                                           |
-`response_filter`| String    | The dotpath used to get the result from guardrails model response.                                                                                                                                                    |
-`response_validation_regex`| String    | The regex expression to check the guradrails model result.                                                                                                                                                            |
+Field | Data type | Description
+:---  | :--- | :---
+`type` | String | The guardrail type. Valid values are [`local_regex`](#example-request-local-regex) and [`model`](#example-request-model). Using `local_regex`, you can specify a regular expression or stop words  
+`input_guardrail`| Object |  The guardrail for the model input. 
+`output_guardrail`| Object |  The guardrail for the model output. 
+`stop_words`| Object | The list of indexes containing stopwords used for the model input/output validation. If the model prompt/response contains a stopword contained in any of the indexes, the predict request on this model is rejected. 
+`index_name`| Object | The name of the index storing the stopwords. 
+`source_fields`| Object | The name of the field storing the stopwords. 
+`regex`| Object |  A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected. 
+`model_id`| String  | The guardrail model used to validate user input and LLM output. 
+`response_filter`| String | The dot path of the field containing the guardrail model response. 
+`response_accept`| String | The regular expression used to validate the guardrail model response.     
 
-#### Example requests: Externally hosted model with guardrails
+## Examples
+
+The following examples configure an externally hosted model with guardrails.
+
+#### Example request: Regex and stopword validation
+
+The following example uses a regular expression and a set of stopwords to validate the LLM response:
 
 ```json
 POST /_plugins/_ml/models/_register
@@ -305,6 +311,13 @@ POST /_plugins/_ml/models/_register
 }
 ```
 {% include copy-curl.html %}
+
+For a complete example, see [Validating input/output using stopwords and regex]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/guardrails/#validating-inputoutput-using-stopwords-and-regex).
+
+#### Example request: Guardrail model validation
+
+The following example uses a guardrail model to validate the LLM response:
+
 ```json
 POST /_plugins/_ml/models/_register?deploy=true
 {
@@ -328,7 +341,7 @@ POST /_plugins/_ml/models/_register?deploy=true
 ```
 {% include copy-curl.html %}
 
-For a complete example, see [Guardrails]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/guardrails/).
+For a complete example, see [Validating input/output using a guardrail model]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/guardrails/#validating-inputoutput-using-a-guardrail-model).
 
 #### Example response
 

--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -260,7 +260,7 @@ To register an externally hosted model with guardrails, provide the `guardrails`
 
 Field | Data type | Description
 :---  | :--- | :---
-`type` | String | The guardrail type. Valid values are [`local_regex`](#example-request-local-regex) and [`model`](#example-request-model). Using `local_regex`, you can specify a regular expression or stop words  
+`type` | String | The guardrail type. Valid values are [`local_regex`](#example-request-regex-and-stopword-validation) and [`model`](#example-request-guardrail-model-validation). Using `local_regex`, you can specify a regular expression or stop words. Using `model`, you can specify a guardrail model. For more information, see [Guardrails]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/guardrails/). 
 `input_guardrail`| Object |  The guardrail for the model input. 
 `output_guardrail`| Object |  The guardrail for the model output. 
 `stop_words`| Object | The list of indexes containing stopwords used for the model input/output validation. If the model prompt/response contains a stopword contained in any of the indexes, the predict request on this model is rejected. 

--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -269,7 +269,7 @@ Field | Data type | Description
 `regex`| Object    | A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected.                                                    |
 `model_id`| String    | The guardrails model to validate user input and LLM output.                                                                                                                                                           |
 `response_filter`| String    | The dotpath used to get the result from guardrails model response.                                                                                                                                                    |
-`response_accept`| String    | The regex expression to check the guradrails model result.                                                                                                                                                            |
+`response_validation_regex`| String    | The regex expression to check the guradrails model result.                                                                                                                                                            |
 
 #### Example requests: Externally hosted model with guardrails
 
@@ -316,11 +316,11 @@ POST /_plugins/_ml/models/_register?deploy=true
     "guardrails": {
         "input_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "output_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "type": "model"
     }

--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -258,17 +258,20 @@ Guardrails are safety measures for large language models (LLMs). They provide a 
 
 To register an externally hosted model with guardrails, provide the `guardrails` parameter, which supports the following fields. All fields are optional.
 
-Field | Data type | Description
-:---  | :--- | :---
-`type` | String | The guardrail type. Currently, only `local_regex` is supported.
-`input_guardrail`| Object |  The guardrail for the model input. |
-`output_guardrail`| Object |  The guardrail for the model output. |
-`stop_words`| Object | The list of indexes containing stopwords used for the model input/output validation. If the model prompt/response contains a stopword contained in any of the indexes, the predict request on this model is rejected. |
-`index_name`| Object | The name of the index storing the stopwords. |
-`source_fields`| Object | The name of the field storing the stopwords. |
-`regex`| Object |  A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected. |
+Field | Data type | Description                                                                                                                                                                                                           
+:---  |:----------|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+`type` | String    | The guardrail type. Currently, we have `local_regex` and `model` types.                                                                                                                                               
+`input_guardrail`| Object    | The guardrail for the model input.                                                                                                                                                                                    |
+`output_guardrail`| Object    | The guardrail for the model output.                                                                                                                                                                                   |
+`stop_words`| Object    | The list of indexes containing stopwords used for the model input/output validation. If the model prompt/response contains a stopword contained in any of the indexes, the predict request on this model is rejected. |
+`index_name`| Object    | The name of the index storing the stopwords.                                                                                                                                                                          |
+`source_fields`| Object    | The name of the field storing the stopwords.                                                                                                                                                                          |
+`regex`| Object    | A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected.                                                    |
+`model_id`| String    | The guardrails model to validate user input and LLM output.                                                                                                                                                           |
+`response_filter`| String    | The dotpath used to get the result from guardrails model response.                                                                                                                                                    |
+`response_accept`| String    | The regex expression to check the guradrails model result.                                                                                                                                                            |
 
-#### Example request: Externally hosted model with guardrails
+#### Example requests: Externally hosted model with guardrails
 
 ```json
 POST /_plugins/_ml/models/_register
@@ -299,6 +302,28 @@ POST /_plugins/_ml/models/_register
       "regex": ["regex1", "regex2"]
     }
   }
+}
+```
+{% include copy-curl.html %}
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+    "name": "Bedrock Claude V2 model with guardrails model",
+    "function_name": "remote",
+    "model_group_id": "ppSmpo8Bi-GZ0tf1i7cD",
+    "description": "Bedrock Claude V2 model with guardrails model",
+    "connector_id": "xnJjDZABNFJeYR3IPvTO",
+    "guardrails": {
+        "input_guardrail": {
+            "model_id": "o3JaDZABNFJeYR3I2fRV",
+            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+        },
+        "output_guardrail": {
+            "model_id": "o3JaDZABNFJeYR3I2fRV",
+            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+        },
+        "type": "model"
+    }
 }
 ```
 {% include copy-curl.html %}

--- a/_ml-commons-plugin/api/model-apis/register-model.md
+++ b/_ml-commons-plugin/api/model-apis/register-model.md
@@ -263,10 +263,10 @@ Field | Data type | Description
 `type` | String | The guardrail type. Valid values are [`local_regex`](#example-request-regex-and-stopword-validation) and [`model`](#example-request-guardrail-model-validation). Using `local_regex`, you can specify a regular expression or stop words. Using `model`, you can specify a guardrail model. For more information, see [Guardrails]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/guardrails/). 
 `input_guardrail`| Object |  The guardrail for the model input. 
 `output_guardrail`| Object |  The guardrail for the model output. 
-`stop_words`| Object | The list of indexes containing stopwords used for the model input/output validation. If the model prompt/response contains a stopword contained in any of the indexes, the predict request on this model is rejected. 
+`stop_words`| Object | The list of indexes containing stopwords used for model input/output validation. If the model prompt/response contains a stopword contained in any of the indexes, then the predict request on the model is rejected. 
 `index_name`| Object | The name of the index storing the stopwords. 
 `source_fields`| Object | The name of the field storing the stopwords. 
-`regex`| Object |  A regular expression used for input/output validation. If the model prompt/response matches the regular expression, the predict request on this model is rejected. 
+`regex`| Object |  A regular expression used for input/output validation. If the model prompt/response matches the regular expression, then the predict request on the model is rejected. 
 `model_id`| String  | The guardrail model used to validate user input and LLM output. 
 `response_filter`| String | The dot path of the field containing the guardrail model response. 
 `response_validation_regex`| String | The regular expression used to validate the guardrail model response.     

--- a/_ml-commons-plugin/api/model-apis/update-model.md
+++ b/_ml-commons-plugin/api/model-apis/update-model.md
@@ -101,11 +101,11 @@ PUT /_plugins/_ml/models/9uGdCJABjaMXYrp14YRj
     "type": "model",
     "input_guardrail": {
       "model_id": "V-G1CJABjaMXYrp1QoUC",
-      "response_accept": "^\\s*[Aa]ccept\\s*$"
+      "response_validation_regex": "^\\s*[Aa]ccept\\s*$"
     },
     "output_guardrail": {
       "model_id": "V-G1CJABjaMXYrp1QoUC",
-      "response_accept": "^\\s*[Aa]ccept\\s*$"
+      "response_validation_regex": "^\\s*[Aa]ccept\\s*$"
     }
   }
 }

--- a/_ml-commons-plugin/api/model-apis/update-model.md
+++ b/_ml-commons-plugin/api/model-apis/update-model.md
@@ -64,12 +64,13 @@ PUT /_plugins/_ml/models/T_S-cY0BKCJ3ot9qr0aP
 ```
 {% include copy-curl.html %}
 
-#### Example request: Updating the guardrails
+#### Example requests: Updating the guardrails
 
 ```json
 PUT /_plugins/_ml/models/MzcIJX8BA7mbufL6DOwl
 {
   "guardrails": {
+    "type": "local_regex",
     "input_guardrail": {
       "stop_words": [
         {
@@ -87,6 +88,24 @@ PUT /_plugins/_ml/models/MzcIJX8BA7mbufL6DOwl
         }
       ],
       "regex": ["updated_regex1", "updated_regex2"]
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+```json
+PUT /_plugins/_ml/models/9uGdCJABjaMXYrp14YRj
+{
+  "guardrails": {
+    "type": "model",
+    "input_guardrail": {
+      "model_id": "V-G1CJABjaMXYrp1QoUC",
+      "response_accept": "^\\s*[Aa]ccept\\s*$"
+    },
+    "output_guardrail": {
+      "model_id": "V-G1CJABjaMXYrp1QoUC",
+      "response_accept": "^\\s*[Aa]ccept\\s*$"
     }
   }
 }

--- a/_ml-commons-plugin/remote-models/guardrails.md
+++ b/_ml-commons-plugin/remote-models/guardrails.md
@@ -548,7 +548,7 @@ The response contains the connector ID that you'll use in the next steps:
 
 ### Step 6: Register and deploy the chat model with guardrails
 
-To register and deploy the Anthropic Claude chat model, send the following request. Note that the `guardrails` object contains a `resonse_validation_regex` parameter, which specifies to only treat the input/output as valid if the guardrail model responds with a variant of the word `accept`:
+To register and deploy the Anthropic Claude chat model, send the following request. Note that the `guardrails` object contains a `response_validation_regex` parameter, which specifies to only treat the input/output as valid if the guardrail model responds with a variant of the word `accept`:
 
 ```json
 POST /_plugins/_ml/models/_register?deploy=true
@@ -561,11 +561,11 @@ POST /_plugins/_ml/models/_register?deploy=true
     "guardrails": {
         "input_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
+            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "output_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
+            "response_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "type": "model"
     }

--- a/_ml-commons-plugin/remote-models/guardrails.md
+++ b/_ml-commons-plugin/remote-models/guardrails.md
@@ -548,7 +548,7 @@ The response contains the connector ID that you'll use in the next steps:
 
 ### Step 6: Register and deploy the chat model with guardrails
 
-To register and deploy the Anthropic Claude chat model, send the following request. Note that the `guardrails` object contains a `response_accept` parameter, which specifies to only treat the input/output as valid if the guardrail model responds with a variant of the word `accept`:
+To register and deploy the Anthropic Claude chat model, send the following request. Note that the `guardrails` object contains a `resonse_validation_regex` parameter, which specifies to only treat the input/output as valid if the guardrail model responds with a variant of the word `accept`:
 
 ```json
 POST /_plugins/_ml/models/_register?deploy=true
@@ -561,11 +561,11 @@ POST /_plugins/_ml/models/_register?deploy=true
     "guardrails": {
         "input_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "output_guardrail": {
             "model_id": "o3JaDZABNFJeYR3I2fRV",
-            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+            "resonse_validation_regex": "^\\s*\"[Aa]ccept\"\\s*$"
         },
         "type": "model"
     }

--- a/_ml-commons-plugin/remote-models/guardrails.md
+++ b/_ml-commons-plugin/remote-models/guardrails.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Guardrails
-has_children: false
+has_children: true
 has_toc: false
 nav_order: 70
 parent: Connecting to externally hosted models 
@@ -14,13 +14,21 @@ grand_parent: Integrating ML models
 
 Guardrails can guide a large language model (LLM) toward desired behavior. They act as a filter, preventing the LLM from generating output that is harmful or violates ethical principles and facilitating safer use of AI. Guardrails also cause the LLM to produce more focused and relevant output. 
 
-To configure guardrails for your LLM, you can provide a list of words to be prohibited in the input or output of the model. Alternatively, you can provide a regular expression against which the model input or output will be matched.
+You can configure guardrails for your LLM using the following methods:
+- Provide a list of words to be prohibited in the input or output of the model. Alternatively, you can provide a regular expression against which the model input or output will be matched. For more information, see [Validating input/output using stopwords and regex](#validating-inputoutput-using-stopwords-and-regex).
+- Configure a separate LLM whose purpose is to validate the user input and the LLM output.
 
 ## Prerequisites
 
 Before you start, make sure you have fulfilled the [prerequisites]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/index/#prerequisites) for connecting to an externally hosted model.
 
-## Step 1: Create a guardrail index
+## Validating input/output using stopwords and regex
+**Introduced 2.13**
+{: .label .label-purple }
+
+A simple way to validate the user input and LLM output is to provide a set of prohibited words (stopwords) or a regular expression for validation.
+
+### Step 1: Create a guardrail index
 
 To start, create an index that will store the excluded words (_stopwords_). In the index settings, specify a `title` field, which will contain excluded words, and a `query` field of the [percolator]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/percolator/) type. The percolator query will be used to match the LLM input or output:
 
@@ -41,7 +49,7 @@ PUT /words0
 ```
 {% include copy-curl.html %}
 
-## Step 2: Index excluded words or phrases
+### Step 2: Index excluded words or phrases
 
 Next, index a query string query that will be used to match excluded words in the model input or output:
 
@@ -71,7 +79,7 @@ PUT /words0/_doc/2?refresh
 
 For more query string options, see [Query string query]({{site.url}}{{site.baseurl}}/query-dsl/full-text/query-string/).
 
-## Step 3: Register a model group
+### Step 3: Register a model group
 
 To register a model group, send the following request:
 
@@ -95,7 +103,7 @@ The response contains the model group ID that you'll use to register a model to 
 
 To learn more about model groups, see [Model access control]({{site.url}}{{site.baseurl}}/ml-commons-plugin/model-access-control/).
 
-## Step 4: Create a connector
+### Step 4: Create a connector
 
 Now you can create a connector for the model. In this example, you'll create a connector to the Anthropic Claude model hosted on Amazon Bedrock:
 
@@ -145,7 +153,7 @@ The response contains the connector ID for the newly created connector:
 }
 ```
 
-## Step 5: Register and deploy the model with guardrails
+### Step 5: Register and deploy the model with guardrails
 
 To register an externally hosted model, provide the model group ID from step 3 and the connector ID from step 4 in the following request. To configure guardrails, include the `guardrails` object:
 
@@ -227,7 +235,7 @@ When the operation is complete, the state changes to `COMPLETED`:
 }
 ```
 
-## Step 6 (Optional): Test the model
+### Step 6 (Optional): Test the model
 
 To demonstrate how guardrails are applied, first run the predict operation that does not contain any excluded words:
 
@@ -241,7 +249,7 @@ POST /_plugins/_ml/models/p94dYo4BrXGpZpgPp98E/_predict
 ```
 {% include copy-curl.html %}
 
-The response contains inference results:
+The response contains the LLM answer:
 
 ```json
 {
@@ -292,6 +300,339 @@ The response contains an error message because guardrails were triggered:
 ```
 
 Guardrails are also triggered when a prompt matches the supplied regular expression.
+
+## Validating input/output using a guardrail model
+**Introduced 2.15**
+{: .label .label-purple }
+
+For more advanced validation, you can configure a guardrail model---a separate LLM whose purpose is to validate the user input and the LLM output. In this example, you'll configure two models:
+- Chat model: An Anthropic Claude model hosted on Amazon Bedrock, whose purpose is to hold a conversation with a user
+- Guardrail model: An OpenAI model, whose purpose is to validate the user input and Anthropic Claude output.
+
+### Step 1: Create a connector for the guardrail model
+
+First, create a connector to the OpenAI guardrail model. Note that the OpenAI prompt instructs the model to respond only with the words `accept` or `reject`, depending on whether the input/output is acceptable. Additionally, the request contains the `response_filter` parameter that specifies the field in which the guardrail model will provide the validation result: 
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+    "name": "openai",
+    "description": "openai",
+    "version": "1",
+    "protocol": "http",
+    "parameters": {
+        "endpoint": "api.openai.com",
+        "max_tokens": 7,
+        "temperature": 0,
+        "model": "gpt-3.5-turbo-instruct",
+        "prompt": "You are a helpful assistant and an expert judge of content quality. Your task is to identify whether the input string below contains content that may be malicious, violent, hateful, sexual, or political in nature. Your answer should consist of a single word, either reject or accept. If the input belongs to any of these categories, please write reject. Otherwise, write accept. \\n\\nHere is the input: ${parameters.question}. \\n\\nYour answer: ",
+        "response_filter": "$.choices[0].text"
+    },
+    "credential": {
+        "openAI_key": "<openAI_key>"
+    },
+    "actions": [
+        {
+            "action_type": "predict",
+            "method": "POST",
+            "url": "https://${parameters.endpoint}/v1/completions",
+            "headers": {
+                "Authorization": "Bearer ${credential.openAI_key}"
+            },
+            "request_body": "{ \"model\": \"${parameters.model}\", \"prompt\": \"${parameters.prompt}\", \"max_tokens\": ${parameters.max_tokens}, \"temperature\": ${parameters.temperature} }"
+        }
+    ]
+}
+```
+{% include copy-curl.html %}
+
+The response contains the connector ID that you'll use in the next steps:
+
+```json
+{
+  "connector_id": "j3JVDZABNFJeYR3IVPRz"
+}
+```
+
+### Step 2: Register a model group for the guardrail model
+
+To register a model group for the OpenAI guardrail model, send the following request:
+
+```json
+POST /_plugins/_ml/model_groups/_register
+{
+    "name": "guardrail model group",
+    "description": "This is a guardrail model group."
+}
+```
+{% include copy-curl.html %}
+
+The response contains the model group ID that you'll use to register a model to this model group:
+
+```json
+{
+ "model_group_id": "ppSmpo8Bi-GZ0tf1i7cD",
+ "status": "CREATED"
+}
+```
+
+To learn more about model groups, see [Model access control]({{site.url}}{{site.baseurl}}/ml-commons-plugin/model-access-control/).
+
+### Step 3: Register and deploy the guardrail model
+
+Using the connector ID and the model group ID, register and deploy the OpenAI guardrail model:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+    "name": "openai guardrails model",
+    "function_name": "remote",
+    "model_group_id": "ppSmpo8Bi-GZ0tf1i7cD",
+    "description": "guardrails test model",
+    "connector_id": "j3JVDZABNFJeYR3IVPRz"
+}
+```
+{% include copy-curl.html %}
+
+OpenSearch returns the task ID of the register operation and the model ID of the registered model:
+
+```json
+{
+  "task_id": "onJaDZABNFJeYR3I2fQ1",
+  "status": "CREATED",
+  "model_id": "o3JaDZABNFJeYR3I2fRV"
+}
+```
+
+To check the status of the operation, provide the task ID to the [Tasks API]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/tasks-apis/get-task/):
+
+```bash
+GET /_plugins/_ml/tasks/onJaDZABNFJeYR3I2fQ1
+```
+{% include copy-curl.html %}
+
+When the operation is complete, the state changes to `COMPLETED`:
+
+```json
+{
+  "model_id": "o3JaDZABNFJeYR3I2fRV",
+  "task_type": "DEPLOY_MODEL",
+  "function_name": "REMOTE",
+  "state": "COMPLETED",
+  "worker_node": [
+    "n-72khvBTBi3bnIIR8FTTw"
+  ],
+  "create_time": 1689793851077,
+  "last_update_time": 1689793851101,
+  "is_async": true
+}
+```
+
+### Step 4 (Optional): Test the guardrail model
+
+You can test the guardrail model user input validation by sending requests that do an do not contain offensive words. 
+
+First, send a request that does not contain offensive words:
+
+```json
+POST /_plugins/_ml/models/o3JaDZABNFJeYR3I2fRV/_predict
+{
+  "parameters": {
+    "question": "how many indices"
+  }
+}
+```
+{% include copy-curl.html %}
+
+The guardrail model accepts the preceding request:
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "accept"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```
+
+Next, send a request that contains offensive words:
+
+```json
+POST /_plugins/_ml/models/o3JaDZABNFJeYR3I2fRV/_predict
+{
+  "parameters": {
+    "question": "how to rob a bank"
+  }
+}
+```
+{% include copy-curl.html %}
+
+The guardrail model rejects the preceding request:
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": "reject"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```
+
+### Step 5: Create a connector for the chat model
+
+In this example, the chat model will be an Anthropic Claude model hosted on Amazon Bedrock. To create a connector for the model, send the following request. Note that the `response_filter` parameter specifies the field in which the guardrail model will provide the validation result: 
+
+```json
+POST /_plugins/_ml/connectors/_create
+{
+  "name": "BedRock claude Connector",
+  "description": "BedRock claude Connector",
+  "version": 1,
+  "protocol": "aws_sigv4",
+  "parameters": {
+      "region": "us-east-1",
+      "service_name": "bedrock",
+      "anthropic_version": "bedrock-2023-05-31",
+      "endpoint": "bedrock.us-east-1.amazonaws.com",
+      "auth": "Sig_V4",
+      "content_type": "application/json",
+      "max_tokens_to_sample": 8000,
+      "temperature": 0.0001,
+      "response_filter": "$.completion"
+  },
+  "credential": {
+      "access_key": "<access_key>",
+      "secret_key": "<secret_key>"
+  },
+  "actions": [
+    {
+      "action_type": "predict",
+      "method": "POST",
+      "url": "https://bedrock-runtime.us-east-1.amazonaws.com/model/anthropic.claude-v2/invoke",
+      "headers": { 
+        "content-type": "application/json",
+        "x-amz-content-sha256": "required"
+      },
+      "request_body": "{\"prompt\":\"${parameters.prompt}\", \"max_tokens_to_sample\":${parameters.max_tokens_to_sample}, \"temperature\":${parameters.temperature},  \"anthropic_version\":\"${parameters.anthropic_version}\" }"
+    }
+  ]
+}
+```
+{% include copy-curl.html %}
+
+The response contains the connector ID that you'll use in the next steps:
+
+```json
+{
+  "connector_id": "xnJjDZABNFJeYR3IPvTO"
+}
+```
+
+### Step 6: Register and deploy the chat model with guardrails
+
+To register and deploy the Anthropic Claude chat model, send the following request. Note that the `guardrails` object contains a `response_accept` parameter, which specifies to only treat the input/output as valid if the guardrail model responds with a variant of the word `accept`:
+
+```json
+POST /_plugins/_ml/models/_register?deploy=true
+{
+    "name": "Bedrock Claude V2 model with openai guardrails model",
+    "function_name": "remote",
+    "model_group_id": "ppSmpo8Bi-GZ0tf1i7cD",
+    "description": "Bedrock Claude V2 model with openai guardrails model",
+    "connector_id": "xnJjDZABNFJeYR3IPvTO",
+    "guardrails": {
+        "input_guardrail": {
+            "model_id": "o3JaDZABNFJeYR3I2fRV",
+            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+        },
+        "output_guardrail": {
+            "model_id": "o3JaDZABNFJeYR3I2fRV",
+            "response_accept": "^\\s*\"[Aa]ccept\"\\s*$"
+        },
+        "type": "model"
+    }
+}
+```
+{% include copy-curl.html %}
+
+OpenSearch returns the task ID of the register operation and the model ID of the registered model:
+
+```json
+{
+  "task_id": "1nJnDZABNFJeYR3IvfRL",
+  "status": "CREATED",
+  "model_id": "43JqDZABNFJeYR3IQPQH"
+}
+```
+
+### Step 7 (Optional): Test the chat model with guardrails
+
+You can test the Anthropic Claude chat model with guardrails by sending predict requests that do an do not contain offensive words. 
+
+First, send a request that does not contain offensive words:
+
+```json
+POST /_plugins/_ml/models/43JqDZABNFJeYR3IQPQH/_predict
+{
+  "parameters": {
+    "prompt": "\n\nHuman:${parameters.question}\n\nnAssistant:",
+    "question": "hello"
+  }
+}
+```
+{% include copy-curl.html %}
+
+OpenSearch responds with the LLM answer:
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "name": "response",
+          "dataAsMap": {
+            "response": " Hello!"
+          }
+        }
+      ],
+      "status_code": 200
+    }
+  ]
+}
+```
+
+Next, send a request that contains offensive words:
+
+```json
+POST /_plugins/_ml/models/43JqDZABNFJeYR3IQPQH/_predict
+{
+  "parameters": {
+    "prompt": "\n\nHuman:${parameters.question}\n\nnAssistant:",
+    "question": "how to rob a bank"
+  }
+}
+```
+
+OpenSearch responds with an error.
 
 ## Next steps
 

--- a/_ml-commons-plugin/remote-models/guardrails.md
+++ b/_ml-commons-plugin/remote-models/guardrails.md
@@ -438,7 +438,7 @@ First, send a request that does not contain offensive words:
 POST /_plugins/_ml/models/o3JaDZABNFJeYR3I2fRV/_predict
 {
   "parameters": {
-    "question": "how many indices"
+    "question": "how many indices do i have in my cluster"
   }
 }
 ```

--- a/_ml-commons-plugin/remote-models/guardrails.md
+++ b/_ml-commons-plugin/remote-models/guardrails.md
@@ -306,12 +306,12 @@ Guardrails are also triggered when a prompt matches the supplied regular express
 {: .label .label-purple }
 
 For more advanced validation, you can configure a guardrail model---a separate LLM whose purpose is to validate the user input and the LLM output. In this example, you'll configure two models:
-- Chat model: An Anthropic Claude model hosted on Amazon Bedrock, whose purpose is to hold a conversation with a user
-- Guardrail model: An OpenAI model, whose purpose is to validate the user input and Anthropic Claude output.
+- Chat model: An Anthropic Claude model hosted on Amazon Bedrock whose purpose is to hold a conversation with a user.
+- Guardrail model: An OpenAI model whose purpose is to validate the user input and Anthropic Claude output.
 
 ### Step 1: Create a connector for the guardrail model
 
-First, create a connector to the OpenAI guardrail model. Note that the OpenAI prompt instructs the model to respond only with the words `accept` or `reject`, depending on whether the input/output is acceptable. Additionally, the request contains the `response_filter` parameter that specifies the field in which the guardrail model will provide the validation result: 
+First, create a connector to the OpenAI guardrail model. Note that the OpenAI prompt instructs the model to respond only with the words `accept` or `reject`, depending on whether the input/output is acceptable. Additionally, the request contains the `response_filter` parameter, which specifies the field in which the guardrail model will provide the validation result: 
 
 ```json
 POST /_plugins/_ml/connectors/_create
@@ -346,7 +346,7 @@ POST /_plugins/_ml/connectors/_create
 ```
 {% include copy-curl.html %}
 
-The response contains the connector ID that you'll use in the next steps:
+The response contains the connector ID used in the next steps:
 
 ```json
 {
@@ -367,7 +367,7 @@ POST /_plugins/_ml/model_groups/_register
 ```
 {% include copy-curl.html %}
 
-The response contains the model group ID that you'll use to register a model to this model group:
+The response contains the model group ID used to register a model to this model group:
 
 ```json
 {
@@ -430,7 +430,7 @@ When the operation is complete, the state changes to `COMPLETED`:
 
 ### Step 4 (Optional): Test the guardrail model
 
-You can test the guardrail model user input validation by sending requests that do an do not contain offensive words. 
+You can test the guardrail model user input validation by sending requests that do and do not contain offensive words. 
 
 First, send a request that does not contain offensive words:
 
@@ -538,7 +538,7 @@ POST /_plugins/_ml/connectors/_create
 ```
 {% include copy-curl.html %}
 
-The response contains the connector ID that you'll use in the next steps:
+The response contains the connector ID used in the next steps:
 
 ```json
 {
@@ -548,7 +548,7 @@ The response contains the connector ID that you'll use in the next steps:
 
 ### Step 6: Register and deploy the chat model with guardrails
 
-To register and deploy the Anthropic Claude chat model, send the following request. Note that the `guardrails` object contains a `response_validation_regex` parameter, which specifies to only treat the input/output as valid if the guardrail model responds with a variant of the word `accept`:
+To register and deploy the Anthropic Claude chat model, send the following request. Note that the `guardrails` object contains a `response_validation_regex` parameter that specifies to only treat the input/output as valid if the guardrail model responds with a variant of the word `accept`:
 
 ```json
 POST /_plugins/_ml/models/_register?deploy=true
@@ -585,7 +585,7 @@ OpenSearch returns the task ID of the register operation and the model ID of the
 
 ### Step 7 (Optional): Test the chat model with guardrails
 
-You can test the Anthropic Claude chat model with guardrails by sending predict requests that do an do not contain offensive words. 
+You can test the Anthropic Claude chat model with guardrails by sending predict requests that do and do not contain offensive words. 
 
 First, send a request that does not contain offensive words:
 


### PR DESCRIPTION
### Description
Add a new type of guardrails, model type.
It supports a remote model as guardrails to validate user input or LLM output.

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/7353

### Version
2.15

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
