### PR TITLE
Add redirects to clients, data prepper, and benchmark sections for 2.11

### DIFF
--- a/_benchmark/index.md
+++ b/_benchmark/index.md
@@ -9,6 +9,7 @@ permalink: /benchmark/
 redirect_from:
   - /benchmark/index/
 canonical_url: https://opensearch.org/docs/latest/benchmark/
+redirect_to: https://opensearch.org/docs/latest/benchmark/
 ---
 
 # OpenSearch Benchmark

--- a/_benchmark/quickstart.md
+++ b/_benchmark/quickstart.md
@@ -3,6 +3,7 @@ layout: default
 title: Quickstart
 nav_order: 2
 canonical_url: https://opensearch.org/docs/latest/benchmark/quickstart/
+redirect_to: https://opensearch.org/docs/latest/benchmark/quickstart/
 ---
 
 # OpenSearch Benchmark quickstart

--- a/_benchmark/reference/commands/command-flags.md
+++ b/_benchmark/reference/commands/command-flags.md
@@ -6,6 +6,7 @@ parent: Command reference
 redirect_from: /benchmark/commands/command-flags/
 grand_parent: OpenSearch Benchmark Reference
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/commands/command-flags/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/commands/command-flags/
 ---
 
 # Command flags

--- a/_benchmark/reference/commands/compare.md
+++ b/_benchmark/reference/commands/compare.md
@@ -6,6 +6,7 @@ parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/compare/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/commands/compare/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/commands/compare/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/download.md
+++ b/_benchmark/reference/commands/download.md
@@ -6,6 +6,7 @@ parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/download/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/commands/download/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/commands/download/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/execute-test.md
+++ b/_benchmark/reference/commands/execute-test.md
@@ -6,6 +6,7 @@ parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/execute-test/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/commands/execute-test/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/commands/execute-test/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/index.md
+++ b/_benchmark/reference/commands/index.md
@@ -6,6 +6,7 @@ has_children: true
 parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/index/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/commands/index/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/commands/index/
 ---
 
 # OpenSearch Benchmark command reference

--- a/_benchmark/reference/commands/info.md
+++ b/_benchmark/reference/commands/info.md
@@ -6,6 +6,7 @@ parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/info/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/commands/info/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/commands/info/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/list.md
+++ b/_benchmark/reference/commands/list.md
@@ -6,6 +6,7 @@ parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/list/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/commands/list/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/commands/list/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -4,6 +4,7 @@ title: OpenSearch Benchmark Reference
 nav_order: 25
 has_children: true
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/index/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/index/
 ---
 
 # OpenSearch Benchmark Reference

--- a/_benchmark/reference/metrics/index.md
+++ b/_benchmark/reference/metrics/index.md
@@ -6,6 +6,7 @@ has_children: true
 parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/metrics/index/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/metrics/index/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/metrics/index/
 ---
 
 # Metrics

--- a/_benchmark/reference/metrics/metric-keys.md
+++ b/_benchmark/reference/metrics/metric-keys.md
@@ -6,6 +6,7 @@ parent: Metrics reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/metrics/metric-keys/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/metrics/metric-keys/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/metrics/metric-keys/
 ---
 
 # Metric keys

--- a/_benchmark/reference/metrics/metric-records.md
+++ b/_benchmark/reference/metrics/metric-records.md
@@ -6,6 +6,7 @@ parent: Metrics reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/metrics/metric-records/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/metrics/metric-records/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/metrics/metric-records/
 ---
 
 # Metric records

--- a/_benchmark/reference/summary-report.md
+++ b/_benchmark/reference/summary-report.md
@@ -4,6 +4,7 @@ title: Summary report
 nav_order: 40
 parent: Metrics
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/summary-report/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/summary-report/
 ---
 
 # Summary report

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -4,6 +4,7 @@ title: Telemetry devices
 nav_order: 45
 parent: OpenSearch Benchmark Reference
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/telemetry/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/telemetry/
 ---
 
 # Telemetry devices

