### PR TITLE
Add Query Insights local index delete after documentation

### DIFF
--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -134,7 +134,7 @@ PUT _cluster/settings
 
 ### Configuring a local index exporter
 
-A local index exporter allows you to save top N query data to automatically created indexes in your OpenSearch domain. Query Insights creates these indexes following the naming pattern `top_queries-YYYY.MM.dd-hashcode`, where `hashcode` is a 5-digit number generated based on the current UTC date. A new index is created daily. For historical top N lookups using the Top Queries API or the Query Insights Dashboard, you must enable the local index exporter.
+A local index exporter allows you to save top N query data to indexes that are automatically created in your OpenSearch domain. Query Insights creates these indexes following the naming pattern `top_queries-YYYY.MM.dd-hashcode`, where `hashcode` is a 5-digit number generated based on the current UTC date. A new index is created daily. For historical top N lookups using the Top Queries API or the Query Insights Dashboard, you must enable the local index exporter.
 
 To use the local index exporter, set the exporter type to `local_index` for the desired metrics:
 

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -150,7 +150,7 @@ PUT _cluster/settings
 ```
 {% include copy-curl.html %}
 
-Use the `delete_after_days` setting (integer) to specify the duration, in days, for automatically deleting local indexes. Query Insights runs a scheduled job once per day to delete top N local indexes older than the specified number of days. The default value for `delete_after_days` is 7, with valid values ranging from `1` to `180`. This setting applies to local index exporters of all metric types.
+Use the `delete_after_days` setting (integer) to specify the number of days after which local indexes are automatically deleted. Query Insights runs a scheduled job once per day to delete top N local indexes older than the specified number of days. The default value for `delete_after_days` is 7, with valid values ranging from `1` to `180`. This setting applies to local index exporters of all metric types.
 
 For example, to delete local indexes after 7 days, send the following request:
 

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -118,13 +118,15 @@ You can configure your desired exporter to export top N query data to different 
 
 ### Configuring a debug exporter
 
-To configure a debug exporter, update the exporter setting for the desired metric type. For example, to export the top N queries by latency using the debug exporter, send the following request:
+To use the debug exporter, update the exporter type for each metric type. For example, send the following request:
 
 ```json
 PUT _cluster/settings
 {
   "persistent" : {
-     "search.insights.top_queries.latency.exporter.type" : "debug"
+    "search.insights.top_queries.latency.exporter.type" : "debug", 
+    "search.insights.top_queries.cpu.exporter.type" : "debug",
+    "search.insights.top_queries.memory.exporter.type" : "debug"
   }
 }
 ```
@@ -132,16 +134,28 @@ PUT _cluster/settings
 
 ### Configuring a local index exporter
 
-A local index exporter allows you to export the top N queries to local OpenSearch indexes. The default index pattern for top N query indexes is `top_queries-YYYY.MM.dd`. All top queries from the same day are saved to the same index, and a new index is created each day. You can change the default index pattern to use other date formats. For more information about supported formats, see [DateTimeFormat](https://www.joda.org/joda-time/apidocs/org/joda/time/format/DateTimeFormat.html).
+A local index exporter allows you to save top N query data to indices in your OpenSearch domain. Query Insights manages the creation of these indices following the naming pattern `top_queries-YYYY.MM.dd-hashcode`. A new index is created daily and "hashcode" is a 5-digit number generated based on the current UTC date. Local index exporter must be enabled to allow historical top N lookups via the `top_queries` API or the Query Insights Dashboard.
 
-To configure the local index exporter for the top N queries by latency, send the following request:
+To use the local index exporter, send the following request:
 
 ```json
 PUT _cluster/settings
 {
   "persistent" : {
     "search.insights.top_queries.latency.exporter.type" : "local_index",
-    "search.insights.top_queries.latency.exporter.config.index" : "YYYY.MM.dd"
+    "search.insights.top_queries.cpu.exporter.type" : "local_index",
+    "search.insights.top_queries.memory.exporter.type" : "local_index"
+  }
+}
+```
+{% include copy-curl.html %}
+
+Use the `delete_after_days` setting (integer) to specify the duration, in days, for automatically deleting local indices. Query Insights runs a scheduled job once per day to delete Top N local indices older than the specified number of days. The default value for `delete_after_days` is 7, with valid values ranging from 1 to 180. This setting applies to local index exporters of all metric types.
+```json
+PUT _cluster/settings
+{
+  "persistent" : {
+    "search.insights.top_queries.delete_after_days" : "7"
   }
 }
 ```

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -118,7 +118,7 @@ You can configure your desired exporter to export top N query data to different 
 
 ### Configuring a debug exporter
 
-To use the debug exporter, update the exporter type for each metric type. For example, send the following request:
+To use the debug exporter, update the exporter type to `debug` for each metric type. For example, to use the debug exporter for all metric types, send the following request:
 
 ```json
 PUT _cluster/settings

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -118,7 +118,7 @@ You can configure your desired exporter to export top N query data to different 
 
 ### Configuring a debug exporter
 
