### PR TITLE
Add a new line before the last quotation mark in copy curl

### DIFF
--- a/assets/js/copy-button.js
+++ b/assets/js/copy-button.js
@@ -62,7 +62,7 @@ function addCurl(textToCopy) {
     result += path + "\"";
 
     if (body.length > 0) {
-        result += " -H 'Content-Type: application/json' -d'\n" + body + "'";
+        result += " -H 'Content-Type: application/json' -d'\n" + body + "\n'";
     }
 
     return result;


### PR DESCRIPTION
Add a newline character before the last quotation mark in copy curl to accommodate bulk requests, which should be terminated by a new line. Addresses https://github.com/opensearch-project/documentation-website/pull/8553

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
