### PR TITLE
Fix: the value of include_defaults is a boolean.

### DIFF
--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -40,7 +40,7 @@ Parameter | Data type | Description
 allow_no_indices | Boolean | Whether to ignore wildcards that don’t match any indexes. Default is `true`.
 expand_wildcards | String | Expands wildcard expressions to different indexes. Combine multiple values with commas. Available values are `all` (match all indexes), `open` (match open indexes), `closed` (match closed indexes), `hidden` (match hidden indexes), and `none` (do not accept wildcard expressions), which must be used with `open`, `closed`, or both. Default is `open`.
 flat_settings | Boolean | Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of “index”: { “creation_date”: “123456789” } is “index.creation_date”: “123456789”.
-include_defaults | String | Whether to include default settings, including settings used within OpenSearch plugins, in the response. Default is false.
+include_defaults | Boolean | Whether to include default settings, including settings used within OpenSearch plugins, in the response. Default is false.
 ignore_unavailable | Boolean | If true, OpenSearch does not include missing or closed indexes in the response.
 local | Boolean | Whether to return information from the local node only instead of the cluster manager node. Default is false.
 cluster_manager_timeout | Time | How long to wait for a connection to the cluster manager node. Default is `30s`.

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -40,7 +40,7 @@ Parameter | Data type | Description
 allow_no_indices | Boolean | Whether to ignore wildcards that don’t match any indexes. Default is `true`.
 expand_wildcards | String | Expands wildcard expressions to different indexes. Combine multiple values with commas. Available values are `all` (match all indexes), `open` (match open indexes), `closed` (match closed indexes), `hidden` (match hidden indexes), and `none` (do not accept wildcard expressions), which must be used with `open`, `closed`, or both. Default is `open`.
 flat_settings | Boolean | Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of “index”: { “creation_date”: “123456789” } is “index.creation_date”: “123456789”.
-include_defaults | Boolean | Whether to include default settings, including settings used within OpenSearch plugins, in the response. Default is false.
+include_defaults | Boolean | Whether to include default settings, including settings used within OpenSearch plugins, in the response. Default is `false`.
 ignore_unavailable | Boolean | If true, OpenSearch does not include missing or closed indexes in the response.
 local | Boolean | Whether to return information from the local node only instead of the cluster manager node. Default is false.
 cluster_manager_timeout | Time | How long to wait for a connection to the cluster manager node. Default is `30s`.


### PR DESCRIPTION
### Description

Fix: the value of include_defaults is a boolean.

### Version

2.x

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
