### PR TITLE
Add strict_allow_templates option for the dynamic mapping parameter

### DIFF
--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -33,7 +33,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-2. Index a document with an object field `patient` containing two string fields using the following request:
+2. Index a document with an object field `patient` containing two string fields by sending the following request:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -93,7 +93,7 @@ The object field `patient` and two subfields `name` and `id` are added to the ma
 
 ## Example: Create an index with `dynamic` set to `false`
 
-1. Create an index with `dynamic` set to `false` and explicit mappings using the following request:
+1. Create an index with `dynamic` set to `false` and explicit mappings by sending the following request:
 
 ```json
 PUT testindex1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -217,7 +217,7 @@ The response returns no results:
 
 ## Example: Create an index with `dynamic` set to `strict`
 
-1. Create an index with `dynamic` set to `strict` and explicit mappings using the following request:
+1. Create an index with `dynamic` set to `strict` and explicit mappings by sending the following request:
 
 ```json
 PUT testindex1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -1,3 +1,13 @@
+---
+layout: default
+title: Dynamic parameter
+nav_order: 10
+redirect_from:
+  - /opensearch/dynamic/
+---
+
+# Dynamic parameter
+
 The `dynamic` parameter specifies whether new detected fields can be added dynamically, it accepts four parameters:
 
 Parameter | Description 

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -91,7 +91,7 @@ The object field `patient` and two subfields `name` and `id` are added to the ma
 
 ---
 
-## Example: Create index with dynamic parameter set to `false`
+## Example: Create an index with `dynamic` set to `false`
 
 1. Create an index with `dynamic` set to `false` and explicit mappings using the following request:
 

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -177,7 +177,7 @@ PUT testindex1/_doc/1
 }
 ```
 
-The following request searches the fields `room` or `floor`, with a response confirming no results returned:
+The following request searches the fields `room` or `floor`:
 
 ```json
 POST testindex1/_search

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -278,7 +278,7 @@ Note that an exception is thrown, as shown in the following response:
 
 ## Example: Create an index with `dynamic` set to `strict_allow_templates`
 
-1. Create an index with `dynamic` set to `strict_allow_templates` and dynamic templates using the following request: 
+1. Create an index with `dynamic` set to `strict_allow_templates` and predefined dynamic templates by sending the following request: 
 
 ```json
 PUT testindex1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -241,7 +241,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-2. Index a document with an object field `patient` containing two string fields, and additional unmapped fields using the following request:
+2. Index a document with an object field `patient` containing two string fields and additional unmapped fields by sending the following request:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -163,7 +163,7 @@ The following response shows that the new fields `room` and `floor` were not add
 }
 ```
 
-4. Get the unmapped fields `room` and `floor` from the document using the following request:
+4. Get the unmapped fields `room` and `floor` from the document by sending the following request:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -117,7 +117,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-2. Index a document with an object field patient containing two string fields and additional unmapped fields using the following request:
+2. Index a document with an object field `patient` containing two string fields and additional unmapped fields by sending the following request:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -19,7 +19,7 @@ Parameter | Description
 
 --- 
 
