### PR TITLE
Fix the k-NN train API command for disk based vector search

### DIFF
--- a/_search-plugins/knn/disk-based-vector-search.md
+++ b/_search-plugins/knn/disk-based-vector-search.md
@@ -167,7 +167,7 @@ GET my-vector-index/_search
 For [model-based indexes]({{site.url}}{{site.baseurl}}/search-plugins/knn/approximate-knn/#building-a-k-nn-index-from-a-model), you can specify the `on_disk` parameter in the training request in the same way that you would specify it during index creation. By default, `on_disk` mode will use the [Faiss IVF method]({{site.url}}{{site.baseurl}}/search-plugins/knn/knn-index/#supported-faiss-methods) and a compression level of `32x`. To run the training API, send the following request:
 
 ```json
-POST /_plugins/_knn/models/_train/test-model
+POST /_plugins/_knn/models/test-model/_train
 {
     "training_index": "train-index-name",
     "training_field": "train-field-name",


### PR DESCRIPTION
### Description
Currently, the train API call `POST /_plugins/_knn/models/_train/test-model` on the disk based vector search page is incorrect.

This PR changes the call to the correct value: `POST /_plugins/_knn/models/test-model/_train`

### Version
2.17

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
