### PR TITLE
Update cat-nodes.md

### DIFF
--- a/_api-reference/cat/cat-nodes.md
+++ b/_api-reference/cat/cat-nodes.md
@@ -39,7 +39,6 @@ Parameter | Type | Description
 :--- | :--- | :---
 bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 full_id | Boolean | If true, return the full node ID. If false, return the shortened node ID. Defaults to false.
-local | Boolean | Whether to return information from the local node only instead of from the cluster_manager node. Default is false.
 cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
 time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 include_unloaded_segments | Boolean | Whether to include information from segments not loaded into memory. Default is false.


### PR DESCRIPTION
'Local' option is deprecated and no has any purpose. See Issue #7625

### Description
The `local` option is deprecated and currently has no function. Will be entirely removed in future versions.

### Issues Resolved

Closes #7625 

### Version
7.10.2

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
Signed-off-by: Landon Lengyel <landon@almonde.org>