### PR TITLE
Add SQL PIT reference

### DIFF
--- a/_search-plugins/searching-data/point-in-time.md
+++ b/_search-plugins/searching-data/point-in-time.md
@@ -39,7 +39,7 @@ In case of a cluster or node failure, all PIT data is lost.
 
 ### PIT in SQL
 
-The [SQL Plugin]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/) also supports pagination using PIT. When the `plugin.sql.pagination.api` setting is enabled (the default), SQL search queries in OpenSearch will automatically use PIT under the hood. See [Pagination in SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql-ppl-api/#paginating-results) for more information.
+The [SQL plugin]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/) also supports pagination using PIT. When the `plugin.sql.pagination.api` setting is enabled (the default), SQL search queries in OpenSearch will automatically use PIT under the hood. See [Pagination in SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql-ppl-api/#paginating-results) for more information.
 
 ## Pagination with PIT and search_after
 

--- a/_search-plugins/searching-data/point-in-time.md
+++ b/_search-plugins/searching-data/point-in-time.md
@@ -37,6 +37,10 @@ The create PIT operation returns a PIT ID, which you can use to run multiple que
 In case of a cluster or node failure, all PIT data is lost.
 {: .note}
 
+### PIT in SQL
+
+The [SQL Plugin]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/) also supports pagination using PIT. When the `plugin.sql.pagination.api` setting is enabled (the default), SQL search queries in OpenSearch will automatically use PIT under the hood. See [Pagination in SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql-ppl-api/#paginating-results) for more information.
+
 ## Pagination with PIT and search_after
 
 When you run a query with a PIT ID, you can use the `search_after` parameter to retrieve the next page of results. This gives you control over the order of documents in the pages of results.

--- a/_search-plugins/searching-data/point-in-time.md
+++ b/_search-plugins/searching-data/point-in-time.md
@@ -39,7 +39,7 @@ In case of a cluster or node failure, all PIT data is lost.
 
 ### PIT in SQL
 
-The [SQL plugin]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/) also supports pagination using PIT. When the `plugin.sql.pagination.api` setting is enabled (the default), SQL search queries in OpenSearch will automatically use PIT under the hood. See [Pagination in SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql-ppl-api/#paginating-results) for more information.
+The [SQL plugin]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/) also supports pagination using PIT. When the `plugin.sql.pagination.api` setting is enabled (the default), SQL search queries in OpenSearch automatically use PIT internally. For more information, see [Pagination in SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/sql-ppl-api/#paginating-results).
 
 ## Pagination with PIT and search_after
 


### PR DESCRIPTION
### Description
Adds a short section to the PIT page indicating that SQL is capable of it too -- this is a new feature in 2.18. Previously SQL internally used the scroll feature leading to inconsistent pages across time.

### Issues Resolved
N/A

### Version
2.18

### Frontend features
N/A

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
