### PR TITLE
Updated min and max aggregations.

### DIFF
--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -20,7 +20,7 @@ The `max` aggregation takes the following parameters.
 
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |
-| `field`   | Required          | String         | Name of the field for which the maximum is computed.    |
+| `field`   | Required          | String         | The name of the field for which the maximum is computed.    |
 | `missing` | Optional          | Numeric        | Value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
 
 ## Example

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -11,7 +11,7 @@ redirect_from:
 
 The `max` metric is a single-value metric that returns the maximum value of a field.
 
-The `max` aggregation compares numeric fields using a `double` (double-precision) representation. Results should be considered approximate for fields containing `long` or `unsigned_long` integer values greater than 2^53, since the number of significant bits in a `double` mantissa is 53.
+The `max` aggregation compares numeric fields using a `double` (double-precision) representation. Results should be considered approximate for fields containing `long` or `unsigned_long` integer values greater than 2<sup>53</sup> because the number of significant bits in a `double` mantissa is 53.
 {: .note}
 
 ## Parameters

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -25,7 +25,7 @@ The `max` aggregation takes the following parameters.
 
 ## Example
 
-This example finds the most expensive item --- the maximum value of the `base_unit_price` --- in the ecommerce sample data:
+This example finds the most expensive item---the item with the maximum value of the `base_unit_price`---in the e-commerce sample data:
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -9,18 +9,32 @@ redirect_from:
 
 # Maximum aggregations
 
-The `max` metric is a single-value metric aggregations that returns the maximum value of a field.
+The `max` metric is a single-value metric that returns the maximum value of a field.
 
