### PR TITLE
Update compare.md

### DIFF
--- a/_benchmark/reference/commands/compare.md
+++ b/_benchmark/reference/commands/compare.md
@@ -130,7 +130,7 @@ You can use the following options to customize the results of your test comparis
 - `--baseline`: The baseline TestExecution ID used to compare the contender TestExecution.  
 - `--contender`: The TestExecution ID for the contender being compared to the baseline. 
 - `--results-format`: Defines the output format for the command line results, either `markdown` or `csv`. Default is `markdown`.
-- `--results-number-align`: Defines the column number alignment for when the `compare` command outputs results. Default is `right`.
+- `--results-numbers-align`: Defines the column number alignment for when the `compare` command outputs results. Default is `right`.
 - `--results-file`: When provided a file path, writes the compare results to the file indicated in the path. 
 - `--show-in-results`: Determines whether or not to include the comparison in the results file. 
 


### PR DESCRIPTION
### Description
The `--results-number-align` option for the compare API is actually spelled `--results-numbers-align`. This change updates the spelling for that option.

### Issues Resolved

### Version
all

### Frontend features

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
