### PR TITLE
Update index-codecs.md

### DIFF
--- a/_im-plugin/index-codecs.md
+++ b/_im-plugin/index-codecs.md
@@ -32,10 +32,10 @@ For the `zstd` and `zstd_no_dict` codecs, you can optionally specify a compressi
 When an index segment is created, it uses the current index codec for compression. If you update the index codec, any segment created after the update will use the new compression algorithm. For specific operation considerations, see [Index codec considerations for index operations](#index-codec-considerations-for-index-operations).
 {: .note}
 
-As of OpenSearch 2.14, hardware-accelerated compression codecs for the `DEFLATE` and `LZ4` compression algorithms are available. These hardware-accelerated codecs are available on the latest 4th and 5th Gen Intel®️ Xeon®️ processors running Linux kernel 3.10 and later. For all other systems and platforms, the codecs use that platform's corresponding software implementations. 
+As of OpenSearch 2.15, hardware-accelerated compression codecs for the `DEFLATE` and `LZ4` compression algorithms are available. These hardware-accelerated codecs are available on the latest 4th and 5th Gen Intel®️ Xeon®️ processors running Linux kernel 3.10 and later. For all other systems and platforms, the codecs use that platform's corresponding software implementations. 
 
 The new hardware-accelerated codecs can be used by setting one of the following `index.codec` values:
-* `qat_lz4` (OpenSearch 2.14 and later): Hardware-accelerated `LZ4`
+* `qat_lz4` (OpenSearch 2.15 and later): Hardware-accelerated `LZ4`
 * `qat_deflate` (OpenSearch 2.15 and later): Hardware-accelerated `DEFLATE`
 
 `qat_deflate` offers a much better compression ratio than `qat_lz4`, with a modest drop in compression and decompression speed.
@@ -78,7 +78,7 @@ When creating a [snapshot]({{site.url}}{{site.baseurl}}/tuning-your-cluster/avai
 
 When you restore the indexes from a snapshot of a cluster to another cluster, it is important to verify that the target cluster supports the codecs of the segments in the source snapshot. For example, if the source snapshot contains segments of the `zstd` or `zstd_no_dict` codecs (introduced in OpenSearch 2.9), you won't be able to restore the snapshot to a cluster that runs on an older OpenSearch version because it doesn't support these codecs. 
 
-For hardware-accelerated compression codecs, available in OpenSearch 2.14 and later, the value of `index.codec.qatmode` affects how snapshots and restores are performed. If the value is `auto` (the default), then snapshots and restores work without issue. However, if the value is `hardware`, then it must be reset to `auto` in order for the restore process to succeed on systems lacking the hardware accelerator.
+For hardware-accelerated compression codecs, available in OpenSearch 2.15 and later, the value of `index.codec.qatmode` affects how snapshots and restores are performed. If the value is `auto` (the default), then snapshots and restores work without issue. However, if the value is `hardware`, then it must be reset to `auto` in order for the restore process to succeed on systems lacking the hardware accelerator.
 
 You can modify the value of `index.codec.qatmode` during the restore process by setting its value as follows: `"index_settings": {"index.codec.qatmode": "auto"}`.
 {: .note}

--- a/_im-plugin/index-codecs.md
+++ b/_im-plugin/index-codecs.md
@@ -36,7 +36,7 @@ As of OpenSearch 2.14, hardware-accelerated compression codecs for the `DEFLATE`
 
 The new hardware-accelerated codecs can be used by setting one of the following `index.codec` values:
 * `qat_lz4` (OpenSearch 2.14 and later): Hardware-accelerated `LZ4`
-* `qat_deflate` (OpenSearch 2.14 and later): Hardware-accelerated `DEFLATE`
+* `qat_deflate` (OpenSearch 2.15 and later): Hardware-accelerated `DEFLATE`
 
 `qat_deflate` offers a much better compression ratio than `qat_lz4`, with a modest drop in compression and decompression speed.
 {: .note}


### PR DESCRIPTION
qat_deflate does not work on 2.14, it does on 2.15.

2.14:

{
  "error": {
    "root_cause": [
      {
        "type": "illegal_argument_exception",
        "reason": "unknown value for [index.codec] must be one of [default, lz4, best_compression, zlib] but was: qat_deflate"
      }
    ],
    "type": "illegal_argument_exception",
    "reason": "unknown value for [index.codec] must be one of [default, lz4, best_compression, zlib] but was: qat_deflate"
  },
  "status": 400
}

2.15:
{
  "acknowledged": true,
  "shards_acknowledged": true,
  "index": "x"
}

### Description


### Issues Resolved
-

### Version
2.14+

### Frontend features
- 

### Checklist
- [*] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
