### PR TITLE
Update syntax.md -- where-filter

### DIFF
--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -24,7 +24,7 @@ Field | Description | Required
 :--- | :--- |:---
 `search` | Specifies search keywords. | Yes
 `index` | Specifies which index to query from. | No
-`where-filter` | A boolean expression that filters searches exactly like a `where` command. | No
+`where-filter` | A Boolean expression that filters searches exactly like a `where` command. | No
 
 ## Examples
 

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -16,15 +16,15 @@ Currently, `PPL` supports only one `search` command, which can be omitted to sim
 ## Syntax
 
 ```sql
-search source=<index> [boolean-expression]
-source=<index> [boolean-expression]
+search source=<index> [where-filter]
+source=<index> [where-filter]
 ```
 
 Field | Description | Required
 :--- | :--- |:---
 `search` | Specifies search keywords. | Yes
 `index` | Specifies which index to query from. | No
-`bool-expression` | Specifies an expression that evaluates to a Boolean value. | No
+`where-filter` | A boolean expression that filters searches exactly like a `where` command. | No
 
 ## Examples
 


### PR DESCRIPTION
The argument to the source= command should be named for what it does, not its type, and the doc should say what it does, not how it is evaluated.

### Description
_Clearer documentation_

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.15 and up_

### Frontend features


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
