### PR TITLE
Update fuzzy.md

### DIFF
--- a/_query-dsl/term/fuzzy.md
+++ b/_query-dsl/term/fuzzy.md
@@ -14,7 +14,7 @@ A fuzzy query searches for documents containing terms that are similar to the se
 - Deletions: **c**at to at
 - Transpositions: **ca**t to **ac**t
 
-A fuzzy query creates a list of all possible expansions of the search term that fall within the Damerau-Levenshtein distance. If you set the `transpositions` field equal to `false`, your search will use the classical [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). You can specify the maximum number of such expansions in the `max_expansions` field. Then it searches for documents that match any of the expansions.
+A fuzzy query creates a list of all possible expansions of the search term that fall within the Damerau-Levenshtein distance (by the way, if you set the `transpositions` field equal to `false`, your search will use the classical [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)). You can specify the maximum number of such expansions in the `max_expansions` field. Then it searches for documents that match any of the expansions.
 
 The following example query searches for the speaker `HALET` (misspelled `HAMLET`). The maximum edit distance is not specified, so the default `AUTO` edit distance is used:
 

--- a/_query-dsl/term/fuzzy.md
+++ b/_query-dsl/term/fuzzy.md
@@ -7,14 +7,14 @@ nav_order: 20
 
 # Fuzzy query
 
-A fuzzy query searches for documents containing terms that are similar to the search term within the maximum allowed [Damerau–Levenshtein distance](https://en.wikipedia.org/wiki/Damerau-Levenshtein_distance). The Damerau–Levenshtein distance measures the number of one-character changes needed to change one term to another term. These changes include:
+A fuzzy query searches for documents containing terms that are similar to the search term within the maximum allowed [Damerau–Levenshtein distance](https://en.wikipedia.org/wiki/Damerau–Levenshtein_distance). The Damerau–Levenshtein distance measures the number of one-character changes needed to change one term to another term. These changes include:
 
 - Replacements: **c**at to **b**at
 - Insertions: cat to cat**s**
 - Deletions: **c**at to at
 - Transpositions: **ca**t to **ac**t
 
-A fuzzy query creates a list of all possible expansions of the search term that fall within the Levenshtein distance. You can specify the maximum number of such expansions in the `max_expansions` field. Then it searches for documents that match any of the expansions.
+A fuzzy query creates a list of all possible expansions of the search term that fall within the Damerau-Levenshtein distance. If you set the `transpositions` field equal to `false`, your search will use the classical [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). You can specify the maximum number of such expansions in the `max_expansions` field. Then it searches for documents that match any of the expansions.
 
 The following example query searches for the speaker `HALET` (misspelled `HAMLET`). The maximum edit distance is not specified, so the default `AUTO` edit distance is used:
 

--- a/_query-dsl/term/fuzzy.md
+++ b/_query-dsl/term/fuzzy.md
@@ -7,7 +7,7 @@ nav_order: 20
 
 # Fuzzy query
 
-A fuzzy query searches for documents containing terms that are similar to the search term within the maximum allowed [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). The Levenshtein distance measures the number of one-character changes needed to change one term to another term. These changes include:
+A fuzzy query searches for documents containing terms that are similar to the search term within the maximum allowed [Damerau–Levenshtein distance](https://en.wikipedia.org/wiki/Damerau-Levenshtein_distance). The Damerau–Levenshtein distance measures the number of one-character changes needed to change one term to another term. These changes include:
 
 - Replacements: **c**at to **b**at
 - Insertions: cat to cat**s**

--- a/_query-dsl/term/fuzzy.md
+++ b/_query-dsl/term/fuzzy.md
@@ -14,7 +14,7 @@ A fuzzy query searches for documents containing terms that are similar to the se
 - Deletions: **c**at to at
 - Transpositions: **ca**t to **ac**t
 
-A fuzzy query creates a list of all possible expansions of the search term that fall within the Damerau-Levenshtein distance (by the way, if you set the `transpositions` field equal to `false`, your search will use the classical [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance)). You can specify the maximum number of such expansions in the `max_expansions` field. Then it searches for documents that match any of the expansions.
+A fuzzy query creates a list of all possible expansions of the search term that fall within the Damerau-Levenshtein distance. You can specify the maximum number of such expansions in the `max_expansions` field. The query then searches for documents that match any of the expansions. If you set the `transpositions` parameter to `false`, then your search will use the classic [Levenshtein distance](https://en.wikipedia.org/wiki/Levenshtein_distance). 
 
 The following example query searches for the speaker `HALET` (misspelled `HAMLET`). The maximum edit distance is not specified, so the default `AUTO` edit distance is used:
 


### PR DESCRIPTION
Corrected the name of the string metric used by default

### Description
The string measure used by default is called Damerau-Levenshtein distance, because transitions are not allowed in the definition of Levenshtein distance.

### Issues Resolved
No issues resolved

### Version
All

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
