### PR TITLE
Split and sort processors

### DIFF
--- a/_ingest-pipelines/processors/split.md
+++ b/_ingest-pipelines/processors/split.md
@@ -30,7 +30,7 @@ Parameter  | Required/Optional  | Description
 :--- | :--- | :--- 
 `field` | Required | The field containing the string to be split. 
 `separator` | Required | The delimiter used to split the string. This can be a regular expression pattern. 
-`preserve_field` | Optional | If set to `true`, preserves empty trailing fields (for example, `''`) in the resulting array. If set to `false`, empty trailing fields are removed from the resulting array. Default is `false`. 
+`preserve_trailing` | Optional | If set to `true`, preserves empty trailing fields (for example, `''`) in the resulting array. If set to `false`, empty trailing fields are removed from the resulting array. Default is `false`. 
 `target_field` | Optional | The field where the array of substrings is stored. If not specified, then the field is updated in-place. 
 `ignore_missing` | Optional	| Specifies whether the processor should ignore documents that do not contain the specified field. If set to `true`, then the processor ignores missing values in the field and leaves the `target_field` unchanged. Default is `false`.  
 `description` | Optional | A brief description of the processor. 

--- a/_search-plugins/search-pipelines/sort-processor.md
+++ b/_search-plugins/search-pipelines/sort-processor.md
@@ -1,0 +1,248 @@
+---
+layout: default
+title: Sort
+nav_order: 32
+has_children: false
+parent: Search processors
+grand_parent: Search pipelines
+---
+
+# Sort processor
+
+The `sort` processor sorts an array of items in either ascending or descending order. Numeric arrays are sorted numerically, while string or mixed arrays (strings and numbers) are sorted lexicographically. The processor throws an error if the input is not an array.
+
+## Request fields
+
+The following table lists all available request fields.
+
+Field | Data type | Description
+:--- | :--- | :---
+`field`  | String | The field to be sorted. Must be an array. Required.
+`order`  | String | The sort order to apply. Accepts `asc` for ascending or `desc` for descending. Default is `asc`.
+`target_field` | String | The name of the field in which the sorted array is stored. If not specified, then the sorted array is stored in the same field as the original array (the `field` variable). 
+`tag` | String | The processor's identifier. 
+`description` | String | A description of the processor. 
+`ignore_failure` | Boolean | If `true`, OpenSearch [ignores any failure]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/creating-search-pipeline/#ignoring-processor-failures) of this processor and continues to run the remaining processors in the search pipeline. Optional. Default is `false`.
+
+## Example 
+
+The following example demonstrates using a search pipeline with a `sort` processor.
+
+### Setup
+
+Create an index named `my_index` and index a document with the field `message`:
+
+```json
+POST /my_index/_doc/1
+{
+  "message": ["one", "two", "three", "four"], 
+  "visibility":"public"
+}
+```
+{% include copy-curl.html %}
+
+### Creating a search pipeline 
+
+The following request creates a search pipeline with a `sort` response processor that sorts the field `message` in `sorted_message`:
+
+```json
+PUT /_search/pipeline/my_pipeline
+{
+  "response_processors": [
+    {
+      "sort": {
+        "field": "message",
+        "target_field": "sorted_message"
+      }
+    }
+  ]
+}
+```
+{% include copy-curl.html %}
+
+### Using a search pipeline
+
+Search for documents in `my_index` without a search pipeline:
+
+```json
+GET /my_index/_search
+```
+{% include copy-curl.html %}
+
+The response contains the field `message`:
+
+<details open markdown="block">
+  <summary>
+    Response
+  </summary>
+  {: .text-delta}
+```json
+{
+  "took": 1,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "my_index",
+        "_id": "1",
+        "_score": 1,
+        "_source": {
+          "message": [
+            "one",
+            "two",
+            "three",
+            "four"
+          ],
+          "visibility": "public"
+        }
+      }
+    ]
+  }
+}
+```
+</details>
+
+To search with a pipeline, specify the pipeline name in the `search_pipeline` query parameter:
+
+```json
+GET /my_index/_search?search_pipeline=my_pipeline
+```
+{% include copy-curl.html %}
+
+The `message` field has been sorted in `sorted_message`:
+
+<details open markdown="block">
+  <summary>
+    Response
+  </summary>
+  {: .text-delta}
+```json
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "my_index",
+        "_id": "1",
+        "_score": 1,
+        "_source": {
+          "visibility": "public",
+          "sorted_message": [
+            "four",
+            "one",
+            "three",
+            "two"
+          ],
+          "message": [
+            "one",
+            "two",
+            "three",
+            "four"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+</details>
+
+You can also use the `fields` option to search for specific fields in a document:
+
+```json
+POST /my_index/_search?pretty&search_pipeline=my_pipeline
+{
+    "fields":["visibility", "message"]
+}
+``` 
+{% include copy-curl.html %}
+
+In the response, the field `message` has been sorted to `sorted_message`:
+
+<details open markdown="block">
+  <summary>
+    Response
+  </summary>
+  {: .text-delta}
+```json
+{
+  "took": 2,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "my_index",
+        "_id": "1",
+        "_score": 1,
+        "_source": {
+          "visibility": "public",
+          "sorted_message": [
+            "four",
+            "one",
+            "three",
+            "two"
+          ],
+          "message": [
+            "one",
+            "two",
+            "three",
+            "four"
+          ]
+        },
+        "fields": {
+          "visibility": [
+            "public"
+          ],
+          "sorted_message": [
+            "four",
+            "one",
+            "three",
+            "two"
+          ],
+          "message": [
+            "one",
+            "two",
+            "three",
+            "four"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+</details>

--- a/_search-plugins/search-pipelines/split-processor.md
+++ b/_search-plugins/search-pipelines/split-processor.md
@@ -1,0 +1,232 @@
+---
+layout: default
+title: Split
+nav_order: 33
+has_children: false
+parent: Search processors
+grand_parent: Search pipelines
+---
+
+# Split processor
+
+The `split` processor is used to split a string field into an array of substrings based on a specified delimiter.
+
+## Request fields
+
+The following table lists all available request fields.
+
+Field | Data type | Description
+:--- | :--- | :---
+`field` | String | The field containing the string to be split. Required.
+`separator` | String | The delimiter used to split the string. This can be a regular expression pattern. Required.
+`preserve_trailing` | Boolean | If set to `true`, preserves empty trailing fields (for example, `''`) in the resulting array. If set to `false`, empty trailing fields are removed from the resulting array. Default is `false`. 
+`target_field` | String | The field where the array of substrings is stored. If not specified, then the field is updated in-place. 
+`tag` | String | The processor's identifier. 
+`description` | String | A description of the processor. 
+`ignore_failure` | Boolean | If `true`, OpenSearch [ignores any failure]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/creating-search-pipeline/#ignoring-processor-failures) of this processor and continues to run the remaining processors in the search pipeline. Optional. Default is `false`.
+
+## Example 
+
+The following example demonstrates using a search pipeline with a `split` processor.
+
+### Setup
+
+Create an index named `my_index` and index a document with the field `message`:
+
+```json
+POST /my_index/_doc/1
+{
+  "message": "ingest, search, visualize, and analyze data",
+  "visibility":"public"
+}
+```
+{% include copy-curl.html %}
+
+### Creating a search pipeline 
+
+The following request creates a search pipeline with a `split` response processor that splits the field `message` in `split_message`:
+
+```json
+PUT /_search/pipeline/my_pipeline
+{
+  "response_processors": [
+    {
+      "split": {
+        "field": "message",
+        "separator": ", ",
+        "target_field": "split_message"
+      }
+    }
+  ]
+}
+```
+{% include copy-curl.html %}
+
+### Using a search pipeline
+
+Search for documents in `my_index` without a search pipeline:
+
+```json
+GET /my_index/_search
+```
+{% include copy-curl.html %}
+
+The response contains the field `message`:
+
+<details open markdown="block">
+  <summary>
+    Response
+  </summary>
+  {: .text-delta}
+```json
+{
+  "took": 3,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "my_index",
+        "_id": "1",
+        "_score": 1,
+        "_source": {
+          "message": "ingest, search, visualize, and analyze data",
+          "visibility": "public"
+        }
+      }
+    ]
+  }
+}
+```
+</details>
+
+To search with a pipeline, specify the pipeline name in the `search_pipeline` query parameter:
+
+```json
+GET /my_index/_search?search_pipeline=my_pipeline
+```
+{% include copy-curl.html %}
+
+The `message` field has been split in `split_message`:
+
+<details open markdown="block">
+  <summary>
+    Response
+  </summary>
+  {: .text-delta}
+```json
+{
+  "took": 6,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "my_index",
+        "_id": "1",
+        "_score": 1,
+        "_source": {
+          "visibility": "public",
+          "message": "ingest, search, visualize, and analyze data",
+          "split_message": [
+            "ingest",
+            "search",
+            "visualize",
+            "and analyze data"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+</details>
+
+You can also use the `fields` option to search for specific fields in a document:
+
+```json
+POST /my_index/_search?pretty&search_pipeline=my_pipeline
+{
+    "fields":["visibility", "message"]
+}
+``` 
+{% include copy-curl.html %}
+
+In the response, the field `message` has been split to `sorted_message`:
+
+<details open markdown="block">
+  <summary>
+    Response
+  </summary>
+  {: .text-delta}
+```json
+{
+  "took": 7,
+  "timed_out": false,
+  "_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+  },
+  "hits": {
+    "total": {
+      "value": 1,
+      "relation": "eq"
+    },
+    "max_score": 1,
+    "hits": [
+      {
+        "_index": "my_index",
+        "_id": "1",
+        "_score": 1,
+        "_source": {
+          "visibility": "public",
+          "message": "ingest, search, visualize, and analyze data",
+          "split_message": [
+            "ingest",
+            "search",
+            "visualize",
+            "and analyze data"
+          ]
+        },
+        "fields": {
+          "visibility": [
+            "public"
+          ],
+          "message": [
+            "ingest, search, visualize, and analyze data"
+          ],
+          "split_message": [
+            "ingest",
+            "search",
+            "visualize",
+            "and analyze data"
+          ]
+        }
+      }
+    ]
+  }
+}
+```
+</details>


### PR DESCRIPTION
### Description

Documents the new Sort and Split SearchResponseProcessors.

Fixes an incorrect field name in the Ingest Split Processor docs.

### Issues Resolved

Fixes #7743 
Fixes #7744
Fixes #7754 

### Version

2.16.0

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
