### PR TITLE
Changed the default value of expand for synonym and synonym_graph to true.

### DIFF
--- a/_analyzers/token-filters/synonym-graph.md
+++ b/_analyzers/token-filters/synonym-graph.md
@@ -19,7 +19,7 @@ Parameter | Required/Optional | Data type | Description
 `synonyms_path` | Either `synonyms` or `synonyms_path` must be specified | String | The file path to a file containing synonym rules (either an absolute path or a path relative to the config directory).
 `lenient` | Optional | Boolean | Whether to ignore exceptions when loading the rule configurations. Default is `false`.
 `format` | Optional | String | Specifies the format used to determine how OpenSearch defines and interprets synonyms. Valid values are:<br>- `solr` <br>- [`wordnet`](https://wordnet.princeton.edu/). <br> Default is `solr`.
-`expand` | Optional | Boolean |  Whether to expand equivalent synonym rules. Default is `false`.<br><br>For example: <br>If `synonyms` are defined as `"quick, fast"` and `expand` is set to `true`, then the synonym rules are configured as follows:<br>- `quick => quick`<br>- `quick => fast`<br>- `fast => quick`<br>- `fast => fast`<br><br>If `expand` is set to `false`, the synonym rules are configured as follows:<br>- `quick => quick`<br>- `fast => quick`
+`expand` | Optional | Boolean |  Whether to expand equivalent synonym rules. Default is `true`.<br><br>For example: <br>If `synonyms` are defined as `"quick, fast"` and `expand` is set to `true`, then the synonym rules are configured as follows:<br>- `quick => quick`<br>- `quick => fast`<br>- `fast => quick`<br>- `fast => fast`<br><br>If `expand` is set to `false`, the synonym rules are configured as follows:<br>- `quick => quick`<br>- `fast => quick`
 
 ## Example: Solr format
 

--- a/_analyzers/token-filters/synonym.md
+++ b/_analyzers/token-filters/synonym.md
@@ -19,7 +19,7 @@ Parameter | Required/Optional | Data type | Description
 `synonyms_path` | Either `synonyms` or `synonyms_path` must be specified | String |  The file path to a file containing synonym rules (either an absolute path or a path relative to the config directory).
 `lenient` | Optional | Boolean | Whether to ignore exceptions when loading the rule configurations. Default is `false`.
 `format` | Optional | String | Specifies the format used to determine how OpenSearch defines and interprets synonyms. Valid values are:<br>- `solr` <br>- [`wordnet`](https://wordnet.princeton.edu/). <br> Default is `solr`.
-`expand` | Optional | Boolean |  Whether to expand equivalent synonym rules. Default is `false`.<br><br>For example: <br>If `synonyms` are defined as `"quick, fast"` and `expand` is set to `true`, then the synonym rules are configured as follows:<br>- `quick => quick`<br>- `quick => fast`<br>- `fast => quick`<br>- `fast => fast`<br><br>If `expand` is set to `false`, the synonym rules are configured as follows:<br>- `quick => quick`<br>- `fast => quick`
+`expand` | Optional | Boolean |  Whether to expand equivalent synonym rules. Default is `true`.<br><br>For example: <br>If `synonyms` are defined as `"quick, fast"` and `expand` is set to `true`, then the synonym rules are configured as follows:<br>- `quick => quick`<br>- `quick => fast`<br>- `fast => quick`<br>- `fast => fast`<br><br>If `expand` is set to `false`, the synonym rules are configured as follows:<br>- `quick => quick`<br>- `fast => quick`
 
 ## Example: Solr format
 


### PR DESCRIPTION
### Description
Changed the default value of expand for synonym and synonym_graph to true.

#### evidence
1. Default configuration location in the OpenSearch source code [here](https://github.com/opensearch-project/OpenSearch/blob/main/modules/analysis-common/src/main/java/org/opensearch/analysis/common/SynonymTokenFilterFactory.java#L90).
2. Actual execution and confirmation (Version 2.18.0).
expand: default
```
GET /_analyze
{
  "tokenizer": {
    "type": "standard",
    "mode": "search"
  },
  "filter": [
    {
      "type": "synonym",
      "synonyms": [
        "quick, fast, speedy"
      ]
    }
  ],
  "text": "fast"
}
# result
{
  "tokens": [
    {
      "token": "fast",
      "start_offset": 0,
      "end_offset": 4,
      "type": "<ALPHANUM>",
      "position": 0
    },
    {
      "token": "quick",
      "start_offset": 0,
      "end_offset": 4,
      "type": "SYNONYM",
      "position": 0
    },
    {
      "token": "speedy",
      "start_offset": 0,
      "end_offset": 4,
      "type": "SYNONYM",
      "position": 0
    }
  ]
}
```
expand: true
```
GET /_analyze
{
  "tokenizer": {
    "type": "standard",
    "mode": "search"
  },
  "filter": [
    {
      "type": "synonym",
      "expand": "true",
      "synonyms": [
        "quick, fast, speedy"
      ]
    }
  ],
  "text": "fast"
}
# result
{
  "tokens": [
    {
      "token": "fast",
      "start_offset": 0,
      "end_offset": 4,
      "type": "<ALPHANUM>",
      "position": 0
    },
    {
      "token": "quick",
      "start_offset": 0,
      "end_offset": 4,
      "type": "SYNONYM",
      "position": 0
    },
    {
      "token": "speedy",
      "start_offset": 0,
      "end_offset": 4,
      "type": "SYNONYM",
      "position": 0
    }
  ]
}
```
expand: false
```
GET /_analyze
{
  "tokenizer": {
    "type": "standard",
    "mode": "search"
  },
  "filter": [
    {
      "type": "synonym",
      "expand": "false",
      "synonyms": [
        "quick, fast, speedy"
      ]
    }
  ],
  "text": "fast"
}
# result
{
  "tokens": [
    {
      "token": "quick",
      "start_offset": 0,
      "end_offset": 4,
      "type": "SYNONYM",
      "position": 0
    }
  ]
}
```
### Version
all

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
