### PR TITLE
Close content gap for doc_values mapping parameter

### DIFF
--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -16,7 +16,7 @@ The `doc_values` parameter accepts the following values.
 
 Parameter | Description
 :--- | :---
-`true` | Enables doc values for the field. Default is `true`.
+`true` | Enables `doc_values` for the field. Default is `true`.
 `false` | Disables doc values for the field.
 
 The `doc_values` parameter is not supported for text fields.

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -17,7 +17,7 @@ The `doc_values` parameter accepts the following values.
 Parameter | Description
 :--- | :---
 `true` | Enables `doc_values` for the field. Default is `true`.
-`false` | Disables doc values for the field.
+`false` | Disables `doc_values` for the field.
 
 The `doc_values` parameter is not supported for text fields.
 

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -12,7 +12,7 @@ has_toc: false
 
 OpenSearch indexes most fields by default for searching. While the inverted index allows quick term-to-document lookups, doc values enable efficient document-to-term access for sorting, aggregations, and scripting.
 
-The `doc_values` parameter accepts the following values:
+The `doc_values` parameter accepts the following values.
 
 Parameter | Description
 :--- | :---

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -10,7 +10,7 @@ has_toc: false
 
 # doc_values
 
-OpenSearch indexes most fields by default for searching. While the inverted index provides quick term-to-document lookups, the `doc_values ` parameter enables document-to-term access for operations such as sorting, aggregations, and scripting.
+OpenSearch indexes most fields by default for searching. The `doc_values ` parameter enables document-to-term lookups for operations such as sorting, aggregations, and scripting.
 
 The `doc_values` parameter accepts the following options.
 

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -1,0 +1,46 @@
+---
+layout: default
+title: doc_values
+parent: Mapping parameters
+grand_parent: Mapping and field types
+nav_order: 25
+has_children: false
+has_toc: false
+---
+
+# Doc_values
+
+OpenSearch indexes most fields by default for searching. While the inverted index allows quick term-to-document lookups, doc values enable efficient document-to-term access for sorting, aggregations, and scripting. Doc values store field values in a column-oriented format, optimizing these operations
+
+The `doc_values` parameter accepts the following values:
+
+Parameter | Description
+:--- | :---
+`true` | Enables doc values for the field. This is the default for most field types that support doc values.
+`false` | Disables doc values for the field.
+
+Doc values are enabled by default for the fields that support them. They are crucial for efficient sorting of query results, calculating aggregations, and accessing field values in scripts.
+
+---
+
+## Example: Creating an index with `doc_values` enabled and disabled
+
+The following example request creates an index with `doc_values` enabled for one field and disabled for another:
+
+```json
+PUT my-index-001
+{
+  "mappings": {
+    "properties": {
+      "status_code": { 
+        "type": "keyword"
+      },
+      "session_id": { 
+        "type": "keyword",
+        "doc_values": false
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -8,13 +8,13 @@ has_children: false
 has_toc: false
 ---
 
-# Doc_values
+# doc_values
 
-OpenSearch indexes most fields by default for searching. While the inverted index allows quick term-to-document lookups, doc values enable efficient document-to-term access for sorting, aggregations, and scripting.
+OpenSearch indexes most fields by default for searching. While the inverted index provides quick term-to-document lookups, the `doc_values ` parameter enables document-to-term access for operations such as sorting, aggregations, and scripting.
 
-The `doc_values` parameter accepts the following values.
+The `doc_values` parameter accepts the following options.
 
-Parameter | Description
+Option | Description
 :--- | :---
 `true` | Enables `doc_values` for the field. Default is `true`.
 `false` | Disables `doc_values` for the field.

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -10,7 +10,7 @@ has_toc: false
 
 # doc_values
 
-OpenSearch indexes most fields by default for searching. The `doc_values ` parameter enables document-to-term lookups for operations such as sorting, aggregations, and scripting.
+By default, OpenSearch indexes most fields for search purposes. The `doc_values ` parameter enables document-to-term lookups for operations such as sorting, aggregations, and scripting.
 
 The `doc_values` parameter accepts the following options.
 

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -19,7 +19,7 @@ Parameter | Description
 `true` | Enables `doc_values` for the field. Default is `true`.
 `false` | Disables `doc_values` for the field.
 
-The `doc_values` parameter is not supported for text fields.
+The `doc_values` parameter is not supported for use in text fields.
 
 ---
 

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -16,7 +16,7 @@ The `doc_values` parameter accepts the following values:
 
 Parameter | Description
 :--- | :---
-`true` | Enables doc values for the field. This is the default for most field types that support doc values. Default is `true`.
+`true` | Enables doc values for the field. Default is `true`.
 `false` | Disables doc values for the field.
 
 ---

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -19,6 +19,8 @@ Parameter | Description
 `true` | Enables doc values for the field. Default is `true`.
 `false` | Disables doc values for the field.
 
+The `doc_values` parameter is not supported for text fields.
+
 ---
 
 ## Example: Creating an index with `doc_values` enabled and disabled

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -10,16 +10,14 @@ has_toc: false
 
 # Doc_values
 
-OpenSearch indexes most fields by default for searching. While the inverted index allows quick term-to-document lookups, doc values enable efficient document-to-term access for sorting, aggregations, and scripting. Doc values store field values in a column-oriented format, optimizing these operations
+OpenSearch indexes most fields by default for searching. While the inverted index allows quick term-to-document lookups, doc values enable efficient document-to-term access for sorting, aggregations, and scripting.
 
 The `doc_values` parameter accepts the following values:
 
 Parameter | Description
 :--- | :---
-`true` | Enables doc values for the field. This is the default for most field types that support doc values.
+`true` | Enables doc values for the field. This is the default for most field types that support doc values. Default is `true`.
 `false` | Disables doc values for the field.
-
-Doc values are enabled by default for the fields that support them. They are crucial for efficient sorting of query results, calculating aggregations, and accessing field values in scripts.
 
 ---
 

--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -3,7 +3,7 @@ layout: default
 title: Dynamic
 parent: Mapping parameters
 grand_parent: Mapping and field types
-nav_order: 25
+nav_order: 30
 has_children: false
 has_toc: false
 redirect_from:


### PR DESCRIPTION
### Description
Closes content gap.

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/4293

### Version


### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
