### PR TITLE
docs: fix typo in CCR Plugin Auto Follow documentation

### DIFF
--- a/_tuning-your-cluster/replication-plugin/auto-follow.md
+++ b/_tuning-your-cluster/replication-plugin/auto-follow.md
@@ -98,7 +98,7 @@ To delete a replication rule, send the following request to the follower cluster
 ```bash
 curl -XDELETE -k -H 'Content-Type: application/json' -u 'admin:<custom-admin-password>' 'https://localhost:9200/_plugins/_replication/_autofollow?pretty' -d '
 {
-   "leader_alias" : "my-conection-alias",
+   "leader_alias" : "my-connection-alias",
    "name": "my-replication-rule"
 }'
 ```


### PR DESCRIPTION
### Description
Corrected a typo in the Auto Follow section of the CCR Plugin documentation, where “conection” was changed to “connection.” This improves the clarity and accuracy of the documentation.

### Issues Resolved
Closes #8391

### Version
2.17

### Frontend features


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
