### PR TITLE
Fix HTTP verb and path for snapshot restore API docs

### DIFF
--- a/_api-reference/snapshots/restore-snapshot.md
+++ b/_api-reference/snapshots/restore-snapshot.md
@@ -22,7 +22,7 @@ If open indexes with the same name that you want to restore already exist in the
 ## Endpoints
 
 ```json
-GET _snapshot/<repository>/<snapshot>/
+POST _snapshot/<repository>/<snapshot>/_restore
 ```
 
 ## Path parameters


### PR DESCRIPTION
### Description
The documentation for the snapshot restore API mistakenly suggests to use `GET` to restore a snapshot, when it should be `POST`. It also is missing the `_restore` URL path fragment.

### Issues Resolved
N/A

### Version
all

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
