### PR TITLE
Disambiguate statement "value defaults to a fixed percentage"

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot.md
@@ -18,7 +18,7 @@ The searchable snapshot feature incorporates techniques like caching frequently 
 
 To configure the searchable snapshots feature, create a node in your `opensearch.yml file` and define the node role as `search`. Optionally, you can also configure the `cache.size` property for the node.
 
-A `search` node reserves storage for the cache to perform searchable snapshot queries. In the case of a dedicated search node where the node exclusively has the `search` role, this value defaults to a fixed percentage of available storage. In other cases, the value needs to be configured by the user using the `node.search.cache.size` setting.
+A `search` node reserves storage for the cache to perform searchable snapshot queries. In the case of a dedicated search node where the node exclusively has the `search` role, this value defaults to a fixed percentage (80%) of available storage. In other cases, the value needs to be configured by the user using the `node.search.cache.size` setting.
 
 Parameter | Type | Description
 :--- | :--- | :---


### PR DESCRIPTION
This page documents that "In the case of a dedicated search node where the node exclusively has the search role, this value defaults to a fixed percentage of available storage."

However, the document does not provide specifics about what this fixed percentage is. From what I can surmise reading the code [[1](https://github.com/opensearch-project/OpenSearch/blob/b984b9f56f9b0f9dbb5322bddf04f3b45940b730/server/src/main/java/org/opensearch/node/Node.java#L396)] [[2](https://github.com/opensearch-project/OpenSearch/blob/b984b9f56f9b0f9dbb5322bddf04f3b45940b730/server/src/main/java/org/opensearch/node/Node.java#L2105)], and from doing real world testing, this value is set to 80% of the available space on the volume where the file cache lives.

### Description

Clarify specifically what fixed percentage is used. See above.

### Issues Resolved

### Version

All.

### Frontend features

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
