### PR TITLE
Update docker compose commands to docker commands

### DIFF
--- a/_getting-started/quickstart.md
+++ b/_getting-started/quickstart.md
@@ -14,8 +14,6 @@ To quickly get started using OpenSearch and OpenSearch Dashboards, deploy your c
 
 Before proceeding, you need to install [Docker](https://docs.docker.com/get-docker/) and [Docker Compose](https://github.com/docker/compose) on your local machine. 
 
-The Docker Compose commands used in this guide are written with a hyphen (for example, `docker-compose`). If you installed Docker Desktop on your machine, which automatically installs a bundled version of Docker Compose, then you should remove the hyphen. For example, change `docker-compose` to `docker compose`.
-{: .note}
 
 ## Starting your cluster
 
@@ -72,14 +70,14 @@ You'll need a special file, called a Compose file, that Docker Compose uses to d
 1. In your terminal application, navigate to the directory containing the `docker-compose.yml` file you downloaded, [set up a custom admin password]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/docker/#setting-a-custom-admin-password), and run the following command to create and start the cluster as a background process:
     
     ```bash
-    docker-compose up -d
+    docker compose up -d
     ```
     {% include copy.html %}
 
-1. Confirm that the containers are running with the command `docker-compose ps`. You should see an output like the following:
+1. Confirm that the containers are running with the command `docker compose ps`. You should see an output like the following:
 
     ```bash
-    $ docker-compose ps
+    $ docker compose ps
     NAME                    COMMAND                  SERVICE                 STATUS              PORTS
     opensearch-dashboards   "./opensearch-dashbo…"   opensearch-dashboards   running             0.0.0.0:5601->5601/tcp
     opensearch-node1        "./opensearch-docker…"   opensearch-node1        running             0.0.0.0:9200->9200/tcp, 9300/tcp, 0.0.0.0:9600->9600/tcp, 9650/tcp

--- a/_install-and-configure/install-dashboards/docker.md
+++ b/_install-and-configure/install-dashboards/docker.md
@@ -19,8 +19,8 @@ You *can* start OpenSearch Dashboards using `docker run` after [creating a Docke
    Just like `opensearch.yml`, you can pass a custom `opensearch_dashboards.yml` to the container in the Docker Compose file.
    {: .tip }
 
-1. Run `docker-compose up`.
+1. Run `docker compose up`.
 
    Wait for the containers to start. Then see the [OpenSearch Dashboards documentation]({{site.url}}{{site.baseurl}}/dashboards/index/).
 
-1. When finished, run `docker-compose down`.
+1. When finished, run `docker compose down`.

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -161,7 +161,7 @@ If none of those files exist in your current directory, the `docker-compose` com
 You can specify a custom file location and name when invoking `docker-compose` with the `-f` flag:
 ```bash
 # Use a relative or absolute path to the file.
-docker-compose -f /path/to/your-file.yml up
+docker compose -f /path/to/your-file.yml up
 ```
 
 If this is your first time launching an OpenSearch cluster using Docker Compose, use the following example `docker-compose.yml` file. Save it in the home directory of your host and name it `docker-compose.yml`. This file creates a cluster that contains three containers: two containers running the OpenSearch service and a single container running OpenSearch Dashboards. These containers communicate over a bridge network called `opensearch-net` and use two volumes, one for each OpenSearch node. Because this file does not explicitly disable the demo security configuration, self-signed TLS certificates are installed and internal users with default names and passwords are created.
@@ -256,20 +256,20 @@ If you override `opensearch_dashboards.yml` settings using environment variables
 
 From the home directory of your host (containing `docker-compose.yml`), create and start the containers in detached mode:
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 {% include copy.html %}
 
 Verify that the service containers started correctly:
 ```bash
-docker-compose ps
+docker compose ps
 ```
 {% include copy.html %}
 
 If a container failed to start, you can review the service logs:
 ```bash
-# If you don't pass a service name, docker-compose will show you logs from all of the nodes
-docker-compose logs <serviceName>
+# If you don't pass a service name, docker compose will show you logs from all of the nodes
+docker compose logs <serviceName>
 ```
 {% include copy.html %}
 
@@ -280,11 +280,11 @@ Remember that `localhost` cannot be accessed remotely. If you are deploying thes
 
 Stop the running containers in your cluster:
 ```bash
-docker-compose down
+docker compose down
 ```
 {% include copy.html %}
 
-`docker-compose down` will stop the running containers, but it will not remove the Docker volumes that exist on the host. If you don't care about the contents of these volumes, use the `-v` option to delete all volumes, for example, `docker-compose down -v`.
+`docker compose down` will stop the running containers, but it will not remove the Docker volumes that exist on the host. If you don't care about the contents of these volumes, use the `-v` option to delete all volumes, for example, `docker compose down -v`.
 {: .tip}
 
 ## Configure OpenSearch
@@ -476,7 +476,7 @@ Use the same process to specify a [Backend configuration]({{site.url}}{{site.bas
 
 After replacing the certificates and creating your own internal users, roles, mappings, action groups, and tenants, use Docker Compose to start the cluster:
 ```bash
-docker-compose up -d
+docker compose up -d
 ```
 {% include copy.html %}
 

--- a/_observing-your-data/log-ingestion.md
+++ b/_observing-your-data/log-ingestion.md
@@ -37,7 +37,7 @@ Download or clone the [Data Prepper repository](https://github.com/opensearch-pr
 - A single-node OpenSearch cluster (`opensearch`)
 - OpenSearch Dashboards (`opensearch-dashboards`).
 
-Close the file and run `docker-compose up --build` to start the containers.
+Close the file and run `docker compose up --build` to start the containers.
 
 After the containers start, your ingestion pipeline is set up and ready to ingest log data. The `fluent-bit` container is configured to read log data from `test.log`. Run the following command to generate log data to send to the log ingestion pipeline.
 

--- a/_observing-your-data/trace/getting-started.md
+++ b/_observing-your-data/trace/getting-started.md
@@ -38,7 +38,7 @@ Download or clone the [Data Prepper repository](https://github.com/opensearch-pr
 - A single-node OpenSearch cluster (`opensearch`)
 - OpenSearch Dashboards (`opensearch-dashboards`).
 
-Close the file and run `docker-compose up --build`. After the containers start, navigate to `http://localhost:8080` in a web browser.
+Close the file and run `docker compose up --build`. After the containers start, navigate to `http://localhost:8080` in a web browser.
 
 ![HotROD web interface]({{site.url}}{{site.baseurl}}/images/hot-rod.png)
 

--- a/_search-plugins/cross-cluster-search.md
+++ b/_search-plugins/cross-cluster-search.md
@@ -61,7 +61,7 @@ humanresources:
 
 ## Sample Docker setup
 
-To define Docker permissions, save the following sample file as `docker-compose.yml` and run `docker-compose up` to start two single-node clusters on the same network:
+To define Docker permissions, save the following sample file as `docker-compose.yml` and run `docker compose up` to start two single-node clusters on the same network:
 
 ```yml
 version: '3'

--- a/_security/authentication-backends/ldap.md
+++ b/_security/authentication-backends/ldap.md
@@ -21,7 +21,7 @@ We provide a fully functional example that can help you understand how to use an
 
 1. Download and unzip [the example zip file]({{site.url}}{{site.baseurl}}/assets/examples/ldap-example-v2.13.zip).
 1. Update the `.env` file with a strong password for `admin` user.
-1. At the command line, run `docker-compose up`.
+1. At the command line, run `docker compose up`.
 1. Review the files:
 
    * `docker-compose.yml` defines a single OpenSearch node, an LDAP server, and a PHP administration tool for the LDAP server.

--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -427,7 +427,7 @@ The following steps use Docker and [Keycloak IdP](https://www.keycloak.org/) to 
   - `new-realm.json` specifies the details of the [realm](https://www.keycloak.org/docs/latest/server_admin/#core-concepts-and-terms). In this example, the realm is named `new`.
   - `config.yml` configures `basic_internal_auth_domain` and `oidc_auth_domain`.
   - `opensearch_dashboards.yml` should point to Keycloak for authentication. Make sure that the `opensearch_security.openid.connect_url` setting points to the URL of the realm.
-5. At the command line, run `docker-compose up`.
+5. At the command line, run `docker compose up`.
 6. Access OpenSearch Dashboards at `http://localhost:5601` and log in with username `testuser` and password `testpassword` configured in the `new-realm.json` file. 
 
 After logging in, the `testuser` receives the backend role `admin` from Keycloak, which is mapped to the `all_access` OpenSearch role. These backend roles can be managed using the Keycloak Administrative Console at http://localhost:8080, using username `admin` and password `admin`.

--- a/_security/authentication-backends/saml.md
+++ b/_security/authentication-backends/saml.md
@@ -38,7 +38,7 @@ We provide a fully functional example that can help you understand how to use SA
 
 1. From the command line, run:
    ```zsh
-   $ docker-compose up.
+   $ docker compose up.
    ```
 
 1. Access OpenSearch Dashboards at [http://localhost:5601](http://localhost:5601){:target='\_blank'}.

--- a/_security/configuration/demo-configuration.md
+++ b/_security/configuration/demo-configuration.md
@@ -29,7 +29,7 @@ Use the following steps to set up the Security plugin using Docker:
 2. Run the following command:
 
 ```bash
-docker-compose up
+docker compose up
 ```
 {% include copy.html %}
 
@@ -49,7 +49,7 @@ If you want to disable the Security plugin when using Docker, set the `DISABLE_S
    - One special character
 
 4. Make sure that Docker is running on your local machine
-5. Run `docker-compose up` from the file directory where your `docker-compose.yml` file and `.env` file are located.
+5. Run `docker compose up` from the file directory where your `docker-compose.yml` file and `.env` file are located.
 
 ### TAR (Linux) and Mac OS 
 

--- a/_security/configuration/disable-enable-security.md
+++ b/_security/configuration/disable-enable-security.md
@@ -96,7 +96,7 @@ Refer to the following installation types to remove the OpenSearch Dashboards pl
 
 1. In `docker-compose.yml`, change `opensearchproject/opensearch-dashboards:{{site.opensearch_dashboards_version}}` to `opensearch-dashboards-no-security`.
 1. Change `OPENSEARCH_HOSTS` or `opensearch.hosts` to `http://` rather than `https://`.
-1. Enter `docker-compose up`.
+1. Enter `docker compose up`.
 
 #### Tarball 
 

--- a/_tuning-your-cluster/replication-plugin/getting-started.md
+++ b/_tuning-your-cluster/replication-plugin/getting-started.md
@@ -55,7 +55,7 @@ plugins.security.nodes_dn:
   ```
 ## Example setup
 
-To start two single-node clusters on the same network, save this sample file as `docker-compose.yml` and run `docker-compose up`:
+To start two single-node clusters on the same network, save this sample file as `docker-compose.yml` and run `docker compose up`:
 
 ```yml
 version: '3'

--- a/_upgrade-to/docker-upgrade-to.md
+++ b/_upgrade-to/docker-upgrade-to.md
@@ -10,4 +10,4 @@ If you use a container orchestration system like Kubernetes (or manage your cont
 
 If you use Docker Compose, we highly recommend that you perform what amounts to a [cluster restart upgrade]({{site.url}}{{site.baseurl}}/upgrade-to/upgrade-to/). Update your cluster configuration with new images, new settings, and new environment variables, and test it. Then stop and start the cluster. This process requires downtime, but takes very few steps and lets you continue to treat the cluster as a single entity that you can reliably deploy and redeploy.
 
-The most important step is to leave your data volumes intact. **Don't** run `docker-compose down -v`.
+The most important step is to leave your data volumes intact. **Don't** run `docker compose down -v`.


### PR DESCRIPTION
Docker has moved the `docker-compose` binary into a subcommand of the `docker` command. This PR updates all references to `docker-compose` to `docker compose`.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
