### PR TITLE
Adds IntelliJ's *.iml to the .gitignore.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,5 @@ _site
 .DS_Store
 Gemfile.lock
 .idea
+*.iml
 .jekyll-cache


### PR DESCRIPTION
### Description

IntelliJ creates `*.iml` files. I have this now and it shows up as an untracked change. We can ignore this in Git.

### Issues Resolved
N/A

### Version
N/A

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
