### PR TITLE
fix typo

### DIFF
--- a/DEVELOPER_GUIDE.md
+++ b/DEVELOPER_GUIDE.md
@@ -52,7 +52,7 @@ If you are working on multiple Markdown files and do not want to keep running th
 bundle exec jekyll spec-insert -W
 ```
 
-By default, when the plugin encounters an error when processing a file, the plugin prints out the error than moves on to the next file. If you want it to short-circuit when an error occurs, add the `--fail-on-error` (or `-F`) flag to the command:
+By default, when the plugin encounters an error when processing a file, the plugin prints out the error then moves on to the next file. If you want it to short-circuit when an error occurs, add the `--fail-on-error` (or `-F`) flag to the command:
 
 ```shell
 bundle exec jekyll spec-insert -F


### PR DESCRIPTION
### Description
Fix typo. Changed "than" used for comparing to "then" describing a sequence.

### Issues Resolved
No Issue created. Hope that is ok for a typo?

### Version
I am not sure about this one.

### Frontend features
- none

### Checklist
- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
