### PR TITLE
Fix k-NN search json to have correct query

### DIFF
--- a/_search-plugins/knn/disk-based-vector-search.md
+++ b/_search-plugins/knn/disk-based-vector-search.md
@@ -146,7 +146,7 @@ GET my-vector-index/_search
       "my_vector_field": {
         "vector": [1.5, 2.5, 3.5, 4.5, 5.5, 6.5, 7.5, 8.5],
         "k": 5,
-        "method_params": {
+        "method_parameters": {
             "ef_search": 512
         },
         "rescore": {

--- a/_search-plugins/knn/knn-vector-quantization.md
+++ b/_search-plugins/knn/knn-vector-quantization.md
@@ -436,7 +436,7 @@ GET my-vector-index/_search
       "my_vector_field": {
         "vector": [1.5, 5.5, 1.5, 5.5, 1.5, 5.5, 1.5, 5.5],
         "k": 10,
-        "method_params": {
+        "method_parameters": {
             "ef_search": 10
         },
         "rescore": {


### PR DESCRIPTION
### Description
Currently, the disk based vector search and k-NN vector quantization files have an incorrect search query.  They specify `method_params` as an option, when it should be `method_parameters`.  This PR modifies the files to say `method_parameters`.

### Version
2.17

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