-To use the debug exporter, update the exporter type to `debug` for each metric type. For example, to use the debug exporter for all metric types, send the following request:
+To use the debug exporter, change the exporter type to `debug` for each metric type. For example, to use the debug exporter for all metric types, send the following request:
 
 ```json
 PUT _cluster/settings

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -150,7 +150,10 @@ PUT _cluster/settings
 ```
 {% include copy-curl.html %}
 
-Use the `delete_after_days` setting (integer) to specify the duration, in days, for automatically deleting local indices. Query Insights runs a scheduled job once per day to delete Top N local indices older than the specified number of days. The default value for `delete_after_days` is 7, with valid values ranging from 1 to 180. This setting applies to local index exporters of all metric types.
+Use the `delete_after_days` setting (integer) to specify the duration, in days, for automatically deleting local indexes. Query Insights runs a scheduled job once per day to delete top N local indexes older than the specified number of days. The default value for `delete_after_days` is 7, with valid values ranging from `1` to `180`. This setting applies to local index exporters of all metric types.
+
+For example, to delete local indexes after 7 days, send the following request:
+
 ```json
 PUT _cluster/settings
 {

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -136,7 +136,7 @@ PUT _cluster/settings
 
 A local index exporter allows you to save top N query data to automatically created indexes in your OpenSearch domain. Query Insights creates these indexes following the naming pattern `top_queries-YYYY.MM.dd-hashcode`, where `hashcode` is a 5-digit number generated based on the current UTC date. A new index is created daily. For historical top N lookups using the Top Queries API or the Query Insights Dashboard, you must enable the local index exporter.
 
-To use the local index exporter, send the following request:
+To use the local index exporter, set the exporter type to `local_index` for the desired metrics:
 
 ```json
 PUT _cluster/settings

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -136,7 +136,7 @@ PUT _cluster/settings
 
 A local index exporter allows you to save top N query data to indexes that are automatically created in your OpenSearch domain. Query Insights creates these indexes following the naming pattern `top_queries-YYYY.MM.dd-hashcode`, where `hashcode` is a 5-digit number generated based on the current UTC date. A new index is created daily. For historical top N lookups using the Top Queries API or the Query Insights Dashboard, you must enable the local index exporter.
 
-To use the local index exporter, set the exporter type to `local_index` for the desired metrics:
+To use the local index exporter, set the exporter type for the desired metrics to `local_index`:
 
 ```json
 PUT _cluster/settings

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -134,7 +134,7 @@ PUT _cluster/settings
 
 ### Configuring a local index exporter
 
-A local index exporter allows you to save top N query data to indices in your OpenSearch domain. Query Insights manages the creation of these indices following the naming pattern `top_queries-YYYY.MM.dd-hashcode`. A new index is created daily and "hashcode" is a 5-digit number generated based on the current UTC date. Local index exporter must be enabled to allow historical top N lookups via the `top_queries` API or the Query Insights Dashboard.
+A local index exporter allows you to save top N query data to automatically created indexes in your OpenSearch domain. Query Insights creates these indexes following the naming pattern `top_queries-YYYY.MM.dd-hashcode`, where `hashcode` is a 5-digit number generated based on the current UTC date. A new index is created daily. For historical top N lookups using the Top Queries API or the Query Insights Dashboard, you must enable the local index exporter.
 
 To use the local index exporter, send the following request:
 


### PR DESCRIPTION
### Description
Webpage: https://opensearch.org/docs/latest/observing-your-data/query-insights/top-n-queries/

- Remove documentation for `search.insights.top_queries.latency.exporter.config.index` setting https://github.com/opensearch-project/query-insights/pull/166
- Add documentation for `search.insights.top_queries.delete_after_days` setting https://github.com/opensearch-project/query-insights/pull/172

### Issues Resolved
Closes #[_insert issue number_]

### Version
2.19

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
