### PR TITLE
Refactor the search section

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -171,7 +171,7 @@ opensearch_collection:
       name: Aggregations
       nav_fold: true
     search-plugins:
-      name: Search 
+      name: Search features
       nav_fold: true
     ml-commons-plugin:
       name: Machine learning

--- a/_search-plugins/collapse-search.md
+++ b/_search-plugins/collapse-search.md
@@ -1,7 +1,8 @@
 ---
 layout: default
 title: Collapse search results
-nav_order: 3
+parent: Searching data
+nav_order: 40
 ---
 
 # Collapse search results

--- a/_search-plugins/filter-search.md
+++ b/_search-plugins/filter-search.md
@@ -1,6 +1,7 @@
 ---
 layout: default
-title: Filter search results
+title: Filter results
+parent: Search options
 nav_order: 36
 ---
 

--- a/_search-plugins/searching-data/autocomplete.md
+++ b/_search-plugins/searching-data/autocomplete.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Autocomplete
-parent: Searching data
-nav_order: 24
+parent: Search options
+nav_order: 60
 redirect_from:
   - /opensearch/search/autocomplete/
 ---

--- a/_search-plugins/searching-data/did-you-mean.md
+++ b/_search-plugins/searching-data/did-you-mean.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Did-you-mean
-parent: Searching data
-nav_order: 25
+parent: Search options
+nav_order: 70
 redirect_from:
   - /opensearch/search/did-you-mean/
 ---

--- a/_search-plugins/searching-data/highlight.md
+++ b/_search-plugins/searching-data/highlight.md
@@ -1,8 +1,8 @@
 ---
 layout: default
 title: Highlight query matches
-parent: Searching data
-nav_order: 23
+parent: Search options
+nav_order: 50
 redirect_from:
   - /opensearch/search/highlight/
 ---

--- a/_search-plugins/searching-data/index.md
+++ b/_search-plugins/searching-data/index.md
@@ -1,22 +1,25 @@
 ---
 layout: default
-title: Searching data
+title: Search options
 nav_order: 5
 has_children: true
 has_toc: false
 redirect_from: /opensearch/ux/
 ---
 
-# Searching data
+# Search options
 
-What users expect from search engines has evolved over the years. Just returning relevant results quickly is no longer enough for most users. Now users seek methods that allow them to get even more relevant results, to sort and organize results, and to highlight their queries. OpenSearch includes many features, described in the following table, that enhance the search experience.
+What users expect from search engines has evolved over the years. Just returning relevant results quickly is no longer enough for most users. Now users seek methods that allow them to get even more relevant results, to sort and organize results, and to highlight their queries. OpenSearch includes many search options, described in the following table, that enhance the search experience.
 
-Feature | Description
+Option | Description
 :--- | :---
 [Autocomplete functionality]({{site.url}}{{site.baseurl}}/opensearch/search/autocomplete/) | Suggest phrases as the user types.
 [Did-you-mean functionality]({{site.url}}{{site.baseurl}}/opensearch/search/did-you-mean/) | Check spelling of phrases as the user types.
 [Paginate results]({{site.url}}{{site.baseurl}}/opensearch/search/paginate/) | Rather than a single, long list, separate search results into pages.
+[Point in Time]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/point-in-time/) | Run different queries against a dataset that is fixed in time. 
 [Sort results]({{site.url}}{{site.baseurl}}/opensearch/search/sort/) | Allow sorting of results by different criteria.
+[Filter results]({{site.url}}{{site.baseurl}}/search-plugins/filter-search/) | Filter search results.
+[Collapse results]({{site.url}}{{site.baseurl}}/search-plugins/collapse-search/) | Collapse search results.
 [Highlight query matches]({{site.url}}{{site.baseurl}}/opensearch/search/highlight/) | Highlight the search term in the results.
 [Retrieve inner hits]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/inner-hits/) | Retrieve underlying hits in nested and parent-join objects.
 [Retrieve specific fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/) | Retrieve only the specific fields

--- a/_search-plugins/searching-data/inner-hits.md
+++ b/_search-plugins/searching-data/inner-hits.md
@@ -1,12 +1,12 @@
 ---
 layout: default
-title: Inner hits
-parent: Searching data
+title: Retrieve inner hits
+parent: Search options
 has_children: false
-nav_order: 70
+nav_order: 75
 ---
 
-# Inner hits
+# Retrieve inner hits
 
 In OpenSearch, when you perform a search using [nested objects]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/nested/) or [parent-join]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/join/), the underlying hits (nested inner objects or child documents) are hidden by default. You can retrieve inner hits by using the `inner_hits` parameter in the search query.
 

--- a/_search-plugins/searching-data/paginate.md
+++ b/_search-plugins/searching-data/paginate.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: Paginate results
-parent: Searching data
+parent: Search options
 nav_order: 10
 redirect_from:
   - /opensearch/search/paginate/
 ---
 
-## Paginate results
+# Paginate results
 
 You can use the following methods to paginate search results in OpenSearch: 
 

--- a/_search-plugins/searching-data/point-in-time-api.md
+++ b/_search-plugins/searching-data/point-in-time-api.md
@@ -4,7 +4,7 @@ title: Point in Time API
 nav_order: 59
 has_children: false
 parent: Point in Time
-grand_parent: Searching data
+grand_parent: Search options
 redirect_from:
   - /opensearch/point-in-time-api/
   - /search-plugins/point-in-time-api/

--- a/_search-plugins/searching-data/point-in-time.md
+++ b/_search-plugins/searching-data/point-in-time.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Point in Time
-parent: Searching data
+parent: Search options
 nav_order: 20
 has_children: true
 has_toc: false

--- a/_search-plugins/searching-data/retrieve-specific-fields.md
+++ b/_search-plugins/searching-data/retrieve-specific-fields.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-parent: Searching data
+parent: Search options
 title: Retrieve specific fields
-nav_order: 60
+nav_order: 80
 ---
 
 # Retrieve specific fields

--- a/_search-plugins/searching-data/search-shard-routing.md
+++ b/_search-plugins/searching-data/search-shard-routing.md
@@ -1,8 +1,8 @@
 ---
 layout: default
-parent: Searching data
+parent: Search options
 title: Search shard routing
-nav_order: 70
+nav_order: 90
 ---
 
 # Search shard routing

--- a/_search-plugins/searching-data/sort.md
+++ b/_search-plugins/searching-data/sort.md
@@ -1,13 +1,13 @@
 ---
 layout: default
 title: Sort results
-parent: Searching data
-nav_order: 22
+parent: Search options
+nav_order: 30
 redirect_from:
   - /opensearch/search/sort/
 ---
 
-## Sort results
+# Sort results
 
 Sorting allows your users to sort results in a way that’s most meaningful to them.
 


### PR DESCRIPTION
Refactor the search section:
- Remame "Search" to "Search features"
- Move collapse and filter pages into the correct section
- Rename "Searching data" to "Search options"
- miscellaneous cleanup

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
