### PR TITLE
Document reprovision param for Update Workflow API

### DIFF
--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -81,7 +81,7 @@ PUT /_plugins/_flow_framework/workflow/<workflow_id>?reprovision=true
 }
 ```
 
-You can add new steps to the workflow but not delete them. Only steps for index settings, search pipelines, and ingest pipelines are currently supported for updating.
+You can add new steps to the workflow but cannot delete them. Only index setting, search pipeline, and ingest pipeline steps can currently be updated.
 {: .note}
 
 The following table lists the available query parameters. All query parameters are optional. User-provided parameters are only allowed if the `provision` parameter is set to `true`.

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -58,7 +58,7 @@ POST /_plugins/_flow_framework/workflow?validation=none
 ```
 {% include copy-curl.html %}
 
-In a workflow that has not been provisioned, you can update fields other than the `workflows` field, such as `name` and `description`:
+In a workflow that has not been provisioned, you can update fields other than the `workflows` field. For example, you can update the `name` and `description` fields as follows:
 
 ```json
 PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -90,7 +90,7 @@ The following table lists the available query parameters. All query parameters a
 | :--- | :--- | :--- |
 | `provision` | Boolean | Whether to provision the workflow as part of the request. Default is `false`. |
 | `update_fields` | Boolean | Whether to update only the fields included in the request body. Default is `false`. |
-| `reprovision` | Boolean | Whether to reprovision the entire template, if it has already been provisioned. A complete template must be provided in the request body. Default is `false`. |
+| `reprovision` | Boolean | Whether to reprovision the entire template if it has already been provisioned. A complete template must be provided in the request body. Default is `false`. |
 | `validation` | String | Whether to validate the workflow. Valid values are `all` (validate the template) and `none` (do not validate the template). Default is `all`. |
 | User-provided substitution expressions | String | Parameters matching substitution expressions in the template. Only allowed if `provision` is set to `true`. Optional. If `provision` is set to `false`, you can pass these parameters in the [Provision Workflow API query parameters]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/#query-parameters). |
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -58,7 +58,7 @@ POST /_plugins/_flow_framework/workflow?validation=none
 ```
 {% include copy-curl.html %}
 
-You cannot update a full workflow once it has been provisioned, but you can update fields other than the `workflows` field, such as `name` and `description`:
+In a workflow that has not been provisioned, you can update fields other than the `workflows` field, such as `name` and `description`:
 
 ```json
 PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true
@@ -72,12 +72,26 @@ PUT /_plugins/_flow_framework/workflow/<workflow_id>?update_fields=true
 You cannot specify both the `provision` and `update_fields` parameters at the same time.
 {: .note}
 
+If a workflow has been provisioned, you can update and reprovision the full template:
+
+```json
+PUT /_plugins/_flow_framework/workflow/<workflow_id>?reprovision=true
+{
+  <updated complete template>
+}
+```
+{% include copy-curl.html %}
+
+You can add new steps to the workflow but not delete them. Only steps for index settings, search pipelines, and ingest pipelines are currently supported for updating.
+{: .note}
+
 The following table lists the available query parameters. All query parameters are optional. User-provided parameters are only allowed if the `provision` parameter is set to `true`.
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |
 | `provision` | Boolean | Whether to provision the workflow as part of the request. Default is `false`. |
 | `update_fields` | Boolean | Whether to update only the fields included in the request body. Default is `false`. |
+| `reprovision` | Boolean | Whether to reprovision the entire template, if it has already been provisioned. A complete template must be provided in the request body. Default is `false`. |
 | `validation` | String | Whether to validate the workflow. Valid values are `all` (validate the template) and `none` (do not validate the template). Default is `all`. |
 | User-provided substitution expressions | String | Parameters matching substitution expressions in the template. Only allowed if `provision` is set to `true`. Optional. If `provision` is set to `false`, you can pass these parameters in the [Provision Workflow API query parameters]({{site.url}}{{site.baseurl}}/automating-configurations/api/provision-workflow/#query-parameters). |
 

--- a/_automating-configurations/api/create-workflow.md
+++ b/_automating-configurations/api/create-workflow.md
@@ -80,7 +80,6 @@ PUT /_plugins/_flow_framework/workflow/<workflow_id>?reprovision=true
   <updated complete template>
 }
 ```
-{% include copy-curl.html %}
 
 You can add new steps to the workflow but not delete them. Only steps for index settings, search pipelines, and ingest pipelines are currently supported for updating.
 {: .note}


### PR DESCRIPTION
### Description

Adds documentation for the Update Workflow API `reprovision` parameter

### Issues Resolved

Resolves #8166

### Version

2.17.0

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
