### PR TITLE
Clarify fetch_size support for SQL

### DIFF
--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -26,7 +26,7 @@ Field | Data Type | Description
 :--- | :--- | :---
 query | String | The query to be executed. Required.
 [filter](#filtering-results) | JSON object | The filter for the results. Optional.
-[fetch_size](#paginating-results) | integer | The number of results to return in one response. Used for paginating results. Default is 1,000. Optional. Only supported for the `jdbc` response format.
+[fetch_size](#paginating-results) | integer | The number of results to return in one response. Used for paginating results. Default is 1,000. Optional. `fetch_size` is supported for SQL, and requires using the `jdbc` response format.
 
 #### Example request
 

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -26,7 +26,7 @@ Field | Data Type | Description
 :--- | :--- | :---
 query | String | The query to be executed. Required.
 [filter](#filtering-results) | JSON object | The filter for the results. Optional.
-[fetch_size](#paginating-results) | integer | The number of results to return in one response. Used for paginating results. Default is 1,000. Optional. `fetch_size` is supported for SQL, and requires using the `jdbc` response format.
+[fetch_size](#paginating-results) | integer | The number of results to return in one response. Used for paginating results. Default is 1,000. Optional. `fetch_size` is supported for SQL and requires using the `jdbc` response format.
 
 #### Example request
 


### PR DESCRIPTION
### Description
Per https://github.com/opensearch-project/sql/issues/3314, it's not clear from the documentation that `fetch_size` is only supported for SQL. This is due to restrictions with how our pagination engine is implemented. This is a one-liner clarification.

### Issues Resolved
Closes https://github.com/opensearch-project/sql/issues/3314

### Version
2.9+

### Frontend features
N/A

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
