### PR TITLE
Update rollover.md

### DIFF
--- a/_api-reference/index-apis/rollover.md
+++ b/_api-reference/index-apis/rollover.md
@@ -94,7 +94,6 @@ Parameter | Type | Description
 | `max_age` | Time units | Triggers a rollover after the maximum elapsed time since index creation is reached. The elapsed time is always calculated since the index creation time, even if the index origination date is configured to a custom date, such as when using the `index.lifecycle.parse_origination_date` or `index.lifecycle.origination_date` settings. Optional. |
 `max_docs` | Integer | Triggers a rollover after the specified maximum number of documents, excluding documents added since the last refresh and documents in replica shards. Optional. 
 `max_size` | Byte units  | Triggers a rollover when the index reaches a specified size, calculated as the total size of all primary shards. Replicas are not counted. Use the `_cat indices` API and check the `pri.store.size` value to see the current index size. Optional.
-`max_primary_shard_size` | Byte units  | Triggers a rollover when the largest primary shard in the index reaches a certain size. This is the maximum size of the primary shards in the index. As with `max_size`, replicas are ignored. To see the current shard size, use the `_cat shards` API. The `store` value shows the size of each shard, and `prirep` indicates whether a shard is a primary (`p`) or a replica (`r`). Optional.
 
 ### `settings`
 


### PR DESCRIPTION
Option doesn't exist:


```
Could not rollover datastream ds-test1 status code: 400 response: {"error":{"root_cause":[{"type":"x_content_parse_exception","reason":"[1:34] [conditions] unknown field [max_primary_shard_size]"}],"type":"x_content_parse_exception","reason":"[1:60] [rollover] failed to parse field [conditions]","caused_by":{"type":"x_content_parse_exception","reason":"[1:34] [conditions] unknown field [max_primary_shard_size]"}},"status":400}
```

```
print(f"Rollover datastream {datastream}")

            body =  {
                "conditions": {
                    "max_age": "5d",
                    "max_primary_shard_size": "50gb"
                }
            }


            response = self.requests.post(f"{self.base_url}/{datastream}/_rollover", json=body)
            if response.status_code == 200:
                print(f"Rollover datastream {datastream} successful")
            else:
                print(f"Could not rollover datastream {datastream} status code: {response.status_code} response: {response.text}")
```

max_size does work.

### Description
2.18.0 doesn't know this parameter

### Issues Resolved
Closes #[_insert issue number_]

### Version
2.18.0

### Frontend features
n/a

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
