### PR TITLE
Clarify master-to-cluster-manager name change

### DIFF
--- a/_tuning-your-cluster/index.md
+++ b/_tuning-your-cluster/index.md
@@ -20,7 +20,7 @@ To create and deploy an OpenSearch cluster according to your requirements, it’
 
 There are many ways to design a cluster. The following illustration shows a basic architecture that includes a four-node cluster that has one dedicated cluster manager node, one dedicated coordinating node, and two data nodes that are cluster manager eligible and also used for ingesting data.
 
-  The nomenclature for the cluster manager node is now referred to as the cluster manager node.
+  The master node is now referred to as the cluster manager node.
    {: .note }
 
 ![multi-node cluster architecture diagram]({{site.url}}{{site.baseurl}}/images/cluster.png)


### PR DESCRIPTION
### Description
In https://github.com/opensearch-project/documentation-website/pull/7660 there was an effort to find-and-replace `master` with `cluster manager`. In this one particular case it was unwarranted however, as the sentence is explaining how master nodes are now called cluster manager nodes.

I also simplified the sentence, as the "nomenclature" part is unnecessary.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
