### PR TITLE
Adds precompute and preaggreate to Vale

### DIFF
--- a/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
@@ -85,6 +85,8 @@ p\d{2}
 [Pp]erformant
 [Pp]laintext
 [Pp]luggable
+[Pp]reaggregate(s|d)?
+[Pp]recompute(s|d)?
 [Pp]reconfigure
 [Pp]refetch
 [Pp]refilter


### PR DESCRIPTION
### Description
Adds "precompute" and "preaggregate" to Vale.

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
