### PR TITLE
Adding that comma seperated lists of indices are supported.

### DIFF
--- a/_api-reference/cluster-api/cluster-health.md
+++ b/_api-reference/cluster-api/cluster-health.md
@@ -25,6 +25,13 @@ GET _cluster/health
 GET _cluster/health/<index>
 ```
 
+## URL Parameters
+The following table lists the available URL parameters. All URL parameters are optional.
+
+Parameter | Type | Description
+:--- | :--- | :---
+&lt;index-name&gt; | String | Limit health reporting to a specific index. Can be a comma-separated list of multiple index names.
+
 ## Query parameters
 
 The following table lists the available query parameters. All query parameters are optional.

--- a/_api-reference/cluster-api/cluster-health.md
+++ b/_api-reference/cluster-api/cluster-health.md
@@ -25,12 +25,13 @@ GET _cluster/health
 GET _cluster/health/<index>
 ```
 
-## URL Parameters
-The following table lists the available URL parameters. All URL parameters are optional.
+## Path parameters
 
-Parameter | Type | Description
+The following table lists the available path parameters. All path parameters are optional.
+
+Parameter | Data type | Description
 :--- | :--- | :---
-&lt;index-name&gt; | String | Limit health reporting to a specific index. Can be a comma-separated list of multiple index names.
+&lt;index-name&gt; | String | Limits health reporting to a specific index. Can be a single index or a comma-separated list of index names.
 
 ## Query parameters
 


### PR DESCRIPTION
Signed-off-by: Landon Lengyel <landon@almonde.org>

### Description
The _cluster/health API supports comma separated indices (like most endpoints) but that isn't specified. This resolves that.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._

### Version
2.16 - Likely all

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
