### PR TITLE
Documentation for query field name and datatype in query shape

### DIFF
--- a/_observing-your-data/query-insights/grouping-top-n-queries.md
+++ b/_observing-your-data/query-insights/grouping-top-n-queries.md
@@ -45,7 +45,7 @@ bool
 
 When queries share the same query structure, they are grouped together, ensuring that all similar queries belong to the same group.
 
-## Configuring query structure
+## Configuring the query structure
 
 The preceding example query shows a simplified query structure. By default, the query structure also includes field names and field data types. 
 

--- a/_observing-your-data/query-insights/grouping-top-n-queries.md
+++ b/_observing-your-data/query-insights/grouping-top-n-queries.md
@@ -70,7 +70,7 @@ For example, consider an index `index1` with the following field mapping:
 }
 ```
 
-The following query on the preceding index:
+If you run the following query on this index:
 
 ```json
 {
@@ -110,7 +110,7 @@ The following query on the preceding index:
 }
 ```
 
-Has the following corresponding query structure:
+Then the query has the following corresponding query structure:
 
 ```c
 bool []

--- a/_observing-your-data/query-insights/grouping-top-n-queries.md
+++ b/_observing-your-data/query-insights/grouping-top-n-queries.md
@@ -45,77 +45,73 @@ bool
 
 When queries share the same query structure, they are grouped together, ensuring that all similar queries belong to the same group.
 
-### Configure query structure
-The previous query structure is of the basic form. We have settings to include the `field name` and `field data type` in the query structure.
+## Configuring query structure
+
+The preceding example query shows a simplified query structure. By default, the query structure also includes field names and field data types. 
+
+For example, consider an index `index1` with the following field mapping:
 
 ```json
-PUT _cluster/settings
-{
-  "persistent" : {
-    "search.insights.top_queries.grouping.attributes.field_name" : true,
-    "search.insights.top_queries.grouping.attributes.field_type" : true
+"mappings": {
+  "properties": {
+    "field1": {
+      "type": "keyword"
+    },
+    "field2": {
+      "type": "text"
+    },
+    "field3": {
+      "type": "text"
+    },
+    "field4": {
+      "type": "long"
+    }
   }
 }
 ```
-Note that both these settings are enabled by default.
 
-Example of how the query structure would look like with the preceding settings enabled.
+The following query on the preceding index:
 
-Query:
 ```json
 {
-    "query": {
-        "bool": {
-            "must": [
-                {
-                    "term": {
-                        "field1": "example_value"
-                    }
-                }
-            ],
-            "filter": [
-                {
-                    "match": {
-                        "field2": "search_text"
-                    }
-                },
-                {
-                    "range": {
-                        "field4": {
-                            "gte": 1,
-                            "lte": 100
-                        }
-                    }
-                }
-            ],
-            "should": [
-                {
-                    "regexp": {
-                        "field3": ".*"
-                    }
-                }
-            ]
+  "query": {
+    "bool": {
+      "must": [
+        {
+          "term": {
+            "field1": "example_value"
+          }
         }
-    }
-}
-```
-Field mapping:
-```json
-{
-    "index1": {
-        "mappings": {
-            "properties": {
-                "field1": { "type": "keyword" },
-                "field2": { "type": "text" },
-                "field3": { "type": "text" },
-                "field4": { "type": "long" }
+      ],
+      "filter": [
+        {
+          "match": {
+            "field2": "search_text"
+          }
+        },
+        {
+          "range": {
+            "field4": {
+              "gte": 1,
+              "lte": 100
             }
+          }
         }
+      ],
+      "should": [
+        {
+          "regexp": {
+            "field3": ".*"
+          }
+        }
+      ]
     }
+  }
 }
 ```
 
-The query structure would be:
+Has the following corresponding query structure:
+
 ```c
 bool []
   must:
@@ -126,6 +122,19 @@ bool []
   should:
     regexp [field3, text]
 ```
