### PR TITLE
Change the person PRs are assigned to by default

### DIFF
--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -32,7 +32,7 @@ jobs:
             const prOwners = ['Naarcha-AWS', 'kolchfa-aws', 'vagimeli', 'natebower'];
             
             if (!prOwners.includes(assignee)) {
-              assignee = 'hdhalter'
+              assignee = 'kolchfa-aws'
             }
 
             github.rest.issues.addAssignees({


### PR DESCRIPTION
Change the person PRs are assigned to by default to Fanit.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