--- a/_benchmark/reference/workloads/corpora.md
+++ b/_benchmark/reference/workloads/corpora.md
@@ -6,6 +6,7 @@ grand_parent: OpenSearch Benchmark Reference
 nav_order: 70
 redirect_from: /benchmark/workloads/corpora/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/workloads/corpora/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/workloads/corpora/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -6,6 +6,7 @@ parent: OpenSearch Benchmark Reference
 has_children: true
 redirect_from: /benchmark/workloads/index/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/workloads/index/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/workloads/index/
 ---
 
 # OpenSearch Benchmark workload reference

--- a/_benchmark/reference/workloads/indices.md
+++ b/_benchmark/reference/workloads/indices.md
@@ -6,6 +6,7 @@ grand_parent: OpenSearch Benchmark Reference
 nav_order: 65
 redirect_from: /benchmark/workloads/indices/
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/workloads/indices/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/workloads/indices/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: OpenSearch Benchmark Reference
 nav_order: 100
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/workloads/operations/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/workloads/operations/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/test-procedures.md
+++ b/_benchmark/reference/workloads/test-procedures.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: OpenSearch Benchmark Reference
 nav_order: 110
 canonical_url: https://opensearch.org/docs/latest/benchmark/reference/workloads/test-procedures/
+redirect_to: https://opensearch.org/docs/latest/benchmark/reference/workloads/test-procedures/
 ---
 
 <!-- vale off -->

--- a/_benchmark/tutorials/index.md
+++ b/_benchmark/tutorials/index.md
@@ -4,6 +4,7 @@ title: Tutorials
 nav_order: 10
 has_children: true
 canonical_url: https://opensearch.org/docs/latest/benchmark/tutorials/index/
+redirect_to: https://opensearch.org/docs/latest/benchmark/tutorials/index/
 ---
 
 # Tutorial

--- a/_benchmark/tutorials/sigv4.md
+++ b/_benchmark/tutorials/sigv4.md
@@ -4,6 +4,7 @@ title: AWS Signature Version 4 support
 nav_order: 70
 parent: Tutorials
 canonical_url: https://opensearch.org/docs/latest/benchmark/tutorials/sigv4/
+redirect_to: https://opensearch.org/docs/latest/benchmark/tutorials/sigv4/
 ---
 
 # Running OpenSearch Benchmark with AWS Signature Version 4

--- a/_benchmark/user-guide/concepts.md
+++ b/_benchmark/user-guide/concepts.md
@@ -4,6 +4,7 @@ title: Concepts
 nav_order: 3
 parent: User guide
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/concepts/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/concepts/
 ---
 
 # Concepts

--- a/_benchmark/user-guide/configuring-benchmark.md
+++ b/_benchmark/user-guide/configuring-benchmark.md
@@ -5,6 +5,7 @@ nav_order: 7
 parent: User guide
 redirect_from: /benchmark/configuring-benchmark/
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/configuring-benchmark/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/configuring-benchmark/
 ---
 
 # Configuring OpenSearch Benchmark

--- a/_benchmark/user-guide/contributing-workloads.md
+++ b/_benchmark/user-guide/contributing-workloads.md
@@ -4,6 +4,7 @@ title: Sharing custom workloads
 nav_order: 11
 parent: User guide
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/contributing-workloads/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/contributing-workloads/
 ---
 
 # Sharing custom workloads

--- a/_benchmark/user-guide/creating-osb-workloads.md
+++ b/_benchmark/user-guide/creating-osb-workloads.md
@@ -7,6 +7,7 @@ redirect_from:
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-custom-workloads
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/creating-custom-workloads/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/creating-custom-workloads/
 ---
 
 # Creating custom workloads

--- a/_benchmark/user-guide/distributed-load.md
+++ b/_benchmark/user-guide/distributed-load.md
@@ -4,6 +4,7 @@ title: Running distributed loads
 nav_order: 15
 parent: User guide
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/distributed-load/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/distributed-load/
 ---
 
 # Running distributed loads 

--- a/_benchmark/user-guide/index.md
+++ b/_benchmark/user-guide/index.md
@@ -4,6 +4,7 @@ title: User guide
 nav_order: 5
 has_children: true
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/index/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/index/
 ---
 
 # OpenSearch Benchmark User Guide

