### PR TITLE
Fix typo in Derived field type

### DIFF
--- a/_field-types/supported-field-types/derived.md
+++ b/_field-types/supported-field-types/derived.md
@@ -69,7 +69,7 @@ PUT logs
           }
         }
       },
-      "client_ip": {
+      "clientip": {
         "type": "keyword"
       }
     }


### PR DESCRIPTION
### Description

Fix typo in the logs index mappings.
"client_ip" -> "clientip"

### Issues Resolved

n/a

### Version
2.15-

### Frontend features
n/a

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