-The following example calculates the maximum of the `taxful_total_price` field:
+The `max` aggregation compares numeric fields using a `double` (double-precision) representation. Results should be considered approximate for fields containing `long` or `unsigned_long` integer values greater than 2^53, since the number of significant bits in a `double` mantissa is 53.
+{: .note}
+
+## Parameters
+
+The `max` aggregation takes the following parameters:
+
+| Parameter | Required/Optional | Data type      | Description |
+| :--       | :--               | :--            | :--         |
+| `field`   | Required          | String         | Name of the field for which the maximum is computed.    |
+| `missing` | Optional          | Numeric        | Value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
+
+## Example
+
+This example finds the most expensive item --- the maximum value of the `base_unit_price` --- in the ecommerce sample data:
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search
 {
   "size": 0,
   "aggs": {
-    "max_taxful_total_price": {
+    "max_base_unit_price": {
       "max": {
-        "field": "taxful_total_price"
+        "field": "products.base_unit_price"
       }
     }
   }
@@ -28,11 +42,13 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
 ```
 {% include copy-curl.html %}
 
-#### Example response
+## Example response
+
+The response is as follows:
 
 ```json
 {
-  "took": 17,
+  "took": 24,
   "timed_out": false,
   "_shards": {
     "total": 1,
@@ -49,9 +65,17 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
     "hits": []
   },
   "aggregations": {
-    "max_taxful_total_price": {
-      "value": 2250
+    "max_base_unit_price": {
+      "value": 540
     }
   }
 }
 ```
+
+The aggregation name (`max_base_unit_price`) can be used as a key to retrieve the aggregation from the response.
+
+## Missing values
+
+You can assign a value to missing instances of the aggregated field. See [Missing aggregations]({{site.url}}{{site.baseurl}}/aggregations/bucket/missing/).
+
+Missing values are normally ignored by `max`. If you use `missing` to assign a value greater than any existing value, `max` returns this replacement value as the maximum value.

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -21,11 +21,11 @@ The `max` aggregation takes the following parameters.
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |
 | `field`   | Required          | String         | The name of the field for which the maximum is computed.    |
-| `missing` | Optional          | Numeric        | The value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
+| `missing` | Optional          | Numeric        | The value to assign to missing instances of the field. If not provided, documents containing missing values are omitted from the aggregation. |
 
 ## Example
 
-This example finds the most expensive item---the item with the maximum value of the `base_unit_price`---in the e-commerce sample data:
+This following example request finds the most expensive item---the item with the maximum value of the `base_unit_price`---in the OpenSearch Dashboards e-commerce sample data:
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search
@@ -76,6 +76,6 @@ You can use the aggregation name (`max_base_unit_price`) as a key to retrieve th
 
 ## Missing values
 
-You can assign a value to missing instances of the aggregated field. See [Missing aggregations]({{site.url}}{{site.baseurl}}/aggregations/bucket/missing/).
+You can assign a value to missing instances of the aggregated field. See [Missing aggregations]({{site.url}}{{site.baseurl}}/aggregations/bucket/missing/) for more information.
 
 Missing values are normally ignored by `max`. If you use `missing` to assign a value greater than any existing value, `max` returns this replacement value as the maximum value.

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -21,7 +21,7 @@ The `max` aggregation takes the following parameters.
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |
 | `field`   | Required          | String         | The name of the field for which the maximum is computed.    |
-| `missing` | Optional          | Numeric        | Value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
+| `missing` | Optional          | Numeric        | The value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
 
 ## Example
 

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -16,7 +16,7 @@ The `max` aggregation compares numeric fields using a `double` (double-precision
 
 ## Parameters
 
-The `max` aggregation takes the following parameters:
+The `max` aggregation takes the following parameters.
 
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -44,7 +44,7 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
 
 ## Example response
 
-The response is as follows:
+As shown in the following example response, the aggregation returns the maximum value of `products.base_unit_price`:
 
 ```json
 {

--- a/_aggregations/metric/maximum.md
+++ b/_aggregations/metric/maximum.md
@@ -72,7 +72,7 @@ The response is as follows:
 }
 ```
 
-The aggregation name (`max_base_unit_price`) can be used as a key to retrieve the aggregation from the response.
+You can use the aggregation name (`max_base_unit_price`) as a key to retrieve the aggregation from the response.
 
 ## Missing values
 

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -11,7 +11,7 @@ redirect_from:
 
 The `min` metric is a single-value metric that returns the minimum value of a field.
 
-The `min` aggregation compares numeric fields using a `double` (double-precision) representation. Results should be considered approximate for fields containing only `long` or `unsigned_long` integer values greater than 2^53, since the number of significant bits in a `double` mantissa is 53.
+The `min` aggregation compares numeric fields using a `double` (double-precision) representation. Results should be considered approximate for fields containing `long` or `unsigned_long` integers with absolute values greater than 2<sup>53</sup> because the number of significant bits in a `double` mantissa is 53.
 {: .note}
 
 ## Parameters

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -44,7 +44,7 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
 
 ## Example response
 
-The response is as follows:
+As shown in the following example response, the aggregation returns the minimum value of `products.base_unit_price`:
 
 ```json
 {

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -21,7 +21,7 @@ The `min` aggregation takes the following parameters.
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |
 | `field`   | Required          | String         | The name of the field for which the minimum is computed.    |
-| `missing` | Optional          | Numeric        | Value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
+| `missing` | Optional          | Numeric        | The value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
 
 ## Example
 

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -25,7 +25,7 @@ The `min` aggregation takes the following parameters.
 
 ## Example
 
-This example finds the least expensive item --- the minimum value of the `base_unit_price` --- in the ecommerce sample data:
+This example finds the least expensive item---the item with the minimum value of the `base_unit_price`---in the e-commerce sample data:
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search
@@ -72,7 +72,7 @@ The response is as follows:
 }
 ```
 
-The aggregation name (`min_base_unit_price`) can be used as a key to retrieve the aggregation from the response.
+You can use the aggregation name (`min_base_unit_price`) as a key to retrieve the aggregation from the response.
 
 ## Missing values
 

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -21,11 +21,11 @@ The `min` aggregation takes the following parameters.
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |
 | `field`   | Required          | String         | The name of the field for which the minimum is computed.    |
-| `missing` | Optional          | Numeric        | The value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
+| `missing` | Optional          | Numeric        | The value to assign to missing instances of the field. If not provided, documents containing missing values are omitted from the aggregation. |
 
 ## Example
 
-This example finds the least expensive item---the item with the minimum value of the `base_unit_price`---in the e-commerce sample data:
+This following example request finds the least expensive item---the item with the minimum value of the `base_unit_price`---in the OpenSearch Dashboards e-commerce sample data:
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search
@@ -76,6 +76,6 @@ You can use the aggregation name (`min_base_unit_price`) as a key to retrieve th
 
 ## Missing values
 
-You can assign a value to missing instances of the aggregated field. See [Missing aggregations]({{site.url}}{{site.baseurl}}/aggregations/bucket/missing/).
+You can assign a value to missing instances of the aggregated field. See [Missing aggregations]({{site.url}}{{site.baseurl}}/aggregations/bucket/missing/) for more information.
 
-Missing values are normally ignored by `min`. If you use `missing` to assign a value less than any existing value, `min` returns this replacement value as the minimum value.
+Missing values are normally ignored by `min`. If you use `missing` to assign a value lower than any existing value, `min` returns this replacement value as the minimum value.

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -20,7 +20,7 @@ The `min` aggregation takes the following parameters.
 
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |
-| `field`   | Required          | String         | Name of the field for which the minimum is computed.    |
+| `field`   | Required          | String         | The name of the field for which the minimum is computed.    |
 | `missing` | Optional          | Numeric        | Value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
 
 ## Example

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -16,7 +16,7 @@ The `min` aggregation compares numeric fields using a `double` (double-precision
 
 ## Parameters
 
-The `min` aggregation takes the following parameters:
+The `min` aggregation takes the following parameters.
 
 | Parameter | Required/Optional | Data type      | Description |
 | :--       | :--               | :--            | :--         |

--- a/_aggregations/metric/minimum.md
+++ b/_aggregations/metric/minimum.md
@@ -9,18 +9,32 @@ redirect_from:
 
 # Minimum aggregations
 
-The `min` metric is a single-value metric aggregations that returns the minimum value of a field.
+The `min` metric is a single-value metric that returns the minimum value of a field.
 
-The following example calculates the minimum of the `taxful_total_price` field:
+The `min` aggregation compares numeric fields using a `double` (double-precision) representation. Results should be considered approximate for fields containing only `long` or `unsigned_long` integer values greater than 2^53, since the number of significant bits in a `double` mantissa is 53.
+{: .note}
+
+## Parameters
+
+The `min` aggregation takes the following parameters:
+
+| Parameter | Required/Optional | Data type      | Description |
+| :--       | :--               | :--            | :--         |
+| `field`   | Required          | String         | Name of the field for which the minimum is computed.    |
+| `missing` | Optional          | Numeric        | Value to assign missing instances of the field. If not given, documents with missing values are omitted from the aggregation. |
+
+## Example
+
+This example finds the least expensive item --- the minimum value of the `base_unit_price` --- in the ecommerce sample data:
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search
 {
   "size": 0,
   "aggs": {
-    "min_taxful_total_price": {
+    "min_base_unit_price": {
       "min": {
-        "field": "taxful_total_price"
+        "field": "products.base_unit_price"
       }
     }
   }
@@ -28,11 +42,13 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
 ```
 {% include copy-curl.html %}
 
-#### Example response
+## Example response
+
+The response is as follows:
 
 ```json
 {
-  "took": 13,
+  "took": 15,
   "timed_out": false,
   "_shards": {
     "total": 1,
@@ -49,9 +65,17 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
     "hits": []
   },
   "aggregations": {
-    "min_taxful_total_price": {
-      "value": 6.98828125
+    "min_base_unit_price": {
+      "value": 5.98828125
     }
   }
 }
 ```
+
+The aggregation name (`min_base_unit_price`) can be used as a key to retrieve the aggregation from the response.
+
+## Missing values
+
+You can assign a value to missing instances of the aggregated field. See [Missing aggregations]({{site.url}}{{site.baseurl}}/aggregations/bucket/missing/).
+
+Missing values are normally ignored by `min`. If you use `missing` to assign a value less than any existing value, `min` returns this replacement value as the minimum value.


### PR DESCRIPTION
### Description

Updated descriptions and examples.

Added admonition about comparing large integers beyond the resolution of the `double` FP mantissa.

Both min and max in this PR since they're a pair and nearly identical.

### Issues Resolved

### Version

### Frontend features

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