--- a/_benchmark/user-guide/installing-benchmark.md
+++ b/_benchmark/user-guide/installing-benchmark.md
@@ -5,6 +5,7 @@ nav_order: 5
 parent: User guide
 redirect_from: /benchmark/installing-benchmark/
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/installing-benchmark/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/installing-benchmark/
 ---
 
 # Installing OpenSearch Benchmark

--- a/_benchmark/user-guide/running-workloads.md
+++ b/_benchmark/user-guide/running-workloads.md
@@ -4,6 +4,7 @@ title: Running a workload
 nav_order: 9
 parent: User guide
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/running-workloads/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/running-workloads/
 ---
 
 # Running a workload

--- a/_benchmark/user-guide/telemetry.md
+++ b/_benchmark/user-guide/telemetry.md
@@ -4,6 +4,7 @@ title: Enabling telemetry devices
 nav_order: 30
 parent: User guide
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/telemetry/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/telemetry/
 ---
 
 Telemetry results will not appear in the summary report. To visualize telemetry results, ingest the data into OpenSearch and visualize the data in OpenSearch Dashboards. 

--- a/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 15
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
 ---
 
 # Anatomy of a workload

--- a/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 20
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
 ---
 
 # Choosing a workload

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -5,6 +5,7 @@ nav_order: 7
 parent: User guide
 has_children: true
 canonical_url: https://opensearch.org/docs/latest/benchmark/user-guide/understanding-workloads/index/
+redirect_to: https://opensearch.org/docs/latest/benchmark/user-guide/understanding-workloads/index/
 ---
 
 # Understanding workloads

--- a/_clients/OSC-dot-net.md
+++ b/_clients/OSC-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 10
 has_children: false
 parent: .NET clients
 canonical_url: https://opensearch.org/docs/latest/clients/OSC-dot-net/
+redirect_to: https://opensearch.org/docs/latest/clients/OSC-dot-net/
 ---
 
 # Getting started with the high-level .NET client (OpenSearch.Client)

--- a/_clients/OSC-example.md
+++ b/_clients/OSC-example.md
@@ -5,6 +5,7 @@ nav_order: 12
 has_children: false
 parent: .NET clients
 canonical_url: https://opensearch.org/docs/latest/clients/OSC-example/
+redirect_to: https://opensearch.org/docs/latest/clients/OSC-example/
 ---
 
 # More advanced features of the high-level .NET client (OpenSearch.Client)

--- a/_clients/OpenSearch-dot-net.md
+++ b/_clients/OpenSearch-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 30
 has_children: false
 parent: .NET clients
 canonical_url: https://opensearch.org/docs/latest/clients/OpenSearch-dot-net/
+redirect_to: https://opensearch.org/docs/latest/clients/OpenSearch-dot-net/
 ---
 
 # Low-level .NET client (OpenSearch.Net)

--- a/_clients/dot-net-conventions.md
+++ b/_clients/dot-net-conventions.md
@@ -5,6 +5,7 @@ nav_order: 20
 has_children: false
 parent: .NET clients
 canonical_url: https://opensearch.org/docs/latest/clients/dot-net-conventions/
+redirect_to: https://opensearch.org/docs/latest/clients/dot-net-conventions/
 ---
 
 # .NET client considerations and best practices

--- a/_clients/dot-net.md
+++ b/_clients/dot-net.md
@@ -5,6 +5,7 @@ nav_order: 75
 has_children: true
 has_toc: false
 canonical_url: https://opensearch.org/docs/latest/clients/dot-net/
+redirect_to: https://opensearch.org/docs/latest/clients/dot-net/
 ---
 
 # .NET clients

--- a/_clients/go.md
+++ b/_clients/go.md
@@ -3,6 +3,7 @@ layout: default
 title: Go client
 nav_order: 50
 canonical_url: https://opensearch.org/docs/latest/clients/go/
+redirect_to: https://opensearch.org/docs/latest/clients/go/
 ---
 
 # Go client

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -8,6 +8,7 @@ permalink: /clients/
 redirect_from:
   - /clients/index/
 canonical_url: https://opensearch.org/docs/latest/clients/
