### PR TITLE
Add PR checklist workflow

### DIFF
--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -2,7 +2,7 @@ name: PR Checklist
 
 on:
   pull_request:
-    types: [opened]
+#    types: [opened]
 
 jobs:
   add-checklist:
@@ -25,9 +25,16 @@ jobs:
         uses: actions/github-script@v6
         with:
           script: |
+            let assignee = context.payload.pull_request.user.login;
+            const prOwners = ['Naarcha-AWS', 'kolchfa-aws', 'vagimeli', 'natebower'];
+            
+            if (!prOwners.includes(assignee)) {
+              assignee = 'hdhalter'
+            }
+
             github.rest.issues.addAssignees({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              assignees: 'hdhalter'
-            })
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                assignees: [assignee]
+              });

--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -29,5 +29,5 @@ jobs:
               issue_number: context.issue.number,
               owner: context.repo.owner,
               repo: context.repo.repo,
-              assignees: context.repo.owner
+              assignees: 'hdhalter'
             })

--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -17,9 +17,9 @@ jobs:
           body: |
             Thank you for submitting your PR. The PR states are In progress (or Draft) -> Tech review -> Doc review -> Editorial review -> Merged.
             
-            Before you mark the PR ready for doc review, make sure the content is technically accurate. If you need help finding a tech reviewer, tag a [maintainer](https://github.com/opensearch-project/documentation-website/blob/main/MAINTAINERS.md).
+            Before you submit your PR for doc review, make sure the content is technically accurate. If you need help finding a tech reviewer, tag a [maintainer](https://github.com/opensearch-project/documentation-website/blob/main/MAINTAINERS.md).
 
-            **When you're ready for doc review, tag the assignee of this PR**. The doc reviewer may push edits to the PR directly, or leave comments and editorial suggestions for you to approve, make changes, and commit yourself (let us know in a comment if you have a preference.) The doc reviewer will arrange for an editorial review.
+            **When you're ready for doc review, tag the assignee of this PR**. The doc reviewer may push edits to the PR directly or leave comments and editorial suggestions for you to address (let us know in a comment if you have a preference). The doc reviewer will arrange for an editorial review.
 
       - name: Auto assign PR to repo owner
         uses: actions/github-script@v6

--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -2,7 +2,7 @@ name: PR Checklist
 
 on:
   pull_request:
-    types: [opened]
+#    types: [opened]
 
 jobs:
   add-checklist:

--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -1,0 +1,33 @@
+name: PR Checklist
+
+on:
+  pull_request:
+    types: [opened]
+
+jobs:
+  add-checklist:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Comment PR with checklist
+        uses: peter-evans/create-or-update-comment@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.pull_request.number }}
+          body: |
+            Thank you for submitting your PR. The PR states are In progress (or Draft) -> Tech review -> Doc review -> Editorial review -> Merged.
+            
+            Before you mark the PR ready for doc review, make sure the content is technically accurate. If you need help finding a tech reviewer, tag a [maintainer](https://github.com/opensearch-project/documentation-website/blob/main/MAINTAINERS.md).
+
+            **When you're ready for doc review, tag the assignee of this PR**. The doc reviewer may push edits to the PR directly, or leave comments and editorial suggestions for you to approve, make changes, and commit yourself (let us know in a comment if you have a preference.) The doc reviewer will arrange for an editorial review.
+
+      - name: Auto assign PR to repo owner
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.addAssignees({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              assignees: context.repo.owner
+            })

--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -2,7 +2,7 @@ name: PR Checklist
 
 on:
   pull_request:
-#    types: [opened]
+    types: [opened]
 
 jobs:
   add-checklist:


### PR DESCRIPTION
Adds a workflow that will comment with the doc repo process and assign all incoming PRs to the repo owner for triage.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
