### PR TITLE
Msearch template API returns status code in each search response

### DIFF
--- a/_api-reference/msearch-template.md
+++ b/_api-reference/msearch-template.md
@@ -106,7 +106,8 @@ OpenSearch returns an array with the results of each search in the same order as
         },
         "max_score": null,
         "hits": []
-      }
+      },
+      "status": 200
     },
     {
       "took": 3,
@@ -124,7 +125,8 @@ OpenSearch returns an array with the results of each search in the same order as
         },
         "max_score": null,
         "hits": []
-      }
+      },
+      "status": 200
     }
   ]
 }


### PR DESCRIPTION
### Description
In 2.18.0, we'll add an enhancement for the msearch template API:https://github.com/opensearch-project/OpenSearch/pull/16265, a status field will be added to each search response, we need to document the change.

### Issues Resolved
No issue.

### Version
2.18.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
