### PR TITLE
Update rolling-upgrade.md

### DIFF
--- a/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
+++ b/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
@@ -131,18 +131,6 @@ Review [Upgrading OpenSearch]({{site.url}}{{site.baseurl}}/upgrade-opensearch/in
    ```bash
    os-node-01 v1.3.7
    ```
-1. Repeat steps 5 through 9 for each node in your cluster. Remember to upgrade an eligible cluster manager node last. After replacing the last node, query the `_cat/nodes` endpoint to confirm that all nodes have joined the cluster. The cluster is now bootstrapped to the new version of OpenSearch. You can verify the cluster version by querying the `_cat/nodes` API endpoint:
-   ```bash
-   GET "/_cat/nodes?v&h=name,version,node.role,master" | column -t
-   ```
-   The response should look similar to the following example:
-   ```bash
-   name        version  node.role  master
-   os-node-04  1.3.7    dimr       -
-   os-node-02  1.3.7    dimr       *
-   os-node-01  1.3.7    dimr       -
-   os-node-03  1.3.7    dimr       -
-   ```
 1. Reenable shard replication:
    ```json
    PUT "/_cluster/settings?pretty"
@@ -192,6 +180,18 @@ Review [Upgrading OpenSearch]({{site.url}}{{site.baseurl}}/upgrade-opensearch/in
      "task_max_waiting_in_queue_millis" : 0,
      "active_shards_percent_as_number" : 100.0
    }
+   ```
+1. Repeat steps 5 through 11 for each node in your cluster. Remember to upgrade an eligible cluster manager node last. After replacing the last node, query the `_cat/nodes` endpoint to confirm that all nodes have joined the cluster. The cluster is now bootstrapped to the new version of OpenSearch. You can verify the cluster version by querying the `_cat/nodes` API endpoint:
+   ```bash
+   GET "/_cat/nodes?v&h=name,version,node.role,master" | column -t
+   ```
+   The response should look similar to the following example:
+   ```bash
+   name        version  node.role  master
+   os-node-04  1.3.7    dimr       -
+   os-node-02  1.3.7    dimr       *
+   os-node-01  1.3.7    dimr       -
+   os-node-03  1.3.7    dimr       -
    ```
 1. The upgrade is now complete, and you can begin enjoying the latest features and fixes!
 


### PR DESCRIPTION
The current procedure doesn't follow the correct order. The shard allocation must be re-enabled after each node restart and the cluster status must be checked before upgrading the next node.

### Description
_Describe what this change achieves._

The documentation issue has been reported in https://forum.opensearch.org/t/shard-fail-while-rolling-upgrade-cluster/20726
The current procedure doesn't follow the correct order. The shard allocation must be re-enabled after each node restart and the cluster status must be checked before upgrading the next node.

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

all 2.x versions 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
