### PR TITLE
Expands on which queries are cacheable in RC

### DIFF
--- a/_search-plugins/caching/request-cache.md
+++ b/_search-plugins/caching/request-cache.md
@@ -12,7 +12,7 @@ The OpenSearch index request cache is a specialized caching mechanism designed t
 
 The cache is automatically invalidated at the configured refresh interval. The invalidation includes document updates (including document deletions) and changes to index settings. This ensures that stale results are never returned from the cache. When the cache size exceeds its configured limit, the least recently used entries are evicted to make room for new entries.
 
-Not all queries are eligible for the request cache. Profiled queries, scroll queries, and search requests with non-deterministic characteristics (such as `Math.random()` or DFS queries) or relative times (such as `now` or `new Date()`) are ineligible for caching. By default, only requests with `size=0` are cacheable, but this behavior can be changed with `indices.requests.cache.maximum_cacheable_size` in OpenSearch 2.19 and later.
+Some queries are ineligible for the request cache. These include profiled queries, scroll queries, and search requests with non-deterministic characteristics (such as those using `Math.random()` or DFS queries) or relative times (such as `now` or `new Date()`). By default, only requests with `size=0` are cacheable. In OpenSearch 2.19 and later, this behavior can be changed using `indices.requests.cache.maximum_cacheable_size`.
 {: .note}
 
 ## Configuring request caching

--- a/_search-plugins/caching/request-cache.md
+++ b/_search-plugins/caching/request-cache.md
@@ -12,7 +12,7 @@ The OpenSearch index request cache is a specialized caching mechanism designed t
 
 The cache is automatically invalidated at the configured refresh interval. The invalidation includes document updates (including document deletions) and changes to index settings. This ensures that stale results are never returned from the cache. When the cache size exceeds its configured limit, the least recently used entries are evicted to make room for new entries.
 
-Search requests with `size=0` are cached in the request cache by default. Search requests with non-deterministic characteristics (such as `Math.random()`) or relative times (such as `now` or `new Date()`) are ineligible for caching.
+Not all queries are eligible for the request cache. Profiled queries, scroll queries, and search requests with non-deterministic characteristics (such as `Math.random()` or DFS queries) or relative times (such as `now` or `new Date()`) are ineligible for caching. By default, only requests with `size=0` are cacheable, but this behavior can be changed with `indices.requests.cache.maximum_cacheable_size` in OpenSearch 2.19 and later.
 {: .note}
 
 ## Configuring request caching


### PR DESCRIPTION
### Description
More explicitly describes which queries can and can't be cached in the request cache. This caused some confusion to a users when comparing latencies between OpenSearch and Elasticsearch. 

### Issues Resolved
Did not raise an issue for this small revision

### Version
2.19 onwards. Without the clause about the `maximum_cacheable_size` setting, the change is accurate for all versions of OpenSearch.

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
