### PR TITLE
Update default engine from nmslib to faiss

### DIFF
--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -89,11 +89,11 @@ A method definition will always contain the name of the method, the space_type t
 (the library) to use, and a map of parameters.
 
 Mapping parameter | Required | Default | Updatable | Description
-:--- | :--- | :--- | :--- | :---
-`name` | true | n/a | false | The identifier for the nearest neighbor method.
-`space_type` | false | l2 | false | The vector space used to calculate the distance between vectors. Note: This value can also be specified at the top level of the mapping.
-`engine` | false | nmslib | false | The approximate k-NN library to use for indexing and search. The available libraries are faiss, nmslib, and Lucene.
-`parameters` | false | null | false | The parameters used for the nearest neighbor method.
+:--- | :--- |:--------| :--- | :---
+`name` | true | n/a     | false | The identifier for the nearest neighbor method.
+`space_type` | false | l2      | false | The vector space used to calculate the distance between vectors. Note: This value can also be specified at the top level of the mapping.
+`engine` | false | faiss   | false | The approximate k-NN library to use for indexing and search. The available libraries are faiss, nmslib, and Lucene.
+`parameters` | false | null    | false | The parameters used for the nearest neighbor method.
 
 ### Supported nmslib methods
 

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -89,11 +89,11 @@ A method definition will always contain the name of the method, the space_type t
 (the library) to use, and a map of parameters.
 
 Mapping parameter | Required | Default | Updatable | Description
-:--- | :--- |:--------| :--- | :---
-`name` | true | n/a     | false | The identifier for the nearest neighbor method.
-`space_type` | false | l2      | false | The vector space used to calculate the distance between vectors. Note: This value can also be specified at the top level of the mapping.
-`engine` | false | faiss   | false | The approximate k-NN library to use for indexing and search. The available libraries are faiss, nmslib, and Lucene.
-`parameters` | false | null    | false | The parameters used for the nearest neighbor method.
+:--- | :--- | :--- | :--- | :---
+`name` | true | n/a | false | The identifier for the nearest neighbor method.
+`space_type` | false | l2 | false | The vector space used to calculate the distance between vectors. Note: This value can also be specified at the top level of the mapping.
+`engine` | false | Faiss  | false | The approximate k-NN library to use for indexing and search. The available libraries are Faiss, nmslib, and Lucene.
+`parameters` | false | null | false | The parameters used for the nearest neighbor method.
 
 ### Supported nmslib methods
 


### PR DESCRIPTION
### Description
Starting 2.18, default knn engine is faiss. Updating the documentation accordingly

### Issues Resolved
#8589 

### Version
2.18 onwards

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
