### PR TITLE
Reorder two token filters alphabetically

### DIFF
--- a/_analyzers/token-filters/synonym.md
+++ b/_analyzers/token-filters/synonym.md
@@ -2,7 +2,7 @@
 layout: default
 title: Synonym
 parent: Token filters
-nav_order: 420
+nav_order: 415
 ---
 
 # Synonym token filter


### PR DESCRIPTION
Synonym token filter should be before synonym graph token filter.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
