### PR TITLE
Add documentation for search_idle_reactivate_count_total

### DIFF
--- a/_api-reference/nodes-apis/nodes-stats.md
+++ b/_api-reference/nodes-apis/nodes-stats.md
@@ -206,6 +206,7 @@ Select the arrow to view the example response.
           "suggest_total": 0,
           "suggest_time_in_millis": 0,
           "suggest_current": 0,
+          "search_idle_reactivate_count_total": 0,
           "request" : {
             "dfs_pre_query" : {
               "time_in_millis" : 0,
@@ -892,6 +893,7 @@ search.point_in_time_current | Integer | The number of shard PIT contexts curren
 search.suggest_total | Integer | The total number of shard suggest operations.
 search.suggest_time_in_millis | Integer | The total amount of time for all shard suggest operations, in milliseconds.
 search.suggest_current | Integer | The number of shard suggest operations that are currently running.
+search.search_idle_reactivate_count_total | Integer | The total number of times for all shards being activated from idle state.
 search.request | Object | Statistics about coordinator search operations for the node.
 search.request.took.time_in_millis | Integer | The total amount of time taken for all search requests, in milliseconds.
 search.request.took.current | Integer | The number of search requests that are currently running.

--- a/_api-reference/nodes-apis/nodes-stats.md
+++ b/_api-reference/nodes-apis/nodes-stats.md
@@ -893,7 +893,7 @@ search.point_in_time_current | Integer | The number of shard PIT contexts curren
 search.suggest_total | Integer | The total number of shard suggest operations.
 search.suggest_time_in_millis | Integer | The total amount of time for all shard suggest operations, in milliseconds.
 search.suggest_current | Integer | The number of shard suggest operations that are currently running.
-search.search_idle_reactivate_count_total | Integer | The total number of times for all shards being activated from idle state.
+search.search_idle_reactivate_count_total | Integer | The total number of times all shards have been activated from an idle state.
 search.request | Object | Statistics about coordinator search operations for the node.
 search.request.took.time_in_millis | Integer | The total amount of time taken for all search requests, in milliseconds.
 search.request.took.current | Integer | The number of search requests that are currently running.

--- a/_api-reference/nodes-apis/nodes-stats.md
+++ b/_api-reference/nodes-apis/nodes-stats.md
@@ -893,7 +893,7 @@ search.point_in_time_current | Integer | The number of shard PIT contexts curren
 search.suggest_total | Integer | The total number of shard suggest operations.
 search.suggest_time_in_millis | Integer | The total amount of time for all shard suggest operations, in milliseconds.
 search.suggest_current | Integer | The number of shard suggest operations that are currently running.
-search.search_idle_reactivate_count_total | Integer | The total number of times all shards have been activated from an idle state.
+search.search_idle_reactivate_count_total | Integer | The total number of times that all shards have been activated from an idle state.
 search.request | Object | Statistics about coordinator search operations for the node.
 search.request.took.time_in_millis | Integer | The total amount of time taken for all search requests, in milliseconds.
 search.request.took.current | Integer | The number of search requests that are currently running.


### PR DESCRIPTION
### Description
Adding documentation for the field "search_idle_reactivate_count_total" in nodes stats api. This field is added in version 2.14 so this PR needs to be backported to 2.14. 

The PR for adding in this field in OpenSearch is [here](https://github.com/opensearch-project/OpenSearch/pull/12768). 
### Version
from version 2.14 to the current version

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