-## Example: Create index with dynamic parameter set to `true`
+## Example: Create an index with `dynamic` set to `true`
 
 1. Create an index with `dynamic` set as `true` using the following request:
 

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -53,7 +53,7 @@ GET testindex1/_mapping
 ```
 {% include copy-curl.html %}
 
-Object field `patient` and two subfields `name` and `id` are added to the mapping, as shown in the following response:
+The object field `patient` and two subfields `name` and `id` are added to the mapping, as shown in the following response:
 
 ```json
 {

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -15,7 +15,7 @@ Parameter | Description
 `true`  | Specfies that new fields can be added dynamically to the mapping. Default is `true`.
 `false` | Specifies that new fields cannot be added dynamically to the mapping. If a new field is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
 `strict` | Throws an exception. The indexing operation fails when new fields are detected.
-`strict_allow_templates` | Adds new fields matching dynamic templates if the new fields match predefined dynamic templates in the mapping; otherwise, indexing fails.
+`strict_allow_templates` | Adds new fields if they match predefined dynamic templates in the mapping.
 
 --- 
 
@@ -46,7 +46,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-3. Check the mapping by sending the following request:
+3. Confirm the mapping works as expected by sending the following request:
 
 ```json
 GET testindex1/_mapping
@@ -93,7 +93,7 @@ The object field `patient` and two subfields `name` and `id` are added to the ma
 
 ## Example: Create an index with `dynamic` set to `false`
 
-1. Create an index with `dynamic` set to `false` and explicit mappings by sending the following request:
+1. Create an index with explicit mappings and `dynamic` set to `false` by sending the following request:
 
 ```json
 PUT testindex1
@@ -132,7 +132,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-3. Check the mapping by sending the following request:
+3.  Confirm the mapping works as expected by sending the following request:
 
 ```json
 GET testindex1/_mapping
@@ -177,7 +177,7 @@ PUT testindex1/_doc/1
 }
 ```
 
-The following request searches the fields `room` or `floor`:
+The following request searches for the fields `room` and `floor`:
 
 ```json
 POST testindex1/_search
@@ -217,7 +217,7 @@ The response returns no results:
 
 ## Example: Create an index with `dynamic` set to `strict`
 
-1. Create an index with `dynamic` set to `strict` and explicit mappings by sending the following request:
+1. Create an index with explicit mappings and `dynamic` set to `strict` by sending the following request:
 
 ```json
 PUT testindex1
@@ -278,7 +278,7 @@ Note that an exception is thrown, as shown in the following response:
 
 ## Example: Create an index with `dynamic` set to `strict_allow_templates`
 
-1. Create an index with `dynamic` set to `strict_allow_templates` and predefined dynamic templates by sending the following request: 
+1. Create an index with predefined dynamic templates and `dynamic` set to `strict_allow_templates` by sending the following request: 
 
 ```json
 PUT testindex1
@@ -313,7 +313,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-2. Index a document with an object field `patient` containing two string fields and a new field `room` that matches the dynamic templates by sending the following request:
+2. Index a document with an object field `patient` containing two string fields and a new field `room` that matches one of the dynamic templates by sending the following request:
 
 ```json
 PUT testindex1/_doc/1
@@ -327,7 +327,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-Indexing succeeds because the new field `room` matches the dynamic templates. However, indexing fails for the new field `floor` because it does not match the dynamic templates and is not explicitly mapped, as shown in the following response:
+Indexing succeeds because the new field `room` matches the dynamic templates. However, indexing fails for the new field `floor` because it does not match one of the dynamic templates and is not explicitly mapped, as shown in the following response:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -46,7 +46,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-3. Check the mapping using the following request:
+3. Check the mapping by sending the following request:
 
 ```json
 GET testindex1/_mapping

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -313,7 +313,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-2. Index a document with an object field `patient` containing two string fields, and a new field `room` matching the dynamic templates using the following request:
+2. Index a document with an object field `patient` containing two string fields and a new field `room` that matches the dynamic templates by sending the following request:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -132,7 +132,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-3. Check the mapping using the following request:
+3. Check the mapping by sending the following request:
 
 ```json
 GET testindex1/_mapping

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -21,7 +21,7 @@ Parameter | Description
 
 ## Example: Create an index with `dynamic` set to `true`
 
-1. Create an index with `dynamic` set as `true` using the following request:
+1. Create an index with `dynamic` set to `true` by sending the following request:
 
 ```json
 PUT testindex1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -8,17 +8,20 @@ redirect_from:
 
 # Dynamic parameter
 
-The `dynamic` parameter specifies whether new detected fields can be added dynamically, it accepts four parameters:
+The `dynamic` parameter specifies whether new detected fields can be added dynamically to the mapping. It accepts the parameters listed in the following table.
 
 Parameter | Description 
 :--- | :--- 
-`true`  | New fields can be added to the mapping dynamically. This is the default.
-`false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the `_source` field.
-`strict` | Throws exception and fail the indexing operation when new fields are detected.
-`strict_allow_templates` | If the new detected fields can match any predefined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
+`true`  | Specfies that new fields can be added dynamically to the mapping. Default is `true`.
+`false` | Specifies that new fields cannot be added dynamically to the mapping. If a new field is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
+`strict` | Throws an exception. The indexing operation fails when new fields are detected.
+`strict_allow_templates` | Adds new fields matching dynamic templates if the new fields match predefined dynamic templates in the mapping; otherwise, indexing fails.
 
-## Example 1
-Create an index with setting `dynamic` to `true`(or do not set):
+--- 
+
+## Example: Create index with dynamic parameter set to `true`
+
+1. Create an index with `dynamic` set as `true` using the following request:
 
 ```json
 PUT testindex1
@@ -30,7 +33,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-Index a document with an object field `patient`, and two string fields under the `patient` object:
+2. Index a document with an object field `patient` containing two string fields using the following request:
 
 ```json
 PUT testindex1/_doc/1
@@ -43,14 +46,14 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-Check the mapping:
+3. Check the mapping using the following request:
 
 ```json
 GET testindex1/_mapping
 ```
 {% include copy-curl.html %}
 
-, you can see that an object field `patient` and two sub-fields `name` and `id` were added to the mapping:
+Object field `patient` and two subfields `name` and `id` are added to the mapping, as shown in the following response:
 
 ```json
 {
@@ -86,8 +89,11 @@ GET testindex1/_mapping
 }
 ```
 
-## Example 2
-Create an index with setting `dynamic` to `false` but with some explicit mapping:
+---
+
+## Example: Create index with dynamic parameter set to `false`
+
+1. Create an index with `dynamic` set to `false` and explicit mappings using the following request:
 
 ```json
 PUT testindex1
@@ -111,7 +117,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-Index a document with an object field `patient`, and two string fields under the `patient` object, and also other new fields which are not shown in the mapping:
+2. Index a document with an object field patient containing two string fields and additional unmapped fields using the following request:
 
 ```json
 PUT testindex1/_doc/1
@@ -126,14 +132,14 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-Check the mapping:
+3. Check the mapping using the following request:
 
 ```json
 GET testindex1/_mapping
 ```
 {% include copy-curl.html %}
 
-, you can see that the new fields `room` and `floor` were not added to the mapping, the mapping didn't change:
+The following response shows that the new fields `room` and `floor` were not added to the mapping, which remained unchanged:
 
 ```json
 {
@@ -157,7 +163,7 @@ GET testindex1/_mapping
 }
 ```
 
-However, you can still get the fields `room` and `floor` from the document:
+4. Get the unmapped fields `room` and `floor` from the document using the following request:
 
 ```json
 PUT testindex1/_doc/1
@@ -170,7 +176,8 @@ PUT testindex1/_doc/1
   "floor": "1"
 }
 ```
-, but search on the fields `room` or `floor` will return no results:
+
+The following request searches the fields `room` or `floor`, with a response confirming no results returned:
 
 ```json
 POST testindex1/_search
@@ -182,7 +189,8 @@ POST testindex1/_search
   }
 }
 ```
-, the response is:
+
+The following response confirms no returned results:
 
 ```json
 {
@@ -205,8 +213,11 @@ POST testindex1/_search
 }
 ```
 
-## Example 3
-Create an index with setting `dynamic` to `strict` but with some explicit mapping:
+---
+
+## Example: Create an index with `dynamic` set to `strict`
+
+1. Create an index with `dynamic` set to `strict` and explicit mappings using the following request:
 
 ```json
 PUT testindex1
@@ -230,7 +241,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-Index a document with an object field `patient`, and two string fields under the `patient` object, and also other new fields which are not shown in the mapping:
+2. Index a document with an object field `patient` containing two string fields, and additional unmapped fields using the following request:
 
 ```json
 PUT testindex1/_doc/1
@@ -245,7 +256,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-This time, an exception is thrown:
+Note that an exception is thrown, as shown in the following response: 
 
 ```json
 {
@@ -263,8 +274,11 @@ This time, an exception is thrown:
 }
 ```
 
-## Example 4
-Create an index with setting `dynamic` to `strict_allow_templates` and with some dynamic templates:
+---
+
+## Example: Create an index with `dynamic` set to `strict_allow_templates`
+
+1. Create an index with `dynamic` set to `strict_allow_templates` and dynamic templates using the following request: 
 
 ```json
 PUT testindex1
@@ -299,7 +313,7 @@ PUT testindex1
 ```
 {% include copy-curl.html %}
 
-Index a document with an object field `patient`, and two string fields under the `patient` object, and a new field `room` which can match the dynamic templates:
+2. Index a document with an object field `patient` containing two string fields, and a new field `room` matching the dynamic templates using the following request:
 
 ```json
 PUT testindex1/_doc/1
@@ -313,9 +327,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-, index this document succeeds because the new detected field `room` can match the predefined dynamic templates.
-
-But index the following document fails because the new detected field `floor` cannot match the predefined dynamic templates and was not set explicitly in the mapping.
+Indexing succeeds because the new field `room` matches the dynamic templates. However, indexing fails for the new field `floor` because it does not match the dynamic templates and is not explicitly mapped, as shown in the following response:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -8,7 +8,7 @@ redirect_from:
 
 # Dynamic parameter
 
-The `dynamic` parameter specifies whether new detected fields can be added dynamically to the mapping. It accepts the parameters listed in the following table.
+The `dynamic` parameter specifies whether newly detected fields can be added dynamically to a mapping. It accepts the parameters listed in the following table.
 
 Parameter | Description 
 :--- | :--- 

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -190,7 +190,7 @@ POST testindex1/_search
 }
 ```
 
-The following response confirms no returned results:
+The response returns no results:
 
 ```json
 {

--- a/_field-types/mapping-parameters/index.md
+++ b/_field-types/mapping-parameters/index.md
@@ -3,9 +3,9 @@ The `dynamic` parameter specifies whether new detected fields can be added dynam
 Parameter | Description 
 :--- | :--- 
 `true`  | New fields can be added to the mapping dynamically. This is the default.
-`false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the _source field.
+`false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the `_source` field.
 `strict` | Throws exception and fail the indexing operation when new fields are detected.
-`strict_allow_templates` | If the new detected fields can match any pre-defined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
+`strict_allow_templates` | If the new detected fields can match any predefined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
 
 ## Example 1
 Create an index with setting `dynamic` to `true`(or do not set):
@@ -303,9 +303,9 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-, index this document succeeds because the new detected field `room` can match the pre-defined dynamic templates.
+, index this document succeeds because the new detected field `room` can match the predefined dynamic templates.
 
-But index the following document fails because the new detected field `floor` cannot match the pre-defined dynamic templates and was not set explicitly in the mapping.
+But index the following document fails because the new detected field `floor` cannot match the predefined dynamic templates and was not set explicitly in the mapping.
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/mapping-parameters/index.md
+++ b/_field-types/mapping-parameters/index.md
@@ -1,0 +1,320 @@
+The `dynamic` parameter specifies whether new detected fields can be added dynamically, it accepts four parameters:
+
+Parameter | Description 
+:--- | :--- 
+`true`  | New fields can be added to the mapping dynamically. This is the default.
+`false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the _source field.
+`strict` | Throws exception and fail the indexing operation when new fields are detected.
+`strict_allow_templates` | If the new detected fields can match any pre-defined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
+
+## Example 1
+Create an index with setting `dynamic` to `true`(or do not set):
+
+```json
+PUT testindex1
+{
+  "mappings": {
+    "dynamic": true
+  }
+}
+```
+{% include copy-curl.html %}
+
+Index a document with an object field `patient`, and two string fields under the `patient` object:
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  } 
+}
+```
+{% include copy-curl.html %}
+
+Check the mapping:
+
+```json
+GET testindex1/_mapping
+```
+{% include copy-curl.html %}
+
+, you can see that an object field `patient` and two sub-fields `name` and `id` were added to the mapping:
+
+```json
+{
+  "testindex1": {
+    "mappings": {
+      "dynamic": "true",
+      "properties": {
+        "patient": {
+          "properties": {
+            "id": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            },
+            "name": {
+              "type": "text",
+              "fields": {
+                "keyword": {
+                  "type": "keyword",
+                  "ignore_above": 256
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+## Example 2
+Create an index with setting `dynamic` to `false` but with some explicit mapping:
+
+```json
+PUT testindex1
+{
+  "mappings": {
+    "dynamic": false,
+    "properties": {
+      "patient": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Index a document with an object field `patient`, and two string fields under the `patient` object, and also other new fields which are not shown in the mapping:
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  },
+  "room": "room1",
+  "floor": "1"
+}
+```
+{% include copy-curl.html %}
+
+Check the mapping:
+
+```json
+GET testindex1/_mapping
+```
+{% include copy-curl.html %}
+
+, you can see that the new fields `room` and `floor` were not added to the mapping, the mapping didn't change:
+
+```json
+{
+  "testindex1": {
+    "mappings": {
+      "dynamic": "false",
+      "properties": {
+        "patient": {
+          "properties": {
+            "id": {
+              "type": "keyword"
+            },
+            "name": {
+              "type": "keyword"
+            }
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+However, you can still get the fields `room` and `floor` from the document:
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  },
+  "room": "room1",
+  "floor": "1"
+}
+```
+, but search on the fields `room` or `floor` will return no results:
+
+```json
+POST testindex1/_search
+{
+  "query": {
+    "term": {
+      "room": "room1"
+    }
+  }
+}
+```
+, the response is:
+
+```json
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 0,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  }
+}
+```
+
+## Example 3
+Create an index with setting `dynamic` to `strict` but with some explicit mapping:
+
+```json
+PUT testindex1
+{
+  "mappings": {
+    "dynamic": strict,
+    "properties": {
+      "patient": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Index a document with an object field `patient`, and two string fields under the `patient` object, and also other new fields which are not shown in the mapping:
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  },
+  "room": "room1",
+  "floor": "1"
+}
+```
+{% include copy-curl.html %}
+
+This time, an exception is thrown:
+
+```json
+{
+  "error": {
+    "root_cause": [
+      {
+        "type": "strict_dynamic_mapping_exception",
+        "reason": "mapping set to strict, dynamic introduction of [room] within [_doc] is not allowed"
+      }
+    ],
+    "type": "strict_dynamic_mapping_exception",
+    "reason": "mapping set to strict, dynamic introduction of [room] within [_doc] is not allowed"
+  },
+  "status": 400
+}
+```
+
+## Example 4
+Create an index with setting `dynamic` to `strict_allow_templates` and with some dynamic templates:
+
+```json
+PUT testindex1
+{
+  "mappings": {
+    "dynamic": "strict_allow_templates",
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "room*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
+    "properties": {
+      "patient": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Index a document with an object field `patient`, and two string fields under the `patient` object, and a new field `room` which can match the dynamic templates:
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  },
+  "room": "room1"
+}
+```
+{% include copy-curl.html %}
+
+, index this document succeeds because the new detected field `room` can match the pre-defined dynamic templates.
+
+But index the following document fails because the new detected field `floor` cannot match the pre-defined dynamic templates and was not set explicitly in the mapping.
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  },
+  "room": "room1",
+  "floor": "1"
+}
+```

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -308,7 +308,7 @@ The following table lists the parameters accepted by object field types. All par
 
 Parameter | Description 
 :--- | :--- 
-[`dynamic`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/object#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to this object. Valid values are `true`, `false`, `strict` and `strict_allow_templates`. Default is `true`.
+[`dynamic`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/object#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to the object. Valid values are `true`, `false`, `strict`, and `strict_allow_templates`. Default is `true`.
 `include_in_parent` | A Boolean value that specifies whether all fields in the child nested object should also be added to the parent document in flattened form. Default is `false`.
 `include_in_root` | A Boolean value that specifies whether all fields in the child nested object should also be added to the root document in flattened form. Default is `false`.
 `properties` | Fields of this object, which can be of any supported type. New properties can be dynamically added to this object if `dynamic` is set to `true`.

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -308,7 +308,7 @@ The following table lists the parameters accepted by object field types. All par
 
 Parameter | Description 
 :--- | :--- 
-[`dynamic`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/object#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to this object. Valid values are `true`, `false`, and `strict`. Default is `true`.
+[`dynamic`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/object#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to this object. Valid values are `true`, `false`, `strict` and `strict_allow_templates`. Default is `true`.
 `include_in_parent` | A Boolean value that specifies whether all fields in the child nested object should also be added to the parent document in flattened form. Default is `false`.
 `include_in_root` | A Boolean value that specifies whether all fields in the child nested object should also be added to the root document in flattened form. Default is `false`.
 `properties` | Fields of this object, which can be of any supported type. New properties can be dynamically added to this object if `dynamic` is set to `true`.

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -149,7 +149,7 @@ Value | Description
 `true` | New fields can be added to the mapping dynamically. This is the default.
 `false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the _source field. 
 `strict` | When new fields are added to the mapping dynamically, an exception is thrown. To add a new field to an object, you have to add it to the mapping first.
-`strict_allow_templates` | If the new detected fields can match any pre-defined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
+`strict_allow_templates` | If the new detected fields can match any predefined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
 
 Inner objects inherit the `dynamic` parameter value from their parent unless they declare their own `dynamic` parameter value.
 {: .note }

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -73,7 +73,7 @@ The following table lists the parameters accepted by object field types. All par
 
 Parameter | Description 
 :--- | :--- 
-[`dynamic`](#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to this object. Valid values are `true`, `false`, `strict` and `strict_allow_templates`. Default is `true`.
+[`dynamic`](#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to the object. Valid values are `true`, `false`, `strict`, and `strict_allow_templates`. Default is `true`.
 `enabled` | A Boolean value that specifies whether the JSON contents of the object should be parsed. If `enabled` is set to `false`, the object's contents are not indexed or searchable, but they are still retrievable from the _source field. Default is `true`.
 `properties` | Fields of this object, which can be of any supported type. New properties can be dynamically added to this object if `dynamic` is set to `true`.
 

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -73,7 +73,7 @@ The following table lists the parameters accepted by object field types. All par
 
 Parameter | Description 
 :--- | :--- 
-[`dynamic`](#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to this object. Valid values are `true`, `false`, and `strict`. Default is `true`.
+[`dynamic`](#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to this object. Valid values are `true`, `false`, `strict` and `strict_allow_templates`. Default is `true`.
 `enabled` | A Boolean value that specifies whether the JSON contents of the object should be parsed. If `enabled` is set to `false`, the object's contents are not indexed or searchable, but they are still retrievable from the _source field. Default is `true`.
 `properties` | Fields of this object, which can be of any supported type. New properties can be dynamically added to this object if `dynamic` is set to `true`.
 
@@ -149,6 +149,7 @@ Value | Description
 `true` | New fields can be added to the mapping dynamically. This is the default.
 `false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the _source field. 
 `strict` | When new fields are added to the mapping dynamically, an exception is thrown. To add a new field to an object, you have to add it to the mapping first.
+`strict_allow_templates` | If the new detected fields can match any pre-defined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
 
 Inner objects inherit the `dynamic` parameter value from their parent unless they declare their own `dynamic` parameter value.
 {: .note }

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -149,7 +149,7 @@ Value | Description
 `true` | New fields can be added to the mapping dynamically. This is the default.
 `false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the _source field. 
 `strict` | When new fields are added to the mapping dynamically, an exception is thrown. To add a new field to an object, you have to add it to the mapping first.
-`strict_allow_templates` | If the new detected fields can match any predefined dynamic template in the mapping, then they will be added to the mapping, if not match an exception will be thrown as same as `strict`.
+`strict_allow_templates` | If the newly detected fields match any of the predefined dynamic templates in the mapping, then they are added to the mapping; if they do not match any of them, then an exception is thrown.
 
 Inner objects inherit the `dynamic` parameter value from their parent unless they declare their own `dynamic` parameter value.
 {: .note }


### PR DESCRIPTION
### Description
In this https://github.com/opensearch-project/OpenSearch/pull/14555, we introduce a new option strict_allow_templates for the dynamic mapping parameter, we need to document the usage.

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/7676

### Version
2.16.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
