### PR TITLE
Update documentation for create / update repository api

### DIFF
--- a/_api-reference/snapshots/create-repository.md
+++ b/_api-reference/snapshots/create-repository.md
@@ -36,6 +36,11 @@ repository | String | Repository name |
 
 Request parameters depend on the type of repository: `fs` or `s3`.
 
+### common parameters
+Request field | Description
+:--- | :---
+`prefix_mode_verification` | When enabled, it will add hashed value of a random seed to the prefix for repository verification. For remote store enabled clusters, a user can add `setting.prefix_mode_verification` to the node attributes for the supplied repository. This will also work for existing repository when supplied. Optional.
+
 ### fs repository
 
 Request field | Description

--- a/_api-reference/snapshots/create-repository.md
+++ b/_api-reference/snapshots/create-repository.md
@@ -42,7 +42,7 @@ The following table lists parameters that can be used with both the `fs` and `s3
 
 Request field | Description
 :--- | :---
-`prefix_mode_verification` | When enabled, adds a hashed value of a random seed to the prefix for repository verification. For remote store enabled clusters, you can add the `setting.prefix_mode_verification` setting to the node attributes for the supplied repository. This field works with both existing and new repositories. Optional.
+`prefix_mode_verification` | When enabled, adds a hashed value of a random seed to the prefix for repository verification. For remote-store-enabled clusters, you can add the `setting.prefix_mode_verification` setting to the node attributes for the supplied repository. This field works with both new and existing repositories. Optional.
 
 ### fs repository
 
@@ -83,7 +83,7 @@ For the `base_path` parameter, do not enter the `s3://` prefix when entering you
 
 ### `fs`
 
-The following example registers an `fs` repository using the local directory `/mnt/snapshots` as `location`.
+The following example registers an `fs` repository using the local directory `/mnt/snapshots` as `location`:
 
 ```json
 PUT /_snapshot/my-fs-repository
@@ -99,7 +99,7 @@ PUT /_snapshot/my-fs-repository
 ### `s3`
 
 
-The following request registers a new S3 repository called `my-opensearch-repo` in an existing bucket called `my-open-search-bucket`. By default, all snapshots are stored in the `my/snapshot/directory`.
+The following request registers a new S3 repository called `my-opensearch-repo` in an existing bucket called `my-open-search-bucket`. By default, all snapshots are stored in the `my/snapshot/directory`:
 
 ```json
 PUT /_snapshot/my-opensearch-repo

--- a/_api-reference/snapshots/create-repository.md
+++ b/_api-reference/snapshots/create-repository.md
@@ -30,16 +30,19 @@ PUT /_snapshot/my-first-repo/
 
 Parameter | Data type | Description
 :--- | :--- | :---
-repository | String | Repository name |
+`repository` | String | Repository name |
 
 ## Request parameters
 
 Request parameters depend on the type of repository: `fs` or `s3`.
 
-### common parameters
+### Common parameters
+
+The following table lists parameters that can be used with both the `fs` and `s3` repositories. 
+
 Request field | Description
 :--- | :---
-`prefix_mode_verification` | When enabled, it will add hashed value of a random seed to the prefix for repository verification. For remote store enabled clusters, a user can add `setting.prefix_mode_verification` to the node attributes for the supplied repository. This will also work for existing repository when supplied. Optional.
+`prefix_mode_verification` | When enabled, adds a hashed value of a random seed to the prefix for repository verification. For remote store enabled clusters, you can add the `setting.prefix_mode_verification` setting to the node attributes for the supplied repository. This field works with both existing and new repositories. Optional.
 
 ### fs repository
 
@@ -53,20 +56,6 @@ Request field | Description
 `remote_store_index_shallow_copy` | Boolean | Determines whether the snapshot of the remote store indexes are captured as a shallow copy. Default is `false`.
 `readonly` | Whether the repository is read-only. Useful when migrating from one cluster (`"readonly": false` when registering) to another cluster (`"readonly": true` when registering). Optional.
 
-## Example request
-
-The following example registers an `fs` repository using the local directory `/mnt/snapshots` as `location`.
-
-```json
-PUT /_snapshot/my-fs-repository
-{
-  "type": "fs",
-  "settings": {
-    "location": "/mnt/snapshots"
-  }
-}
-```
-{% include copy-curl.html %}
 
 #### s3 repository
 
@@ -90,7 +79,25 @@ Request field | Description
 For the `base_path` parameter, do not enter the `s3://` prefix when entering your S3 bucket details. Only the name of the bucket is required.
 {: .note}
 
-## Example request
+## Example requests
+
+### `fs`
+
+The following example registers an `fs` repository using the local directory `/mnt/snapshots` as `location`.
+
+```json
+PUT /_snapshot/my-fs-repository
+{
+  "type": "fs",
+  "settings": {
+    "location": "/mnt/snapshots"
+  }
+}
+```
+{% include copy-curl.html %}
+
+### `s3`
+
 
 The following request registers a new S3 repository called `my-opensearch-repo` in an existing bucket called `my-open-search-bucket`. By default, all snapshots are stored in the `my/snapshot/directory`.
 


### PR DESCRIPTION
### Description
Adds setting `prefix_mode_verification` in creation of repositories. When enabled, it will add hashed value of a random seed to the prefix for repository verification. For remote store enabled clusters, a user can add setting.prefix_mode_verification to the node attributes for the supplied repository. This will also work for existing repository when supplied.


### Issues Resolved
Closes [#7749](https://github.com/opensearch-project/documentation-website/issues/7749)

### Version
2.16

### Frontend features
NA

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
