### PR TITLE
Execution hint documentation added to cardinality agg

### DIFF
--- a/_aggregations/metric/cardinality.md
+++ b/_aggregations/metric/cardinality.md
@@ -59,3 +59,25 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
   }
 }
 ```
+
+You can choose the mechanism by which the aggregation is executed with the `execution_hint` setting. This setting accepts two values:
+
+1. `direct`: Use field values directly.
+2. `ordinals`: Use ordinals of the field.
+
+If not specified, mechanism that is appropriate for the field is selected. Note that specifying `ordinals` on a non-ordinal field will have no effect. Similarly, `direct` will have no effect on ordinal fields.
+
+```json
+GET opensearch_dashboards_sample_data_ecommerce/_search
+{
+  "size": 0,
+  "aggs": {
+    "unique_products": {
+      "cardinality": {
+        "field": "products.product_id",
+        "execution_hint": "ordinals"
+      }
+    }
+  }
+}
+```


### PR DESCRIPTION
### Description
This PR adds documentation for `execution_hint` field that is being added for cardinality aggregator introduced in https://github.com/opensearch-project/OpenSearch/pull/15764. Waiting for main repo PR to be merged.

### Issues Resolved
Closes #8264 

### Version
No idea

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