+redirect_to: https://opensearch.org/docs/latest/clients/
 ---
 
 # OpenSearch language clients

--- a/_clients/java-rest-high-level.md
+++ b/_clients/java-rest-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: Java high-level REST client
 nav_order: 20
 canonical_url: https://opensearch.org/docs/latest/clients/java-rest-high-level/
+redirect_to: https://opensearch.org/docs/latest/clients/java-rest-high-level/
 ---
 
 # Java high-level REST client

--- a/_clients/java.md
+++ b/_clients/java.md
@@ -3,6 +3,7 @@ layout: default
 title: Java client
 nav_order: 30
 canonical_url: https://opensearch.org/docs/latest/clients/java/
+redirect_to: https://opensearch.org/docs/latest/clients/java/
 ---
 
 # Java client

--- a/_clients/javascript/helpers.md
+++ b/_clients/javascript/helpers.md
@@ -4,6 +4,7 @@ title: Helper methods
 parent: JavaScript client
 nav_order: 2
 canonical_url: https://opensearch.org/docs/latest/clients/javascript/helpers/
+redirect_to: https://opensearch.org/docs/latest/clients/javascript/helpers/
 ---
 
 # Helper methods

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -6,6 +6,7 @@ nav_order: 40
 redirect_from:
   - /clients/javascript/
 canonical_url: https://opensearch.org/docs/latest/clients/javascript/index/
+redirect_to: https://opensearch.org/docs/latest/clients/javascript/index/
 ---
 
 # JavaScript client

--- a/_clients/opensearch-py-ml.md
+++ b/_clients/opensearch-py-ml.md
@@ -3,6 +3,7 @@ layout: default
 title: Opensearch-py-ml
 nav_order: 11
 canonical_url: https://opensearch.org/docs/latest/clients/opensearch-py-ml/
+redirect_to: https://opensearch.org/docs/latest/clients/opensearch-py-ml/
 ---
 
 # opensearch-py-ml

--- a/_clients/php.md
+++ b/_clients/php.md
@@ -3,6 +3,7 @@ layout: default
 title: PHP client
 nav_order: 70
 canonical_url: https://opensearch.org/docs/latest/clients/php/
+redirect_to: https://opensearch.org/docs/latest/clients/php/
 ---
 
 # PHP client

--- a/_clients/python-high-level.md
+++ b/_clients/python-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: High-level Python client
 nav_order: 5
 canonical_url: https://opensearch.org/docs/latest/clients/python-high-level/
+redirect_to: https://opensearch.org/docs/latest/clients/python-high-level/
 ---
 
 The OpenSearch high-level Python client (`opensearch-dsl-py`) will be deprecated after version 2.1.0. We recommend switching to the [Python client (`opensearch-py`)]({{site.url}}{{site.baseurl}}/clients/python-low-level/), which now includes the functionality of `opensearch-dsl-py`.

--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -5,6 +5,7 @@ nav_order: 10
 redirect_from: 
   - /clients/python/
 canonical_url: https://opensearch.org/docs/latest/clients/python-low-level/
+redirect_to: https://opensearch.org/docs/latest/clients/python-low-level/
 ---
 
 # Low-level Python client

--- a/_clients/ruby.md
+++ b/_clients/ruby.md
@@ -4,6 +4,7 @@ title: Ruby client
 nav_order: 60
 has_children: false
 canonical_url: https://opensearch.org/docs/latest/clients/ruby/
+redirect_to: https://opensearch.org/docs/latest/clients/ruby/
 ---
 
 # Ruby client

--- a/_clients/rust.md
+++ b/_clients/rust.md
@@ -3,6 +3,7 @@ layout: default
 title: Rust client
 nav_order: 100
 canonical_url: https://opensearch.org/docs/latest/clients/rust/
+redirect_to: https://opensearch.org/docs/latest/clients/rust/
 ---
 
 # Rust client

