### PR TITLE
Add warning about case insensitive term queries in 2.x

### DIFF
--- a/_query-dsl/term/term.md
+++ b/_query-dsl/term/term.md
@@ -42,6 +42,9 @@ GET shakespeare/_search
 ```
 {% include copy-curl.html %}
 
+In OpenSearch 2.x and previous versions, every (alphabetic) character in such a query doubles the complexity of the search, consuming heap memory and potentially crashing nodes due to high CPU with GC thrashing. Even a relatively short search term (about 16 characters) could result in nearly 8 GB of heap. Case-insensitive searches should be avoided by using a [lowercase token filter]({{site.url}}{{site.baseurl}}/analyzers/token-filters/lowercase/) on the indexed field's analyzer, and then using lowercase query terms instead of relying on case-insensitive searches.
+{: .warning}
+
 The response contains the matching documents despite any differences in case:
 
 ```json


### PR DESCRIPTION
### Description

Adds a warning about the potential performance impacts of `case_insensitive` term queries.

### Issues Resolved
Closes #9028

### Version
All versions 2.x and prior

NOTE: no code changes were made in 2.19 and this isn't critical to go out with ongoing 2.19 release, but would be helpful to add to current documentation. It will be fixed in 3.0.0.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
