### PR TITLE
Clarify doc on text_chunking processor: nested field in input and output 

### DIFF
--- a/_ingest-pipelines/processors/text-chunking.md
+++ b/_ingest-pipelines/processors/text-chunking.md
@@ -42,7 +42,7 @@ The following table lists the required and optional parameters for the `text_chu
 | `description`	              | String	    | Optional	 | A brief description of the processor. |
 | `tag`	| String	    | Optional	 | An identifier tag for the processor. Useful when debugging in order to distinguish between processors of the same type.	|
 
-To perform chunking on nested fields, specify `input_field` and `output_field` values as JSON objects. Providing a dot path of the nested field is not supported. For example, use `"field_map": { "foo": { "bar": "bar_chunk"} }` instead of `"field_map": { "foo.bar": "foo.bar_chunk"}`.
+To perform chunking on nested fields, specify `input_field` and `output_field` values as JSON objects. Dot paths of nested fields are not supported. For example, use `"field_map": { "foo": { "bar": "bar_chunk"} }` instead of `"field_map": { "foo.bar": "foo.bar_chunk"}`.
 {: .note}
 
 ### Fixed token length algorithm

--- a/_ingest-pipelines/processors/text-chunking.md
+++ b/_ingest-pipelines/processors/text-chunking.md
@@ -42,7 +42,7 @@ The following table lists the required and optional parameters for the `text_chu
 | `description`	              | String	    | Optional	 | A brief description of the processor. |
 | `tag`	| String	    | Optional	 | An identifier tag for the processor. Useful when debugging in order to distinguish between processors of the same type.	|
 
-If you wish to perform chunking on nested map values, please specify `input_field` and `output_field` in a map-like format and not use `.`. Instead of `"field_map": { "foo.bar": "foo.bar_chunk"}`, you should use `"field_map": { "foo": { "bar": "bar_chunk"} }`.
+To perform chunking on nested fields, specify `input_field` and `output_field` values as JSON objects. Providing a dot path of the nested field is not supported. For example, use `"field_map": { "foo": { "bar": "bar_chunk"} }` instead of `"field_map": { "foo.bar": "foo.bar_chunk"}`.
 {: .note}
 
 ### Fixed token length algorithm

--- a/_ingest-pipelines/processors/text-chunking.md
+++ b/_ingest-pipelines/processors/text-chunking.md
@@ -42,6 +42,9 @@ The following table lists the required and optional parameters for the `text_chu
 | `description`	              | String	    | Optional	 | A brief description of the processor. |
 | `tag`	| String	    | Optional	 | An identifier tag for the processor. Useful when debugging in order to distinguish between processors of the same type.	|
 
+If you wish to perform chunking on nested map values, please specify `input_field` and `output_field` in a map-like format and not use `.`. Instead of `"field_map": { "foo.bar": "foo.bar_chunk"}`, you should use `"field_map": { "foo": { "bar": "bar_chunk"} }`.
+{: .note}
+
 ### Fixed token length algorithm
 
 The following table lists the optional parameters for the `fixed_token_length` algorithm.


### PR DESCRIPTION
### Description
As is suggested by a github user, we can better clarify the parameter description on input and output in `text_chunking` processor https://github.com/opensearch-project/neural-search/issues/895#issuecomment-2345048588.

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/8230

### Version
Since 2.13.

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