--- a/_data-prepper/common-use-cases/codec-processor-combinations.md
+++ b/_data-prepper/common-use-cases/codec-processor-combinations.md
@@ -4,6 +4,7 @@ title: Codec processor combinations
 parent: Common use cases
 nav_order: 25
 canonical_url: https://opensearch.org/docs/latest/data-prepper/common-use-cases/codec-processor-combinations/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/common-use-cases/codec-processor-combinations/
 ---
 
 # Codec processor combinations

--- a/_data-prepper/common-use-cases/common-use-cases.md
+++ b/_data-prepper/common-use-cases/common-use-cases.md
@@ -6,6 +6,7 @@ nav_order: 15
 redirect_from: 
   - /data-prepper/common-use-cases/
 canonical_url: https://opensearch.org/docs/latest/data-prepper/common-use-cases/common-use-cases/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/common-use-cases/common-use-cases/
 ---
 
 # Common use cases

--- a/_data-prepper/common-use-cases/log-analytics.md
+++ b/_data-prepper/common-use-cases/log-analytics.md
@@ -4,6 +4,7 @@ title: Log analytics
 parent: Common use cases
 nav_order: 10
 canonical_url: https://opensearch.org/docs/latest/data-prepper/common-use-cases/log-analytics/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/common-use-cases/log-analytics/
 ---
 
 # Log analytics

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -4,6 +4,7 @@ title: S3 logs
 parent: Common use cases
 nav_order: 20
 canonical_url: https://opensearch.org/docs/latest/data-prepper/common-use-cases/s3-logs/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/common-use-cases/s3-logs/
 ---
 
 # S3 logs

--- a/_data-prepper/common-use-cases/trace-analytics.md
+++ b/_data-prepper/common-use-cases/trace-analytics.md
@@ -4,6 +4,7 @@ title: Trace analytics
 parent: Common use cases
 nav_order: 5
 canonical_url: https://opensearch.org/docs/latest/data-prepper/common-use-cases/trace-analytics/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/common-use-cases/trace-analytics/
 ---
 
 # Trace analytics

--- a/_data-prepper/getting-started.md
+++ b/_data-prepper/getting-started.md
@@ -5,6 +5,7 @@ nav_order: 5
 redirect_from:
   - /clients/data-prepper/get-started/
 canonical_url: https://opensearch.org/docs/latest/data-prepper/getting-started/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/getting-started/
 ---
 
 # Getting started with Data Prepper

--- a/_data-prepper/index.md
+++ b/_data-prepper/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /monitoring-plugins/trace/data-prepper/
   - /data-prepper/index/
 canonical_url: https://opensearch.org/docs/latest/data-prepper/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/
 ---
 
 # Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/configuring-data-prepper.md
@@ -7,6 +7,7 @@ redirect_from:
  - /clients/data-prepper/data-prepper-reference/
  - /monitoring-plugins/trace/data-prepper-reference/
 canonical_url: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
 ---
 
 # Configuring Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-log4j.md
+++ b/_data-prepper/managing-data-prepper/configuring-log4j.md
@@ -4,6 +4,7 @@ title: Configuring Log4j
 parent: Managing Data Prepper
 nav_order: 20
 canonical_url: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-log4j/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/configuring-log4j/
 ---
 
 # Configuring Log4j

--- a/_data-prepper/managing-data-prepper/core-apis.md
+++ b/_data-prepper/managing-data-prepper/core-apis.md
@@ -4,6 +4,7 @@ title: Core APIs
 parent: Managing Data Prepper
 nav_order: 15
 canonical_url: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/core-apis/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/core-apis/
 ---
 
 # Core APIs

--- a/_data-prepper/managing-data-prepper/managing-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/managing-data-prepper.md
@@ -4,6 +4,7 @@ title: Managing Data Prepper
 has_children: true
 nav_order: 20
 canonical_url: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/managing-data-prepper/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/managing-data-prepper/
 ---
 
 # Managing Data Prepper

--- a/_data-prepper/managing-data-prepper/monitoring.md
+++ b/_data-prepper/managing-data-prepper/monitoring.md
@@ -4,6 +4,7 @@ title: Monitoring
 parent: Managing Data Prepper
 nav_order: 25
 canonical_url: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/monitoring/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/monitoring/
 ---
  
 # Monitoring Data Prepper with metrics

