### PR TITLE
Document setting allowing size > 0 queries into request cache

### DIFF
--- a/_search-plugins/caching/request-cache.md
+++ b/_search-plugins/caching/request-cache.md
@@ -28,6 +28,7 @@ Setting | Data type  | Default | Level | Static/Dynamic | Description
 `indices.cache.cleanup_interval` | Time unit  | `1m` (1 minute)  | Cluster | Static | Schedules a recurring background task that cleans up expired entries from the cache at the specified interval. 
 `indices.requests.cache.size` | Percentage | `1%`      | Cluster | Static | The cache size as a percentage of the heap size (for example, to use 1% of the heap, specify `1%`). 
 `index.requests.cache.enable` | Boolean    | `true`    | Index | Dynamic | Enables or disables the request cache. 
+`indices.requests.cache.enable_for_all_requests` | Boolean    | `false`    | Cluster | Dynamic | Enables or disables caching `size > 0` queries.
 
 ### Example
 

--- a/_search-plugins/caching/request-cache.md
+++ b/_search-plugins/caching/request-cache.md
@@ -28,7 +28,7 @@ Setting | Data type  | Default | Level | Static/Dynamic | Description
 `indices.cache.cleanup_interval` | Time unit  | `1m` (1 minute)  | Cluster | Static | Schedules a recurring background task that cleans up expired entries from the cache at the specified interval. 
 `indices.requests.cache.size` | Percentage | `1%`      | Cluster | Static | The cache size as a percentage of the heap size (for example, to use 1% of the heap, specify `1%`). 
 `index.requests.cache.enable` | Boolean    | `true`    | Index | Dynamic | Enables or disables the request cache. 
-`indices.requests.cache.enable_for_all_requests` | Boolean    | `false`    | Cluster | Dynamic | Enables or disables caching `size > 0` queries.
+`indices.requests.cache.enable_for_all_requests` | Boolean    | `false`    | Cluster | Dynamic | Enables or disables caching queries in which `size` is greater than `0`.
 
 ### Example
 


### PR DESCRIPTION
### Description
Minor change: adds documentation for a new request cache setting allowing caching size > 0 queries, which will be added in https://github.com/opensearch-project/OpenSearch/pull/16484.

### Issues Resolved
N/A

### Version
2.x (new change in open source)

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
