### PR TITLE
Add binary Lucene vector updates for 2.19

### DIFF
--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -49,6 +49,9 @@ Starting with k-NN plugin version 2.17, you can use `byte` vectors with the `fai
 
 Starting with k-NN plugin version 2.16, you can use `binary` vectors with the `faiss` engine to reduce the amount of required storage space. For more information, see [Binary vectors]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/knn-vector#binary-vectors).
 
+Starting with k-NN plugin version 2.19 you can also use `binary` vectors with the `lucene` engine.
+{: .note}
+
 ## SIMD optimization for the Faiss engine
 
 Starting with version 2.13, the k-NN plugin supports [Single Instruction Multiple Data (SIMD)](https://en.wikipedia.org/wiki/Single_instruction,_multiple_data) processing if the underlying hardware supports SIMD instructions (AVX2 on x64 architecture and Neon on ARM64 architecture). SIMD is supported by default on Linux machines only for the Faiss engine. SIMD architecture helps boost overall performance by improving indexing throughput and reducing search latency. Starting with version 2.18, the k-NN plugin supports AVX512 SIMD instructions on x64 architecture. 
@@ -155,9 +158,12 @@ The IVF algorithm requires a training step. To create an index that uses IVF, yo
 
 ### Supported Lucene methods
 
-Method name | Requires training | Supported spaces | Description
+Method name | Requires training | Supported spaces                                                                | Description
 :--- | :--- |:--------------------------------------------------------------------------------| :---
-`hnsw` | false | l2, cosinesimil, innerproduct (supported in OpenSearch 2.13 and later) | Hierarchical proximity graph approach to approximate k-NN search.
+`hnsw` | false | l2, cosinesimil, innerproduct (supported in OpenSearch 2.13 and later), hamming | Hierarchical proximity graph approach to approximate k-NN search.
+
+The `hamming` space type is supported for binary vectors in OpenSearch version 2.19 and later. For more information, see [Binary k-NN vectors]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/knn-vector#binary-vectors).
+{: .note}
 
 #### HNSW parameters
 

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -49,8 +49,7 @@ Starting with k-NN plugin version 2.17, you can use `byte` vectors with the `fai
 
 Starting with k-NN plugin version 2.16, you can use `binary` vectors with the `faiss` engine to reduce the amount of required storage space. For more information, see [Binary vectors]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/knn-vector#binary-vectors).
 
-Starting with k-NN plugin version 2.19 you can also use `binary` vectors with the `lucene` engine.
-{: .note}
+Starting with k-NN plugin version 2.19, you can use `binary` vectors with the `lucene` engine.
 
 ## SIMD optimization for the Faiss engine
 


### PR DESCRIPTION
### Description
Binary vector support is added for the Lucene engine in 2.19, this PR updates the documentation accordingly.

### Issues Resolved
Closes #8955

### Version
2.19

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