--- a/_data-prepper/managing-data-prepper/peer-forwarder.md
+++ b/_data-prepper/managing-data-prepper/peer-forwarder.md
@@ -4,6 +4,7 @@ title: Peer forwarder
 nav_order: 12
 parent: Managing Data Prepper
 canonical_url: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/peer-forwarder/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/peer-forwarder/
 ---
 
 # Peer forwarder

--- a/_data-prepper/managing-data-prepper/source-coordination.md
+++ b/_data-prepper/managing-data-prepper/source-coordination.md
@@ -4,6 +4,7 @@ title: Source coordination
 nav_order: 35
 parent: Managing Data Prepper
 canonical_url: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/source-coordination/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/managing-data-prepper/source-coordination/
 ---
 
 # Source coordination

--- a/_data-prepper/migrate-open-distro.md
+++ b/_data-prepper/migrate-open-distro.md
@@ -3,6 +3,7 @@ layout: default
 title: Migrating from Open Distro
 nav_order: 30
 canonical_url: https://opensearch.org/docs/latest/data-prepper/migrate-open-distro/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/migrate-open-distro/
 ---
 
 # Migrating from Open Distro

--- a/_data-prepper/migrating-from-logstash-data-prepper.md
+++ b/_data-prepper/migrating-from-logstash-data-prepper.md
@@ -5,6 +5,7 @@ nav_order: 25
 redirect_from: 
   - /data-prepper/configure-logstash-data-prepper/
 canonical_url: https://opensearch.org/docs/latest/data-prepper/migrating-from-logstash-data-prepper/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/migrating-from-logstash-data-prepper/
 ---
 
 # Migrating from Logstash

--- a/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
+++ b/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
 ---
 
 # Bounded blocking

--- a/_data-prepper/pipelines/configuration/buffers/buffers.md
+++ b/_data-prepper/pipelines/configuration/buffers/buffers.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 20
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/buffers/buffers/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/buffers/buffers/
 ---
 
 # Buffers

--- a/_data-prepper/pipelines/configuration/buffers/kafka.md
+++ b/_data-prepper/pipelines/configuration/buffers/kafka.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/buffers/kafka/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/buffers/kafka/
 ---
 
 # kafka

--- a/_data-prepper/pipelines/configuration/processors/add-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/add-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/add-entries/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/add-entries/
 ---
 
 # add_entries

--- a/_data-prepper/pipelines/configuration/processors/aggregate.md
+++ b/_data-prepper/pipelines/configuration/processors/aggregate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 41
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/aggregate/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/aggregate/
 ---
 
 # aggregate

--- a/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
+++ b/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
 ---
 
 # anomaly_detector

--- a/_data-prepper/pipelines/configuration/processors/convert_entry_type.md
+++ b/_data-prepper/pipelines/configuration/processors/convert_entry_type.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 47
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/convert_entry_type/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/convert_entry_type/
 ---
 
 # convert_entry_type

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 48
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/copy-values/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/copy-values/
 ---
 
 # copy_values

--- a/_data-prepper/pipelines/configuration/processors/csv.md
+++ b/_data-prepper/pipelines/configuration/processors/csv.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 49
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/csv/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/csv/
 ---
 
 # csv

--- a/_data-prepper/pipelines/configuration/processors/date.md
+++ b/_data-prepper/pipelines/configuration/processors/date.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/date/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/date/
 ---
 
 # date

--- a/_data-prepper/pipelines/configuration/processors/delete-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/delete-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 51
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/delete-entries/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/delete-entries/
 ---
 
 # delete_entries

--- a/_data-prepper/pipelines/configuration/processors/dissect.md
+++ b/_data-prepper/pipelines/configuration/processors/dissect.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 52
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/dissect/
 ---
 
 # dissect

--- a/_data-prepper/pipelines/configuration/processors/drop-events.md
+++ b/_data-prepper/pipelines/configuration/processors/drop-events.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 53
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/drop-events/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/drop-events/
 ---
 
 # drop_events

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 54
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/grok/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/grok/
 ---
 
 # Grok

