### PR TITLE
Fix: expand_wildcards in _refresh API.

### DIFF
--- a/_api-reference/index-apis/refresh.md
+++ b/_api-reference/index-apis/refresh.md
@@ -45,7 +45,7 @@ The following table lists the available query parameters. All query parameters a
 | :--- | :--- | :--- |
 | `ignore_unavailable` | Boolean | When `false`, the request returns an error when it targets a missing or closed index. Default is `false`.
 | `allow_no_indices` | Boolean | When `false`, the Refresh Index API returns an error when a wildcard expression, index alias, or `_all` targets only closed or missing indexes, even when the request is made against open indexes. Default is `true`. |
-| `expand_wildcard` | String | The type of index that the wildcard patterns can match. If the request targets data streams, this argument determines whether the wildcard expressions match any hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are `all`, `open`, `closed`, `hidden`, and `none`.
+| `expand_wildcards` | String | The type of index that the wildcard patterns can match. If the request targets data streams, this argument determines whether the wildcard expressions match any hidden data streams. Supports comma-separated values, such as `open,hidden`. Valid values are `all`, `open`, `closed`, `hidden`, and `none`.
 
 
 


### PR DESCRIPTION
### Description

In https://github.com/opensearch-project/documentation-website/pull/6954 we documented _refresh and there are examples in the docs of how you can call it. The `expand_wildcard` parameter is incorrect, it's `expand_wildcards`. I added a test in https://github.com/opensearch-project/opensearch-api-specification/pull/374 for the spec that runs against an actual OpenSearch to demonstrate.

### Version

2.x

### Frontend features

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
