### PR TITLE
Remove references to PLUGGABLE_CACHING feature flag

### DIFF
--- a/_search-plugins/caching/index.md
+++ b/_search-plugins/caching/index.md
@@ -25,9 +25,6 @@ OpenSearch supports the following on-heap cache types:
 **Introduced 2.14**
 {: .label .label-purple }
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/10024).    
-{: .warning}
-
 In addition to existing custom OpenSearch on-heap cache stores, cache plugins provide the following cache stores: 
 
 - **Disk cache**: Stores the precomputed result of a query on disk. Use a disk cache to cache much larger datasets, provided that the disk's latency is within an acceptable range.

--- a/_search-plugins/caching/tiered-cache.md
+++ b/_search-plugins/caching/tiered-cache.md
@@ -8,25 +8,11 @@ nav_order: 10
 
 # Tiered cache
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/10024).    
-{: .warning}
-
 A tiered cache is a multi-level cache in which each tier has its own characteristics and performance levels. By combining different tiers, you can achieve a balance between cache performance and size.
 
 ## Types of tiered caches
 
 OpenSearch provides an implementation of a `_tiered` spillover `cache_`. This implementation spills any items removed from the upper tiers to the lower tiers of cache. The upper tier, such as the on-heap tier, is smaller in size but offers better latency. The lower tier, such as the disk cache, is larger in size but slower in terms of latency. OpenSearch offers both on-heap and disk tiers. 
-
-## Enabling a tiered cache
-
-To enable a tiered cache, configure the following setting in `opensearch.yml`:
-
-```yaml
-opensearch.experimental.feature.pluggable.caching.enabled: true
-```
-{% include copy.html %}
-
-For more information about ways to enable experimental features, see [Experimental feature flags]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/experimental/).
 
 ## Installing required plugins
 


### PR DESCRIPTION
### Description
As of 3.0 pluggable caching will no longer be experimental. Removes references to the feature flag setting which is removed as part of GA launch. See this PR which removes it: https://github.com/opensearch-project/OpenSearch/pull/17344. 

I believe I got all references to the setting itself or to warnings about the feature being experimental, but please let me know if I missed any! 

### Issues Resolved
Did not raise an issue for this small modification

### Version
3.0 and onwards

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
