### PR TITLE
docs: add validation requirement for message fields

### DIFF
--- a/_ml-commons-plugin/api/memory-apis/create-message.md
+++ b/_ml-commons-plugin/api/memory-apis/create-message.md
@@ -44,11 +44,14 @@ The following table lists the available request fields.
 
 Field | Data type | Required/Optional | Updatable | Description
 :--- | :--- | :--- | :--- | :---
-| `input` | String | Optional | No | The question (human input) in the message. |
-| `prompt_template` | String | Optional | No | The prompt template that was used for the message. The template may contain instructions or examples that were sent to the large language model. |
-| `response` | String | Optional | No | The answer (generative AI output) to the question. |
-| `origin` | String | Optional | No | The name of the AI or other system that generated the response. |
-| `additional_info` | Object | Optional | Yes | Any other information that was sent to the `origin`. |
+`input` | String | Optional | No | The question (human input) in the message. |
+`prompt_template` | String | Optional | No | The prompt template that was used for the message. The template may contain instructions or examples that were sent to the large language model. |
+`response` | String | Optional | No | The answer (generative AI output) to the question. |
+`origin` | String | Optional | No | The name of the AI or other system that generated the response. |
+`additional_info` | Object | Optional | Yes | Any other information that was sent to the `origin`. |
+
+At least one of the above fields must be provided and cannot be null or empty for a successful message creation or update
+{: .note}
 
 #### Example request: Create a message
 


### PR DESCRIPTION
### Description
Add note clarifying that at least one field must be non-null and non-empty for successful message creation/update operations

### Issues Resolved
Closes #8999

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._
2.19 and above

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
