### PR TITLE
float and double field type don’t accept special values like NaN nor Infinity

### DIFF
--- a/_field-types/index.md
+++ b/_field-types/index.md
@@ -28,8 +28,8 @@ Type | Description
 :--- | :---
 `null` | A `null` field can't be indexed or searched. When a field is set to null, OpenSearch behaves as if the field has no value.
 `boolean` | OpenSearch accepts `true` and `false` as Boolean values. An empty string is equal to `false.`
-`float` | A single-precision, 32-bit floating-point number.
-`double` | A double-precision, 64-bit floating-point number.
+`float` | A single-precision, 32-bit IEEE 754 floating-point number, restricted to finite values.
+`double` | A double-precision, 64-bit IEEE 754 floating-point number, restricted to finite values.
 `integer` | A signed 32-bit number.
 `object` | Objects are standard JSON objects, which can have fields and mappings of their own. For example, a `movies` object can have additional properties such as `title`, `year`, and `director`.
 `array` | OpenSearch does not have a specific array data type. Arrays are represented as a set of values of the same data type (for example, integers or strings) associated with a field. When indexing, you can pass multiple values for a field, and OpenSearch will treat it as an array. Empty arrays are valid and recognized as array fields with zero elements---not as fields with no values. OpenSearch supports querying and filtering arrays, including checking for values, range queries, and array operations like concatenation and intersection. Nested arrays, which may contain complex objects or other arrays, can also be used for advanced data modeling. 


### PR DESCRIPTION
### Description
According to [IEEE 754 floating point numbers support special values like NaN nor Infinity](https://en.wikipedia.org/wiki/Floating-point_arithmetic#IEEE_754:_floating_point_in_modern_computers). OpenSearch does not support them. This change adds this restriction to the documentation for the supported datatypes.

Note that this restriction should also apply to half_float but this is not explicitly documented.

https://github.com/elastic/elasticsearch/issues/27653

This change was still done under [Apache-2.0](https://github.com/cbuescher/elasticsearch/blob/2d7f0089ee3a924156905aaeedde5c50bc50ec2d/LICENSE.txt) so copy-paste should be no issue.

### Issues Resolved

I did not find open issues about that, neither in https://github.com/opensearch-project/documentation-website nor https://github.com/opensearch-project/OpenSearch.

### Version
All supported (I guess).

### Frontend features
Backend change.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).