### PR TITLE
Close content gap for enabled mapping parameters

### DIFF
--- a/_field-types/mapping-parameters/enabled.md
+++ b/_field-types/mapping-parameters/enabled.md
@@ -1,0 +1,47 @@
+---
+layout: default
+title: enabled
+parent: Mapping parameters
+grand_parent: Mapping and field types
+nav_order: 40
+has_children: false
+has_toc: false
+---
+
+# Enabled
+
+The `enabled` parameter allows you to control whether OpenSearch parses the contents of a field. This parameter can be applied to the top-level mapping definition and to object fields.
+
+The `enabled` parameter accepts the following values. 
+
+Parameter | Description
+:--- | :---
+`true` | The field is parsed and indexed. Default is `true`.
+`false` | The field is not parsed or indexed, but still retrievable from the `_source` field. When `enabled` is set to `false`, OpenSearch stores the field's value in the `_source` field but does not index or parse its contents. This can be useful for fields that you want to store but don't need to search, sort, or aggregate on.
+
+---
+
+## Example: Using the `enabled` parameter
+
+In the following example request, the `session_data` field is disabled. OpenSearch stores its contents in the `_source` field but does not index or parse them:
+
+```json
+PUT my-index-002
+{
+  "mappings": {
+    "properties": {
+      "user_id": {
+        "type": "keyword"
+      },
+      "last_updated": {
+        "type": "date"
+      },
+      "session_data": {
+        "type": "object",
+        "enabled": false
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}


### PR DESCRIPTION
### Description
Closes content gap for mapping parameters

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/4293

### Version


### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
