### PR TITLE
Removed incorrect ignore_malformed query parameter.

### DIFF
--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -76,7 +76,6 @@ Parameter | Data type | Description
 allow_no_indices | Boolean | Whether to ignore wildcards that don’t match any indexes. Default is `true`.
 expand_wildcards | String | Expands wildcard expressions to different indexes. Combine multiple values with commas. Available values are `all` (match all indexes), `open` (match open indexes), `closed` (match closed indexes), `hidden` (match hidden indexes), and `none` (do not accept wildcard expressions), which must be used with `open`, `closed`, or both. Default is `open`.
 ignore_unavailable | Boolean | If true, OpenSearch does not include missing or closed indexes in the response.
-ignore_malformed | Boolean | Use this parameter with the `ip_range` data type to specify that OpenSearch should ignore malformed fields. If `true`, OpenSearch does not include entries that do not match the IP range specified in the index in the response. The default is `false`.
 cluster_manager_timeout | Time | How long to wait for a connection to the cluster manager node. Default is `30s`.
 timeout | Time | How long to wait for the response to return. Default is `30s`.
 write_index_only | Boolean | Whether OpenSearch should apply mapping updates only to the write index.


### PR DESCRIPTION
### Description

The [documentation for `put_mapping`](https://opensearch.org/docs/latest/api-reference/index-apis/put-mapping/) seems to imply that `ignore_malformed` can be specified as a query parameter. It's a valid index field mapping parameter but doesn't look like it can be specified on the query string. It's also not in the API spec.

```
$ curl -k -u admin:$OPENSEARCH_PASSWORD -X PUT https://localhost:9200/movies | jq
{
  "acknowledged": true,
  "shards_acknowledged": true,
  "index": "movies"
}

$ curl -k -u admin:$OPENSEARCH_PASSWORD -X PUT https://localhost:9200/movies/_mapping?ignore_unavailable=true --json "{}" | jq
{
  "acknowledged": true
}

$ curl -k -u admin:$OPENSEARCH_PASSWORD -X PUT https://localhost:9200/movies/_mapping?ignore_malformed=true --json "{}" | jq
{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "request [/movies/_mapping] contains unrecognized parameter: [ignore_malformed] -> did you mean [ignore_throttled]?"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "request [/movies/_mapping] contains unrecognized parameter: [ignore_malformed] -> did you mean [ignore_throttled]?"
  },
  "status": 400
}
```

The `ignore_throttled` parameter mentioned here looks deprecated, so we don't document it, which I think is right/separate problem.

### Version

2.x

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
