### PR TITLE
Update repo maintainers: Remove maintainers that are not active

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @kolchfa-aws @Naarcha-AWS @AMoo-Miki @natebower @dlvenable @stephen-crawford @epugh
+*  @kolchfa-aws @Naarcha-AWS @AMoo-Miki @natebower @dlvenable @epugh

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @kolchfa-aws @Naarcha-AWS @vagimeli @AMoo-Miki @natebower @dlvenable @stephen-crawford @epugh
+*  @kolchfa-aws @Naarcha-AWS @AMoo-Miki @natebower @dlvenable @stephen-crawford @epugh

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -11,7 +11,6 @@ This document lists the maintainers in this repo. See [opensearch-project/.githu
 | Nathan Bower     | [natebower](https://github.com/natebower)       | Amazon      |
 | Miki Barahmand   | [AMoo-Miki](https://github.com/AMoo-Miki)       | Amazon      |
 | David Venable    | [dlvenable](https://github.com/dlvenable)       | Amazon      | 
-| Stephen Crawford | [stephen-crawford](https://github.com/stephen-crawford) | Amazon      |
 | Eric Pugh        | [epugh](https://github.com/epugh)               | OpenSource Connections  | 
 
 ## Emeritus

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -15,6 +15,8 @@ This document lists the maintainers in this repo. See [opensearch-project/.githu
 
 ## Emeritus
 
-| Maintainer       | GitHub ID                                       | Affiliation |
-| ---------------- | ----------------------------------------------- | ----------- |
-| Heather Halter   | [hdhalter](https://github.com/hdhalter)         | Amazon      |
+| Maintainer       | GitHub ID                                               | Affiliation |
+| ---------------- | ------------------------------------------------------- | ----------- |
+| Heather Halter   | [hdhalter](https://github.com/hdhalter)                 | Amazon      |
+| Melissa Vagi     | [vagimeli](https://github.com/vagimeli)                 | Amazon      |
+| Stephen Crawford | [stephen-crawford](https://github.com/stephen-crawford) | Amazon      |

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -9,7 +9,6 @@ This document lists the maintainers in this repo. See [opensearch-project/.githu
 | Fanit Kolchina   | [kolchfa-aws](https://github.com/kolchfa-aws)   | Amazon      |
 | Nate Archer      | [Naarcha-AWS](https://github.com/Naarcha-AWS)   | Amazon      |
 | Nathan Bower     | [natebower](https://github.com/natebower)       | Amazon      |
-| Melissa Vagi     | [vagimeli](https://github.com/vagimeli)         | Amazon      |
 | Miki Barahmand   | [AMoo-Miki](https://github.com/AMoo-Miki)       | Amazon      |
 | David Venable    | [dlvenable](https://github.com/dlvenable)       | Amazon      | 
 | Stephen Crawford | [stephen-crawford](https://github.com/stephen-crawford) | Amazon      |

--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ If you encounter problems or have questions when contributing to the documentati
 
 - [kolchfa-aws](https://github.com/kolchfa-aws)
 - [Naarcha-AWS](https://github.com/Naarcha-AWS)
-- [vagimeli](https://github.com/vagimeli)
 
 
 ## Code of conduct


### PR DESCRIPTION
Update repo maintainers: Remove maintainers that are not active

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
