### PR TITLE
Change Data Prepper to OpenSearch Data Prepper in Vale

### DIFF
--- a/.github/vale/styles/Vocab/OpenSearch/Products/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Products/accept.txt
@@ -15,7 +15,7 @@ Cohere Embed English
 Cohere Embed Multilingual
 Cognito
 Dashboards Query Language
-Data Prepper
+OpenSearch Data Prepper
 Debian
 Dev Tools
 Docker

--- a/.github/vale/styles/Vocab/OpenSearch/Products/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Products/accept.txt
@@ -15,7 +15,7 @@ Cohere Embed English
 Cohere Embed Multilingual
 Cognito
 Dashboards Query Language
-OpenSearch Data Prepper
+Data Prepper
 Debian
 Dev Tools
 Docker

--- a/TERMS.md
+++ b/TERMS.md
@@ -46,7 +46,7 @@ Use to describe a list of items that are allowed (not blocked). Do not use as a 
 
 **Amazon OpenSearch Service**
 
-Amazon OpenSearch Service is a managed service that makes it easy to deploy, operate, and scale OpenSearch clusters in the AWS Cloud. Amazon OpenSearch Service is the successor to Amazon Elasticsearch Service (Amazon ES) and supports OpenSearch and legacy Elasticsearch OSS (up to 7.10, the final open-source version of the software).
+Use "Amazon OpenSearch Service" on first appearance; "OpenSearch Service" is acceptable for subsequent appearances. Amazon OpenSearch Service is a managed service that makes it easy to deploy, operate, and scale OpenSearch clusters in the AWS Cloud. Amazon OpenSearch Service is the successor to Amazon Elasticsearch Service (Amazon ES) and supports OpenSearch and legacy Elasticsearch OSS (up to 7.10, the final open-source version of the software).
 
 **Anomaly Detection**
 
@@ -195,6 +195,10 @@ Except when dictated by open standards, use as a prefix in a closed compound: do
 Use data is, not data are. Don't use datas. Use pieces of data or equivalent to describe individual items within a set of data.
 
 **data center**
+
+**OpenSearch Data Prepper**
+
+Use "OpenSearch Data Prepper" on first appearance; "Data Prepper" is acceptable for subsequent appearances. OpenSearch Data Prepper is a server-side data collector capable of filtering, enriching, transforming, normalizing, and aggregating data for downstream analytics and visualization. Data Prepper also lets users build custom pipelines to improve the operational view of applications.
 
 **dataset**
 


### PR DESCRIPTION
### Description
Changes "Data Prepper" to "OpenSearch Data Prepper" in Vale.

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
