### PR TITLE
Update Data Prepper copy-values processor docs

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -17,7 +17,7 @@ You can configure the `copy_values` processor with the following options.
 | Option | Required | Type | Description |
 :--- | :--- | :--- | :---
 | `entries` | Yes | [entry](#entry) | A list of entries to be copied in an event. See [entry](#entry) for more information. |
-| `from_list` | No | String | The key of the list of objects to be copied. |
+| `from_list` | No | String | The key for the list of objects to be copied. |
 | `to_list` | No | String | The key of the new list to be added. |
 | `overwrite_if_to_list_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` specified by `to_list` already exists in the event. Default is `false`. |
 

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -27,7 +27,7 @@ For each entry, you can configure the following options.
 
 | Option | Required | Type | Description |
 :--- | :--- | :--- | :---
-| `from_key` | Yes | String | The key of the entry to be copied. |
+| `from_key` | Yes | String | The key for the entry to be copied. |
 | `to_key` | Yes | String | The key of the new entry to be added. |
 | `overwrite_if_to_key_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` already exists in the event. Default is `false`. |
 

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -28,7 +28,7 @@ For each entry, you can configure the following options.
 | Option | Required | Type | Description |
 :--- | :--- | :--- | :---
 | `from_key` | Yes | String | The key for the entry to be copied. |
-| `to_key` | Yes | String | The key of the new entry to be added. |
+| `to_key` | Yes | String | The key for the new entry to be added. |
 | `overwrite_if_to_key_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` already exists in the event. Default is `false`. |
 
 

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -123,7 +123,7 @@ When the input event contains the following data:
 }
 ```
 
-The processed event contains "newlist" with selectively copied fields:
+The processed event contains `newlist` with selectively copied fields:
 
 ```json
 {

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -16,7 +16,7 @@ You can configure the `copy_values` processor with the following options.
 
 | Option | Required | Type | Description |
 :--- | :--- | :--- | :---
-| `entries` | Yes | [entry](#entry) | A list of entries to be copied in an event. See [entry](#entry) for details. |
+| `entries` | Yes | [entry](#entry) | A list of entries to be copied in an event. See [entry](#entry) for more information. |
 | `from_list` | No | String | The key of the list of objects to be copied. |
 | `to_list` | No | String | The key of the new list to be added. |
 | `overwrite_if_to_list_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` specified by `to_list` already exists in the event. Default is `false`. |

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -14,44 +14,125 @@ The `copy_values` processor copies values within an event and is a [mutate event
 
 You can configure the `copy_values` processor with the following options.
 
-| Option | Required | Description |
-:--- | :--- | :---
-| `entries` | Yes | A list of entries to be copied in an event. |
-| `from_key` | Yes | The key of the entry to be copied. |
-| `to_key` | Yes | The key of the new entry to be added. |
-| `overwrite_if_to_key_exists` | No | When set to `true`, the existing value is overwritten if `key` already exists in the event. The default value is `false`. |
+| Option | Required | Type | Description |
+:--- | :--- | :--- | :---
+| `entries` | Yes | [entry](#entry) | A list of entries to be copied in an event. See [entry](#entry) for details. |
+| `from_list` | No | String | The key of the list of objects to be copied. |
+| `to_list` | No | String | The key of the new list to be added. |
+| `overwrite_if_to_list_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` specified by `to_list` already exists in the event. The default value is `false`. |
+
+## entry
+For each entry, you can configure the following options.
+
+| Option | Required | Type | Description |
+:--- | :--- | :--- | :---
+| `from_key` | Yes | String | The key of the entry to be copied. |
+| `to_key` | Yes | String | The key of the new entry to be added. |
+| `overwrite_if_to_key_exists` | No | Boolean | When set to `true`, the existing value is overwritten if `key` already exists in the event. The default value is `false`. |
+
 
 ## Usage
 
-To get started, create the following `pipeline.yaml` file:
+The following examples show how the `copy_values` processor can be used in different cases.
+
+### Example: Copy values and skip existing fields
+
+The following example shows you how to configure the processor to copy values and not overwrite existing fields:
 
 ```yaml
-pipeline:
-  source:
-    ...
-  ....  
+...
   processor:
     - copy_values:
         entries:
-        - from_key: "message"
-          to_key: "newMessage"
-          overwrite_if_to_key_exists: true
-  sink:
+          - from_key: "message1"
+            to_key: "message2"
+          - from_key: "message1"
+            to_key: "message3"
+...
 ```
 {% include copy.html %}
 
-Next, create a log file named `logs_json.log` and replace the `path` in the file source of your `pipeline.yaml` file with that filepath. For more information, see [Configuring Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/getting-started/#2-configuring-data-prepper). 
-
-For example, before you run the `copy_values` processor, if the `logs_json.log` file contains the following event record:
+When the input event contains the following data:
 
 ```json
-{"message": "hello"}
+{"message1": "hello", "message2": "bye"}
 ```
 
-When you run this processor, it parses the message into the following output:
+The processor will copy "message1" to "message3" but not to "message2" because "message2" already exists. The processed event will contain the following data:
 
 ```json
-{"message": "hello", "newMessage": "hello"}
+{"message1": "hello", "message2": "bye", "message3": "hello"}
 ```
 
-If `newMessage` already exists, its existing value is overwritten with `value`.
+### Example: Copy values with overwrites
+
+The following example shows you how to configure the processor to copy values:
+
+```yaml
+...
+  processor:
+    - copy_values:
+        entries:
+          - from_key: "message1"
+            to_key: "message2"
+            overwrite_if_to_key_exists: true
+          - from_key: "message1"
+            to_key: "message3"
+...
+```
+{% include copy.html %}
+
+When the input event contains the following data:
+
+```json
+{"message1": "hello", "message2": "bye"}
+```
+
+The processor will copy "message1" to both "message2" and "message3", overwriting the existing value in "message2". The processed event will contain the following data:
+
+```json
+{"message1": "hello", "message2": "hello", "message3": "hello"}
+```
+
+### Example: Selectively copy values between two lists of objects
+
+The following example shows you how to configure the processor to copy values between lists:
+
+```yaml
+...
+  processor:
+    - copy_values:
+        from_list: mylist
+        to_list: newlist
+        entries:
+          - from_key: name
+            to_key: fruit_name
+...
+```
+{% include copy.html %}
+
+When the input event contains the following data:
+
+```json
+{
+  "mylist": [
+    {"name": "apple", "color": "red"},
+    {"name": "orange", "color": "orange"}
+  ]
+}
+```
+
+The processed event will contain "newlist" with selectively copied fields:
+
+```json
+{
+  "newlist": [
+    {"fruit_name": "apple"},
+    {"fruit_name": "orange"}
+  ],
+  "mylist": [
+    {"name": "apple", "color": "red"},
+    {"name": "orange", "color": "orange"}
+  ]
+}
+```

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -19,16 +19,17 @@ You can configure the `copy_values` processor with the following options.
 | `entries` | Yes | [entry](#entry) | A list of entries to be copied in an event. See [entry](#entry) for details. |
 | `from_list` | No | String | The key of the list of objects to be copied. |
 | `to_list` | No | String | The key of the new list to be added. |
-| `overwrite_if_to_list_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` specified by `to_list` already exists in the event. The default value is `false`. |
+| `overwrite_if_to_list_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` specified by `to_list` already exists in the event. Default is `false`. |
 
 ## entry
+
 For each entry, you can configure the following options.
 
 | Option | Required | Type | Description |
 :--- | :--- | :--- | :---
 | `from_key` | Yes | String | The key of the entry to be copied. |
 | `to_key` | Yes | String | The key of the new entry to be added. |
-| `overwrite_if_to_key_exists` | No | Boolean | When set to `true`, the existing value is overwritten if `key` already exists in the event. The default value is `false`. |
+| `overwrite_if_to_key_exists` | No | Boolean | When set to `true`, the existing value is overwritten if `key` already exists in the event. Default is `false`. |
 
 
 ## Usage
@@ -58,7 +59,7 @@ When the input event contains the following data:
 {"message1": "hello", "message2": "bye"}
 ```
 
-The processor will copy "message1" to "message3" but not to "message2" because "message2" already exists. The processed event will contain the following data:
+The processor copies "message1" to "message3" but not to "message2" because "message2" already exists. The processed event contains the following data:
 
 ```json
 {"message1": "hello", "message2": "bye", "message3": "hello"}
@@ -88,7 +89,7 @@ When the input event contains the following data:
 {"message1": "hello", "message2": "bye"}
 ```
 
-The processor will copy "message1" to both "message2" and "message3", overwriting the existing value in "message2". The processed event will contain the following data:
+The processor copies "message1" to both "message2" and "message3", overwriting the existing value in "message2". The processed event contains the following data:
 
 ```json
 {"message1": "hello", "message2": "hello", "message3": "hello"}
@@ -122,7 +123,7 @@ When the input event contains the following data:
 }
 ```
 
-The processed event will contain "newlist" with selectively copied fields:
+The processed event contains "newlist" with selectively copied fields:
 
 ```json
 {

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -38,7 +38,7 @@ The following examples show you how to use the `copy_values` processor.
 
 ### Example: Copy values and skip existing fields
 
-The following example shows you how to configure the processor to copy values and not overwrite existing fields:
+The following example shows you how to configure the processor to copy values and skip existing fields:
 
 ```yaml
 ...

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -34,7 +34,7 @@ For each entry, you can configure the following options.
 
 ## Usage
 
-The following examples show how the `copy_values` processor can be used in different cases.
+The following examples show you how to use the `copy_values` processor.
 
 ### Example: Copy values and skip existing fields
 

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -29,7 +29,7 @@ For each entry, you can configure the following options.
 :--- | :--- | :--- | :---
 | `from_key` | Yes | String | The key of the entry to be copied. |
 | `to_key` | Yes | String | The key of the new entry to be added. |
-| `overwrite_if_to_key_exists` | No | Boolean | When set to `true`, the existing value is overwritten if `key` already exists in the event. Default is `false`. |
+| `overwrite_if_to_key_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` already exists in the event. Default is `false`. |
 
 
 ## Usage

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -18,7 +18,7 @@ You can configure the `copy_values` processor with the following options.
 :--- | :--- | :--- | :---
 | `entries` | Yes | [entry](#entry) | A list of entries to be copied in an event. See [entry](#entry) for more information. |
 | `from_list` | No | String | The key for the list of objects to be copied. |
-| `to_list` | No | String | The key of the new list to be added. |
+| `to_list` | No | String | The key for the new list to be added. |
 | `overwrite_if_to_list_exists` | No | Boolean | When set to `true`, the existing value is overwritten if the `key` specified by `to_list` already exists in the event. Default is `false`. |
 
 ## entry

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -123,7 +123,7 @@ When the input event contains the following data:
 }
 ```
 
-The processed event contains `newlist` with selectively copied fields:
+The processed event contains a `newlist` with selectively copied fields:
 
 ```json
 {


### PR DESCRIPTION
### Description
Adds a few new options to copy-values processor and rewrite the examples.

### Issues Resolved
Closes #6390 

### Version
Since Data Prepper 2.7

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
