### PR TITLE
Migration Assistant supports Elasticsearch 5.6

### DIFF
--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -18,6 +18,8 @@ There are also tools available for migrating cluster configuration, templates, a
 
 | **Source Version**          | **Target Version**               |
 |-----------------------------|----------------------------------|
+| Elasticsearch 5.6           | OpenSearch 1.3                   |
+| Elasticsearch 5.6           | OpenSearch 2.15                  |
 | Elasticsearch 6.8           | OpenSearch 1.3                   |
 | Elasticsearch 6.8           | OpenSearch 2.15                  |
 | Elasticsearch 7.10.2        | OpenSearch 1.3                   |


### PR DESCRIPTION
### Description
Migration Assistant recently added changes to support migrations from Elasticsearch 5.6 onto both OpenSearch 1.3 and OpenSearch 2.x versions.

### Issues Resolved
- Resolves [MIGRATIONS-2428 | Update documentation to include support for Elasticsearch 5.6](https://opensearch.atlassian.net/browse/MIGRATIONS-2428)
- Related [MIGRATIONS-2374 | Switch ES5 clusters to be processed with Lucene6](https://opensearch.atlassian.net/browse/MIGRATIONS-2374)
- Related https://github.com/opensearch-project/opensearch-migrations/pull/1317

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
