### PR TITLE
Remove obsolete compose version specifier

### DIFF
--- a/assets/examples/docker-compose.yml
+++ b/assets/examples/docker-compose.yml
@@ -1,4 +1,3 @@
-version: '3'
 services:
   opensearch-node1: # This is also the hostname of the container within the Docker network (i.e. https://opensearch-node1/)
     image: opensearchproject/opensearch:latest

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -1,5 +1,3 @@
-version: "3"
-
 services:
   doc_builder:
     image: ruby:3.2.4


### PR DESCRIPTION
Hey @peterzhuamazon,

I should have kept this PR https://github.com/opensearch-project/documentation-website/pull/8606 in draft mode as I wasn't finished yet. Anyway, here is are two files I missed. 

This GitHub Code search yields many more across the [opensearch org](https://github.com/search?q=org%3Aopensearch-project++%28path%3A*.yml+OR+path%3A*.yaml%29+%2F%5Eversion%3A%5B%5Cs%5CS%5D%2Bservices%3A%2F&type=code)

I'd think the ones in the main project are definitely worth fixing, so I created this PR: https://github.com/opensearch-project/OpenSearch/pull/17382