### PR TITLE
mention both Dashboards and endpoint

### DIFF
--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -37,7 +37,11 @@ PPL filters, transforms, and aggregates data using a series of commands. See [Co
 
 ## Using PPL within OpenSearch
 
-To use PPL, you must have installed OpenSearch Dashboards. PPL is available within the [Query Workbench tool](https://playground.opensearch.org/app/opensearch-query-workbench#/). See the [Query Workbench]({{site.url}}{{site.baseurl}}/dashboards/query-workbench/) documentation for a tutorial on using PPL within OpenSearch.
+You can run PPL queries interactively in OpenSearch Dashboards or programmatically using the ``_ppl`` endpoint.
+
+In OpenSearch Dashboards, the [Query Workbench tool](https://playground.opensearch.org/app/opensearch-query-workbench#/) provides an interactive testing environment, documented in [Query Workbench documentation]({{site.url}}{{site.baseurl}}/dashboards/query-workbench/).
+
+To run a PPL query using the API, see [SQL and PPL API]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql-ppl-api/).
 
 ## Developer documentation
 

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -37,11 +37,15 @@ PPL filters, transforms, and aggregates data using a series of commands. See [Co
 
 ## Using PPL within OpenSearch
 
-You can run PPL queries interactively in OpenSearch Dashboards or programmatically using the ``_ppl`` endpoint.
+The SQL plugin is required to run PPL queries in OpenSearch. If you're running a minimal distribution of OpenSearch, you might have to [install the SQL plugin]({{site.url}}{{site.baseurl}}/install-and-configure/plugins/) before using PPL.
+{: .note}
+
+You can run PPL queries interactively in OpenSearch Dashboards or programmatically using the ``_ppl`` endpoint. 
 
 In OpenSearch Dashboards, the [Query Workbench tool](https://playground.opensearch.org/app/opensearch-query-workbench#/) provides an interactive testing environment, documented in [Query Workbench documentation]({{site.url}}{{site.baseurl}}/dashboards/query-workbench/).
 
 To run a PPL query using the API, see [SQL and PPL API]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql-ppl-api/).
+
 
 ## Developer documentation
 


### PR DESCRIPTION
Old text said that Dashboards are a prerequisite for using PPL, and mentioned only the Query Workbench, not the _ppl endpoint.

Is it really true that Dashboards are a prerequisite? Or is it just the SQL plugin that is a prerequisite?

### Description
_Describe what this change achieves._

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
