### PR TITLE
Correcting contradictions on SecurityAdmin.sh port

### DIFF
--- a/_security/configuration/security-admin.md
+++ b/_security/configuration/security-admin.md
@@ -197,7 +197,7 @@ If you run a default OpenSearch installation, which listens on port 9200 and use
 Name | Description
 :--- | :---
 `-h` | OpenSearch hostname. Default is `localhost`.
-`-p` | OpenSearch port. Default is 9200 - not the HTTP port.
+`-p` | OpenSearch port. Default is 9200
 `-cn` | Cluster name. Default is `opensearch`.
 `-icl` | Ignore cluster name.
 `-sniff` | Sniff cluster nodes. Sniffing detects available nodes using the OpenSearch `_cluster/state` API.

--- a/_troubleshoot/security-admin.md
+++ b/_troubleshoot/security-admin.md
@@ -24,8 +24,8 @@ If `securityadmin.sh` can't reach the cluster, it outputs:
 
 ```
 OpenSearch Security Admin v6
-Will connect to localhost:9300
-ERR: Seems there is no opensearch running on localhost:9300 - Will exit
+Will connect to localhost:9200
+ERR: Seems there is no opensearch running on localhost:9200 - Will exit
 ```
 
 
@@ -36,9 +36,9 @@ By default, `securityadmin.sh` uses `localhost`. If your cluster runs on any oth
 
 ### Check the port
 
-Check that you are running `securityadmin.sh` against the transport port, **not** the HTTP port.
+Check that you are running `securityadmin.sh` against the HTTP port, **not** the transport port.
 
-By default, `securityadmin.sh` uses `9300`. If your cluster runs on a different port, use the `-p` option to specify the port number.
+By default, `securityadmin.sh` uses `9200`. If your cluster runs on a different port, use the `-p` option to specify the port number.
 
 
 ## None of the configured nodes are available


### PR DESCRIPTION
Signed-off-by: Landon Lengyel <landon.lengyel@slcschools.org>

### Description
Fixes contradictions regarding which port to use with `SecurityAdmin.sh`

### Issues Resolved
Fixes issue #7985 

### Version
2.16.0 (likely more, I only tested with the currently released version)

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

