### PR TITLE
Add new update_fields parameter to update workflow API

### DIFF
--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -53,7 +53,7 @@ When set to `true`, the [Provision Workflow API]({{site.url}}{{site.baseurl}}/au
 
 By default, workflows are validated when they are created to ensure that the syntax is valid and that the graph does not contain cycles. This behavior can be controlled with the `validation` query parameter. If `validation` is set to `all`, OpenSearch performs a complete template validation. Any other value of the `validation` parameter suppresses validation, allowing an incomplete/work-in-progress template to be saved. To disable template validation, set `validation` to `none`:
 
-You can not update a full workflow that has been provisioned, but you can update fields other than the `workflows` field, such as the name and description.
+You cannot update a full workflow once it has been provisioned, but you can update fields other than the `workflows` field, such as `name` and `description`.
 
 ```json
 PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -20,9 +20,9 @@ You can include placeholder expressions in the value of workflow step fields. Fo
 
 Once a workflow is created, provide its `workflow_id` to other APIs.
 
-The `POST` method creates a new workflow. The `PUT` method updates an existing workflow. 
+The `POST` method creates a new workflow. The `PUT` method updates an existing workflow. With the `update_fields` parameter, only the included fields are updated.
 
-You can only update a workflow if it has not yet been provisioned.
+You can only update a complete workflow if it has not yet been provisioned.
 {: .note}
 
 ## Path and HTTP methods
@@ -53,6 +53,15 @@ When set to `true`, the [Provision Workflow API]({{site.url}}{{site.baseurl}}/au
 
 By default, workflows are validated when they are created to ensure that the syntax is valid and that the graph does not contain cycles. This behavior can be controlled with the `validation` query parameter. If `validation` is set to `all`, OpenSearch performs a complete template validation. Any other value of the `validation` parameter suppresses validation, allowing an incomplete/work-in-progress template to be saved. To disable template validation, set `validation` to `none`:
 
+You can not update a full workflow that has been provisioned, but you can update fields other than the `workflows` field, such as the name and description.
+
+```json
+PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true
+```
+{% include copy-curl.html %}
+
+You can not use both the `provision` and `update_fields` parameters at the same time.
+
 ```json
 POST /_plugins/_flow_framework/workflow?validation=none
 ```
@@ -63,6 +72,7 @@ The following table lists the available query parameters. All query parameters a
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
 | `provision` | Boolean | Whether to provision the workflow as part of the request. Default is `false`. |
+| `update_fields` | Boolean | Whether to update only the fields included in the request body. Default is `false`. |
 | `validation` | String | Whether to validate the workflow. Valid values are `all` (validate the template) and `none` (do not validate the template). Default is `all`. |
 | User-provided substitution expressions | String | Parameters matching substitution expressions in the template. Only allowed if `provision` is set to `true`. Optional. If `provision` is set to `false`, you can pass these parameters in the [Provision Workflow API query parameters]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/#query-parameters). |
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -58,7 +58,7 @@ POST /_plugins/_flow_framework/workflow?validation=none
 ```
 {% include copy-curl.html %}
 
-You cannot update a full workflow once it has been provisioned, but you can update fields other than the `workflows` field, such as `name` and `description`.
+You cannot update a full workflow once it has been provisioned, but you can update fields other than the `workflows` field, such as `name` and `description`:
 
 ```json
 PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -60,7 +60,8 @@ PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true
 ```
 {% include copy-curl.html %}
 
-You can not use both the `provision` and `update_fields` parameters at the same time.
+You cannot specify both the `provision` and `update_fields` parameters at the same time.
+{: .note}
 
 ```json
 POST /_plugins/_flow_framework/workflow?validation=none

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -53,20 +53,24 @@ When set to `true`, the [Provision Workflow API]({{site.url}}{{site.baseurl}}/au
 
 By default, workflows are validated when they are created to ensure that the syntax is valid and that the graph does not contain cycles. This behavior can be controlled with the `validation` query parameter. If `validation` is set to `all`, OpenSearch performs a complete template validation. Any other value of the `validation` parameter suppresses validation, allowing an incomplete/work-in-progress template to be saved. To disable template validation, set `validation` to `none`:
 
+```json
+POST /_plugins/_flow_framework/workflow?validation=none
+```
+{% include copy-curl.html %}
+
 You cannot update a full workflow once it has been provisioned, but you can update fields other than the `workflows` field, such as `name` and `description`.
 
 ```json
 PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true
+{
+  "name": "new-template-name",
+  "description": "A new description for the existing template"
+}
 ```
 {% include copy-curl.html %}
 
 You cannot specify both the `provision` and `update_fields` parameters at the same time.
 {: .note}
-
-```json
-POST /_plugins/_flow_framework/workflow?validation=none
-```
-{% include copy-curl.html %}
 
 The following table lists the available query parameters. All query parameters are optional. User-provided parameters are only allowed if the `provision` parameter is set to `true`.
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -20,7 +20,7 @@ You can include placeholder expressions in the value of workflow step fields. Fo
 
 Once a workflow is created, provide its `workflow_id` to other APIs.
 
-The `POST` method creates a new workflow. The `PUT` method updates an existing workflow. With the `update_fields` parameter, only the included fields are updated.
+The `POST` method creates a new workflow. The `PUT` method updates an existing workflow. You can specify the `update_fields` parameter to update specific fields.
 
 You can only update a complete workflow if it has not yet been provisioned.
 {: .note}


### PR DESCRIPTION
### Description

Documents the addition of a new `update_fields` parameter for the Update Workflow API.

### Issues Resolved

Fixes #7649 

Corresponding feature PR:
 - https://github.com/opensearch-project/flow-framework/pull/757

### Version

2.16.0

### Frontend features

This API will be consumed by the Flow Framework Dashboards Plugin for UI metadata, which is not yet released.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