+
+To exclude field names and field data types from the query structure, configure the following settings:
+
+```json
+PUT _cluster/settings
+{
+  "persistent" : {
+    "search.insights.top_queries.grouping.attributes.field_name" : false,
+    "search.insights.top_queries.grouping.attributes.field_type" : false
+  }
+}
+```
+{% include copy-curl.html %}
 
 ## Aggregate metrics per group
 

--- a/_observing-your-data/query-insights/grouping-top-n-queries.md
+++ b/_observing-your-data/query-insights/grouping-top-n-queries.md
@@ -45,8 +45,8 @@ bool
 
 When queries share the same query structure, they are grouped together, ensuring that all similar queries belong to the same group.
 
-### Configure Query Structure
-The above query structure is of the basic form. We have settings to include the `field name` and `field data type` in the query structure.
+### Configure query structure
+The previous query structure is of the basic form. We have settings to include the `field name` and `field data type` in the query structure.
 
 ```json
 PUT _cluster/settings
@@ -59,7 +59,7 @@ PUT _cluster/settings
 ```
 Note that both these settings are enabled by default.
 
-Example of how the query structure would look like with the above settings enabled.
+Example of how the query structure would look like with the preceding settings enabled.
 
 Query:
 ```json

--- a/_observing-your-data/query-insights/grouping-top-n-queries.md
+++ b/_observing-your-data/query-insights/grouping-top-n-queries.md
@@ -45,6 +45,87 @@ bool
 
 When queries share the same query structure, they are grouped together, ensuring that all similar queries belong to the same group.
 
+### Configure Query Structure
+The above query structure is of the basic form. We have settings to include the `field name` and `field data type` in the query structure.
+
+```json
+PUT _cluster/settings
+{
+  "persistent" : {
+    "search.insights.top_queries.grouping.attributes.field_name" : true,
+    "search.insights.top_queries.grouping.attributes.field_type" : true
+  }
+}
+```
+Note that both these settings are enabled by default.
+
+Example of how the query structure would look like with the above settings enabled.
+
+Query:
+```json
+{
+    "query": {
+        "bool": {
+            "must": [
+                {
+                    "term": {
+                        "field1": "example_value"
+                    }
+                }
+            ],
+            "filter": [
+                {
+                    "match": {
+                        "field2": "search_text"
+                    }
+                },
+                {
+                    "range": {
+                        "field4": {
+                            "gte": 1,
+                            "lte": 100
+                        }
+                    }
+                }
+            ],
+            "should": [
+                {
+                    "regexp": {
+                        "field3": ".*"
+                    }
+                }
+            ]
+        }
+    }
+}
+```
+Field mapping:
+```json
+{
+    "index1": {
+        "mappings": {
+            "properties": {
+                "field1": { "type": "keyword" },
+                "field2": { "type": "text" },
+                "field3": { "type": "text" },
+                "field4": { "type": "long" }
+            }
+        }
+    }
+}
+```
+
+The query structure would be:
+```c
+bool []
+  must:
+    term [field1, keyword]
+  filter:
+    match [field2, text]
+    range [field4, long]
+  should:
+    regexp [field3, text]
+```
 
 ## Aggregate metrics per group
 

--- a/_observing-your-data/query-insights/index.md
+++ b/_observing-your-data/query-insights/index.md
@@ -4,6 +4,8 @@ title: Query insights
 nav_order: 40
 has_children: true
 has_toc: false
+redirect_from:
+  - /query-insights/
 ---
 
 # Query insights


### PR DESCRIPTION
### Description
As a followup to : https://github.com/opensearch-project/documentation-website/pull/8173
Need to add documentation for field name and field type settings and field that is included in the query structure while grouping top b by similarity.

- Need to add documentation for the 2 settings
- Need to modify the example query shape to now show field name and field data type and mention that we take this into account for the query shape.

### Issues Resolved
Closes #8539 

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
