### PR TITLE
Add documentation changes for cluster level dynamic limit settings to block cat/indices, _cat/shards and _cat/segments

### DIFF
--- a/_api-reference/cat/cat-indices.md
+++ b/_api-reference/cat/cat-indices.md
@@ -62,3 +62,7 @@ GET _cat/indices/index1,index2,index3
 health | status | index | uuid | pri | rep | docs.count | docs.deleted | store.size | pri.store.size
 green  | open | movies | UZbpfERBQ1-3GSH2bnM3sg | 1 | 1 | 1 | 0 | 7.7kb | 3.8kb
 ```
+
+## Limiting the response size
+
+To limit the number of indexes returned, configure the `cat.indices.response.limit.number_of_indices` setting. For more information, see [Cluster-level CAT response limit settings]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-cat-response-limit-settings).

--- a/_api-reference/cat/cat-segments.md
+++ b/_api-reference/cat/cat-segments.md
@@ -57,3 +57,7 @@ index | shard | prirep | ip | segment | generation | docs.count | docs.deleted |
 movies | 0 | p | 172.18.0.4 | _0 | 0 | 1 | 0 | 3.5kb | 1364 | true | true | 8.7.0 | true
 movies | 0 | r | 172.18.0.3 | _0 | 0 | 1 | 0 | 3.5kb | 1364 | true | true | 8.7.0 | true
 ```
+
+## Limiting the response size
+
+To limit the number of indexes returned, configure the `cat.segments.response.limit.number_of_indices` setting. For more information, see [Cluster-level CAT response limit settings]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-cat-response-limit-settings).

--- a/_api-reference/cat/cat-shards.md
+++ b/_api-reference/cat/cat-shards.md
@@ -66,3 +66,7 @@ index | shard | prirep | state   | docs | store | ip |       | node
 plugins | 0   |   p    | STARTED |   0  |  208b | 172.18.0.4 | odfe-node1
 plugins | 0   |   r    | STARTED |   0  |  208b | 172.18.0.3 |  odfe-node2          
 ```
+
+## Limiting the response size
+
+To limit the number of shards returned, configure the `cat.shards.response.limit.number_of_shards` setting. For more information, see [Cluster-level CAT response limit settings]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/cluster-settings/#cluster-level-cat-response-limit-settings).

--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -149,3 +149,13 @@ OpenSearch supports the following cluster-level coordination settings. All setti
 - `cluster.fault_detection.leader_check.timeout` (Time unit): The amount of time a node waits for a response from the elected cluster manager during a leader check before deeming the check a failure. Valid values are from `1ms` to `60s`, inclusive. Default is `10s`. Changing this setting to a value other than the default can result in an unstable cluster.
 
 - `cluster.fault_detection.follower_check.timeout` (Time unit): The amount of time the elected cluster manager waits for a response during a follower check before deeming the check a failure. Valid values are from `1ms` to `60s`, inclusive. Default is `10s`. Changing this setting to a value other than the default can result in an unstable cluster.
+
+## Cluster-level cat response limit settings
+
+OpenSearch supports the following cluster-level cat API response limit settings. All settings in the list are dynamic:
+
+- `cat.indices.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/indices API and limit will be applied on number of indices. Default is `-1`. In case of response limit is breached, _cat/indices API will throw error with `429` status.
+
+- `cat.shards.response.limit.number_of_shards` (Integer):  Sets the response limit in _cat/shards API and limit will be applied on number of shards. Default is `-1`. In case of response limit is breached, _cat/shards API will throw error with `429` status.
+
+- `cat.segments.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/segments API and limit will be applied on number of indices. Default is `-1`.  In case of response limit is breached, _cat/segments API will throw error with `429` status.

--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -150,12 +150,12 @@ OpenSearch supports the following cluster-level coordination settings. All setti
 
 - `cluster.fault_detection.follower_check.timeout` (Time unit): The amount of time the elected cluster manager waits for a response during a follower check before deeming the check a failure. Valid values are from `1ms` to `60s`, inclusive. Default is `10s`. Changing this setting to a value other than the default can result in an unstable cluster.
 
-## Cluster-level cat response limit settings
+## Cluster-level CAT response limit settings
 
-OpenSearch supports the following cluster-level cat API response limit settings. All settings in the list are dynamic:
+OpenSearch supports the following cluster-level CAT API response limit settings. All settings in the list are dynamic:
 
-- `cat.indices.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/indices API and limit will be applied on number of indices. Default is `-1`. In case of response limit is breached, _cat/indices API will throw error with `429` status. If limit is breached, use index pattern filter in your query. e.g. `_cat/indices/<index-pattern>`
+- `cat.indices.response.limit.number_of_indices` (Integer): Sets a limit on the number of indexes returned by the [CAT Indices API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-indices/). The default value is `-1` (no limit). If the number of indexes in the response exceeds this limit, the API returns a `429` error. To avoid this, you can specify an index pattern filter in your query (for example, `_cat/indices/<index-pattern>`).
 
