### PR TITLE
Update pipeline.md - Source mistakenly described as sink

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sources/pipeline.md
@@ -12,7 +12,7 @@ Use the `pipeline` sink to read from another pipeline.
 
 ## Configuration options
 
-The `pipeline` sink supports the following configuration options.
+The `pipeline` source supports the following configuration options.
 
 | Option | Required | Type   | Description                            |
 |:-------|:---------|:-------|:---------------------------------------|


### PR DESCRIPTION
### Description
The page describes the pipeline source as a sink by error

### Issues Resolved
N/A

### Version
N/A

### Frontend features
N/A 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
