### PR TITLE
Add a case-sensitive substitution error rule to Vale

### DIFF
--- a/.github/vale/styles/OpenSearch/SubstitutionErroCaseSensitive.yml
+++ b/.github/vale/styles/OpenSearch/SubstitutionErroCaseSensitive.yml
@@ -1,0 +1,8 @@
+extends: substitution
+message: "Use '%s' instead of '%s'. Note the correct capitalization."
+ignorecase: false
+level: error
+action:
+  name: replace
+swap:
+  'Retrieval-Augmented Generation': retrieval-augmented generation

--- a/.github/vale/tests/test-style-pos.md
+++ b/.github/vale/tests/test-style-pos.md
@@ -76,6 +76,8 @@ This sentence tests splling.
 
 This sentence tests substitution error by using the word indices.
 
+This sentence tests substitution case-sensitive error by using the word Retrieval-Augmented Generation.
+
 This sentence tests substitution suggestion due to its nature.
 
 This Table | tests capitalization

--- a/.vale.ini
+++ b/.vale.ini
@@ -61,6 +61,7 @@ OpenSearch.SpacingSlash = YES
 OpenSearch.SpacingWords = YES
 OpenSearch.Spelling = YES
 OpenSearch.StackedHeadings = YES
+OpenSearch.SubstitutionsErrorCaseSensitive = YES
 OpenSearch.SubstitutionsError = YES
 OpenSearch.SubstitutionsSuggestion = YES
 OpenSearch.TableHeadings = YES


### PR DESCRIPTION
Adds  a case-sensitive substitution error rule to Vale

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
