### PR TITLE
Update syntax.md

### DIFF
--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -8,23 +8,25 @@ nav_order: 1
 
 # PPL syntax
 
-Every PPL query starts with the `search` command. It specifies the index to search and retrieve documents from. Subsequent commands can follow in any order.
+Every PPL query starts with the `search` command. It specifies the index to search and retrieve documents from.
 
-Currently, `PPL` supports only one `search` command, which can be omitted to simplify the query.
-{ : .note}
+`PPL` supports exactly one `search` command per PPL query, and it is always the first command. The word `search` can be omitted.
+
+Subsequent commands can follow in any order.
+
+{: .note}
 
 ## Syntax
 
 ```sql
-search source=<index> [where-filter]
-source=<index> [where-filter]
+search source=<index> [boolean-expression]
+source=<index> [boolean-expression]
 ```
 
 Field | Description | Required
 :--- | :--- |:---
-`search` | Specifies search keywords. | Yes
-`index` | Specifies which index to query from. | No
-`where-filter` | A Boolean expression that filters searches exactly like a `where` command. | No
+`index` | Specifies the index to query. | No
+`bool-expression` | Specifies an expression that evaluates to a Boolean value. | No
 
 ## Examples
 

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -14,7 +14,6 @@ Every PPL query starts with the `search` command. It specifies the index to sear
 
 Subsequent commands can follow in any order.
 
-{: .note}
 
 ## Syntax
 


### PR DESCRIPTION
Rewrite the PPL syntax section. It doesn't seem useful to say that PPL "currently" supports "only" one search command, as though we have plans to support multiple search commands (with what semantics?). Just say what it does.

I also removed the incorrect space in [{ : .note}], which caused that text to appear in the formatted output. I have no idea what that command is supposed to do, but I notice another one later in the file that doesn't have the space, and doesn't appear in the formatted output, so I'm assuming that [{: .note}] is correct.

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