--- a/_data-prepper/pipelines/configuration/processors/key-value.md
+++ b/_data-prepper/pipelines/configuration/processors/key-value.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 56
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/key-value/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/key-value/
 ---
 
 # key_value

--- a/_data-prepper/pipelines/configuration/processors/list-to-map.md
+++ b/_data-prepper/pipelines/configuration/processors/list-to-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 58
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/list-to-map/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/list-to-map/
 ---
 
 # list_to_map

--- a/_data-prepper/pipelines/configuration/processors/lowercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/lowercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
 ---
 
 # lowercase_string

--- a/_data-prepper/pipelines/configuration/processors/mutate-event.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-event.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 65
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/mutate-event/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/mutate-event/
 ---
 
 # Mutate event processors

--- a/_data-prepper/pipelines/configuration/processors/mutate-string.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/mutate-string/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/mutate-string/
 ---
 
 # Mutate string processors

--- a/_data-prepper/pipelines/configuration/processors/obfuscate.md
+++ b/_data-prepper/pipelines/configuration/processors/obfuscate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 71
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/obfuscate/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/obfuscate/
 ---
 
 # obfuscate

--- a/_data-prepper/pipelines/configuration/processors/otel-metrics.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-metrics.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 72
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
 ---
 
 # otel_metrics 

--- a/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 73
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
 ---
 
 # otel_trace_group 

--- a/_data-prepper/pipelines/configuration/processors/otel-trace-raw.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-trace-raw.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 75
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-trace-raw/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/otel-trace-raw/
 ---
 
 # otel_trace

--- a/_data-prepper/pipelines/configuration/processors/parse-json.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-json.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/parse-json/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/parse-json/
 ---
 
 # parse_json

--- a/_data-prepper/pipelines/configuration/processors/processors.md
+++ b/_data-prepper/pipelines/configuration/processors/processors.md
@@ -5,6 +5,7 @@ has_children: true
 parent: Pipelines
 nav_order: 25
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/processors/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/processors/
 ---
 
 # Processors

--- a/_data-prepper/pipelines/configuration/processors/rename-keys.md
+++ b/_data-prepper/pipelines/configuration/processors/rename-keys.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 85
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/rename-keys/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/rename-keys/
 ---
 
 # rename_keys

--- a/_data-prepper/pipelines/configuration/processors/routes.md
+++ b/_data-prepper/pipelines/configuration/processors/routes.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/routes/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/routes/
 ---
 
 # Routes

--- a/_data-prepper/pipelines/configuration/processors/service-map-stateful.md
+++ b/_data-prepper/pipelines/configuration/processors/service-map-stateful.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 95
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/service-map-stateful/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/service-map-stateful/
 ---
 
 # service_map

--- a/_data-prepper/pipelines/configuration/processors/split-string.md
+++ b/_data-prepper/pipelines/configuration/processors/split-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 100
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/split-string/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/split-string/
 ---
 
 # split_string

--- a/_data-prepper/pipelines/configuration/processors/string-converter.md
+++ b/_data-prepper/pipelines/configuration/processors/string-converter.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 105
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/string-converter/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/string-converter/
 ---
 
 # string_converter

--- a/_data-prepper/pipelines/configuration/processors/substitute-string.md
+++ b/_data-prepper/pipelines/configuration/processors/substitute-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 110
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/substitute-string/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/substitute-string/
 ---
 
 # substitute_string

--- a/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
+++ b/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 115
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
 ---
 
 # trace peer forwarder

--- a/_data-prepper/pipelines/configuration/processors/translate.md
+++ b/_data-prepper/pipelines/configuration/processors/translate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 117
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/translate/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/translate/
 ---
 
 # translate

--- a/_data-prepper/pipelines/configuration/processors/trim-string.md
+++ b/_data-prepper/pipelines/configuration/processors/trim-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 120
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/trim-string/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/trim-string/
 ---
 
 # trim_string

--- a/_data-prepper/pipelines/configuration/processors/uppercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/uppercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 125
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
 ---
 
 # uppercase_string

--- a/_data-prepper/pipelines/configuration/processors/user-agent.md
+++ b/_data-prepper/pipelines/configuration/processors/user-agent.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 130
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/user-agent/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/processors/user-agent/
 ---
 
 # user_agent

