### PR TITLE
Update fuzzy.md

### DIFF
--- a/_query-dsl/term/fuzzy.md
+++ b/_query-dsl/term/fuzzy.md
@@ -12,7 +12,6 @@ A fuzzy query searches for documents containing terms that are similar to the se
 - Replacements: **c**at to **b**at
 - Insertions: cat to cat**s**
 - Deletions: **c**at to at
-- Transpositions: **ca**t to **ac**t
 
 A fuzzy query creates a list of all possible expansions of the search term that fall within the Levenshtein distance. You can specify the maximum number of such expansions in the `max_expansions` field. Then it searches for documents that match any of the expansions.
 


### PR DESCRIPTION
Corrected description of the Levenshtein's distance in accordance with the Wikipedia's page

### Description
My change corrected the description of the Leveinshein's distance, because it does not allow transpositions. If they are allowed, the distance will have to be named Damerau-Levenshtein's one.

### Issues Resolved
No issues resolved

### Version
All

### Frontend features
Non-fronted feature

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
