### PR TITLE
Update _search query match field in Documentation

### DIFF
--- a/_field-types/supported-field-types/text.md
+++ b/_field-types/supported-field-types/text.md
@@ -122,7 +122,7 @@ GET testindex/_search
 {
   "query": {
     "match": {
-      "text": "date of birth"
+      "dob": "date of birth"
     }
   },
   "highlight": {

--- a/_field-types/supported-field-types/text.md
+++ b/_field-types/supported-field-types/text.md
@@ -127,7 +127,7 @@ GET testindex/_search
   },
   "highlight": {
     "fields": {
-      "text": {} 
+      "dob": {} 
     }
   }
 }


### PR DESCRIPTION

### Description
Fixes documention where field  name was `text` in the search query but the field where the match should occur should be `dob` which returns the actual match.


### Issues Resolved

### Version
2.18.
### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
