### PR TITLE
Adds documentation for providing search pipeline id in the search/msearch request

### DIFF
--- a/_search-plugins/search-pipelines/using-search-pipeline.md
+++ b/_search-plugins/search-pipelines/using-search-pipeline.md
@@ -17,17 +17,20 @@ You can use a search pipeline in the following ways:
 
 ## Specifying an existing search pipeline for a request
 
-After you [create a search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/creating-search-pipeline/), you can use the pipeline with a query by specifying the pipeline name in the `search_pipeline` query parameter:
+After you [create a search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/creating-search-pipeline/), you can use the pipeline with a query in the following ways. For a complete example of using a search pipeline with a `filter_query` processor, see [`filter_query` processor example]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/filter-query-processor#example).
+
+### Specifying the pipeline in a query parameter
+
+You can specify the pipeline name in the `search_pipeline` query parameter as follows:
 
 ```json
 GET /my_index/_search?search_pipeline=my_pipeline
 ```
 {% include copy-curl.html %}
 
-For a complete example of using a search pipeline with a `filter_query` processor, see [`filter_query` processor example]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/filter-query-processor#example).
+### Specifying the pipeline in the request body
 
-## Using a temporary search pipeline for a request
-1. You can provide a search pipeline id in the search request:
+You can provide a search pipeline ID in the search request body as follows:
 
 ```json
 GET /my-index/_search
@@ -40,8 +43,10 @@ GET /my-index/_search
     "search_pipeline": "my_pipeline"
 }
 ```
+{% include copy-curl.html %}
 
-or for msearch
+For multi-search, you can provide a search pipeline ID in the search request body as follows:
+
 ```json
 GET /_msearch
 { "index": "test"}
@@ -52,7 +57,9 @@ GET /_msearch
 ```
 {% include copy-curl.html %}
 
-2. As an alternative to creating a search pipeline, you can define a temporary search pipeline to be used for only the current query:
+## Using a temporary search pipeline for a request
+
+As an alternative to creating a search pipeline, you can define a temporary search pipeline to be used for only the current query:
 
 ```json
 POST /my-index/_search

--- a/_search-plugins/search-pipelines/using-search-pipeline.md
+++ b/_search-plugins/search-pipelines/using-search-pipeline.md
@@ -27,8 +27,32 @@ GET /my_index/_search?search_pipeline=my_pipeline
 For a complete example of using a search pipeline with a `filter_query` processor, see [`filter_query` processor example]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/filter-query-processor#example).
 
 ## Using a temporary search pipeline for a request
+1. You can provide a search pipeline id in the search request:
 
-As an alternative to creating a search pipeline, you can define a temporary search pipeline to be used for only the current query:
+```json
+GET /my-index/_search
+{
+    "query": {
+        "match_all": {}
+    },
+    "from": 0,
+    "size": 10,
+    "search_pipeline": "my_pipeline"
+}
+```
+
+or for msearch
+```json
+GET /_msearch
+{ "index": "test"}
+{ "query": { "match_all": {} }, "from": 0, "size": 10, "search_pipeline": "my_pipeline"}
+{ "index": "test-1", "search_type": "dfs_query_then_fetch"}
+{ "query": { "match_all": {} }, "search_pipeline": "my_pipeline1" }
+
+```
+{% include copy-curl.html %}
+
+2. As an alternative to creating a search pipeline, you can define a temporary search pipeline to be used for only the current query:
 
 ```json
 POST /my-index/_search


### PR DESCRIPTION
### Description
Added support for msearch API to pass search pipeline name.
With this change a search pipeline name can be provided while making a msearch call

```
{ "index": "test"}
{ "query": { "match_all": {} }, "from": 0, "size": 10, "search_pipeline": "my_pipeline"}
{ "index": "test-1", "search_type": "dfs_query_then_fetch"}
{ "query": { "match_all": {} }, "search_pipeline": "my_pipeline1" }
```

### Issues Resolved
https://github.com/opensearch-project/OpenSearch/pull/15923

### Version
2.18

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
