### PR TITLE
Update automerge backport workflow to wait 300 seconds

### DIFF
--- a/.github/workflows/automerge-backport.yml
+++ b/.github/workflows/automerge-backport.yml
@@ -25,7 +25,7 @@ jobs:
           MERGE_LABELS: "backport-automerge,!On hold"
           MERGE_FILTER_AUTHOR: "opensearch-trigger-bot[bot]"
           MERGE_REQUIRED_APPROVALS: "1"
-          MERGE_RETRIES: "20"
+          MERGE_RETRIES: "30"
           MERGE_RETRY_SLEEP: "10000"
           MERGE_ERROR_FAIL: "true"
           MERGE_FORKS: "false"


### PR DESCRIPTION
### Description
Update automerge backport workflow to wait 300 seconds

### Issues Resolved
https://github.com/opensearch-project/documentation-website/actions/runs/13706709244/job/38333636231

### Version
Would need to backport this to all the branches that need automerge backports.

### Frontend features
None

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