--- a/_data-prepper/pipelines/configuration/sinks/file.md
+++ b/_data-prepper/pipelines/configuration/sinks/file.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/file/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/file/
 ---
 
 # file

--- a/_data-prepper/pipelines/configuration/sinks/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sinks/opensearch.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/opensearch/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/opensearch/
 ---
 
 # opensearch

--- a/_data-prepper/pipelines/configuration/sinks/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sinks/pipeline.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 55
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/pipeline/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/pipeline/
 ---
 
 # pipeline

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 55
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/s3/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/s3/
 ---
 
 # s3

--- a/_data-prepper/pipelines/configuration/sinks/sinks.md
+++ b/_data-prepper/pipelines/configuration/sinks/sinks.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 30
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/sinks/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/sinks/
 ---
 
 # Sinks

--- a/_data-prepper/pipelines/configuration/sinks/stdout.md
+++ b/_data-prepper/pipelines/configuration/sinks/stdout.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/stdout/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sinks/stdout/
 ---
 
 # stdout sink

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 3
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
 ---
 
 # dynamodb

--- a/_data-prepper/pipelines/configuration/sources/http-source.md
+++ b/_data-prepper/pipelines/configuration/sources/http-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 5
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/http-source/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/http-source/
 ---
 
 # http_source

--- a/_data-prepper/pipelines/configuration/sources/kafka.md
+++ b/_data-prepper/pipelines/configuration/sources/kafka.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 6
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/kafka/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/kafka/
 ---
 
 # kafka

--- a/_data-prepper/pipelines/configuration/sources/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sources/opensearch.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 30
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/opensearch/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/opensearch/
 ---
 
 # opensearch

--- a/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 25
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
 ---
 
 # otel_logs_source

--- a/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
 ---
 
 # otel_metrics_source

--- a/_data-prepper/pipelines/configuration/sources/otel-trace.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-trace.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 15
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
 ---
 
 

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/s3/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/s3/
 ---
 
 # s3 source

--- a/_data-prepper/pipelines/configuration/sources/sources.md
+++ b/_data-prepper/pipelines/configuration/sources/sources.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 15
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/sources/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/configuration/sources/sources/
 ---
 
 # Sources

--- a/_data-prepper/pipelines/dlq.md
+++ b/_data-prepper/pipelines/dlq.md
@@ -4,6 +4,7 @@ title: Dead-letter queues
 parent: Pipelines
 nav_order: 13
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/dlq/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/dlq/
 ---
 
 # Dead-letter queues

--- a/_data-prepper/pipelines/expression-syntax.md
+++ b/_data-prepper/pipelines/expression-syntax.md
@@ -4,6 +4,7 @@ title: Expression syntax
 parent: Pipelines
 nav_order: 12
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/expression-syntax/
 ---
 
 # Expression syntax 

--- a/_data-prepper/pipelines/pipelines-configuration-options.md
+++ b/_data-prepper/pipelines/pipelines-configuration-options.md
@@ -4,6 +4,7 @@ title: Pipeline options
 parent: Pipelines
 nav_order: 11
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/pipelines-configuration-options/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/pipelines-configuration-options/
 ---
 
 # Pipeline options

--- a/_data-prepper/pipelines/pipelines.md
+++ b/_data-prepper/pipelines/pipelines.md
@@ -7,6 +7,7 @@ redirect_from:
   - /data-prepper/pipelines/
   - /clients/data-prepper/pipelines/
 canonical_url: https://opensearch.org/docs/latest/data-prepper/pipelines/pipelines/
+redirect_to: https://opensearch.org/docs/latest/data-prepper/pipelines/pipelines/
 ---
 
 # Pipelines

--- a/_observing-your-data/log-analytics.md
+++ b/_observing-your-data/log-analytics.md
@@ -1,1 +1,0 @@
-canonical_url: https://opensearch.org/docs/latest/data-prepper/common-use-cases/log-analytics/


### PR DESCRIPTION
Add redirects to clients, data prepper, and benchmark sections for 2.11

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
