### PR TITLE
Documentation Updates for plugins.query.datasources.enabled SQL Setting

### DIFF
--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -78,7 +78,7 @@ Setting | Default | Description
 `plugins.sql.cursor.keep_alive` | 1 minute | Configures how long the cursor context is kept open. Cursor contexts are resource-intensive, so we recommend a low value.
 `plugins.query.memory_limit` | 85% | Configures the heap memory usage limit for the circuit breaker of the query engine.
 `plugins.query.size_limit` | 200 | Sets the default size of index that the query engine fetches from OpenSearch.
-`plugins.query.datasources.enabled` | true | Change to `false` to disable the data source support in the plugin.
+`plugins.query.datasources.enabled` | true | Change to `false` to disable support for data sources in the plugin.
 
 ## Spark connector settings
 

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -78,6 +78,7 @@ Setting | Default | Description
 `plugins.sql.cursor.keep_alive` | 1 minute | Configures how long the cursor context is kept open. Cursor contexts are resource-intensive, so we recommend a low value.
 `plugins.query.memory_limit` | 85% | Configures the heap memory usage limit for the circuit breaker of the query engine.
 `plugins.query.size_limit` | 200 | Sets the default size of index that the query engine fetches from OpenSearch.
+`plugins.query.datasources.enabled` | true | Change to `false` to disable the data source support in the plugin.
 
 ## Spark connector settings
 


### PR DESCRIPTION
### Description
_Describe what this change achieves._

This setting allows users to toggle the data source code paths in the SQL plugin. Ref:

https://github.com/opensearch-project/sql/pull/2811/files

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

None

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

2.16 +

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

None

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
