### PR TITLE
CAT API automation (Part II) (#9060)

### DIFF
--- a/_api-reference/cat/cat-aliases.md
+++ b/_api-reference/cat/cat-aliases.md
@@ -32,19 +32,23 @@ GET /_cat/aliases/{name}
 <!-- spec_insert_start
 api: cat.aliases
 component: query_parameters
-columns: Parameter,Type,Description,Default
+columns: Parameter, Data type, Description, Default
 include_deprecated: false
 -->
 ## Query parameters
-Parameter | Type | Description | Default
-:--- | :--- | :--- | :---
-`expand_wildcards` | List or String | Expands wildcard expressions to concrete indexes. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. | 
-`format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | 
-`h` | List | A comma-separated list of column names to display. | 
-`help` | Boolean | Returns help information. | `false`
-`local` | Boolean | Whether to return information from the local node only instead of from the cluster manager node. | `false`
-`s` | List | A comma-separated list of column names or column aliases to sort by. | 
-`v` | Boolean | Enables verbose mode, which displays column headers. | `false`
+
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `expand_wildcards` | List or String | Specifies the type of index that wildcard expressions can match. Supports comma-separated values. <br> Valid values are: <br> - `all`: Match any index, including hidden ones. <br> - `closed`: Match closed, non-hidden indexes. <br> - `hidden`: Match hidden indexes. Must be combined with open, closed, or both. <br> - `none`: Wildcard expressions are not accepted. <br> - `open`: Match open, non-hidden indexes. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Whether to return information from the local node only instead of from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
 <!-- spec_insert_end -->
 
 

--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -31,10 +31,11 @@ GET /_cat/allocation/{node_id}
 <!-- spec_insert_start
 api: cat.allocation
 component: query_parameters
-columns: Parameter,Type,Description,Default
+columns: Parameter, Data type, Description, Default
 include_deprecated: false
 -->
 ## Query parameters
+<<<<<<< HEAD
 Parameter | Type | Description | Default
 :--- | :--- | :--- | :---
 `bytes` | String | The units used to display byte values. | 
@@ -45,6 +46,22 @@ Parameter | Type | Description | Default
 `local` | Boolean | Returns local information but does not retrieve the state from cluster manager node. | `false`
 `s` | List | A comma-separated list of column names or column aliases to sort by. | 
 `v` | Boolean | Enables verbose mode, which displays column headers. | `false`
+=======
+
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `cluster_manager_timeout` | String | A timeout for connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the HTTP `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from cluster-manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+>>>>>>> 0713861e (CAT API automation (Part II) (#9060))
 <!-- spec_insert_end -->
 
 ## Example requests

--- a/_api-reference/cat/cat-cluster_manager.md
+++ b/_api-reference/cat/cat-cluster_manager.md
@@ -15,19 +15,41 @@ has_children: false
 The CAT cluster manager operation lists information that helps identify the elected cluster manager node.
 
 
+<!-- spec_insert_start
+api: cat.cluster_manager
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/cluster_manager
+GET /_cat/cluster_manager
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.cluster_manager
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+The following table lists the available query parameters. All query parameters are optional.
 
-## Example requests
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | A timeout for connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the HTTP `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
+
+
+## Example request
 
 ```
 GET _cat/cluster_manager?v

--- a/_api-reference/cat/cat-count.md
+++ b/_api-reference/cat/cat-count.md
@@ -16,12 +16,37 @@ redirect_from:
 The CAT count operation lists the number of documents in your cluster.
 
 
+<!-- spec_insert_start
+api: cat.count
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/count?v
-GET _cat/count/<index>?v
+GET /_cat/count
+GET /_cat/count/{index}
 ```
+<!-- spec_insert_end -->
+
+
+<!-- spec_insert_start
+api: cat.count
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
+## Query parameters
+
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/_api-reference/cat/cat-field-data.md
+++ b/_api-reference/cat/cat-field-data.md
@@ -14,19 +14,38 @@ redirect_from:
 
 The CAT Field Data operation lists the memory size used by each field per node.
 
-
+<!-- spec_insert_start
+api: cat.fielddata
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/fielddata?v
-GET _cat/fielddata/<field_name>?v
+GET /_cat/fielddata
+GET /_cat/fielddata/{fields}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.fielddata
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/_api-reference/cat/cat-health.md
+++ b/_api-reference/cat/cat-health.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT health
 parent: CAT API
-
 nav_order: 20
 has_children: false
 redirect_from:
@@ -16,18 +15,38 @@ redirect_from:
 The CAT health operation lists the status of the cluster, how long the cluster has been up, the number of nodes, and other useful information that helps you analyze the health of your cluster.
 
 
+<!-- spec_insert_start
+api: cat.health
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/health?v
+GET /_cat/health
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.health
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-ts | Boolean | If true, returns HH:MM:SS and Unix epoch timestamps. Default is `true`.
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | The unit used to display time values. <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `ts` | Boolean | When `true`, returns `HH:MM:SS` and Unix epoch timestamps. | `true` |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example request
 

--- a/_api-reference/cat/cat-indices.md
+++ b/_api-reference/cat/cat-indices.md
@@ -15,24 +15,45 @@ redirect_from:
 The CAT indices operation lists information related to indexes, that is, how much disk space they are using, how many shards they have, their health status, and so on.
 
 
+<!-- spec_insert_start
+api: cat.indices
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/indices/<index>
-GET _cat/indices
+GET /_cat/indices
+GET /_cat/indices/{index}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.indices
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-health | String | Limit indexes based on their health status. Supported values are `green`, `yellow`, and `red`.
-include_unloaded_segments | Boolean | Whether to include information from segments not loaded into memory. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
-pri | Boolean | Whether to return information only from the primary shards. Default is `false`.
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-expand_wildcards | Enum | Expands wildcard expressions to concrete indexes. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. Default is `open`.
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `expand_wildcards` | List or String | Specifies the type of index that wildcard expressions can match. Supports comma-separated values. <br> Valid values are: <br> - `all`: Match any index, including hidden ones. <br> - `closed`: Match closed, non-hidden indexes. <br> - `hidden`: Match hidden indexes. Must be combined with open, closed, or both. <br> - `none`: Wildcard expressions are not accepted. <br> - `open`: Match open, non-hidden indexes. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `health` | String | Limits indexes based on their health status. Supported values are `green`, `yellow`, and `red`. <br> Valid values are: `green`, `GREEN`, `yellow`, `YELLOW`, `red`, `RED` | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `include_unloaded_segments` | Boolean | Whether to include information from segments not loaded into memory. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `pri` | Boolean | When `true`, returns information only from the primary shards. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | Specifies the time units. <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/_api-reference/cat/cat-nodeattrs.md
+++ b/_api-reference/cat/cat-nodeattrs.md
@@ -15,18 +15,38 @@ redirect_from:
 The CAT nodeattrs operation lists the attributes of custom nodes.
 
 
+<!-- spec_insert_start
+api: cat.nodeattrs
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/nodeattrs
+GET /_cat/nodeattrs
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.nodeattrs
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example request
 

--- a/_api-reference/cat/cat-nodes.md
+++ b/_api-reference/cat/cat-nodes.md
@@ -17,25 +17,40 @@ The CAT nodes operation lists node-level information, including node roles and l
 A few important node metrics are `pid`, `name`, `cluster_manager`, `ip`, `port`, `version`, `build`, `jdk`, along with `disk`, `heap`, `ram`, and `file_desc`.
 
 
+<!-- spec_insert_start
+api: cat.nodes
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/nodes
+GET /_cat/nodes
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.nodes
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-All CAT nodes URL parameters are optional.
+The following table lists the available query parameters. All query parameters are optional.
 
-In addition to the [common URL parameters]({{site.url}}{{site.baseurl}}/api-reference/cat/index), you can specify the following parameters:
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `full_id` | Boolean or String | When `true`, returns the full node ID. When `false`, returns the shortened node ID. | `false` |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/). <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
 
-Parameter | Type | Description
-:--- | :--- | :---
-bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-full_id | Boolean | If true, return the full node ID. If false, return the shortened node ID. Defaults to false.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-include_unloaded_segments | Boolean | Whether to include information from segments not loaded into memory. Default is `false`.
+<!-- spec_insert_end -->
 
 ## Example request
 

--- a/_api-reference/cat/cat-pending-tasks.md
+++ b/_api-reference/cat/cat-pending-tasks.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT pending tasks
 parent: CAT API
-
 nav_order: 45
 has_children: false
 redirect_from:
@@ -16,19 +15,39 @@ redirect_from:
 The CAT pending tasks operation lists the progress of all pending tasks, including task priority and time in queue.
 
 
+<!-- spec_insert_start
+api: cat.pending_tasks
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/pending_tasks
+GET /_cat/pending_tasks
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.pending_tasks
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/). <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example request
 

--- a/_api-reference/cat/cat-pit-segments.md
+++ b/_api-reference/cat/cat-pit-segments.md
@@ -1,0 +1,82 @@
+---
+layout: default
+title: CAT PIT segments
+parent: CAT API
+nav_order: 46
+---
+
+# CAT PIT segments
+
+The CAT point-in-time (PIT) segments operation returns information about one or more PIT segments.
+
+## Endpoints
+
+<!-- spec_insert_start
+api: cat.pit_segments
+component: endpoints
+omit_header: true
+-->
+```json
+GET /_cat/pit_segments
+```
+<!-- spec_insert_end -->
+
+<!-- spec_insert_start
+api: cat.all_pit_segments
+component: endpoints
+omit_header: true
+-->
+```json
+GET /_cat/pit_segments/_all
+```
+<!-- spec_insert_end -->
+
+<!-- spec_insert_start
+api: cat.pit_segments
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
+## Query parameters
+
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
+
+## Request body fields
+
+Field | Data type | Description  
+:--- | :--- | :---
+pit_id | [Base64 encoded binary]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/binary/) or an array of binaries | The PIT IDs of the PITs whose segments are to be listed. Required.
+
+## Example request
+
+```json
+GET /_cat/pit_segments
+{
+    "pit_id": [
+        "o463QQEPbXktaW5kZXgtMDAwMDAxFkhGN09fMVlPUkVPLXh6MUExZ1hpaEEAFjBGbmVEZHdGU1EtaFhhUFc4ZkR5cWcAAAAAAAAAAAEWaXBPNVJtZEhTZDZXTWFFR05waXdWZwEWSEY3T18xWU9SRU8teHoxQTFnWGloQQAA",
+        "o463QQEPbXktaW5kZXgtMDAwMDAxFkhGN09fMVlPUkVPLXh6MUExZ1hpaEEAFjBGbmVEZHdGU1EtaFhhUFc4ZkR5cWcAAAAAAAAAAAIWaXBPNVJtZEhTZDZXTWFFR05waXdWZwEWSEY3T18xWU9SRU8teHoxQTFnWGloQQAA"
+    ]
+}
+```
+{% include copy.html %}
+
+## Example response
+
+```json
+index  shard prirep ip            segment generation docs.count docs.deleted  size size.memory committed searchable version compound
+index1 0     r      10.212.36.190 _0               0          4            0 3.8kb        1364 false     true       8.8.2   true
+index1 1     p      10.212.36.190 _0               0          3            0 3.7kb        1364 false     true       8.8.2   true
+index1 2     r      10.212.74.139 _0               0          2            0 3.6kb        1364 false     true       8.8.2   true
+```
+

--- a/_api-reference/cat/cat-plugins.md
+++ b/_api-reference/cat/cat-plugins.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT plugins
 parent: CAT API
-
 nav_order: 50
 has_children: false
 redirect_from:
@@ -15,25 +14,40 @@ redirect_from:
 
 The CAT plugins operation lists the names, components, and versions of the installed plugins.
 
-
+<!-- spec_insert_start
+api: cat.plugins
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/plugins
+GET /_cat/plugins
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.plugins
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-All parameters are optional.
+The following table lists the available query parameters. All query parameters are optional.
 
-In addition to the [common parameters]({{site.url}}{{site.baseurl}}/api-reference/cat/index), you can specify the following parameters:
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
 
-Parameter | Type | Description
-:--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+<!-- spec_insert_end -->
 
-## Example requests
+## Example request
 
 The following example request lists all installed plugins:
 

--- a/_api-reference/cat/cat-recovery.md
+++ b/_api-reference/cat/cat-recovery.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT recovery
 parent: CAT API
-
 nav_order: 50
 has_children: false
 redirect_from:
@@ -16,20 +15,41 @@ redirect_from:
 The CAT recovery operation lists all completed and ongoing index and shard recoveries.
 
 
+<!-- spec_insert_start
+api: cat.recovery
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/recovery
+GET /_cat/recovery
+GET /_cat/recovery/{index}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.recovery
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-active_only | Boolean | Whether to only include ongoing shard recoveries. Default is `false`.
-bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-detailed | Boolean | Whether to include detailed information about shard recoveries. Default is `false`.
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `active_only` | Boolean | If `true`, the response only includes ongoing shard recoveries. | `false` |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `detailed` | Boolean | When `true`, includes detailed information about shard recoveries. | `false` |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/). <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/_api-reference/cat/cat-repositories.md
+++ b/_api-reference/cat/cat-repositories.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT repositories
 parent: CAT API
-
 nav_order: 52
 has_children: false
 redirect_from:
@@ -15,19 +14,38 @@ redirect_from:
 
 The CAT repositories operation lists all snapshot repositories for a cluster.
 
+<!-- spec_insert_start
+api: cat.repositories
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/repositories
+GET /_cat/repositories
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.repositories
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
+The following table lists the available query parameters. All query parameters are optional.
 
-Parameter | Type | Description
-:--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example request
 

--- a/_api-reference/cat/cat-segment-replication.md
+++ b/_api-reference/cat/cat-segment-replication.md
@@ -15,12 +15,64 @@ The CAT segment replication operation returns information about active and last 
 Call the CAT Segment Replication API only on indexes with segment replication enabled.
 {: .note}
 
+<!-- spec_insert_start
+api: cat.segment_replication
+component: endpoints
+-->
 ## Endpoints
-
 ```json
 GET /_cat/segment_replication
-GET /_cat/segment_replication/<index>
+GET /_cat/segment_replication/{index}
 ```
+<!-- spec_insert_end -->
+
+<!-- spec_insert_start
+api: cat.segment_replication
+component: path_parameters
+columns: Parameter, Data type, Description
+include_deprecated: false
+-->
+## Path parameters
+
+The following table lists the available path parameters. All path parameters are optional.
+
+| Parameter | Data type | Description |
+| :--- | :--- | :--- |
+| `index` | List | A comma-separated list of data streams, indexes, and aliases used to limit the request. Supports wildcards (`*`). To target all data streams and indexes, omit this parameter or use `*` or `_all`. |
+
+<!-- spec_insert_end -->
+
+
+<!-- spec_insert_start
+api: cat.segment_replication
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
+## Query parameters
+
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `active_only` | Boolean | When `true`, the response only includes ongoing segment replication events. | `false` |
+| `allow_no_indices` | Boolean | Whether to ignore the index if a wildcard index expression resolves to no concrete indexes. This includes the `_all` string or when no indexes have been specified. | N/A |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `completed_only` | Boolean | When `true`, the response only includes the last-completed segment replication events. | `false` |
+| `detailed` | Boolean | When `true`, the response includes additional metrics for each stage of a segment replication event. | `false` |
+| `expand_wildcards` | List or String | Specifies the type of index that wildcard expressions can match. Supports comma-separated values. <br> Valid values are: <br> - `all`: Match any index, including hidden ones. <br> - `closed`: Match closed, non-hidden indexes. <br> - `hidden`: Match hidden indexes. Must be combined with open, closed, or both. <br> - `none`: Wildcard expressions are not accepted. <br> - `open`: Match open, non-hidden indexes. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `ignore_throttled` | Boolean | Whether specified concrete, expanded, or aliased indexes should be ignored when throttled. | N/A |
+| `ignore_unavailable` | Boolean | Whether the specified concrete indexes should be ignored when missing or closed. | N/A |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `shards` | List | A comma-separated list of shards to display. | N/A |
+| `time` | String | Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/). <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `timeout` | String | The operation timeout. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Path parameters
 

--- a/_api-reference/cat/cat-segments.md
+++ b/_api-reference/cat/cat-segments.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT segments
 parent: CAT API
-
 nav_order: 55
 has_children: false
 redirect_from:
@@ -16,18 +15,39 @@ redirect_from:
 The cat segments operation lists Lucene segment-level information for each index.
 
 
+<!-- spec_insert_start
+api: cat.segments
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/segments
+GET /_cat/segments
+GET /_cat/segments/{index}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.segments
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/)..
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/_api-reference/cat/cat-shards.md
+++ b/_api-reference/cat/cat-shards.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT shards
 parent: CAT API
-
 nav_order: 60
 has_children: false
 redirect_from:
@@ -16,25 +15,41 @@ redirect_from:
 The CAT shards operation lists the state of all primary and replica shards and how they are distributed.
 
 
+<!-- spec_insert_start
+api: cat.shards
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/shards
+GET /_cat/shards
+GET /_cat/shards/{index}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.shards
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-All parameters are optional.
+The following table lists the available query parameters. All query parameters are optional.
 
-In addition to the [common parameters]({{site.url}}{{site.baseurl}}/api-reference/cat/index), you can specify the following parameters:
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `bytes` | String | The units used to display byte values. <br> Valid values are: `b`, `kb`, `k`, `mb`, `m`, `gb`, `g`, `tb`, `t`, `pb`, `p` | N/A |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/). <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
 
-Parameter | Type | Description
-:--- | :--- | :---
-bytes | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
-cancel_after_time_interval | Time | The amount of time after which the shard request will be canceled. Default is `-1`.
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/_api-reference/cat/cat-snapshots.md
+++ b/_api-reference/cat/cat-snapshots.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT snapshots
 parent: CAT API
-
 nav_order: 65
 has_children: false
 redirect_from:
@@ -16,18 +15,40 @@ redirect_from:
 The CAT snapshots operation lists all snapshots for a repository.
 
 
+<!-- spec_insert_start
+api: cat.snapshots
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/snapshots
+GET /_cat/snapshots
+GET /_cat/snapshots/{repository}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.snapshots
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `ignore_unavailable` | Boolean | When `true`, the response does not include information from unavailable snapshots. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/). <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example request
 

--- a/_api-reference/cat/cat-tasks.md
+++ b/_api-reference/cat/cat-tasks.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT tasks
 parent: CAT API
-
 nav_order: 70
 has_children: false
 redirect_from:
@@ -15,20 +14,41 @@ redirect_from:
 
 The CAT tasks operation lists the progress of all tasks currently running on your cluster.
 
+<!-- spec_insert_start
+api: cat.tasks
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/tasks
+GET /_cat/tasks
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.tasks
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-nodes | List | A comma-separated list of node IDs or names to limit the returned information. Use `_local` to return information from the node you're connecting to, specify the node name to get information from specific nodes, or keep the parameter empty to get information from all nodes.
-detailed | Boolean | Returns detailed task information. (Default: false)
-parent_task_id | String | Returns tasks with a specified parent task ID (node_id:task_number). Keep empty or set to -1 to return all.
-time | Time | Specify the units for time. For example, `5d` or `7h`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `actions` | List | The task action names used to limit the response. | N/A |
+| `detailed` | Boolean | If `true`, the response includes detailed information about shard recoveries. | `false` |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `nodes` | List | A comma-separated list of node IDs or names used to limit the returned information.  Use `_local` to return information from the node to which you're connecting, specify a specific node from which to get information, or keep the parameter empty to get information from all nodes. | N/A |
+| `parent_task_id` | String | The parent task identifier, which is used to limit the response. | N/A |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `time` | String | Specifies the time units, for example, `5d` or `7h`. For more information, see [Supported units](https://opensearch.org/docs/latest/api-reference/units/). <br> Valid values are: `nanos`, `micros`, `ms`, `s`, `m`, `h`, `d` | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example request
 

--- a/_api-reference/cat/cat-templates.md
+++ b/_api-reference/cat/cat-templates.md
@@ -2,7 +2,6 @@
 layout: default
 title: CAT templates
 parent: CAT API
-
 nav_order: 70
 has_children: false
 redirect_from:
@@ -16,18 +15,39 @@ redirect_from:
 The CAT templates operation lists the names, patterns, order numbers, and version numbers of index templates.
 
 
+<!-- spec_insert_start
+api: cat.templates
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/templates
+GET /_cat/templates
+GET /_cat/templates/{name}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.templates
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | The amount of time allowed to establish a connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/_api-reference/cat/cat-thread-pool.md
+++ b/_api-reference/cat/cat-thread-pool.md
@@ -15,18 +15,40 @@ redirect_from:
 The CAT thread pool operation lists the active, queued, and rejected threads of different thread pools on each node.
 
 
+<!-- spec_insert_start
+api: cat.thread_pool
+component: endpoints
+-->
 ## Endpoints
-
 ```json
-GET _cat/thread_pool
+GET /_cat/thread_pool
+GET /_cat/thread_pool/{thread_pool_patterns}
 ```
+<!-- spec_insert_end -->
 
+
+<!-- spec_insert_start
+api: cat.thread_pool
+component: query_parameters
+columns: Parameter, Data type, Description, Default
+include_deprecated: false
+-->
 ## Query parameters
 
-Parameter | Type | Description
-:--- | :--- | :---
-local | Boolean | Whether to return information from the local node only instead of from the cluster manager node. Default is `false`.
-cluster_manager_timeout | Time | The amount of time to wait for a connection to the cluster manager node. Default is 30 seconds.
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description | Default |
+| :--- | :--- | :--- | :--- |
+| `cluster_manager_timeout` | String | A timeout for connection to the cluster manager node. | N/A |
+| `format` | String | A short version of the `Accept` header, such as `json` or `yaml`. | N/A |
+| `h` | List | A comma-separated list of column names to display. | N/A |
+| `help` | Boolean | Returns help information. | `false` |
+| `local` | Boolean | Returns local information but does not retrieve the state from the cluster manager node. | `false` |
+| `s` | List | A comma-separated list of column names or column aliases to sort by. | N/A |
+| `size` | Integer | The multiplier in which to display values. | N/A |
+| `v` | Boolean | Enables verbose mode, which displays column headers. | `false` |
+
+<!-- spec_insert_end -->
 
 ## Example requests
 

--- a/spec-insert/lib/renderers/parameter_table_renderer.rb
+++ b/spec-insert/lib/renderers/parameter_table_renderer.rb
@@ -1,0 +1,98 @@
+# frozen_string_literal: true
+
+require_relative 'table_renderer'
+require_relative '../config'
+
+# Renders a table of parameters of an API action
+class ParameterTableRenderer
+  COLUMNS = ['Parameter', 'Description', 'Required', 'Data type', 'Default'].freeze
+  DEFAULT_COLUMNS = ['Parameter', 'Data type', 'Description'].freeze
+
+  # @param [Array<Parameter>] parameters
+  # @param [InsertArguments] args
+  def initialize(parameters, args)
+    @config = CONFIG.param_table
+    @parameters = filter_parameters(parameters, args)
+    @columns = determine_columns(args)
+    @pretty = args.pretty
+  end
+
+  # @return [String]
+  def render
+    columns = @columns.map { |col| TableRenderer::Column.new(col, col) }
+    rows = @parameters.map { |arg| row(arg) }
+    TableRenderer.new(columns, rows, pretty: @pretty).render_lines.join("\n")
+  end
+
+  private
+
+  # @param [InsertArguments] args
+  def determine_columns(args)
+    if args.columns.present?
+      invalid = args.columns - COLUMNS
+      raise ArgumentError, "Invalid column(s): #{invalid.join(', ')}." unless invalid.empty?
+      return args.columns
+    end
+
+    required = @parameters.any?(&:required) ? 'Required' : nil
+    default = @parameters.any? { |p| p.default.present? } ? 'Default' : nil
+    ['Parameter', required, 'Data type', 'Description', default].compact
+  end
+
+  # @param [Array<Parameter>] parameters
+  # @param [InsertArguments] args
+  def filter_parameters(parameters, args)
+    parameters = parameters.reject(&:deprecated) unless args.include_deprecated
+    parameters.sort_by { |arg| [arg.required ? 0 : 1, arg.deprecated ? 1 : 0, arg.name] }
+  end
+
+  def row(param)
+    {
+      'Parameter' => "`#{param.name}`#{' <br> _DEPRECATED_' if param.deprecated}",
+      'Description' => description(param),
+      'Required' => param.required ? @config.required_column.true_text : @config.required_column.false_text,
+      'Data type' => param.doc_type,
+      'Default' => param.default.nil? ? @config.default_column.empty_text : "`#{param.default}`"
+    }
+  end
+
+  # @param [Parameter] param
+  def description(param)
+    deprecation = deprecation(param)
+    required = param.required && @columns.exclude?('Required') ? '**(Required)** ' : ''
+    description = param.description.gsub("\n", ' ')
+    valid_values = valid_values(param)
+    default = param.default.nil? || @columns.include?('Default') ? '' : " _(Default: `#{param.default}`)_"
+
+    "#{deprecation}#{required}#{description}#{default}#{valid_values}"
+  end
+
+  # @param [Parameter] param
+  def valid_values(param)
+    enums = extract_enum_values(param.schema)&.compact
+    return '' unless enums.present?
+    if enums.none? { |enum| enum[:description].present? }
+      " <br> Valid values are: #{enums.map { |enum| "`#{enum[:value]}`" }.join(', ')}"
+    else
+      " <br> Valid values are: <br> #{enums.map { |enum| "- `#{enum[:value]}`: #{enum[:description]}" }
+                                           .join(' <br> ')}"
+    end
+  end
+
+  # @param [SpecHash] schema
+  # @return [Hash]
+  def extract_enum_values(schema)
+    return schema.enum.map { |value| { value: } } if schema.enum.present?
+    if schema.const.present?
+      { value: schema.const, description: schema.description }
+    elsif schema.oneOf.present?
+      schema.oneOf.map { |sch| extract_enum_values(sch) }.flatten
+    end
+  end
+
+  def deprecation(param)
+    message = ": #{param.deprecation_message}" if param.deprecation_message.present?
+    since = " since #{param.version_deprecated}" if param.version_deprecated.present?
+    "_(Deprecated#{since}#{message})_ " if param.deprecated
+  end
+end

--- a/spec-insert/lib/renderers/table_renderer.rb
+++ b/spec-insert/lib/renderers/table_renderer.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+# TableRenderer renders a markdown table with the given columns and rows
+class TableRenderer
+  # Column object for rendering markdown tables
+  class Column
+    attr_reader :title, :key
+    attr_accessor :width
+
+    # @param [String] title display title
+    # @param [String | Symbol] key key to access in row hash
+    def initialize(title, key)
+      @title = title
+      @key = key
+      @width = 0
+    end
+  end
+
+  # @param [Array<Column>] columns
+  # @param [Array<Hash>] rows
+  # @param [Boolean] pretty whether to render a pretty table or a compact one
+  def initialize(columns, rows, pretty:)
+    @column = columns
+    @rows = rows
+    @pretty = pretty
+  end
+
+  # @return [Array<String>]
+  def render_lines
+    calculate_column_widths if @pretty
+    ['', render_column, render_divider] + render_rows + ['']
+  end
+
+  private
+
+  def calculate_column_widths
+    @column.each do |column|
+      column.width = [@rows.map { |row| row[column.key].to_s.length }.max || 0, column.title.length].max
+    end
+  end
+
+  def render_column
+    columns = @column.map { |column| column.title.ljust(column.width) }.join(' | ')
+    "| #{columns} |"
+  end
+
+  def render_divider
+    dividers = @column.map { |column| ":#{'-' * [column.width + 1, 3].max}" }
+    @pretty ? "|#{dividers.join('|')}|" : "| #{dividers.join(' | ')} |"
+  end
+
+  def render_rows
+    @rows.map do |row|
+      cells = @column.map { |column| row[column.key].to_s.ljust(column.width).gsub('|', '\|') }.join(' | ')
+      "| #{cells} |"
+    end
+  end
+end

--- a/spec-insert/lib/renderers/templates/path_parameters.mustache
+++ b/spec-insert/lib/renderers/templates/path_parameters.mustache
@@ -1,0 +1,6 @@
+{{^omit_header}}
+## Path parameters
+
+The following table lists the available path parameters.{{#optional}} All path parameters are optional.{{/optional}}
+{{/omit_header}}
+{{{table}}}

--- a/spec-insert/lib/renderers/templates/query_parameters.mustache
+++ b/spec-insert/lib/renderers/templates/query_parameters.mustache
@@ -1,0 +1,6 @@
+{{^omit_header}}
+## Query parameters
+
+The following table lists the available query parameters.{{#optional}} All query parameters are optional.{{/optional}}
+{{/omit_header}}
+{{{table}}}

--- a/spec-insert/spec/_fixtures/expected_output/param_tables.md
+++ b/spec-insert/spec/_fixtures/expected_output/param_tables.md
@@ -1,0 +1,74 @@
+Typical Path Parameters Example
+
+<!-- spec_insert_start
+api: search
+component: path_parameters
+-->
+## Path parameters
+
+The following table lists the available path parameters. All path parameters are optional.
+
+| Parameter | Data type | Description |
+| :--- | :--- | :--- |
+| `index` | List or String | Comma-separated list of data streams, indexes, and aliases to search. Supports wildcards (`*`). To search all data streams and indexes, omit this parameter or use `*` or `_all`. <br> Valid values are: `_all`, `_any`, `_none` |
+
+<!-- spec_insert_end -->
+
+Query Parameters Example with Global Parameters, Pretty Print, and Custom Columns
+
+<!-- spec_insert_start
+api: search
+component: query_parameters
+include_global: true
+pretty: true
+columns: Data type, Parameter, Description, Required, Default
+-->
+## Query parameters
+
+The following table lists the available query parameters.
+
+| Data type      | Parameter                 | Description                                                                                                                        | Required     | Default |
+|:---------------|:--------------------------|:-----------------------------------------------------------------------------------------------------------------------------------|:-------------|:--------|
+| Boolean        | `analyze_wildcard`        | If true, wildcard and prefix queries are analyzed. This parameter can only be used when the q query string parameter is specified. | **Required** | `false` |
+| String         | `analyzer`                | Analyzer to use for the query string. This parameter can only be used when the q query string parameter is specified.              | _Optional_   | N/A     |
+| List or String | `expand_wildcards`        | Comma-separated list of expand wildcard options. <br> Valid values are: `open`, `closed`, `none`, `all`                            | _Optional_   | N/A     |
+| Boolean        | `pretty`                  | Whether to pretty format the returned JSON response.                                                                               | _Optional_   | N/A     |
+| Boolean        | `human` <br> _DEPRECATED_ | _(Deprecated since 3.0: Use the `format` parameter instead.)_ Whether to return human readable values for statistics.              | _Optional_   | `true`  |
+
+<!-- spec_insert_end -->
+
+Query Parameters Example with only Parameter and Description Columns
+
+<!-- spec_insert_start
+api: search
+component: query_parameters
+columns: Parameter, Description
+omit_header: true
+-->
+
+| Parameter | Description |
+| :--- | :--- |
+| `analyze_wildcard` | **(Required)** If true, wildcard and prefix queries are analyzed. This parameter can only be used when the q query string parameter is specified. _(Default: `false`)_ |
+| `analyzer` | Analyzer to use for the query string. This parameter can only be used when the q query string parameter is specified. |
+| `expand_wildcards` | Comma-separated list of expand wildcard options. <br> Valid values are: `open`, `closed`, `none`, `all` |
+
+<!-- spec_insert_end -->
+
+Optional Params Text
+
+<!-- spec_insert_start
+api: cat.health
+component: query_parameters
+include_global: true
+-->
+## Query parameters
+
+The following table lists the available query parameters.
+
+| Parameter | Required | Data type | Description | Default |
+| :--- | :--- | :--- | :--- | :--- |
+| `expand_wildcard` | **Required** | String | Whether to expand wildcard expression to concrete indices that are open, closed, or both. <br> Valid values are: <br> - `open`: Expand wildcards to open indices only. <br> - `closed`: Expand wildcards to closed indices only. <br> - `none`: Do not expand wildcards. | N/A |
+| `pretty` | _Optional_ | Boolean | Whether to pretty format the returned JSON response. | N/A |
+| `human` <br> _DEPRECATED_ | _Optional_ | Boolean | _(Deprecated since 3.0: Use the `format` parameter instead.)_ Whether to return human readable values for statistics. | `true` |
+
+<!-- spec_insert_end -->


### PR DESCRIPTION
* Add CAT API automation

Signed-off-by: Archer <naarcha@amazon.com>

* Add CAT API reference

Signed-off-by: Archer <naarcha@amazon.com>

* Update cat-pit-segments.md

Signed-off-by: Naarcha-AWS <97990722+Naarcha-AWS@users.noreply.github.com>

* Fix mustache template

Signed-off-by: Archer <naarcha@amazon.com>

* Fix table spacing

Signed-off-by: Archer <naarcha@amazon.com>

* Updated expected output

Signed-off-by: Archer <naarcha@amazon.com>

* Revert back to type

Signed-off-by: Archer <naarcha@amazon.com>

* Fix pretty test expected result

Signed-off-by: Archer <naarcha@amazon.com>

* Add updated tables.

Signed-off-by: Archer <naarcha@amazon.com>

* Add CAT API automation with updated spec-insert

Signed-off-by: Archer <naarcha@amazon.com>

* Add updated CAT API tables

Signed-off-by: Archer <naarcha@amazon.com>

* See if an extra space will fix the table.

Signed-off-by: Archer <naarcha@amazon.com>

* Update mustache template to add spaces

Signed-off-by: Archer <naarcha@amazon.com>

* Mustache template update

Signed-off-by: Archer <naarcha@amazon.com>

* Update expected output.

Signed-off-by: Archer <naarcha@amazon.com>

* Add lines to renderer.

Signed-off-by: Archer <naarcha@amazon.com>

* Add new lines

Signed-off-by: Archer <naarcha@amazon.com>

* Try another way

Signed-off-by: Archer <naarcha@amazon.com>

* Fix mustache spec

Signed-off-by: Archer <naarcha@amazon.com>

* Add line breaks correctly.

Signed-off-by: Archer <naarcha@amazon.com>

* Update endpoint expected output.

Signed-off-by: Archer <naarcha@amazon.com>

* Fix renderer spacing. Fix tests.

Signed-off-by: Archer <naarcha@amazon.com>

* Fix expected output.

Signed-off-by: Archer <naarcha@amazon.com>

* Fix table

Signed-off-by: Archer <naarcha@amazon.com>

* Update expected results

Signed-off-by: Archer <naarcha@amazon.com>

* Fix output, again.

Signed-off-by: Archer <naarcha@amazon.com>

* Add another test

Signed-off-by: Archer <naarcha@amazon.com>

* Theoretically the correct spacing.

Signed-off-by: Archer <naarcha@amazon.com>

* Add Theo's suggestions

Signed-off-by: Archer <naarcha@amazon.com>

* Fix BR tags

Signed-off-by: Archer <naarcha@amazon.com>

* Fix expected output.

Signed-off-by: Archer <naarcha@amazon.com>

* Make wildcard defintion consistent.

Signed-off-by: Archer <naarcha@amazon.com>

---------

Signed-off-by: Archer <naarcha@amazon.com>
Signed-off-by: Naarcha-AWS <97990722+Naarcha-AWS@users.noreply.github.com>
(cherry picked from commit 0713861ee2c33b642d4966c591e72a0576781095)

### Description
_Describe what this change achieves._

### Issues Resolved
Closes #[_insert issue number_]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
