### PR TITLE
Replace Ubuntu 20.04 with Ubuntu 24.04 as it will be deprecated soon

### DIFF
--- a/_install-and-configure/os-comp.md
+++ b/_install-and-configure/os-comp.md
@@ -27,7 +27,7 @@ The following table lists changes made to operating system compatibility.
 
 | Date       | Issue | PR | Details |
 |:-----------|:-------|:-------|:--------------------------|
-| 2025-02-06 | [opensearch-build Issue 5270](https://github.com/opensearch-project/opensearch-build/issues/5270) | [PR]() | Remove [Ubuntu 20.04](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare) |
+| 2025-02-06 | [opensearch-build Issue 5270](https://github.com/opensearch-project/opensearch-build/issues/5270) | [PR 9165](https://github.com/opensearch-project/documentation-website/pull/9165) | Remove [Ubuntu 20.04](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare) |
 | 2024-07-23 | [opensearch-build Issue 4379](https://github.com/opensearch-project/opensearch-build/issues/4379) | [PR 7821](https://github.com/opensearch-project/documentation-website/pull/7821) | Remove [CentOS7](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/) |
 | 2024-03-08 | [opensearch-build Issue 4573](https://github.com/opensearch-project/opensearch-build/issues/4573) | [PR 6637](https://github.com/opensearch-project/documentation-website/pull/6637) | Remove CentOS8, add Almalinux8/Rockylinux8, and remove Ubuntu 16.04/18.04 because we currently only test on 20.04 |
 | 2023-06-06 | [documentation-website Issue 4217](https://github.com/opensearch-project/documentation-website/issues/4217) | [PR 4218](https://github.com/opensearch-project/documentation-website/pull/4218) | Support matrix creation |

--- a/_install-and-configure/os-comp.md
+++ b/_install-and-configure/os-comp.md
@@ -15,7 +15,7 @@ OS | Version
 Rocky Linux | 8
 Alma Linux | 8
 Amazon Linux | 2/2023
-Ubuntu | 20.04
+Ubuntu | 24.04
 Windows Server | 2019
 
 
@@ -27,6 +27,7 @@ The following table lists changes made to operating system compatibility.
 
 | Date       | Issue | PR | Details |
 |:-----------|:-------|:-------|:--------------------------|
-| 2024-07-23 | [opensearch-build Issue 4379](https://github.com/opensearch-project/opensearch-build/issues/4379) | [PR 7821](https://github.com/opensearch-project/documentation-website/pull/7821) | Remove [CentOS7](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/). |
+| 2025-02-06 | [opensearch-build Issue 5270](https://github.com/opensearch-project/opensearch-build/issues/5270) | [PR]() | Remove [Ubuntu 20.04](https://ubuntu.com/blog/ubuntu-20-04-lts-end-of-life-standard-support-is-coming-to-an-end-heres-how-to-prepare) |
+| 2024-07-23 | [opensearch-build Issue 4379](https://github.com/opensearch-project/opensearch-build/issues/4379) | [PR 7821](https://github.com/opensearch-project/documentation-website/pull/7821) | Remove [CentOS7](https://blog.centos.org/2023/04/end-dates-are-coming-for-centos-stream-8-and-centos-linux-7/) |
 | 2024-03-08 | [opensearch-build Issue 4573](https://github.com/opensearch-project/opensearch-build/issues/4573) | [PR 6637](https://github.com/opensearch-project/documentation-website/pull/6637) | Remove CentOS8, add Almalinux8/Rockylinux8, and remove Ubuntu 16.04/18.04 because we currently only test on 20.04 |
 | 2023-06-06 | [documentation-website Issue 4217](https://github.com/opensearch-project/documentation-website/issues/4217) | [PR 4218](https://github.com/opensearch-project/documentation-website/pull/4218) | Support matrix creation |


### PR DESCRIPTION
### Description
Replace Ubuntu 20.04 with Ubuntu 24.04 as it will be deprecated soon

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-build/issues/5270

### Version
2.19.2 (NOT 2.19.0 or 2.19.1)
We will add a proper deprecation notice in 2.19.0 release highlights and blog soon.
The docs website will be updated by 2.19.2.

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
