### PR TITLE
Update text about default role.yml file in default distribution

### DIFF
--- a/_security/configuration/yaml.md
+++ b/_security/configuration/yaml.md
@@ -265,7 +265,7 @@ kibana_server:
 
 ## roles.yml
 
-This file contains any initial roles that you want to add to the Security plugin. By default, this file contains pre-defined roles that grant usage to plugins within the default distribution of OpenSearch. The Security plugin will also add a number of static roles automatically.
+This file contains any initial roles that you want to add to the Security plugin. By default, this file contains predefined roles that grant usage to plugins within the default distribution of OpenSearch. The Security plugin will also add a number static roles automatically.
 
 ```yml
 ---

--- a/_security/configuration/yaml.md
+++ b/_security/configuration/yaml.md
@@ -265,7 +265,7 @@ kibana_server:
 
 ## roles.yml
 
-This file contains any initial roles that you want to add to the Security plugin. Aside from some metadata, the default file is empty, because the Security plugin has a number of static roles that it adds automatically.
+This file contains any initial roles that you want to add to the Security plugin. By default, this file contains pre-defined roles that grant usage to plugins within the default distribution of OpenSearch. The Security plugin will also add a number of static roles automatically.
 
 ```yml
 ---


### PR DESCRIPTION
### Description

Updates text on the documentation website that wrongly states that default roles.yml file is empty. Reported to security repo here: https://github.com/opensearch-project/security/issues/4730

Default roles.yml file: https://github.com/opensearch-project/security/blob/main/config/roles.yml

Static roles added: https://github.com/opensearch-project/security/blob/main/src/main/resources/static_config/static_roles.yml

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
