### PR TITLE
Fix ISM error prevention setting key is not correct

### DIFF
--- a/_im-plugin/ism/api.md
+++ b/_im-plugin/ism/api.md
@@ -553,13 +553,13 @@ Introduced 2.4
 
 ISM allows you to run an action automatically. However, running an action can fail for a variety of reasons. You can use error prevention validation to test an action in order to rule out failures.
 
-To enable error prevention validation, set the `plugins.index_state_management.validation_service.enabled` setting to `true`:
+To enable error prevention validation, set the `plugins.index_state_management.action_validation.enabled` setting to `true`:
 
 ```bash
 PUT _cluster/settings
 {
    "persistent":{
-      "plugins.index_state_management.validation_action.enabled": true
+      "plugins.index_state_management.action_validation.enabled": true
    }
 }
 ```

--- a/_im-plugin/ism/error-prevention/api.md
+++ b/_im-plugin/ism/error-prevention/api.md
@@ -12,7 +12,7 @@ The ISM Error Prevention API allows you to enable Index State Management (ISM) e
 
 ## Enable error prevention validation
 
-You can configure error prevention validation by setting the `plugins.index_state_management.validation_service.enabled` parameter.
+You can configure error prevention validation by setting the `plugins.index_state_management.action_validation.enabled` parameter.
 
 #### Example request
 
@@ -20,7 +20,7 @@ You can configure error prevention validation by setting the `plugins.index_stat
 PUT _cluster/settings
 {
    "persistent":{
-      "plugins.index_state_management.validation_action.enabled": true
+      "plugins.index_state_management.action_validation.enabled": true
    }
 }
 ```


### PR DESCRIPTION
### Description
The setting key `plugins.index_state_management.validation_action.enabled` doesn't exist, actually it is `plugins.index_state_management.action_validation.enabled`.

<img width="570" alt="image" src="https://github.com/user-attachments/assets/5bb96584-6480-407e-88cd-102848f6e191">
<img width="1169" alt="image" src="https://github.com/user-attachments/assets/4a44b946-ccaf-4793-b3ff-94250926cefb">


### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/7776.

### Version
2.4-2.15

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
