### PR TITLE
Drop repeated key/word in inverted index

### DIFF
--- a/_getting-started/intro.md
+++ b/_getting-started/intro.md
@@ -106,7 +106,6 @@ in | 1
 the | 1, 2
 eye | 1
 of | 1
-the | 1
 beholder | 1
 and | 2
 beast | 2 


### PR DESCRIPTION
"the" appears twice as a key in the inverted index; keys should only appear once. The correct key-value pair is kept, with a value of "1, 2" as "the" appears in both documents.

### Description
It looks like "the" is repeated twice in the inverted index. From my understanding, all keys must be unique. The correct key-value pair should be `"the": 1, 2` as "the" appears in both documents.

### Issues Resolved
No issue was created.

### Version
No version is necessary since this is a minor typo correction.

### Frontend features
Not applicable

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
