### PR TITLE
Add blog post link to score ranker processor for hybrid search

### DIFF
--- a/_search-plugins/search-pipelines/score-ranker-processor.md
+++ b/_search-plugins/search-pipelines/score-ranker-processor.md
@@ -68,3 +68,5 @@ PUT /_search/pipeline/<rrf-pipeline>
 ```
 
 For more information about setting up hybrid search, see [Using hybrid search]({{site.url}}{{site.baseurl}}/search-plugins/hybrid-search/#using-hybrid-search).
+
+For a detailed exploration of the Score Ranker processor and Reciprocal Rank Fusion (RRF), including experimental data and practical use cases, check out our blog post: [Introducing Reciprocal Rank Fusion for hybrid search in OpenSearch](https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/). The blog post provides examples, performance comparisons, and insights into how RRF can improve search relevancy in various scenarios.

--- a/_search-plugins/search-pipelines/score-ranker-processor.md
+++ b/_search-plugins/search-pipelines/score-ranker-processor.md
@@ -69,4 +69,6 @@ PUT /_search/pipeline/<rrf-pipeline>
 
 For more information about setting up hybrid search, see [Using hybrid search]({{site.url}}{{site.baseurl}}/search-plugins/hybrid-search/#using-hybrid-search).
 
-For a detailed exploration of the Score Ranker processor and Reciprocal Rank Fusion (RRF), including experimental data and practical use cases, check out our blog post: [Introducing Reciprocal Rank Fusion for hybrid search in OpenSearch](https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/). The blog post provides examples, performance comparisons, and insights into how RRF can improve search relevancy in various scenarios.
+## Next steps
+
+- For a detailed exploration of the `score-ranker-processor` and RRF, including experimental data and practical use cases, see [this blog post](https://opensearch.org/blog/introducing-reciprocal-rank-fusion-hybrid-search/). The blog post provides examples, performance comparisons, and insights into how RRF can improve search relevance in various scenarios.


### PR DESCRIPTION
### Description
Adds a blog post link to more information and examples to the score ranker processor documentation

### Version
2.19 (Score ranker processor just released with 2.19)

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
