### PR TITLE
fix a typo

### DIFF
--- a/_ml-commons-plugin/agents-tools/index.md
+++ b/_ml-commons-plugin/agents-tools/index.md
@@ -130,7 +130,7 @@ POST /_plugins/_ml/agents/_register
     {
       "type": "VectorDBTool",
       "name": "VectorDBTool",
-      "description": "A tool to search opensearch index with natural language question. If you don't know answer for some question, you should always try to search data with this tool. Action Input: <natrual language question>",
+      "description": "A tool to search opensearch index with natural language question. If you don't know answer for some question, you should always try to search data with this tool. Action Input: <natural language question>",
       "parameters": {
         "model_id": "YOUR_TEXT_EMBEDDING_MODEL_ID",
         "index": "my_test_data",

--- a/_ml-commons-plugin/api/agent-apis/register-agent.md
+++ b/_ml-commons-plugin/api/agent-apis/register-agent.md
@@ -161,7 +161,7 @@ POST /_plugins/_ml/agents/_register
     {
       "type": "VectorDBTool",
       "name": "VectorDBTool",
-      "description": "A tool to search opensearch index with natural language question. If you don't know answer for some question, you should always try to search data with this tool. Action Input: <natrual language question>",
+      "description": "A tool to search opensearch index with natural language question. If you don't know answer for some question, you should always try to search data with this tool. Action Input: <natural language question>",
       "parameters": {
         "model_id": "<embedding_model_id>",
         "index": "<your_knn_index>",


### PR DESCRIPTION
### Description
I had to clean up my fork of the documentation-website to match the origin.  In the process, found another typo.

### Issues Resolved

### Version
2.15

### Frontend features
m/a
### Checklist
- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
