### PR TITLE
Add Sycamore page

### DIFF
--- a/_tools/index.md
+++ b/_tools/index.md
@@ -18,6 +18,7 @@ This section provides documentation for OpenSearch-supported tools, including:
 - [OpenSearch CLI](#opensearch-cli)
 - [OpenSearch Kubernetes operator](#opensearch-kubernetes-operator)
 - [OpenSearch upgrade, migration, and comparison tools](#opensearch-upgrade-migration-and-comparison-tools)
+- [Sycamore](#sycamore) for AI-powered ETL on complex documents for vector and hybrid search
 
 For information about Data Prepper, the server-side data collector for filtering, enriching, transforming, normalizing, and aggregating data for downstream analytics and visualization, see [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/index/).
 
@@ -122,3 +123,9 @@ The OpenSearch Kubernetes Operator is an open-source Kubernetes operator that he
 OpenSearch migration tools facilitate migrations to OpenSearch and upgrades to newer versions of OpenSearch. These can help you can set up a proof-of-concept environment locally using Docker containers or deploy to AWS using a one-click deployment script. This empowers you to fine-tune cluster configurations and manage workloads more effectively before migration. 
 
 For more information about OpenSearch migration tools, see the documentation in the [OpenSearch Migration GitHub repository](https://github.com/opensearch-project/opensearch-migrations/tree/capture-and-replay-v0.1.0).
+
+## Sycamore 
+
+[Sycamore](https://github.com/aryn-ai/sycamore) is an open-source, AI-powered document processing engine designed to prepare unstructured data for retrieval-augmented generation (RAG) and semantic search using Python. Sycamore supports chunking and enriching a wide range of complex document types, including reports, presentations, transcripts, and manuals. Additionally, Sycamore can extract and process embedded elements, such as tables, figures, graphs, and other infographics. It can then load the data into target indexes, including vector and keyword indexes, using an [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html). 
+
+To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html).

--- a/_tools/index.md
+++ b/_tools/index.md
@@ -18,7 +18,7 @@ This section provides documentation for OpenSearch-supported tools, including:
 - [OpenSearch CLI](#opensearch-cli)
 - [OpenSearch Kubernetes operator](#opensearch-kubernetes-operator)
 - [OpenSearch upgrade, migration, and comparison tools](#opensearch-upgrade-migration-and-comparison-tools)
-- [Sycamore](#sycamore) for AI-powered ETL on complex documents for vector and hybrid search
+- [Sycamore](#sycamore) for AI-powered extract, transform, load (ETL) on complex documents for vector and hybrid search
 
 For information about Data Prepper, the server-side data collector for filtering, enriching, transforming, normalizing, and aggregating data for downstream analytics and visualization, see [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/index/).
 

--- a/_tools/index.md
+++ b/_tools/index.md
@@ -128,4 +128,4 @@ For more information about OpenSearch migration tools, see the documentation in 
 
 [Sycamore](https://github.com/aryn-ai/sycamore) is an open-source, AI-powered document processing engine designed to prepare unstructured data for retrieval-augmented generation (RAG) and semantic search using Python. Sycamore supports chunking and enriching a wide range of complex document types, including reports, presentations, transcripts, and manuals. Additionally, Sycamore can extract and process embedded elements, such as tables, figures, graphs, and other infographics. It can then load the data into target indexes, including vector and keyword indexes, using an [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html). 
 
-To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html).
+For more information, see [Sycamore]({{site.url}}{{site.baseurl}}/tools/sycamore/).

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -1,4 +1,4 @@
-# Sycamore ETL
+# Sycamore
 
 [Sycamore](https://github.com/aryn-ai/sycamore) is an open source, AI-powered document processing engine to prepare unstructured data for RAG and semantic search using Python. Sycamore can chunk and enrich a wide range of complex document types including reports, presentations, transcripts, manuals, and more, and it can extract and process embedded tables, figures, graphs, and other infographics. It can then load a target index, including vector and keyword indexes, using a connector (like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html)). 
 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -1,3 +1,10 @@
+---
+layout: default
+title: Sycamore
+nav_order: 210
+has_children: false
+---
+
 # Sycamore
 
 [Sycamore](https://github.com/aryn-ai/sycamore) is an open-source, AI-powered document processing engine designed to prepare unstructured data for retrieval-augmented generation (RAG) and semantic search using Python. Sycamore supports chunking and enriching a wide range of complex document types, including reports, presentations, transcripts, and manuals. Additionally, Sycamore can extract and process embedded elements, such as tables, figures, graphs, and other infographics. It can then load the data into target indexes, including vector and keyword indexes, using a connector like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html). 
@@ -35,3 +42,7 @@ By default, Sycamore works with the Aryn Partitioning Service to process PDFs. T
 pip install sycamore-ai[opensearch,local-inference]
 ```
 {% include copy.html %}
+
+## Next steps
+
+For more information, visit the [Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html).

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -27,6 +27,7 @@ We recommend installing the Sycamore library using `pip`. The connector for Open
 ```bash
 pip install sycamore-ai[opensearch]
 ```
+{% include copy.html %}
 
 By default, Sycamore works with the Aryn Partitioning Service to process PDFs. To run inference locally for partitioning or embedding, install the `local-inference` extra as follows:
 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -13,23 +13,23 @@ To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.
 
 # Sycamore ETL pipeline structure
 
-A Sycamore Extract, Transform, Load (ETL) pipeline applies a series of transformations to a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets), which is a collection of documents and their constituent elements (for example, tables, blocks of text, or headers). At the end of the pipeline, the DocSet is loaded into OpenSearch vector and keyword indexes.
+A Sycamore extract, transform, load (ETL) pipeline applies a series of transformations to a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets), which is a collection of documents and their constituent elements (for example, tables, blocks of text, or headers). At the end of the pipeline, the DocSet is loaded into OpenSearch vector and keyword indexes.
 
 A typical pipeline for preparing unstructured data for vector or hybrid search in OpenSearch consists of the following steps:
 
-* Read documents into a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets)
-* [Partition documents](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/partition.html) into structured JSON elements
-* Extract metadata, filter and clean data using [transforms](https://sycamore.readthedocs.io/en/stable/sycamore/APIs/docset.html)
-* Create [chunks](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/merge.html) from groups of elements
-* Embed the chunks using the model of your choice
-* [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) the embeddings, metadata, and text into OpenSearch vector and keyword indexes
+* Read documents into a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets).
+* [Partition documents](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/partition.html) into structured JSON elements.
+* Extract metadata, filter, and clean data using [transforms](https://sycamore.readthedocs.io/en/stable/sycamore/APIs/docset.html).
+* Create [chunks](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/merge.html) from groups of elements.
+* Embed the chunks using the model of your choice.
+* [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) the embeddings, metadata, and text into OpenSearch vector and keyword indexes.
 
-For an example pipeline that follows this flow, see [this notebook](https://github.com/aryn-ai/sycamore/blob/main/notebooks/opensearch_docs_etl.ipynb).
+For an example pipeline that uses this workflow, see [this notebook](https://github.com/aryn-ai/sycamore/blob/main/notebooks/opensearch_docs_etl.ipynb).
 
 
 # Install Sycamore
 
-We recommend installing the Sycamore library using `pip`. The connector for OpenSearch can be specified and installed via extras. For example:
+We recommend installing the Sycamore library using `pip`. The connector for OpenSearch can be specified and installed using extras. For example:
 
 ```bash
 pip install sycamore-ai[opensearch]

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -28,7 +28,7 @@ We recommend installing the Sycamore library using `pip`. The connector for Open
 pip install sycamore-ai[opensearch]
 ```
 
-By default, Sycamore works with the Aryn Partitioning Service to process PDFs. To run inference locally for partitioning or embedding, install the local-inference extra as follows:
+By default, Sycamore works with the Aryn Partitioning Service to process PDFs. To run inference locally for partitioning or embedding, install the `local-inference` extra as follows:
 
 ```
 pip install sycamore-ai[opensearch,local-inference]

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -12,7 +12,7 @@ A typical pipeline for preparing unstructured data for vector or hybrid search i
 
 * Read documents into a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets)
 * [Partition documents](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/partition.html) into structured JSON elements
-* Extract metadata, filter, and clean data with [transforms](https://sycamore.readthedocs.io/en/stable/sycamore/APIs/docset.html)
+* Extract metadata, filter and clean data using [transforms](https://sycamore.readthedocs.io/en/stable/sycamore/APIs/docset.html)
 * Create [chunks](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/merge.html) from groups of elements
 * Embed with the model of your choice
 * [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) OpenSearch

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -33,3 +33,4 @@ By default, Sycamore works with the Aryn Partitioning Service to process PDFs. T
 ```bash
 pip install sycamore-ai[opensearch,local-inference]
 ```
+{% include copy.html %}

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -30,6 +30,6 @@ pip install sycamore-ai[opensearch]
 
 By default, Sycamore works with the Aryn Partitioning Service to process PDFs. To run inference locally for partitioning or embedding, install the `local-inference` extra as follows:
 
-```
+```bash
 pip install sycamore-ai[opensearch,local-inference]
 ```

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -4,7 +4,7 @@
 
 To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html).
 
-# Structure of an ETL Pipeline
+# Sycamore ETL pipeline structure
 
 A Sycamore ETL pipeline is a series of transformations on a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets), which is a collection of documents and their constintuent elements (e.g. a table, block of text, or header). At the end of the pipeline, the DocSet is loaded into OpenSearch vector and keyword indexes.
 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -14,7 +14,7 @@ A typical pipeline for preparing unstructured data for vector or hybrid search i
 * [Partition documents](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/partition.html) into structured JSON elements
 * Extract metadata, filter and clean data using [transforms](https://sycamore.readthedocs.io/en/stable/sycamore/APIs/docset.html)
 * Create [chunks](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/merge.html) from groups of elements
-* Embed with the model of your choice
+* Embed the chunks using the model of your choice
 * [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) OpenSearch
 
 You can see an example pipeline with this flow in [this notebook](https://github.com/aryn-ai/sycamore/blob/main/notebooks/opensearch_docs_etl.ipynb).

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -6,7 +6,7 @@ To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.
 
 # Sycamore ETL pipeline structure
 
-A Sycamore ETL pipeline is a series of transformations on a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets), which is a collection of documents and their constintuent elements (e.g. a table, block of text, or header). At the end of the pipeline, the DocSet is loaded into OpenSearch vector and keyword indexes.
+A Sycamore Extract, Transform, Load (ETL) pipeline applies a series of transformations to a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets), which is a collection of documents and their constituent elements (for example, tables, blocks of text, or headers). At the end of the pipeline, the DocSet is loaded into OpenSearch vector and keyword indexes.
 
 A pipeline to prepare unstructured data for vector or hybrid search in OpenSearch generally has these parts:
 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -24,7 +24,7 @@ You can see an example pipeline with this flow in [this notebook](https://github
 
 We recommend installing the Sycamore library using `pip`. The connector for OpenSearch can be installed via extras. For example:
 
-```
+```bash
 pip install sycamore-ai[opensearch]
 ```
 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -1,6 +1,6 @@
 # Sycamore
 
-[Sycamore](https://github.com/aryn-ai/sycamore) is an open source, AI-powered document processing engine to prepare unstructured data for RAG and semantic search using Python. Sycamore can chunk and enrich a wide range of complex document types including reports, presentations, transcripts, manuals, and more, and it can extract and process embedded tables, figures, graphs, and other infographics. It can then load a target index, including vector and keyword indexes, using a connector (like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html)). 
+[Sycamore](https://github.com/aryn-ai/sycamore) is an open-source, AI-powered document processing engine designed to prepare unstructured data for retrieval-augmented generation (RA)G and semantic search using Python. Sycamore supports chunking and enriching a wide range of complex document types, including reports, presentations, transcripts, and manuals. Additionally, Sycamore can extract and process embedded elements, such as tables, figures, graphs, and other infographics. It can then load the data into target indexes, including vector and keyword indexes, using a connector like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html). 
 
 [Visit the Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html) to get started.
 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -1,0 +1,3 @@
+# Sycamore
+
+Sycamore is an open source, AI-powered document processing engine for ETL, RAG, LLM-based applications, and analytics on unstructured data. Sycamore can partition and enrich a wide range of document types including reports, presentations, transcripts, manuals, and more. It can analyze and chunk complex documents such as PDFs and images with embedded tables, figures, graphs, and other infographics. 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -2,7 +2,7 @@
 
 [Sycamore](https://github.com/aryn-ai/sycamore) is an open-source, AI-powered document processing engine designed to prepare unstructured data for retrieval-augmented generation (RA)G and semantic search using Python. Sycamore supports chunking and enriching a wide range of complex document types, including reports, presentations, transcripts, and manuals. Additionally, Sycamore can extract and process embedded elements, such as tables, figures, graphs, and other infographics. It can then load the data into target indexes, including vector and keyword indexes, using a connector like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html). 
 
-[Visit the Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html) to get started.
+To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html).
 
 # Structure of an ETL Pipeline
 

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -1,22 +1,35 @@
 # Sycamore ETL
 
-[Sycamore](https://github.com/aryn-ai/sycamore) is an open source, AI-powered document processing engine to prepare unstructured data for RAG and semantic search. Sycamore can chunk and enrich a wide range of complex document types including reports, presentations, transcripts, manuals, and more, and it can extract and process embedded tables, figures, graphs, and other infographics. It can then load a target index, including vector and keyword indexes, using a connector (like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html)). 
+[Sycamore](https://github.com/aryn-ai/sycamore) is an open source, AI-powered document processing engine to prepare unstructured data for RAG and semantic search using Python. Sycamore can chunk and enrich a wide range of complex document types including reports, presentations, transcripts, manuals, and more, and it can extract and process embedded tables, figures, graphs, and other infographics. It can then load a target index, including vector and keyword indexes, using a connector (like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html)). 
 
 [Visit the Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html) to get started.
 
 # Structure of an ETL Pipeline
 
-A Sycamore ETL pipeline to prepare unstructured data for vector or hybrid search in OpenSearch generally has these parts:
+A Sycamore ETL pipeline is a series of transformations on a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets), which is a collection of documents and their constintuent elements (e.g. a table, block of text, or header). At the end of the pipeline, the DocSet is loaded into OpenSearch vector and keyword indexes.
 
-* Read documents into a DocSet
-* Partition documents into structured JSON
-* Extract metadata and clean data
-* Create chunks
-* Embed
-* Load OpenSearch
+A pipeline to prepare unstructured data for vector or hybrid search in OpenSearch generally has these parts:
 
-You can see an example pipeline with this flow in this notebook.
+* Read documents into a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets)
+* [Partition documents](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/partition.html) into structured JSON elements
+* Extract metadata, filter, and clean data with [transforms](https://sycamore.readthedocs.io/en/stable/sycamore/APIs/docset.html)
+* Create [chunks](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/merge.html) from groups of elements
+* Embed with the model of your choice
+* [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) OpenSearch
 
+You can see an example pipeline with this flow in [this notebook](https://github.com/aryn-ai/sycamore/blob/main/notebooks/opensearch_docs_etl.ipynb).
 
 
 # Install Sycamore
+
+We recommend installing the Sycamore library using `pip`. The connector for OpenSearch can be installed via extras. For example:
+
+```
+pip install sycamore-ai[opensearch]
+```
+
+By default, Sycamore works with the Aryn Partitioning Service to process PDFs. To run inference locally for partitioning or embedding, install the local-inference extra as follows:
+
+```
+pip install sycamore-ai[opensearch,local-inference]
+```

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -17,7 +17,7 @@ A typical pipeline for preparing unstructured data for vector or hybrid search i
 * Embed the chunks using the model of your choice
 * [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) OpenSearch
 
-You can see an example pipeline with this flow in [this notebook](https://github.com/aryn-ai/sycamore/blob/main/notebooks/opensearch_docs_etl.ipynb).
+For an example pipeline that follows this flow, see [this notebook](https://github.com/aryn-ai/sycamore/blob/main/notebooks/opensearch_docs_etl.ipynb).
 
 
 # Install Sycamore

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -1,3 +1,22 @@
-# Sycamore
+# Sycamore ETL
 
-Sycamore is an open source, AI-powered document processing engine for ETL, RAG, LLM-based applications, and analytics on unstructured data. Sycamore can partition and enrich a wide range of document types including reports, presentations, transcripts, manuals, and more. It can analyze and chunk complex documents such as PDFs and images with embedded tables, figures, graphs, and other infographics. 
+[Sycamore](https://github.com/aryn-ai/sycamore) is an open source, AI-powered document processing engine to prepare unstructured data for RAG and semantic search. Sycamore can chunk and enrich a wide range of complex document types including reports, presentations, transcripts, manuals, and more, and it can extract and process embedded tables, figures, graphs, and other infographics. It can then load a target index, including vector and keyword indexes, using a connector (like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html)). 
+
+[Visit the Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html) to get started.
+
+# Structure of an ETL Pipeline
+
+A Sycamore ETL pipeline to prepare unstructured data for vector or hybrid search in OpenSearch generally has these parts:
+
+* Read documents into a DocSet
+* Partition documents into structured JSON
+* Extract metadata and clean data
+* Create chunks
+* Embed
+* Load OpenSearch
+
+You can see an example pipeline with this flow in this notebook.
+
+
+
+# Install Sycamore

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -8,7 +8,7 @@ To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.
 
 A Sycamore Extract, Transform, Load (ETL) pipeline applies a series of transformations to a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets), which is a collection of documents and their constituent elements (for example, tables, blocks of text, or headers). At the end of the pipeline, the DocSet is loaded into OpenSearch vector and keyword indexes.
 
-A pipeline to prepare unstructured data for vector or hybrid search in OpenSearch generally has these parts:
+A typical pipeline for preparing unstructured data for vector or hybrid search in OpenSearch consists of the following steps:
 
 * Read documents into a [DocSet](https://sycamore.readthedocs.io/en/stable/sycamore/get_started/concepts.html#docsets)
 * [Partition documents](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/partition.html) into structured JSON elements

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -15,21 +15,21 @@ A typical pipeline for preparing unstructured data for vector or hybrid search i
 * Extract metadata, filter and clean data using [transforms](https://sycamore.readthedocs.io/en/stable/sycamore/APIs/docset.html)
 * Create [chunks](https://sycamore.readthedocs.io/en/stable/sycamore/transforms/merge.html) from groups of elements
 * Embed the chunks using the model of your choice
-* [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) OpenSearch
+* [Load](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html) the embeddings, metadata, and text into OpenSearch vector and keyword indexes
 
 For an example pipeline that follows this flow, see [this notebook](https://github.com/aryn-ai/sycamore/blob/main/notebooks/opensearch_docs_etl.ipynb).
 
 
 # Install Sycamore
 
-We recommend installing the Sycamore library using `pip`. The connector for OpenSearch can be installed via extras. For example:
+We recommend installing the Sycamore library using `pip`. The connector for OpenSearch can be specified and installed via extras. For example:
 
 ```bash
 pip install sycamore-ai[opensearch]
 ```
 {% include copy.html %}
 
-By default, Sycamore works with the Aryn Partitioning Service to process PDFs. To run inference locally for partitioning or embedding, install the `local-inference` extra as follows:
+By default, Sycamore works with the Aryn Partitioning Service to process PDFs. To run inference locally for partitioning or embedding, install Sycamore with the `local-inference` extra as follows:
 
 ```bash
 pip install sycamore-ai[opensearch,local-inference]

--- a/_tools/sycamore.md
+++ b/_tools/sycamore.md
@@ -1,6 +1,6 @@
 # Sycamore
 
-[Sycamore](https://github.com/aryn-ai/sycamore) is an open-source, AI-powered document processing engine designed to prepare unstructured data for retrieval-augmented generation (RA)G and semantic search using Python. Sycamore supports chunking and enriching a wide range of complex document types, including reports, presentations, transcripts, and manuals. Additionally, Sycamore can extract and process embedded elements, such as tables, figures, graphs, and other infographics. It can then load the data into target indexes, including vector and keyword indexes, using a connector like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html). 
+[Sycamore](https://github.com/aryn-ai/sycamore) is an open-source, AI-powered document processing engine designed to prepare unstructured data for retrieval-augmented generation (RAG) and semantic search using Python. Sycamore supports chunking and enriching a wide range of complex document types, including reports, presentations, transcripts, and manuals. Additionally, Sycamore can extract and process embedded elements, such as tables, figures, graphs, and other infographics. It can then load the data into target indexes, including vector and keyword indexes, using a connector like the [OpenSearch connector](https://sycamore.readthedocs.io/en/stable/sycamore/connectors/opensearch.html). 
 
 To get started, visit the [Sycamore documentation](https://sycamore.readthedocs.io/en/stable/sycamore/get_started.html).
 


### PR DESCRIPTION
### Description
This adds a page about using the open source Sycamore library for ETL into OpenSearch.

### Issues Resolved
N/A

### Version
2.9--2.16

### Frontend features
N/A

### Checklist
- [X ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
