### PR TITLE
Vector Search Tutorials: fix link of RAG Chatbot not working

### DIFF
--- a/_vector-search/tutorials/index.md
+++ b/_vector-search/tutorials/index.md
@@ -152,7 +152,7 @@ rag:
       - "<b>Deployment:</b> Amazon SageMaker"  
 chatbots:
   - heading: RAG chatbot
-    link: vector-search/tutorials/chatbots/rag-chatbot/
+    link: /vector-search/tutorials/chatbots/rag-chatbot/
     list:
       - "<b>Platform:</b> OpenSearch"
       - "<b>Model:</b> Anthropic Claude" 


### PR DESCRIPTION
The link of the RAG Chatbot pointet to : https://opensearch.org/docs/latestvector-search/tutorials/chatbots/rag-chatbot/ between latest and vector-search a "/" was missing.

### Description
At the moment the link to the tutorial RAG-Chatbot does not work.

### Issues Resolved
added missing "/".

### Checklist
- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
