### PR TITLE
Clarify how a boolean query's must_not works with multiple clauses

### DIFF
--- a/_query-dsl/compound/bool.md
+++ b/_query-dsl/compound/bool.md
@@ -18,7 +18,7 @@ Use the following query clauses within a `bool` query:
 Clause | Behavior
 :--- | :---
 `must` | Logical `and` operator. The results must match all queries in this clause. 
-`must_not` | Logical `not` operator. All matches are excluded from the results. If `must_not` has multiple clauses, only documents which match none of those clauses will be returned. For example, `"must_not":[{clause_A}, {clause_B}]` is equivalent to `NOT(A OR B)`. 
+`must_not` | Logical `not` operator. All matches are excluded from the results. If `must_not` has multiple clauses, only documents that do not match any of those clauses are returned. For example, `"must_not":[{clause_A}, {clause_B}]` is equivalent to `NOT(A OR B)`. 
 `should` | Logical `or` operator. The results must match at least one of the queries. Matching more `should` clauses increases the document's relevance score. You can set the minimum number of queries that must match using the [`minimum_should_match`]({{site.url}}{{site.baseurl}}/query-dsl/query-dsl/minimum-should-match/) parameter. If a query contains a `must` or `filter` clause, the default `minimum_should_match` value is 0. Otherwise, the default `minimum_should_match` value is 1.
 `filter` | Logical `and` operator that is applied first to reduce your dataset before applying the queries. A query within a filter clause is a yes or no option. If a document matches the query, it is returned in the results; otherwise, it is not. The results of a filter query are generally cached to allow for a faster return. Use the filter query to filter the results based on exact matches, ranges, dates, or numbers.
 

--- a/_query-dsl/compound/bool.md
+++ b/_query-dsl/compound/bool.md
@@ -18,7 +18,7 @@ Use the following query clauses within a `bool` query:
 Clause | Behavior
 :--- | :---
 `must` | Logical `and` operator. The results must match all queries in this clause. 
-`must_not` | Logical `not` operator. All matches are excluded from the results.
+`must_not` | Logical `not` operator. All matches are excluded from the results. If `must_not` has multiple clauses, only documents which match none of those clauses will be returned. For example, `"must_not":[{clause_A}, {clause_B}]` is equivalent to `NOT(A OR B)`. 
 `should` | Logical `or` operator. The results must match at least one of the queries. Matching more `should` clauses increases the document's relevance score. You can set the minimum number of queries that must match using the [`minimum_should_match`]({{site.url}}{{site.baseurl}}/query-dsl/query-dsl/minimum-should-match/) parameter. If a query contains a `must` or `filter` clause, the default `minimum_should_match` value is 0. Otherwise, the default `minimum_should_match` value is 1.
 `filter` | Logical `and` operator that is applied first to reduce your dataset before applying the queries. A query within a filter clause is a yes or no option. If a document matches the query, it is returned in the results; otherwise, it is not. The results of a filter query are generally cached to allow for a faster return. Use the filter query to filter the results based on exact matches, ranges, dates, or numbers.
 


### PR DESCRIPTION
### Description
When testing with boolean queries it wasn't clear to me whether `must_not` with multiple clauses `A` and `B` acted as `NOT(A OR B)` or `NOT(A AND B)`. Clarifies it's the former. 

### Issues Resolved
Did not raise an issue for this minor clarification

### Version
All

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