-- `cat.shards.response.limit.number_of_shards` (Integer):  Sets the response limit in _cat/shards API and limit will be applied on number of shards. Default is `-1`. In case of response limit is breached, _cat/shards API will throw error with `429` status. If limit is breached, use index pattern filter in your query. e.g. `_cat/shards/<index-pattern>`
+- `cat.shards.response.limit.number_of_shards` (Integer):  Sets a limit on the number of shards returned by the [CAT Shards API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-shards/). The default value is `-1` (no limit). If the number of shards in the response exceeds this limit, the API returns a `429` error. To avoid this, you can specify an index pattern filter in your query (for example, `_cat/shards/<index-pattern>`).
 
-- `cat.segments.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/segments API and limit will be applied on number of indices. Default is `-1`.  In case of response limit is breached, _cat/segments API will throw error with `429` status. If limit is breached, use index pattern filter in your query. e.g. `_cat/segments/<index-pattern>`
+- `cat.segments.response.limit.number_of_indices` (Integer): Sets a limit on the number of indexes returned by the [CAT Segments API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-segments/). The default value is `-1` (no limit). If the number of indexes in the response exceeds this limit, the API returns a `429` error. To avoid this, you can specify an index pattern filter in your query (for example, `_cat/segments/<index-pattern>`).

--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -152,10 +152,10 @@ OpenSearch supports the following cluster-level coordination settings. All setti
 
 ## Cluster-level CAT response limit settings
 
-OpenSearch supports the following cluster-level CAT API response limit settings. All settings in the list are dynamic:
+OpenSearch supports the following cluster-level CAT API response limit settings, all of which are dynamic:
 
 - `cat.indices.response.limit.number_of_indices` (Integer): Sets a limit on the number of indexes returned by the [CAT Indices API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-indices/). The default value is `-1` (no limit). If the number of indexes in the response exceeds this limit, the API returns a `429` error. To avoid this, you can specify an index pattern filter in your query (for example, `_cat/indices/<index-pattern>`).
 
-- `cat.shards.response.limit.number_of_shards` (Integer):  Sets a limit on the number of shards returned by the [CAT Shards API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-shards/). The default value is `-1` (no limit). If the number of shards in the response exceeds this limit, the API returns a `429` error. To avoid this, you can specify an index pattern filter in your query (for example, `_cat/shards/<index-pattern>`).
+- `cat.shards.response.limit.number_of_shards` (Integer): Sets a limit on the number of shards returned by the [CAT Shards API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-shards/). The default value is `-1` (no limit). If the number of shards in the response exceeds this limit, the API returns a `429` error. To avoid this, you can specify an index pattern filter in your query (for example, `_cat/shards/<index-pattern>`).
 
 - `cat.segments.response.limit.number_of_indices` (Integer): Sets a limit on the number of indexes returned by the [CAT Segments API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-segments/). The default value is `-1` (no limit). If the number of indexes in the response exceeds this limit, the API returns a `429` error. To avoid this, you can specify an index pattern filter in your query (for example, `_cat/segments/<index-pattern>`).

--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -154,8 +154,8 @@ OpenSearch supports the following cluster-level coordination settings. All setti
 
 OpenSearch supports the following cluster-level cat API response limit settings. All settings in the list are dynamic:
 
-- `cat.indices.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/indices API and limit will be applied on number of indices. Default is `-1`. In case of response limit is breached, _cat/indices API will throw error with `429` status.
+- `cat.indices.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/indices API and limit will be applied on number of indices. Default is `-1`. In case of response limit is breached, _cat/indices API will throw error with `429` status. If limit is breached, use index pattern filter in your query. e.g. `_cat/indices/<index-pattern>`
 
-- `cat.shards.response.limit.number_of_shards` (Integer):  Sets the response limit in _cat/shards API and limit will be applied on number of shards. Default is `-1`. In case of response limit is breached, _cat/shards API will throw error with `429` status.
+- `cat.shards.response.limit.number_of_shards` (Integer):  Sets the response limit in _cat/shards API and limit will be applied on number of shards. Default is `-1`. In case of response limit is breached, _cat/shards API will throw error with `429` status. If limit is breached, use index pattern filter in your query. e.g. `_cat/shards/<index-pattern>`
 
-- `cat.segments.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/segments API and limit will be applied on number of indices. Default is `-1`.  In case of response limit is breached, _cat/segments API will throw error with `429` status.
+- `cat.segments.response.limit.number_of_indices` (Integer): Sets the response limit in _cat/segments API and limit will be applied on number of indices. Default is `-1`.  In case of response limit is breached, _cat/segments API will throw error with `429` status. If limit is breached, use index pattern filter in your query. e.g. `_cat/segments/<index-pattern>`


### PR DESCRIPTION
### Description
Add documentation changes for cluster level dynamic limit settings to block cat/indices, _cat/shards and _cat/segments

### Issues Resolved
Closes [#8460](https://github.com/opensearch-project/documentation-website/issues/8460)

### Version
OS 2.18 and above.

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 
NA

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
