### PR TITLE
fix typo in viz-index.md

### DIFF
--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -81,7 +81,7 @@ Region maps show patterns and trends across geographic locations. A region map i
 
 ### Markdown
 
-Markdown is a the markup language used in Dashboards to provide context to your data visualizations. Using Markdown, you can display information and instructions along with the visualization. 
+Markdown is the markup language used in Dashboards to provide context to your data visualizations. Using Markdown, you can display information and instructions along with the visualization. 
 
 <img src="{{site.url}}{{site.baseurl}}/images/dashboards/markdown.png" width="600" height="600" alt="Example coordinate map in OpenSearch Dashboards">
 


### PR DESCRIPTION
### Description
The change fixes a typo. Theoretically in the sentence that was fixed, either "a" or "the" could have been removed, however I assumed that leaving "the" there made more sense.

### Issues Resolved
NA

### Version
All Versions of OpenSearch 2 as well as OpenSearch 1.3

### Frontend features
NA

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
