### PR TITLE
Add Breaking Changes viewer to assessing-your-cluster-for-migration.md

### DIFF
--- a/_data/migration-assistant/breaking-changes.yml
+++ b/_data/migration-assistant/breaking-changes.yml
@@ -42,30 +42,14 @@ breaking_changes:
     comp: []
     transformation:
       title: "Type Mapping Deprecation"
-      url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
-  - title: "Elasticsearch 6.0 Breaking Changes"
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html"
+      url: "/docs/latest/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+  - title: "Elasticsearch 6.0 - 6.6 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes.html"
     introducedIn: "Elasticsearch 6.8"
     comp: []
-  - title: "Elasticsearch 6.2 Breaking Changes"
-    url: "https://wwwhttps://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.2.html"
-    introducedIn: "Elasticsearch 6.8"
-    comp: []
-  - title: "Elasticsearch 6.3 Breaking Changes"
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.3.html"
-    introducedIn: "Elasticsearch 6.8"
-    comp: []
-  - title: "Elasticsearch 6.4 Breaking Changes"
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.4.html"
-    introducedIn: "Elasticsearch 6.8"
-    comp: []
-  - title: "Elasticsearch 6.6 Breaking Changes"
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.6.html"
-    introducedIn: "Elasticsearch 6.8"
-    comp: []
-  - title: "Elasticsearch 6.7 Breaking Changes"
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html"
-    introducedIn: "Elasticsearch 6.8"
+  - title: "Elasticsearch 7.0 - 7.10 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/breaking-changes.html"
+    introducedIn: "Elasticsearch 7.10"
     comp: []
   - title: "Kibana 6 Breaking Changes"
     url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes.html"

--- a/_data/migration-assistant/breaking-changes.yml
+++ b/_data/migration-assistant/breaking-changes.yml
@@ -1,0 +1,77 @@
+# Breaking changes data for migration paths
+#
+# Data structure:
+# breaking_changes: Array of breaking change objects with:
+#   - title: Display name of the breaking change
+#   - url: Link to documentation
+#   - introducedIn: Version where the breaking change was introduced
+#   - affects (optional): Object with minSource and maxTarget versions
+#     - minSource: Minimum source version affected
+#     - maxTarget: Maximum target version affected
+#   - comp: Array of components affected (e.g., ["dashboards"])
+#   - transformation (optional): Optional object with transformation information
+#     - title: Title of the transformation guide
+#     - url: Link to transformation guide
+breaking_changes:
+  - title: "Amazon OpenSearch Service: Upgrade Guidance"
+    url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html"
+    introducedIn: "OpenSearch 1.3"
+    comp: []
+  - title: "Amazon OpenSearch Service: Rename - Summary of changes"
+    url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html"
+    introducedIn: "OpenSearch 1.3"
+    comp: []
+  - title: "OpenSearch 2.0: Remove mapping types parameter"
+    url: "/docs/latest/breaking-changes/#remove-mapping-types-parameter"
+    introducedIn: "OpenSearch 2.19"
+    comp: []
+    transformation:
+      title: "Type Mapping Deprecation"
+      url: "/docs/latest/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+  - title: "OpenSearch Notifications Plugins"
+    url: "/breaking-changes/#add-opensearch-notifications-plugins"
+    introducedIn: "OpenSearch 2.19"
+    comp: []
+  - title: "OpenSearch 2.0: Client JDK 8 Support Dropped"
+    url: "/docs/latest/breaking-changes/#drop-support-for-jdk-8"
+    introducedIn: "OpenSearch 2.19"
+    comp: []
+  - title: "Removal of Types in Elasticsearch 7.x"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/removal-of-types.html"
+    introducedIn: "Elasticsearch 7.10"
+    comp: []
+    transformation:
+      title: "Type Mapping Deprecation"
+      url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+  - title: "Elasticsearch 6.0 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html"
+    introducedIn: "Elasticsearch 6.8"
+    comp: []
+  - title: "Elasticsearch 6.2 Breaking Changes"
+    url: "https://wwwhttps://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.2.html"
+    introducedIn: "Elasticsearch 6.8"
+    comp: []
+  - title: "Elasticsearch 6.3 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.3.html"
+    introducedIn: "Elasticsearch 6.8"
+    comp: []
+  - title: "Elasticsearch 6.4 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.4.html"
+    introducedIn: "Elasticsearch 6.8"
+    comp: []
+  - title: "Elasticsearch 6.6 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.6.html"
+    introducedIn: "Elasticsearch 6.8"
+    comp: []
+  - title: "Elasticsearch 6.7 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html"
+    introducedIn: "Elasticsearch 6.8"
+    comp: []
+  - title: "Kibana 6 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes.html"
+    introducedIn: "Elasticsearch 6.8"
+    comp: ["dashboards"]
+  - title: "Kibana 7 Breaking Changes"
+    url: "https://www.elastic.co/guide/en/kibana/7.10/breaking-changes.html"
+    introducedIn: "Elasticsearch 7.10"
+    comp: ["dashboards"]

--- a/_data/migration-assistant/valid_migrations.yml
+++ b/_data/migration-assistant/valid_migrations.yml
@@ -1,0 +1,24 @@
+# Migration paths for Migration Assistant
+migration_paths:
+  - source: "Elasticsearch 5.6"
+    targets: 
+      - "OpenSearch 1.3"
+      - "OpenSearch 2.19"
+  - source: "Elasticsearch 6.8"
+    targets:
+      - "OpenSearch 1.3"
+      - "OpenSearch 2.19"
+  - source: "Elasticsearch 7.10"
+    targets:
+      - "OpenSearch 1.3"
+      - "OpenSearch 2.19"
+  - source: "Elasticsearch 7.17"
+    targets:
+      - "OpenSearch 1.3"
+      - "OpenSearch 2.19"
+  - source: "OpenSearch 1.3"
+    targets:
+      - "OpenSearch 2.19"
+  - source: "OpenSearch 2.19"
+    targets:
+      - "OpenSearch 2.19"

--- a/_migration-assistant/assets/css/breaking-changes-selector.css
+++ b/_migration-assistant/assets/css/breaking-changes-selector.css
@@ -1,0 +1,31 @@
+.breaking-changes-selector {
+  background: #f5f7f7;
+  padding: 15px;
+  border-radius: 4px;
+  margin-bottom: 20px;
+}
+
+.breaking-changes-selector div {
+  margin: 10px 0;
+}
+
+.breaking-changes-selector label {
+  margin-right: 8px;
+}
+
+.breaking-changes-selector select {
+  margin-right: 15px;
+  padding: 4px;
+}
+
+.breaking-changes-selector input[type="checkbox"] {
+  margin-right: 4px;
+}
+
+#breaking-changes-results {
+  margin-top: 15px;
+}
+
+#breaking-changes-results ul {
+  margin-top: 10px;
+}

--- a/_migration-assistant/assets/css/breaking-changes-selector.css
+++ b/_migration-assistant/assets/css/breaking-changes-selector.css
@@ -29,3 +29,27 @@
 #breaking-changes-results ul {
   margin-top: 10px;
 }
+
+.transformation-info {
+  margin-left: 20px;
+  padding: 5px 10px;
+  background-color: #e6f7ff;
+  border-left: 3px solid #1890ff;
+  margin-top: 5px;
+  margin-bottom: 5px;
+  font-size: 0.9em;
+}
+
+.component-checkbox {
+  display: inline-block;
+  margin-left: 20px;
+}
+
+.transformation-request {
+  margin-top: 15px;
+  padding: 10px;
+  background-color: #f0f0f0;
+  border-radius: 4px;
+  font-size: 0.9em;
+  font-style: italic;
+}

--- a/_migration-assistant/assets/js/breaking-changes-data.js
+++ b/_migration-assistant/assets/js/breaking-changes-data.js
@@ -8,9 +8,11 @@
  *   - title: Display name of the breaking change
  *   - url: Link to documentation
  *   - introducedIn: Version where the breaking change was introduced
- *   - affects: Object with minSource and maxTarget versions
+ *   - affects (optional): Object with minSource and maxTarget versions
+ *     - minSource: Minimum source version affected
+ *     - maxTarget: Maximum target version affected
  *   - comp: Array of components affected
- *   - transformation: Optional object with transformation information
+ *   - transformation (optional): Optional object with transformation information
  */
 
 // Variables to store version ordering
@@ -165,20 +167,21 @@ function initializeMigrationData() {
 
 // Function to initialize the breaking changes data from the data attribute
 function initializeBreakingChangesData() {
-  const breakingChangesElement = document.getElementById('breaking-changes-data');
+  const migrationDataElement = document.getElementById('migration-data');
   
-  if (breakingChangesElement && breakingChangesElement.dataset.breakingChanges) {
-    try {
-      // Parse the JSON data from the data attribute
-      breakingChanges = JSON.parse(breakingChangesElement.dataset.breakingChanges);
-      console.log('Loaded breaking changes data:', breakingChanges.length);
-    } catch (error) {
-      console.error('Failed to parse breaking changes data:', error);
-      // Fallback to empty array if parsing fails
-      breakingChanges = [];
-    }
-  } else {
-    console.error('Breaking changes data element not found or empty');
+  if (!migrationDataElement || !migrationDataElement.dataset.breakingChanges) {
+    console.error('Breaking changes data not found in migration-data element. Make sure to add data-breaking-changes attribute.');
+    return;
+  }
+  
+  try {
+    // Parse the JSON data from the data attribute
+    breakingChanges = JSON.parse(migrationDataElement.dataset.breakingChanges);
+    console.log('Loaded breaking changes data:', breakingChanges.length);
+  } catch (error) {
+    console.error('Failed to parse breaking changes data:', error);
+    // Fallback to empty array if parsing fails
+    breakingChanges = [];
   }
 }
 
@@ -187,3 +190,6 @@ document.addEventListener('DOMContentLoaded', () => {
   initializeMigrationData();
   initializeBreakingChangesData();
 });
+
+// Export the breaking changes array for use in other modules
+export { breakingChanges };

--- a/_migration-assistant/assets/js/breaking-changes-data.js
+++ b/_migration-assistant/assets/js/breaking-changes-data.js
@@ -2,43 +2,49 @@
  * Breaking changes data for migration paths
  * 
  * Data structure:
- * - VERSIONS: Array of version objects with type and value
- * - COMPONENTS: Array of component types (add new component types here)
+ * - VERSIONS: Array of version strings
  * - breakingChanges: Array of breaking change objects with:
  *   - title: Display name of the breaking change
  *   - url: Link to documentation
  *   - desc: Brief description
- *   - src: Array of source versions affected (format: "type:value")
- *   - tgt: Array of target versions affected (format: "type:value")
- *   - comp: Array of components affected (empty array means all components)
+ *   - src: Array of source versions affected
+ *   - tgt: Array of target versions affected
+ *   - comp: Array of components affected
+ *   - transformation: Optional object with transformation information
  */
 
-// Configuration - unified version list
-const VERSIONS = [
-  { type: "ES", value: "5.x" },
-  { type: "ES", value: "6.x" },
-  { type: "ES", value: "7.x" },
-  { type: "OS", value: "1.x" },
-  { type: "OS", value: "2.x" }
-];
-
-// Define valid migration paths (source version -> valid target versions)
-// Format: "sourceType:sourceValue" -> ["targetType:targetValue", ...]
-const VALID_MIGRATIONS = {
-  "ES:5.x": ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
-  "ES:6.x": ["ES:7.x", "OS:1.x", "OS:2.x"],
-  "ES:7.x": ["OS:1.x", "OS:2.x"],
-  "OS:1.x": ["OS:2.x"],
-  "OS:2.x": ["OS:2.x"]
+// Variables to store migration data
+let VALID_MIGRATIONS = {};
+let VERSIONS = [];
+let MIGRATION_MAP = {
+  sourceToTargets: {},
+  targetToSources: {}
 };
+
+// Extract all unique versions for dropdowns
+function extractUniqueVersions(migrationsMap) {
+  const versions = new Set();
+  
+  // Add all sources
+  Object.keys(migrationsMap).forEach(source => {
+    versions.add(source);
+  });
+  
+  // Add all targets
+  Object.values(migrationsMap).forEach(targets => {
+    targets.forEach(target => {
+      versions.add(target);
+    });
+  });
+  
+  return Array.from(versions).sort();
+}
 
 // Function to generate the reverse mapping (target -> sources)
 function generateReverseMigrationMap(forwardMap) {
   const reverseMap = {};
   
-  // Iterate through each source and its targets
   Object.entries(forwardMap).forEach(([source, targets]) => {
-    // For each target, add the source to its list of sources
     targets.forEach(target => {
       if (!reverseMap[target]) {
         reverseMap[target] = [];
@@ -50,124 +56,162 @@ function generateReverseMigrationMap(forwardMap) {
   return reverseMap;
 }
 
-// Create bidirectional migration map
-const MIGRATION_MAP = {
-  sourceToTargets: VALID_MIGRATIONS,
-  targetToSources: generateReverseMigrationMap(VALID_MIGRATIONS)
-};
-const COMPONENTS = ["data", "dashboards"];
+// Function to initialize the migration data from the data attribute
+function initializeMigrationData() {
+  const migrationDataElement = document.getElementById('migration-data');
+  
+  if (migrationDataElement && migrationDataElement.dataset.migrationPaths) {
+    try {
+      // Parse the JSON data from the data attribute
+      const migrationPaths = JSON.parse(migrationDataElement.dataset.migrationPaths);
+      
+      // Transform the data structure from YAML format to the expected JavaScript object format
+      VALID_MIGRATIONS = migrationPaths.reduce((acc, path) => {
+        acc[path.source] = path.targets;
+        return acc;
+      }, {});
+      
+      // Now that we have the migration data, create the derived data structures
+      VERSIONS = extractUniqueVersions(VALID_MIGRATIONS);
+      MIGRATION_MAP = {
+        sourceToTargets: VALID_MIGRATIONS,
+        targetToSources: generateReverseMigrationMap(VALID_MIGRATIONS)
+      };
+    } catch (error) {
+      console.error('Failed to parse migration data:', error);
+      // Fallback to empty object if parsing fails
+      VALID_MIGRATIONS = {};
+      VERSIONS = [];
+      MIGRATION_MAP = { sourceToTargets: {}, targetToSources: {} };
+    }
+  } else {
+    console.warn('Migration data element not found or empty');
+  }
+}
 
+// Initialize the migration data when the DOM is loaded
+document.addEventListener('DOMContentLoaded', initializeMigrationData);
+
+// Updated breaking changes data with full version names
 const breakingChanges = [
   {
-    title: "Upgrading Amazon Service Domains",
+    title: "Amazon OpenSearch Service: Upgrade Guidance",
     url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html",
-    desc: "Guide for upgrading Amazon OpenSearch Service domains",
-    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
-    tgt: ["OS:1.x", "OS:2.x"],
-    comp: ["data"]
+    desc: "",
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    tgt: ["OpenSearch 1.3", "OpenSearch 2.19"],
+    comp: []
   },
   {
-    title: "Changes from Elasticsearch to OpenSearch fork",
+    title: "Amazon OpenSearch Service: Rename - Summary of changes",
     url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html",
-    desc: "Documentation of changes from Elasticsearch to OpenSearch fork",
-    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
-    tgt: ["OS:1.x", "OS:2.x"],
-    comp: ["data"]
+    desc: "",
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10", "Elasticsearch 7.17"],
+    tgt: ["OpenSearch 1.3", "OpenSearch 2.19"],
+    comp: []
   },
   {
-    title: "Mapping Types Removal",
-    url: "/breaking-changes/#remove-mapping-types-parameter",
-    desc: "Removal of mapping types parameter in OpenSearch 2.0",
-    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
-    tgt: ["OS:2.x"],
-    comp: ["data"]
+    title: "OpenSearch 2.0: Remove mapping types parameter",
+    url: "/docs/latest/breaking-changes/#remove-mapping-types-parameter",
+    desc: "",
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3"],
+    tgt: ["OpenSearch 2.19"],
+    comp: [],
+    transformation: {
+      title: "Type Mapping Deprecation",
+      url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+    }
   },
   {
     title: "OpenSearch Notifications Plugins",
     url: "/breaking-changes/#add-opensearch-notifications-plugins",
     desc: "Integration of Alerting plugin with new Notifications plugins in OpenSearch 2.0",
-    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
-    tgt: ["OS:2.x"],
-    comp: ["data"]
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3"],
+    tgt: ["OpenSearch 2.19"],
+    comp: []
   },
   {
-    title: "JDK 8 Support Dropped",
-    url: "/breaking-changes/#drop-support-for-jdk-8",
-    desc: "OpenSearch 2.0 dropped support for JDK 8",
-    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
-    tgt: ["OS:2.x"],
-    comp: ["data"]
+    title: "OpenSearch 2.0: Client JDK 8 Support Dropped",
+    url: "/docs/latest/breaking-changes/#drop-support-for-jdk-8",
+    desc: "",
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3"],
+    tgt: ["OpenSearch 2.19"],
+    comp: []
   },
   {
     title: "Removal of Types in Elasticsearch 7.x",
     url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/removal-of-types.html",
     desc: "Removal of mapping types in Elasticsearch 7.x",
-    src: ["ES:5.x", "ES:6.x"],
-    tgt: ["ES:7.x", "OS:1.x", "OS:2.x"],
-    comp: ["data"]
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
+    tgt: ["Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    comp: [],
+    transformation: {
+      title: "Type Mapping Deprecation",
+      url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+    }
   },
   {
     title: "Elasticsearch 6.0 Breaking Changes",
     url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html",
     desc: "Breaking changes when upgrading from ES 5.x to ES 6.x",
-    src: ["ES:5.x"],
-    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
-    comp: ["data"]
+    src: ["Elasticsearch 5.6"],
+    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    comp: []
   },
   {
     title: "Elasticsearch 6.7 Breaking Changes",
     url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html",
     desc: "Breaking changes when upgrading to ES 6.7",
-    src: ["ES:5.x", "ES:6.x"],
-    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
-    comp: ["data"]
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
+    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    comp: []
   },
   {
     title: "Kibana 6.0 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes-6.0.html",
     desc: "Breaking changes when upgrading from Kibana 5.x to 6.x",
-    src: ["ES:5.x"],
-    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    src: ["Elasticsearch 5.6"],
+    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.3 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.3.0.html#breaking-6.3.0",
     desc: "Breaking changes in Kibana 6.3",
-    src: ["ES:5.x", "ES:6.x"],
-    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
+    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.4 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.4.0.html#breaking-6.4.0",
     desc: "Breaking changes in Kibana 6.4",
-    src: ["ES:5.x", "ES:6.x"],
-    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
+    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.6 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.6.0.html#breaking-6.6.0",
     desc: "Breaking changes in Kibana 6.6",
-    src: ["ES:5.x", "ES:6.x"],
-    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
+    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.7 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.7.0.html#breaking-6.7.0",
     desc: "Breaking changes in Kibana 6.7",
-    src: ["ES:5.x", "ES:6.x"],
-    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
+    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
     comp: ["dashboards"]
   },
   {
     title: "Kibana 7.0 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/7.10/breaking-changes-7.0.html",
     desc: "Breaking changes in Kibana 7.0",
-    src: ["ES:6.x"],
-    tgt: ["ES:7.x", "OS:1.x", "OS:2.x"],
+    src: ["Elasticsearch 6.8"],
+    tgt: ["Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
     comp: ["dashboards"]
   }
 ];

--- a/_migration-assistant/assets/js/breaking-changes-data.js
+++ b/_migration-assistant/assets/js/breaking-changes-data.js
@@ -7,7 +7,6 @@
  * - breakingChanges: Array of breaking change objects with:
  *   - title: Display name of the breaking change
  *   - url: Link to documentation
- *   - desc: Brief description
  *   - introducedIn: Version where the breaking change was introduced
  *   - affects: Object with minSource and maxTarget versions
  *   - comp: Array of components affected
@@ -88,6 +87,9 @@ let MIGRATION_MAP = {
   targetToSources: {}
 };
 
+// Variables to store breaking changes data
+let breakingChanges = [];
+
 // Extract all unique versions for dropdowns
 function extractUniqueVersions(migrationsMap) {
   const versions = new Set();
@@ -157,175 +159,31 @@ function initializeMigrationData() {
       VERSION_ORDER = [];
     }
   } else {
-    console.warn('Migration data element not found or empty');
+    console.error('Migration data element not found or empty');
   }
 }
 
-// Initialize the migration data when the DOM is loaded
-document.addEventListener('DOMContentLoaded', initializeMigrationData);
-
-// Updated breaking changes data with full version names
-const breakingChanges = [
-  {
-    title: "Amazon OpenSearch Service: Upgrade Guidance",
-    url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html",
-    desc: "",
-    introducedIn: "OpenSearch 1.3",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: []
-  },
-  {
-    title: "Amazon OpenSearch Service: Rename - Summary of changes",
-    url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html",
-    desc: "",
-    introducedIn: "OpenSearch 1.3",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: []
-  },
-  {
-    title: "OpenSearch 2.0: Remove mapping types parameter",
-    url: "/docs/latest/breaking-changes/#remove-mapping-types-parameter",
-    desc: "",
-    introducedIn: "OpenSearch 2.19",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: [],
-    transformation: {
-      title: "Type Mapping Deprecation",
-      url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+// Function to initialize the breaking changes data from the data attribute
+function initializeBreakingChangesData() {
+  const breakingChangesElement = document.getElementById('breaking-changes-data');
+  
+  if (breakingChangesElement && breakingChangesElement.dataset.breakingChanges) {
+    try {
+      // Parse the JSON data from the data attribute
+      breakingChanges = JSON.parse(breakingChangesElement.dataset.breakingChanges);
+      console.log('Loaded breaking changes data:', breakingChanges.length);
+    } catch (error) {
+      console.error('Failed to parse breaking changes data:', error);
+      // Fallback to empty array if parsing fails
+      breakingChanges = [];
     }
-  },
-  {
-    title: "OpenSearch Notifications Plugins",
-    url: "/breaking-changes/#add-opensearch-notifications-plugins",
-    desc: "Integration of Alerting plugin with new Notifications plugins in OpenSearch 2.0",
-    introducedIn: "OpenSearch 2.19",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: []
-  },
-  {
-    title: "OpenSearch 2.0: Client JDK 8 Support Dropped",
-    url: "/docs/latest/breaking-changes/#drop-support-for-jdk-8",
-    desc: "",
-    introducedIn: "OpenSearch 2.19",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: []
-  },
-  {
-    title: "Removal of Types in Elasticsearch 7.x",
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/removal-of-types.html",
-    desc: "Removal of mapping types in Elasticsearch 7.x",
-    introducedIn: "Elasticsearch 7.10",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: [],
-    transformation: {
-      title: "Type Mapping Deprecation",
-      url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
-    }
-  },
-  {
-    title: "Elasticsearch 6.0 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html",
-    desc: "Breaking changes when upgrading from ES 5.x to ES 6.x",
-    introducedIn: "Elasticsearch 6.8",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: []
-  },
-  {
-    title: "Elasticsearch 6.7 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html",
-    desc: "Breaking changes when upgrading to ES 6.7",
-    introducedIn: "Elasticsearch 6.8",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: []
-  },
-  {
-    title: "Kibana 6.0 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes-6.0.html",
-    desc: "Breaking changes when upgrading from Kibana 5.x to 6.x",
-    introducedIn: "Elasticsearch 6.8",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: ["dashboards"]
-  },
-  {
-    title: "Kibana 6.3 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.3.0.html#breaking-6.3.0",
-    desc: "Breaking changes in Kibana 6.3",
-    introducedIn: "Elasticsearch 6.8",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: ["dashboards"]
-  },
-  {
-    title: "Kibana 6.4 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.4.0.html#breaking-6.4.0",
-    desc: "Breaking changes in Kibana 6.4",
-    introducedIn: "Elasticsearch 6.8",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: ["dashboards"]
-  },
-  {
-    title: "Kibana 6.6 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.6.0.html#breaking-6.6.0",
-    desc: "Breaking changes in Kibana 6.6",
-    introducedIn: "Elasticsearch 6.8",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: ["dashboards"]
-  },
-  {
-    title: "Kibana 6.7 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.7.0.html#breaking-6.7.0",
-    desc: "Breaking changes in Kibana 6.7",
-    introducedIn: "Elasticsearch 6.8",
-    affects: {
-      minSource: "Elasticsearch 5.6",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: ["dashboards"]
-  },
-  {
-    title: "Kibana 7.0 Breaking Changes",
-    url: "https://www.elastic.co/guide/en/kibana/7.10/breaking-changes-7.0.html",
-    desc: "Breaking changes in Kibana 7.0",
-    introducedIn: "Elasticsearch 7.10",
-    affects: {
-      minSource: "Elasticsearch 6.8",
-      maxTarget: "OpenSearch 2.19"
-    },
-    comp: ["dashboards"]
+  } else {
+    console.error('Breaking changes data element not found or empty');
   }
-];
+}
+
+// Initialize the data when the DOM is loaded
+document.addEventListener('DOMContentLoaded', () => {
+  initializeMigrationData();
+  initializeBreakingChangesData();
+});

--- a/_migration-assistant/assets/js/breaking-changes-data.js
+++ b/_migration-assistant/assets/js/breaking-changes-data.js
@@ -2,16 +2,83 @@
  * Breaking changes data for migration paths
  * 
  * Data structure:
- * - VERSIONS: Array of version strings
+ * - VERSIONS: Array of version strings derived from valid_migrations.yml
+ * - VERSION_ORDER: Array of version strings in strict order (derived from VERSIONS)
  * - breakingChanges: Array of breaking change objects with:
  *   - title: Display name of the breaking change
  *   - url: Link to documentation
  *   - desc: Brief description
- *   - src: Array of source versions affected
- *   - tgt: Array of target versions affected
+ *   - introducedIn: Version where the breaking change was introduced
+ *   - affects: Object with minSource and maxTarget versions
  *   - comp: Array of components affected
  *   - transformation: Optional object with transformation information
  */
+
+// Variables to store version ordering
+let VERSION_ORDER = [];
+
+// Version utility functions that use the dynamically determined version order
+export function getVersionIndex(version) {
+  const index = VERSION_ORDER.indexOf(version);
+  if (index === -1) throw new Error(`Unknown version: ${version}`);
+  return index;
+}
+
+export function isVersionBetween(target, min, max) {
+  const targetIdx = getVersionIndex(target);
+  const minIdx = getVersionIndex(min);
+  const maxIdx = getVersionIndex(max);
+  return targetIdx >= minIdx && targetIdx <= maxIdx;
+}
+
+// Helper function to determine version ordering based on migration paths
+function determineVersionOrder(versions, migrationMap) {
+  // Start with a copy of all versions
+  const remainingVersions = [...versions];
+  const orderedVersions = [];
+  
+  // First, find versions that are only sources (not targets)
+  // These are the oldest versions
+  const onlySources = versions.filter(v => 
+    !Object.values(migrationMap.targetToSources).flat().includes(v) && 
+    migrationMap.sourceToTargets[v]
+  );
+  
+  // Add oldest versions first
+  onlySources.forEach(v => {
+    orderedVersions.push(v);
+    const index = remainingVersions.indexOf(v);
+    if (index !== -1) remainingVersions.splice(index, 1);
+  });
+  
+  // Then add the rest based on migration paths
+  while (remainingVersions.length > 0) {
+    let added = false;
+    
+    for (let i = 0; i < remainingVersions.length; i++) {
+      const version = remainingVersions[i];
+      const sources = migrationMap.targetToSources[version] || [];
+      
+      // If all sources of this version are already in orderedVersions,
+      // we can add this version next
+      if (sources.every(s => orderedVersions.includes(s))) {
+        orderedVersions.push(version);
+        remainingVersions.splice(i, 1);
+        added = true;
+        break;
+      }
+    }
+    
+    // If we couldn't add any version in this pass, there might be a cycle
+    // Just add the first remaining version to break the cycle
+    if (!added && remainingVersions.length > 0) {
+      orderedVersions.push(remainingVersions[0]);
+      remainingVersions.splice(0, 1);
+    }
+  }
+  
+  return orderedVersions;
+}
 
 // Variables to store migration data
 let VALID_MIGRATIONS = {};
@@ -77,12 +144,17 @@ function initializeMigrationData() {
         sourceToTargets: VALID_MIGRATIONS,
         targetToSources: generateReverseMigrationMap(VALID_MIGRATIONS)
       };
+      
+      // Determine version ordering based on migration paths
+      VERSION_ORDER = determineVersionOrder(VERSIONS, MIGRATION_MAP);
+      console.log('Determined version order:', VERSION_ORDER);
     } catch (error) {
       console.error('Failed to parse migration data:', error);
       // Fallback to empty object if parsing fails
       VALID_MIGRATIONS = {};
       VERSIONS = [];
       MIGRATION_MAP = { sourceToTargets: {}, targetToSources: {} };
+      VERSION_ORDER = [];
     }
   } else {
     console.warn('Migration data element not found or empty');
@@ -98,24 +170,33 @@ const breakingChanges = [
     title: "Amazon OpenSearch Service: Upgrade Guidance",
     url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html",
     desc: "",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
-    tgt: ["OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "OpenSearch 1.3",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: []
   },
   {
     title: "Amazon OpenSearch Service: Rename - Summary of changes",
     url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html",
     desc: "",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10", "Elasticsearch 7.17"],
-    tgt: ["OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "OpenSearch 1.3",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: []
   },
   {
     title: "OpenSearch 2.0: Remove mapping types parameter",
     url: "/docs/latest/breaking-changes/#remove-mapping-types-parameter",
     desc: "",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3"],
-    tgt: ["OpenSearch 2.19"],
+    introducedIn: "OpenSearch 2.19",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: [],
     transformation: {
       title: "Type Mapping Deprecation",
@@ -126,24 +207,33 @@ const breakingChanges = [
     title: "OpenSearch Notifications Plugins",
     url: "/breaking-changes/#add-opensearch-notifications-plugins",
     desc: "Integration of Alerting plugin with new Notifications plugins in OpenSearch 2.0",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3"],
-    tgt: ["OpenSearch 2.19"],
+    introducedIn: "OpenSearch 2.19",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: []
   },
   {
     title: "OpenSearch 2.0: Client JDK 8 Support Dropped",
     url: "/docs/latest/breaking-changes/#drop-support-for-jdk-8",
     desc: "",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3"],
-    tgt: ["OpenSearch 2.19"],
+    introducedIn: "OpenSearch 2.19",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: []
   },
   {
     title: "Removal of Types in Elasticsearch 7.x",
     url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/removal-of-types.html",
     desc: "Removal of mapping types in Elasticsearch 7.x",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
-    tgt: ["Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 7.10",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: [],
     transformation: {
       title: "Type Mapping Deprecation",
@@ -154,64 +244,88 @@ const breakingChanges = [
     title: "Elasticsearch 6.0 Breaking Changes",
     url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html",
     desc: "Breaking changes when upgrading from ES 5.x to ES 6.x",
-    src: ["Elasticsearch 5.6"],
-    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 6.8",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: []
   },
   {
     title: "Elasticsearch 6.7 Breaking Changes",
     url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html",
     desc: "Breaking changes when upgrading to ES 6.7",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
-    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 6.8",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: []
   },
   {
     title: "Kibana 6.0 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes-6.0.html",
     desc: "Breaking changes when upgrading from Kibana 5.x to 6.x",
-    src: ["Elasticsearch 5.6"],
-    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 6.8",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.3 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.3.0.html#breaking-6.3.0",
     desc: "Breaking changes in Kibana 6.3",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
-    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 6.8",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.4 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.4.0.html#breaking-6.4.0",
     desc: "Breaking changes in Kibana 6.4",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
-    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 6.8",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.6 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.6.0.html#breaking-6.6.0",
     desc: "Breaking changes in Kibana 6.6",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
-    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 6.8",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: ["dashboards"]
   },
   {
     title: "Kibana 6.7 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.7.0.html#breaking-6.7.0",
     desc: "Breaking changes in Kibana 6.7",
-    src: ["Elasticsearch 5.6", "Elasticsearch 6.8"],
-    tgt: ["Elasticsearch 6.8", "Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 6.8",
+    affects: {
+      minSource: "Elasticsearch 5.6",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: ["dashboards"]
   },
   {
     title: "Kibana 7.0 Breaking Changes",
     url: "https://www.elastic.co/guide/en/kibana/7.10/breaking-changes-7.0.html",
     desc: "Breaking changes in Kibana 7.0",
-    src: ["Elasticsearch 6.8"],
-    tgt: ["Elasticsearch 7.10.2", "Elasticsearch 7.17", "OpenSearch 1.3", "OpenSearch 2.19"],
+    introducedIn: "Elasticsearch 7.10",
+    affects: {
+      minSource: "Elasticsearch 6.8",
+      maxTarget: "OpenSearch 2.19"
+    },
     comp: ["dashboards"]
   }
 ];

--- a/_migration-assistant/assets/js/breaking-changes-data.js
+++ b/_migration-assistant/assets/js/breaking-changes-data.js
@@ -1,0 +1,173 @@
+/**
+ * Breaking changes data for migration paths
+ * 
+ * Data structure:
+ * - VERSIONS: Array of version objects with type and value
+ * - COMPONENTS: Array of component types (add new component types here)
+ * - breakingChanges: Array of breaking change objects with:
+ *   - title: Display name of the breaking change
+ *   - url: Link to documentation
+ *   - desc: Brief description
+ *   - src: Array of source versions affected (format: "type:value")
+ *   - tgt: Array of target versions affected (format: "type:value")
+ *   - comp: Array of components affected (empty array means all components)
+ */
+
+// Configuration - unified version list
+const VERSIONS = [
+  { type: "ES", value: "5.x" },
+  { type: "ES", value: "6.x" },
+  { type: "ES", value: "7.x" },
+  { type: "OS", value: "1.x" },
+  { type: "OS", value: "2.x" }
+];
+
+// Define valid migration paths (source version -> valid target versions)
+// Format: "sourceType:sourceValue" -> ["targetType:targetValue", ...]
+const VALID_MIGRATIONS = {
+  "ES:5.x": ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+  "ES:6.x": ["ES:7.x", "OS:1.x", "OS:2.x"],
+  "ES:7.x": ["OS:1.x", "OS:2.x"],
+  "OS:1.x": ["OS:2.x"],
+  "OS:2.x": ["OS:2.x"]
+};
+
+// Function to generate the reverse mapping (target -> sources)
+function generateReverseMigrationMap(forwardMap) {
+  const reverseMap = {};
+  
+  // Iterate through each source and its targets
+  Object.entries(forwardMap).forEach(([source, targets]) => {
+    // For each target, add the source to its list of sources
+    targets.forEach(target => {
+      if (!reverseMap[target]) {
+        reverseMap[target] = [];
+      }
+      reverseMap[target].push(source);
+    });
+  });
+  
+  return reverseMap;
+}
+
+// Create bidirectional migration map
+const MIGRATION_MAP = {
+  sourceToTargets: VALID_MIGRATIONS,
+  targetToSources: generateReverseMigrationMap(VALID_MIGRATIONS)
+};
+const COMPONENTS = ["data", "dashboards"];
+
+const breakingChanges = [
+  {
+    title: "Upgrading Amazon Service Domains",
+    url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html",
+    desc: "Guide for upgrading Amazon OpenSearch Service domains",
+    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
+    tgt: ["OS:1.x", "OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "Changes from Elasticsearch to OpenSearch fork",
+    url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html",
+    desc: "Documentation of changes from Elasticsearch to OpenSearch fork",
+    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
+    tgt: ["OS:1.x", "OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "Mapping Types Removal",
+    url: "/breaking-changes/#remove-mapping-types-parameter",
+    desc: "Removal of mapping types parameter in OpenSearch 2.0",
+    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
+    tgt: ["OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "OpenSearch Notifications Plugins",
+    url: "/breaking-changes/#add-opensearch-notifications-plugins",
+    desc: "Integration of Alerting plugin with new Notifications plugins in OpenSearch 2.0",
+    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
+    tgt: ["OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "JDK 8 Support Dropped",
+    url: "/breaking-changes/#drop-support-for-jdk-8",
+    desc: "OpenSearch 2.0 dropped support for JDK 8",
+    src: ["ES:5.x", "ES:6.x", "ES:7.x"],
+    tgt: ["OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "Removal of Types in Elasticsearch 7.x",
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/removal-of-types.html",
+    desc: "Removal of mapping types in Elasticsearch 7.x",
+    src: ["ES:5.x", "ES:6.x"],
+    tgt: ["ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "Elasticsearch 6.0 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html",
+    desc: "Breaking changes when upgrading from ES 5.x to ES 6.x",
+    src: ["ES:5.x"],
+    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "Elasticsearch 6.7 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html",
+    desc: "Breaking changes when upgrading to ES 6.7",
+    src: ["ES:5.x", "ES:6.x"],
+    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["data"]
+  },
+  {
+    title: "Kibana 6.0 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes-6.0.html",
+    desc: "Breaking changes when upgrading from Kibana 5.x to 6.x",
+    src: ["ES:5.x"],
+    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["dashboards"]
+  },
+  {
+    title: "Kibana 6.3 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.3.0.html#breaking-6.3.0",
+    desc: "Breaking changes in Kibana 6.3",
+    src: ["ES:5.x", "ES:6.x"],
+    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["dashboards"]
+  },
+  {
+    title: "Kibana 6.4 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.4.0.html#breaking-6.4.0",
+    desc: "Breaking changes in Kibana 6.4",
+    src: ["ES:5.x", "ES:6.x"],
+    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["dashboards"]
+  },
+  {
+    title: "Kibana 6.6 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.6.0.html#breaking-6.6.0",
+    desc: "Breaking changes in Kibana 6.6",
+    src: ["ES:5.x", "ES:6.x"],
+    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["dashboards"]
+  },
+  {
+    title: "Kibana 6.7 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.7.0.html#breaking-6.7.0",
+    desc: "Breaking changes in Kibana 6.7",
+    src: ["ES:5.x", "ES:6.x"],
+    tgt: ["ES:6.x", "ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["dashboards"]
+  },
+  {
+    title: "Kibana 7.0 Breaking Changes",
+    url: "https://www.elastic.co/guide/en/kibana/7.10/breaking-changes-7.0.html",
+    desc: "Breaking changes in Kibana 7.0",
+    src: ["ES:6.x"],
+    tgt: ["ES:7.x", "OS:1.x", "OS:2.x"],
+    comp: ["dashboards"]
+  }
+];

--- a/_migration-assistant/assets/js/breaking-changes-filter.js
+++ b/_migration-assistant/assets/js/breaking-changes-filter.js
@@ -9,6 +9,7 @@
  * - Supports bidirectional filtering of source and target versions
  */
 import { getVersionIndex, breakingChanges } from './breaking-changes-data.js';
+import BreakingChangesUI from './breaking-changes-ui.js';
 document.addEventListener('DOMContentLoaded', () => {
   // Wait for migration data to be initialized
   if (typeof initializeMigrationData === 'function') {
@@ -132,7 +133,7 @@ document.addEventListener('DOMContentLoaded', () => {
     
     // Show message if source or target not selected
     if (!selectedSrc || !selectedTgt) {
-      results.innerHTML = '<p>Please select both source and target versions to see breaking changes.</p>';
+      results.innerHTML = '<p>Select both source and target versions to see breaking changes.</p>';
       return;
     }
     
@@ -164,6 +165,7 @@ document.addEventListener('DOMContentLoaded', () => {
       
       const versionMatch = 
         introducedInIdx <= targetVersionIdx && // Breaking change was introduced at or before target
+        introducedInIdx > sourceVersionIdx && // Breaking change was introduced after source
         sourceVersionIdx < targetVersionIdx && // Valid migration path (source before target)
         sourceVersionIdx >= getVersionIndex(minSource) && // Source is affected
         targetVersionIdx <= getVersionIndex(maxTarget); // Target is affected
@@ -178,41 +180,8 @@ document.addEventListener('DOMContentLoaded', () => {
       return versionMatch && componentMatch;
     });
     
-    // Display results
-    if (relevantChanges.length) {
-      results.innerHTML = `
-        <h4>Relevant Breaking Changes:</h4>
-        <ul>${relevantChanges.map(change => {
-          let transformationHtml = '';
-          if (change.transformation) {
-            transformationHtml = `
-              <div class="transformation-info">
-                <strong>Available Migration Assistant Transformation:</strong> 
-                <a href="${change.transformation.url}">${change.transformation.title}</a>
-              </div>
-            `;
-          }
-          return `
-            <li>
-              <a href="${change.url}">${change.title}</a>: ${change.desc}
-              ${transformationHtml}
-            </li>
-          `;
-        }).join('')}</ul>
-        <p class="transformation-request">
-          To request additional transformations to be built into the Migration Assistant, 
-          open a github issue <a href="https://github.com/opensearch-project/opensearch-migrations/issues">here</a>.
-        </p>
-      `;
-    } else {
-      results.innerHTML = `
-        <p>No specific breaking changes found for your selection.</p>
-        <p class="transformation-request">
-          To request additional transformations to be built into the Migration Assistant, 
-          open a github issue <a href="https://github.com/opensearch-project/opensearch-migrations/issues">here</a>.
-        </p>
-      `;
-    }
+    // Use the UI module's displayResults function to avoid duplication
+    BreakingChangesUI.UIManager.displayResults(relevantChanges, results);
   };
   
   // Add event listeners for checkboxes

--- a/_migration-assistant/assets/js/breaking-changes-filter.js
+++ b/_migration-assistant/assets/js/breaking-changes-filter.js
@@ -8,7 +8,7 @@
  * - Displays results in a formatted list
  * - Supports bidirectional filtering of source and target versions
  */
-import { isVersionBetween, getVersionIndex } from './breaking-changes-data.js';
+import { getVersionIndex, breakingChanges } from './breaking-changes-data.js';
 document.addEventListener('DOMContentLoaded', () => {
   // Wait for migration data to be initialized
   if (typeof initializeMigrationData === 'function') {
@@ -157,11 +157,16 @@ document.addEventListener('DOMContentLoaded', () => {
       // 1. The breaking change was introduced in a version that is between source and target (inclusive of target)
       // 2. The source version is at or after the minimum source version affected
       // 3. The target version is at or before the maximum target version affected
+      
+      // Handle optional affects field by using defaults if not present
+      const minSource = change.affects && change.affects.minSource ? change.affects.minSource : VERSIONS[0]; // Default to oldest version
+      const maxTarget = change.affects && change.affects.maxTarget ? change.affects.maxTarget : VERSIONS[VERSIONS.length - 1]; // Default to newest version
+      
       const versionMatch = 
         introducedInIdx <= targetVersionIdx && // Breaking change was introduced at or before target
         sourceVersionIdx < targetVersionIdx && // Valid migration path (source before target)
-        sourceVersionIdx >= getVersionIndex(change.affects.minSource) && // Source is affected
-        targetVersionIdx <= getVersionIndex(change.affects.maxTarget); // Target is affected
+        sourceVersionIdx >= getVersionIndex(minSource) && // Source is affected
+        targetVersionIdx <= getVersionIndex(maxTarget); // Target is affected
       
       // For component filtering:
       // - Always include changes with empty comp array (default/data components)

--- a/_migration-assistant/assets/js/breaking-changes-filter.js
+++ b/_migration-assistant/assets/js/breaking-changes-filter.js
@@ -1,0 +1,176 @@
+/**
+ * Breaking changes filter - displays relevant breaking changes based on selected versions and components
+ * 
+ * Features:
+ * - Dynamically generates dropdowns and checkboxes from configuration arrays
+ * - Automatically checks all component checkboxes by default
+ * - Filters breaking changes based on source version, target version, and components
+ * - Displays results in a formatted list
+ * - Supports bidirectional filtering of source and target versions
+ */
+document.addEventListener('DOMContentLoaded', () => {
+  // Cache DOM elements
+  const src = document.getElementById('source-version');
+  const tgt = document.getElementById('target-version');
+  const componentContainer = document.getElementById('component-checkboxes');
+  const results = document.getElementById('breaking-changes-results');
+  
+  // Flag to prevent infinite loops when updating dropdowns
+  let isUpdating = false;
+  
+  // Helper function to create dropdown options
+  const createOption = (value, text) => {
+    const option = document.createElement('option');
+    option.value = value;
+    option.textContent = text;
+    return option;
+  };
+  
+  // Helper function to populate a dropdown with versions
+  const populateDropdown = (dropdown, versions, placeholder = 'Select Version') => {
+    const currentValue = dropdown.value;
+    
+    while (dropdown.firstChild) {
+      dropdown.removeChild(dropdown.firstChild);
+    }
+    
+    dropdown.appendChild(createOption('', placeholder));
+    
+    versions.forEach(versionStr => {
+      const [type, value] = versionStr.split(':');
+      dropdown.appendChild(createOption(versionStr, `${type} ${value}`));
+    });
+    
+    if (currentValue && versions.includes(currentValue)) {
+      dropdown.value = currentValue;
+    }
+  };
+  
+  // Get all available version strings
+  const allVersionStrings = VERSIONS.map(v => `${v.type}:${v.value}`);
+  
+  // Populate source dropdown with all versions initially
+  populateDropdown(src, allVersionStrings, 'Select Source');
+  
+  // Populate target dropdown with all versions initially
+  populateDropdown(tgt, allVersionStrings, 'Select Target');
+  
+  // Function to update target dropdown based on selected source
+  const updateTargetDropdown = () => {
+    if (isUpdating) return;
+    isUpdating = true;
+    
+    const selectedSrc = src.value;
+    
+    if (selectedSrc) {
+      // Get valid targets for this source
+      const validTargets = MIGRATION_MAP.sourceToTargets[selectedSrc] || [];
+      populateDropdown(tgt, validTargets, 'Select Target');
+    } else {
+      // If no source selected, show all possible targets
+      populateDropdown(tgt, allVersionStrings, 'Select Target');
+    }
+    
+    isUpdating = false;
+    updateResults();
+  };
+  
+  // Function to update source dropdown based on selected target
+  const updateSourceDropdown = () => {
+    if (isUpdating) return;
+    isUpdating = true;
+    
+    const selectedTgt = tgt.value;
+    
+    if (selectedTgt) {
+      // Get valid sources for this target
+      const validSources = MIGRATION_MAP.targetToSources[selectedTgt] || [];
+      populateDropdown(src, validSources, 'Select Source');
+    } else {
+      // If no target selected, show all possible sources
+      populateDropdown(src, allVersionStrings, 'Select Source');
+    }
+
+    isUpdating = false;
+    updateResults();
+  };
+  
+  // Add event listeners for dropdown changes
+  src.addEventListener('change', updateTargetDropdown);
+  tgt.addEventListener('change', updateSourceDropdown);
+  
+  const uiComponents = COMPONENTS;
+  
+  uiComponents.forEach(comp => {
+    const id = `component-${comp}`;
+    
+    const span = document.createElement('span');
+    span.className = 'component-checkbox';
+    
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.id = id;
+    checkbox.value = comp;
+    checkbox.checked = true; // Check by default
+    
+    const label = document.createElement('label');
+    label.htmlFor = id;
+    label.textContent = comp.charAt(0).toUpperCase() + comp.slice(1);
+    
+    span.appendChild(checkbox);
+    span.appendChild(label);
+    componentContainer.appendChild(span);
+  });
+  
+  // Get all checkboxes
+  const checkboxes = document.querySelectorAll('#component-checkboxes input[type="checkbox"]');
+  
+  // Update results based on selected filters
+  const updateResults = () => {
+    const selectedSrc = src.value;
+    const selectedTgt = tgt.value;
+    
+    // Show message if source or target not selected
+    if (!selectedSrc || !selectedTgt) {
+      results.innerHTML = '<p>Please select both source and target versions to see breaking changes.</p>';
+      return;
+    }
+    
+    const selectedComp = Array.from(checkboxes)
+      .filter(cb => cb.checked)
+      .map(cb => cb.value);
+    
+    // Check if source and target are the same
+    if (selectedSrc === selectedTgt) {
+      results.innerHTML = '<p>No breaking changes when source and target versions are the same.</p>';
+      return;
+    }
+    
+    // Filter breaking changes based on selection
+    const relevantChanges = breakingChanges.filter(change => 
+      change.src.includes(selectedSrc) && 
+      change.tgt.includes(selectedTgt) && 
+      (change.comp.length === 0 || 
+       selectedComp.length === 0 || 
+       change.comp.some(c => selectedComp.includes(c)))
+    );
+    
+    // Display results
+    if (relevantChanges.length) {
+      results.innerHTML = `
+        <h4>Relevant Breaking Changes:</h4>
+        <ul>${relevantChanges.map(change => 
+          `<li><a href="${change.url}">${change.title}</a>: ${change.desc}</li>`
+        ).join('')}</ul>
+      `;
+    } else {
+      results.innerHTML = '<p>No specific breaking changes found for your selection.</p>';
+    }
+  };
+  
+  // Add event listeners for checkboxes
+  checkboxes.forEach(el => el.addEventListener('change', updateResults));
+  
+  // Initialize results
+  updateResults();
+});

--- a/_migration-assistant/assets/js/breaking-changes-index.js
+++ b/_migration-assistant/assets/js/breaking-changes-index.js
@@ -1,0 +1,55 @@
+/**
+ * Breaking Changes Index
+ * 
+ * Main entry point for the breaking changes functionality
+ * Initializes modules and wires everything together
+ */
+
+import BreakingChangesModule from './breaking-changes-module.js';
+import BreakingChangesUI from './breaking-changes-ui.js';
+
+// Export initializeMigrationData function for compatibility with original code
+export function initializeMigrationData() {
+  // Get migration data from the data attribute
+  const migrationDataElement = document.getElementById('migration-data');
+  
+  if (!migrationDataElement) {
+    console.error('Migration data element not found');
+    return;
+  }
+  
+  try {
+    // Parse the JSON data from the data attribute
+    const migrationPaths = JSON.parse(migrationDataElement.dataset.migrationPaths || '[]');
+    
+    // Initialize the module with data
+    BreakingChangesModule.initialize(migrationPaths);
+  } catch (error) {
+    console.error('Failed to initialize migration data:', error);
+  }
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  // Get migration data from the data attribute
+  const migrationDataElement = document.getElementById('migration-data');
+  
+  if (!migrationDataElement) {
+    console.error('Migration data element not found');
+    return;
+  }
+  
+  try {
+    // Parse the JSON data from the data attribute
+    const migrationPaths = JSON.parse(migrationDataElement.dataset.migrationPaths || '[]');
+    
+    // Initialize the module with data
+    BreakingChangesModule.initialize(migrationPaths);
+    
+    // Initialize UI
+    BreakingChangesUI.UIManager.initialize();
+    
+    console.log('Breaking changes functionality initialized successfully');
+  } catch (error) {
+    console.error('Failed to initialize breaking changes functionality:', error);
+  }
+});

--- a/_migration-assistant/assets/js/breaking-changes-index.js
+++ b/_migration-assistant/assets/js/breaking-changes-index.js
@@ -29,7 +29,8 @@ export function initializeMigrationData() {
   }
 }
 
-document.addEventListener('DOMContentLoaded', () => {
+// Function to initialize the breaking changes functionality
+function initializeBreakingChanges() {
   // Get migration data from the data attribute
   const migrationDataElement = document.getElementById('migration-data');
   
@@ -41,6 +42,7 @@ document.addEventListener('DOMContentLoaded', () => {
   try {
     // Parse the JSON data from the data attribute
     const migrationPaths = JSON.parse(migrationDataElement.dataset.migrationPaths || '[]');
+    const breakingChangesData = JSON.parse(migrationDataElement.dataset.breakingChanges || '[]');
     
     // Initialize the module with data
     BreakingChangesModule.initialize(migrationPaths);
@@ -51,5 +53,18 @@ document.addEventListener('DOMContentLoaded', () => {
     console.log('Breaking changes functionality initialized successfully');
   } catch (error) {
     console.error('Failed to initialize breaking changes functionality:', error);
+  }
+}
+
+// Initialize on DOMContentLoaded
+document.addEventListener('DOMContentLoaded', initializeBreakingChanges);
+
+// Also initialize on window load to handle browser back/forward navigation
+window.addEventListener('pageshow', (event) => {
+  // The pageshow event is fired when the page is shown, including when navigating back to the page
+  // The persisted property is true if the page is being restored from the bfcache
+  if (event.persisted) {
+    console.log('Page restored from back-forward cache, reinitializing breaking changes');
+    initializeBreakingChanges();
   }
 });

--- a/_migration-assistant/assets/js/breaking-changes-module.js
+++ b/_migration-assistant/assets/js/breaking-changes-module.js
@@ -1,0 +1,464 @@
+/**
+ * Breaking Changes Module
+ * 
+ * Handles version management, breaking changes data, and filtering logic
+ * Provides a clean API for the UI layer to interact with
+ */
+
+// Global variables for compatibility with existing code
+// These will be initialized by the module and exported
+export let VERSIONS = [];
+export let VERSION_ORDER = [];
+export let MIGRATION_MAP = { sourceToTargets: {}, targetToSources: {} };
+export let breakingChanges = [];
+
+// Export utility functions for compatibility with existing code
+export function getVersionIndex(version) {
+  const index = VERSION_ORDER.indexOf(version);
+  if (index === -1) throw new Error(`Unknown version: ${version}`);
+  return index;
+}
+
+export function isVersionBetween(target, min, max) {
+  const targetIdx = getVersionIndex(target);
+  const minIdx = getVersionIndex(min);
+  const maxIdx = getVersionIndex(max);
+  return targetIdx >= minIdx && targetIdx <= maxIdx;
+}
+
+const BreakingChangesModule = (function() {
+  // Private variables
+  let versions = [];
+  let versionOrder = [];
+  let migrationMap = { sourceToTargets: {}, targetToSources: {} };
+  
+  // Breaking changes data
+  const breakingChangesData = [
+    {
+      title: "Amazon OpenSearch Service: Upgrade Guidance",
+      url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html",
+      introducedIn: "OpenSearch 1.3",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: []
+    },
+    {
+      title: "Amazon OpenSearch Service: Rename - Summary of changes",
+      url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html",
+      introducedIn: "OpenSearch 1.3",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: []
+    },
+    {
+      title: "OpenSearch 2.0: Remove mapping types parameter",
+      url: "/docs/latest/breaking-changes/#remove-mapping-types-parameter",
+      introducedIn: "OpenSearch 2.19",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: [],
+      transformation: {
+        title: "Type Mapping Deprecation",
+        url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+      }
+    },
+    {
+      title: "OpenSearch Notifications Plugins",
+      url: "/breaking-changes/#add-opensearch-notifications-plugins",
+      introducedIn: "OpenSearch 2.19",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: []
+    },
+    {
+      title: "OpenSearch 2.0: Client JDK 8 Support Dropped",
+      url: "/docs/latest/breaking-changes/#drop-support-for-jdk-8",
+      introducedIn: "OpenSearch 2.19",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: []
+    },
+    {
+      title: "Removal of Types in Elasticsearch 7.x",
+      url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/removal-of-types.html",
+      introducedIn: "Elasticsearch 7.10",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: [],
+      transformation: {
+        title: "Type Mapping Deprecation",
+        url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+      }
+    },
+    {
+      title: "Elasticsearch 6.0 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html",
+      introducedIn: "Elasticsearch 6.8",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: []
+    },
+    {
+      title: "Elasticsearch 6.7 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html",
+      introducedIn: "Elasticsearch 6.8",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: []
+    },
+    {
+      title: "Kibana 6.0 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes-6.0.html",
+      introducedIn: "Elasticsearch 6.8",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: ["dashboards"]
+    },
+    {
+      title: "Kibana 6.3 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.3.0.html#breaking-6.3.0",
+      introducedIn: "Elasticsearch 6.8",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: ["dashboards"]
+    },
+    {
+      title: "Kibana 6.4 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.4.0.html#breaking-6.4.0",
+      introducedIn: "Elasticsearch 6.8",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: ["dashboards"]
+    },
+    {
+      title: "Kibana 6.6 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.6.0.html#breaking-6.6.0",
+      introducedIn: "Elasticsearch 6.8",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: ["dashboards"]
+    },
+    {
+      title: "Kibana 6.7 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.7.0.html#breaking-6.7.0",
+      introducedIn: "Elasticsearch 6.8",
+      affects: {
+        minSource: "Elasticsearch 5.6",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: ["dashboards"]
+    },
+    {
+      title: "Kibana 7.0 Breaking Changes",
+      url: "https://www.elastic.co/guide/en/kibana/7.10/breaking-changes-7.0.html",
+      introducedIn: "Elasticsearch 7.10",
+      affects: {
+        minSource: "Elasticsearch 6.8",
+        maxTarget: "OpenSearch 2.19"
+      },
+      comp: ["dashboards"]
+    }
+  ];
+
+  /**
+   * Version Manager - Handles all version-related operations
+   */
+  const VersionManager = {
+    /**
+     * Get the index of a version in the ordered version array
+     * @param {string} version - The version to find
+     * @returns {number} The index of the version
+     */
+    getVersionIndex(version) {
+      const index = versionOrder.indexOf(version);
+      if (index === -1) throw new Error(`Unknown version: ${version}`);
+      return index;
+    },
+
+    /**
+     * Check if a version is between two other versions (inclusive)
+     * @param {string} target - The version to check
+     * @param {string} min - The minimum version
+     * @param {string} max - The maximum version
+     * @returns {boolean} True if the target is between min and max
+     */
+    isVersionBetween(target, min, max) {
+      const targetIdx = this.getVersionIndex(target);
+      const minIdx = this.getVersionIndex(min);
+      const maxIdx = this.getVersionIndex(max);
+      return targetIdx >= minIdx && targetIdx <= maxIdx;
+    },
+
+    /**
+     * Get all valid target versions for a given source version
+     * @param {string} source - The source version
+     * @returns {Array} Array of valid target versions
+     */
+    getValidTargets(source) {
+      return migrationMap.sourceToTargets[source] || [];
+    },
+
+    /**
+     * Get all valid source versions for a given target version
+     * @param {string} target - The target version
+     * @returns {Array} Array of valid source versions
+     */
+    getValidSources(target) {
+      return migrationMap.targetToSources[target] || [];
+    },
+
+    /**
+     * Get all available versions
+     * @returns {Array} Array of all versions
+     */
+    getAllVersions() {
+      return versions;
+    },
+
+    /**
+     * Get the ordered list of versions
+     * @returns {Array} Array of versions in order
+     */
+    getVersionOrder() {
+      return versionOrder;
+    }
+  };
+
+  /**
+   * Breaking Changes Manager - Handles breaking changes data and filtering
+   */
+  const BreakingChangesManager = {
+    /**
+     * Get all breaking changes
+     * @returns {Array} Array of breaking changes
+     */
+    getBreakingChanges() {
+      return breakingChangesData;
+    },
+
+    /**
+     * Filter breaking changes based on source, target, and components
+     * @param {string} source - The source version
+     * @param {string} target - The target version
+     * @param {Array} selectedComponents - Array of selected component names
+     * @returns {Array} Filtered breaking changes
+     */
+    filterBreakingChanges(source, target, selectedComponents) {
+      if (!source || !target || source === target) {
+        return [];
+      }
+
+      return breakingChangesData.filter(change => {
+        // Check if the breaking change applies to this migration path
+        const sourceVersionIdx = VersionManager.getVersionIndex(source);
+        const targetVersionIdx = VersionManager.getVersionIndex(target);
+        const introducedInIdx = VersionManager.getVersionIndex(change.introducedIn);
+        
+        // A breaking change applies if:
+        // 1. The breaking change was introduced in a version that is between source and target (inclusive of target)
+        // 2. The source version is at or after the minimum source version affected
+        // 3. The target version is at or before the maximum target version affected
+        const versionMatch = 
+          introducedInIdx <= targetVersionIdx && // Breaking change was introduced at or before target
+          sourceVersionIdx < targetVersionIdx && // Valid migration path (source before target)
+          sourceVersionIdx >= VersionManager.getVersionIndex(change.affects.minSource) && // Source is affected
+          targetVersionIdx <= VersionManager.getVersionIndex(change.affects.maxTarget); // Target is affected
+        
+        // For component filtering:
+        // - Always include changes with empty comp array (default/data components)
+        // - Only include dashboard components if the checkbox is checked
+        const componentMatch = 
+          change.comp.length === 0 || // Include changes with no specific component (default/data)
+          change.comp.some(comp => selectedComponents.includes(comp)); // Include if any component matches
+        
+        return versionMatch && componentMatch;
+      });
+    },
+
+    /**
+     * Get all unique components from breaking changes
+     * @returns {Array} Array of unique component names
+     */
+    getUniqueComponents() {
+      const components = new Set();
+      breakingChangesData.forEach(change => {
+        change.comp.forEach(comp => components.add(comp));
+      });
+      return Array.from(components);
+    }
+  };
+
+  /**
+   * Initialize the module with migration data
+   * @param {Array} migrationPaths - Array of migration paths from YAML
+   */
+  function initialize(migrationPaths) {
+    try {
+      // Transform the data structure from YAML format to the expected JavaScript object format
+      const validMigrations = migrationPaths.reduce((acc, path) => {
+        acc[path.source] = path.targets;
+        return acc;
+      }, {});
+      
+      // Extract unique versions
+      versions = extractUniqueVersions(validMigrations);
+      
+      // Generate migration maps
+      migrationMap = {
+        sourceToTargets: validMigrations,
+        targetToSources: generateReverseMigrationMap(validMigrations)
+      };
+      
+      // Determine version ordering
+      versionOrder = determineVersionOrder(versions, migrationMap);
+      
+      // Update global variables for compatibility with existing code
+      VERSIONS = [...versions];
+      VERSION_ORDER = [...versionOrder];
+      MIGRATION_MAP = {
+        sourceToTargets: {...migrationMap.sourceToTargets},
+        targetToSources: {...migrationMap.targetToSources}
+      };
+      breakingChanges = [...breakingChangesData];
+      
+      console.log('Initialized version order:', versionOrder);
+    } catch (error) {
+      console.error('Failed to initialize migration data:', error);
+      // Fallback to empty arrays if initialization fails
+      versions = [];
+      versionOrder = [];
+      migrationMap = { sourceToTargets: {}, targetToSources: {} };
+    }
+  }
+
+  /**
+   * Extract all unique versions from migration paths
+   * @param {Object} migrationsMap - Map of source versions to target versions
+   * @returns {Array} Array of unique versions
+   */
+  function extractUniqueVersions(migrationsMap) {
+    const versionsSet = new Set();
+    
+    // Add all sources
+    Object.keys(migrationsMap).forEach(source => {
+      versionsSet.add(source);
+    });
+    
+    // Add all targets
+    Object.values(migrationsMap).forEach(targets => {
+      targets.forEach(target => {
+        versionsSet.add(target);
+      });
+    });
+    
+    return Array.from(versionsSet).sort();
+  }
+
+  /**
+   * Generate a reverse mapping from target versions to source versions
+   * @param {Object} forwardMap - Map of source versions to target versions
+   * @returns {Object} Map of target versions to source versions
+   */
+  function generateReverseMigrationMap(forwardMap) {
+    const reverseMap = {};
+    
+    Object.entries(forwardMap).forEach(([source, targets]) => {
+      targets.forEach(target => {
+        if (!reverseMap[target]) {
+          reverseMap[target] = [];
+        }
+        reverseMap[target].push(source);
+      });
+    });
+    
+    return reverseMap;
+  }
+
+  /**
+   * Determine the order of versions based on migration paths
+   * @param {Array} versions - Array of all versions
+   * @param {Object} migrationMap - Map of source versions to target versions and vice versa
+   * @returns {Array} Ordered array of versions
+   */
+  function determineVersionOrder(versions, migrationMap) {
+    // Start with a copy of all versions
+    const remainingVersions = [...versions];
+    const orderedVersions = [];
+    
+    // First, find versions that are only sources (not targets)
+    // These are the oldest versions
+    const onlySources = versions.filter(v => 
+      !Object.values(migrationMap.targetToSources).flat().includes(v) && 
+      migrationMap.sourceToTargets[v]
+    );
+    
+    // Add oldest versions first
+    onlySources.forEach(v => {
+      orderedVersions.push(v);
+      const index = remainingVersions.indexOf(v);
+      if (index !== -1) remainingVersions.splice(index, 1);
+    });
+    
+    // Then add the rest based on migration paths
+    while (remainingVersions.length > 0) {
+      let added = false;
+      
+      for (let i = 0; i < remainingVersions.length; i++) {
+        const version = remainingVersions[i];
+        const sources = migrationMap.targetToSources[version] || [];
+        
+        // If all sources of this version are already in orderedVersions,
+        // we can add this version next
+        if (sources.every(s => orderedVersions.includes(s))) {
+          orderedVersions.push(version);
+          remainingVersions.splice(i, 1);
+          added = true;
+          break;
+        }
+      }
+      
+      // If we couldn't add any version in this pass, there might be a cycle
+      // Just add the first remaining version to break the cycle
+      if (!added && remainingVersions.length > 0) {
+        orderedVersions.push(remainingVersions[0]);
+        remainingVersions.splice(0, 1);
+      }
+    }
+    
+    return orderedVersions;
+  }
+
+  // Public API
+  return {
+    initialize,
+    VersionManager,
+    BreakingChangesManager
+  };
+})();
+
+// Export for ES modules
+export default BreakingChangesModule;

--- a/_migration-assistant/assets/js/breaking-changes-module.js
+++ b/_migration-assistant/assets/js/breaking-changes-module.js
@@ -140,6 +140,7 @@ const BreakingChangesModule = (function() {
         
         const versionMatch = 
           introducedInIdx <= targetVersionIdx && // Breaking change was introduced at or before target
+          introducedInIdx > sourceVersionIdx && // Breaking change was introduced after source
           sourceVersionIdx < targetVersionIdx && // Valid migration path (source before target)
           sourceVersionIdx >= VersionManager.getVersionIndex(minSource) && // Source is affected
           targetVersionIdx <= VersionManager.getVersionIndex(maxTarget); // Target is affected

--- a/_migration-assistant/assets/js/breaking-changes-module.js
+++ b/_migration-assistant/assets/js/breaking-changes-module.js
@@ -32,157 +32,8 @@ const BreakingChangesModule = (function() {
   let versionOrder = [];
   let migrationMap = { sourceToTargets: {}, targetToSources: {} };
   
-  // Breaking changes data
-  const breakingChangesData = [
-    {
-      title: "Amazon OpenSearch Service: Upgrade Guidance",
-      url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html",
-      introducedIn: "OpenSearch 1.3",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: []
-    },
-    {
-      title: "Amazon OpenSearch Service: Rename - Summary of changes",
-      url: "https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html",
-      introducedIn: "OpenSearch 1.3",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: []
-    },
-    {
-      title: "OpenSearch 2.0: Remove mapping types parameter",
-      url: "/docs/latest/breaking-changes/#remove-mapping-types-parameter",
-      introducedIn: "OpenSearch 2.19",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: [],
-      transformation: {
-        title: "Type Mapping Deprecation",
-        url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
-      }
-    },
-    {
-      title: "OpenSearch Notifications Plugins",
-      url: "/breaking-changes/#add-opensearch-notifications-plugins",
-      introducedIn: "OpenSearch 2.19",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: []
-    },
-    {
-      title: "OpenSearch 2.0: Client JDK 8 Support Dropped",
-      url: "/docs/latest/breaking-changes/#drop-support-for-jdk-8",
-      introducedIn: "OpenSearch 2.19",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: []
-    },
-    {
-      title: "Removal of Types in Elasticsearch 7.x",
-      url: "https://www.elastic.co/guide/en/elasticsearch/reference/7.10/removal-of-types.html",
-      introducedIn: "Elasticsearch 7.10",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: [],
-      transformation: {
-        title: "Type Mapping Deprecation",
-        url: "/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
-      }
-    },
-    {
-      title: "Elasticsearch 6.0 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.0.html",
-      introducedIn: "Elasticsearch 6.8",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: []
-    },
-    {
-      title: "Elasticsearch 6.7 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/elasticsearch/reference/6.8/breaking-changes-6.7.html",
-      introducedIn: "Elasticsearch 6.8",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: []
-    },
-    {
-      title: "Kibana 6.0 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/kibana/6.8/breaking-changes-6.0.html",
-      introducedIn: "Elasticsearch 6.8",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: ["dashboards"]
-    },
-    {
-      title: "Kibana 6.3 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.3.0.html#breaking-6.3.0",
-      introducedIn: "Elasticsearch 6.8",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: ["dashboards"]
-    },
-    {
-      title: "Kibana 6.4 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.4.0.html#breaking-6.4.0",
-      introducedIn: "Elasticsearch 6.8",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: ["dashboards"]
-    },
-    {
-      title: "Kibana 6.6 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.6.0.html#breaking-6.6.0",
-      introducedIn: "Elasticsearch 6.8",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: ["dashboards"]
-    },
-    {
-      title: "Kibana 6.7 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/kibana/6.8/release-notes-6.7.0.html#breaking-6.7.0",
-      introducedIn: "Elasticsearch 6.8",
-      affects: {
-        minSource: "Elasticsearch 5.6",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: ["dashboards"]
-    },
-    {
-      title: "Kibana 7.0 Breaking Changes",
-      url: "https://www.elastic.co/guide/en/kibana/7.10/breaking-changes-7.0.html",
-      introducedIn: "Elasticsearch 7.10",
-      affects: {
-        minSource: "Elasticsearch 6.8",
-        maxTarget: "OpenSearch 2.19"
-      },
-      comp: ["dashboards"]
-    }
-  ];
+  // Breaking changes data - will be loaded from the data attribute
+  let breakingChangesData = [];
 
   /**
    * Version Manager - Handles all version-related operations
@@ -282,11 +133,16 @@ const BreakingChangesModule = (function() {
         // 1. The breaking change was introduced in a version that is between source and target (inclusive of target)
         // 2. The source version is at or after the minimum source version affected
         // 3. The target version is at or before the maximum target version affected
+        
+        // Handle optional affects field by using defaults if not present
+        const minSource = change.affects && change.affects.minSource ? change.affects.minSource : versions[0]; // Default to oldest version
+        const maxTarget = change.affects && change.affects.maxTarget ? change.affects.maxTarget : versions[versions.length - 1]; // Default to newest version
+        
         const versionMatch = 
           introducedInIdx <= targetVersionIdx && // Breaking change was introduced at or before target
           sourceVersionIdx < targetVersionIdx && // Valid migration path (source before target)
-          sourceVersionIdx >= VersionManager.getVersionIndex(change.affects.minSource) && // Source is affected
-          targetVersionIdx <= VersionManager.getVersionIndex(change.affects.maxTarget); // Target is affected
+          sourceVersionIdx >= VersionManager.getVersionIndex(minSource) && // Source is affected
+          targetVersionIdx <= VersionManager.getVersionIndex(maxTarget); // Target is affected
         
         // For component filtering:
         // - Always include changes with empty comp array (default/data components)
@@ -317,6 +173,27 @@ const BreakingChangesModule = (function() {
    * @param {Array} migrationPaths - Array of migration paths from YAML
    */
   function initialize(migrationPaths) {
+    // Get the migration data element
+    const migrationDataElement = document.getElementById('migration-data');
+    
+    if (!migrationDataElement) {
+      console.error('Migration data element not found');
+      return;
+    }
+    
+    // Load breaking changes data if available
+    if (migrationDataElement.dataset.breakingChanges) {
+      try {
+        breakingChangesData = JSON.parse(migrationDataElement.dataset.breakingChanges);
+        console.log('Loaded breaking changes data:', breakingChangesData.length);
+      } catch (error) {
+        console.error('Failed to parse breaking changes data:', error);
+        breakingChangesData = [];
+      }
+    } else {
+      console.error('Breaking changes data not found in migration-data element');
+      breakingChangesData = [];
+    }
     try {
       // Transform the data structure from YAML format to the expected JavaScript object format
       const validMigrations = migrationPaths.reduce((acc, path) => {

--- a/_migration-assistant/assets/js/breaking-changes-ui.js
+++ b/_migration-assistant/assets/js/breaking-changes-ui.js
@@ -283,11 +283,16 @@ const BreakingChangesUI = (function() {
           // 1. The breaking change was introduced in a version that is between source and target (inclusive of target)
           // 2. The source version is at or after the minimum source version affected
           // 3. The target version is at or before the maximum target version affected
+          
+          // Handle optional affects field by using defaults if not present
+          const minSource = change.affects && change.affects.minSource ? change.affects.minSource : VERSIONS[0]; // Default to oldest version
+          const maxTarget = change.affects && change.affects.maxTarget ? change.affects.maxTarget : VERSIONS[VERSIONS.length - 1]; // Default to newest version
+          
           const versionMatch = 
             introducedInIdx <= targetVersionIdx && // Breaking change was introduced at or before target
             sourceVersionIdx < targetVersionIdx && // Valid migration path (source before target)
-            sourceVersionIdx >= getVersionIndex(change.affects.minSource) && // Source is affected
-            targetVersionIdx <= getVersionIndex(change.affects.maxTarget); // Target is affected
+            sourceVersionIdx >= getVersionIndex(minSource) && // Source is affected
+            targetVersionIdx <= getVersionIndex(maxTarget); // Target is affected
           
           // For component filtering:
           // - Always include changes with empty comp array (default/data components)

--- a/_migration-assistant/assets/js/breaking-changes-ui.js
+++ b/_migration-assistant/assets/js/breaking-changes-ui.js
@@ -1,0 +1,356 @@
+/**
+ * Breaking Changes UI Module
+ * 
+ * Handles all UI operations for the breaking changes selector
+ * Provides a clean separation between UI logic and data logic
+ */
+
+import BreakingChangesModule, { VERSIONS, VERSION_ORDER, MIGRATION_MAP, breakingChanges, getVersionIndex } from './breaking-changes-module.js';
+
+const BreakingChangesUI = (function() {
+  // Cache for DOM elements
+  const elements = {
+    sourceSelect: null,
+    targetSelect: null,
+    componentContainer: null,
+    resultsContainer: null
+  };
+
+  // Flag to prevent infinite loops when updating dropdowns
+  let isUpdating = false;
+
+  /**
+   * UI Manager - Handles all UI operations
+   */
+  const UIManager = {
+    /**
+     * Initialize the UI
+     */
+    initialize() {
+      // Cache DOM elements
+      elements.sourceSelect = document.getElementById('source-version');
+      elements.targetSelect = document.getElementById('target-version');
+      elements.componentContainer = document.getElementById('component-checkboxes');
+      elements.resultsContainer = document.getElementById('breaking-changes-results');
+      
+      if (!elements.sourceSelect || !elements.targetSelect || 
+          !elements.componentContainer || !elements.resultsContainer) {
+        console.error('Required DOM elements not found');
+        return;
+      }
+      
+      // Set up event listeners
+      this.setupEventListeners();
+      
+      // Populate dropdowns with all versions
+      // Use the global VERSIONS array for compatibility with original code
+      const allVersions = VERSIONS;
+      console.log('Available versions:', allVersions);
+      this.populateVersionDropdowns(allVersions);
+      
+      // Set up component checkboxes
+      this.setupComponentCheckboxes();
+      
+      // Initialize results
+      this.updateResults();
+    },
+
+    /**
+     * Set up event listeners for dropdowns and checkboxes
+     */
+    setupEventListeners() {
+      elements.sourceSelect.addEventListener('change', () => {
+        this.onSourceChange();
+      });
+      
+      elements.targetSelect.addEventListener('change', () => {
+        this.onTargetChange();
+      });
+    },
+
+    /**
+     * Create an option element for a dropdown
+     * @param {string} value - The option value
+     * @param {string} text - The option text
+     * @returns {HTMLOptionElement} The created option element
+     */
+    createOption(value, text) {
+      const option = document.createElement('option');
+      option.value = value;
+      option.textContent = text;
+      return option;
+    },
+
+    /**
+     * Populate a dropdown with versions
+     * @param {Array} versions - Array of version strings
+     * @param {HTMLSelectElement} dropdown - The dropdown to populate
+     * @param {string} placeholder - Placeholder text for the default option
+     */
+    populateDropdown(dropdown, versions, placeholder = 'Select Version') {
+      const currentValue = dropdown.value;
+      
+      // Clear existing options
+      while (dropdown.firstChild) {
+        dropdown.removeChild(dropdown.firstChild);
+      }
+      
+      // Add placeholder option
+      dropdown.appendChild(this.createOption('', placeholder));
+      
+      // Add version options
+      versions.forEach(version => {
+        dropdown.appendChild(this.createOption(version, version));
+      });
+      
+      // Restore selected value if it still exists
+      if (currentValue && versions.includes(currentValue)) {
+        dropdown.value = currentValue;
+      }
+    },
+
+    /**
+     * Populate both version dropdowns
+     * @param {Array} versions - Array of version strings
+     */
+    populateVersionDropdowns(versions) {
+      this.populateDropdown(elements.sourceSelect, versions, 'Select Source');
+      this.populateDropdown(elements.targetSelect, versions, 'Select Target');
+    },
+
+    /**
+     * Handle source version change
+     */
+    onSourceChange() {
+      if (isUpdating) return;
+      isUpdating = true;
+      
+      const selectedSource = elements.sourceSelect.value;
+      
+      if (selectedSource) {
+        // Get valid targets for this source
+        const validTargets = MIGRATION_MAP.sourceToTargets[selectedSource] || [];
+        console.log('Valid targets for', selectedSource, ':', validTargets);
+        this.populateDropdown(elements.targetSelect, validTargets, 'Select Target');
+      } else {
+        // If no source selected, show all possible targets
+        this.populateDropdown(elements.targetSelect, VERSIONS, 'Select Target');
+      }
+      
+      isUpdating = false;
+      this.updateResults();
+    },
+
+    /**
+     * Handle target version change
+     */
+    onTargetChange() {
+      if (isUpdating) return;
+      isUpdating = true;
+      
+      const selectedTarget = elements.targetSelect.value;
+      
+      if (selectedTarget) {
+        // Get valid sources for this target
+        const validSources = MIGRATION_MAP.targetToSources[selectedTarget] || [];
+        console.log('Valid sources for', selectedTarget, ':', validSources);
+        this.populateDropdown(elements.sourceSelect, validSources, 'Select Source');
+      } else {
+        // If no target selected, show all possible sources
+        this.populateDropdown(elements.sourceSelect, VERSIONS, 'Select Source');
+      }
+      
+      isUpdating = false;
+      this.updateResults();
+    },
+
+    /**
+     * Set up component checkboxes based on available components
+     */
+    setupComponentCheckboxes() {
+      // Clear existing checkboxes
+      elements.componentContainer.innerHTML = '';
+      
+      // Get unique components from breaking changes
+      const components = this.getUniqueComponents();
+      console.log('Available components:', components);
+      
+      // Create a checkbox for each component
+      components.forEach(component => {
+        const span = document.createElement('span');
+        span.className = 'component-checkbox';
+        
+        const checkbox = document.createElement('input');
+        checkbox.type = 'checkbox';
+        checkbox.id = `component-${component}`;
+        checkbox.value = component;
+        checkbox.checked = false; // Unchecked by default
+        
+        // Add event listener to checkbox
+        checkbox.addEventListener('change', () => {
+          this.updateResults();
+        });
+        
+        const label = document.createElement('label');
+        label.htmlFor = `component-${component}`;
+        label.textContent = component.charAt(0).toUpperCase() + component.slice(1); // Capitalize first letter
+        
+        span.appendChild(checkbox);
+        span.appendChild(label);
+        elements.componentContainer.appendChild(span);
+      });
+      
+      // If no components found, add a message
+      if (components.length === 0) {
+        elements.componentContainer.innerHTML = '<p>No component filters available</p>';
+      }
+    },
+
+    /**
+     * Get selected components from checkboxes
+     * @returns {Array} Array of selected component names
+     */
+    getSelectedComponents() {
+      const checkboxes = elements.componentContainer.querySelectorAll('input[type="checkbox"]');
+      return Array.from(checkboxes)
+        .filter(cb => cb.checked)
+        .map(cb => cb.value);
+    },
+    
+    /**
+     * Get all unique components from breaking changes
+     * @returns {Array} Array of unique component names
+     */
+    getUniqueComponents() {
+      const components = new Set();
+      breakingChanges.forEach(change => {
+        change.comp.forEach(comp => components.add(comp));
+      });
+      return Array.from(components);
+    },
+
+    /**
+     * Update results based on selected filters
+     */
+    updateResults() {
+      const selectedSource = elements.sourceSelect.value;
+      const selectedTarget = elements.targetSelect.value;
+      
+      // Show message if source or target not selected
+      if (!selectedSource || !selectedTarget) {
+        elements.resultsContainer.innerHTML = '<p>Please select both source and target versions to see breaking changes.</p>';
+        return;
+      }
+      
+      // Check if source and target are the same
+      if (selectedSource === selectedTarget) {
+        elements.resultsContainer.innerHTML = '<p>No breaking changes when source and target versions are the same.</p>';
+        return;
+      }
+      
+      // Get selected components
+      const selectedComponents = this.getSelectedComponents();
+      
+      // Filter breaking changes directly using the global variables
+      const relevantChanges = this.filterBreakingChanges(selectedSource, selectedTarget, selectedComponents);
+      console.log('Filtered breaking changes:', relevantChanges);
+      
+      // Display results
+      this.displayResults(relevantChanges);
+    },
+    
+    /**
+     * Filter breaking changes based on source, target, and components
+     * @param {string} source - The source version
+     * @param {string} target - The target version
+     * @param {Array} selectedComponents - Array of selected component names
+     * @returns {Array} Filtered breaking changes
+     */
+    filterBreakingChanges(source, target, selectedComponents) {
+      if (!source || !target || source === target) {
+        return [];
+      }
+
+      try {
+        // Use the imported getVersionIndex function
+        const sourceVersionIdx = getVersionIndex(source);
+        const targetVersionIdx = getVersionIndex(target);
+        
+        return breakingChanges.filter(change => {
+          const introducedInIdx = getVersionIndex(change.introducedIn);
+          
+          // A breaking change applies if:
+          // 1. The breaking change was introduced in a version that is between source and target (inclusive of target)
+          // 2. The source version is at or after the minimum source version affected
+          // 3. The target version is at or before the maximum target version affected
+          const versionMatch = 
+            introducedInIdx <= targetVersionIdx && // Breaking change was introduced at or before target
+            sourceVersionIdx < targetVersionIdx && // Valid migration path (source before target)
+            sourceVersionIdx >= getVersionIndex(change.affects.minSource) && // Source is affected
+            targetVersionIdx <= getVersionIndex(change.affects.maxTarget); // Target is affected
+          
+          // For component filtering:
+          // - Always include changes with empty comp array (default/data components)
+          // - Only include dashboard components if the checkbox is checked
+          const componentMatch = 
+            change.comp.length === 0 || // Include changes with no specific component (default/data)
+            change.comp.some(comp => selectedComponents.includes(comp)); // Include if any component matches
+          
+          return versionMatch && componentMatch;
+        });
+      } catch (error) {
+        console.error('Error filtering breaking changes:', error);
+        return [];
+      }
+    },
+
+    /**
+     * Display filtered breaking changes
+     * @param {Array} changes - Array of breaking changes to display
+     */
+    displayResults(changes) {
+      if (changes.length) {
+        elements.resultsContainer.innerHTML = `
+          <h4>Relevant Breaking Changes:</h4>
+          <ul>${changes.map(change => {
+            let transformationHtml = '';
+            if (change.transformation) {
+              transformationHtml = `
+                <div class="transformation-info">
+                  <strong>Available Migration Assistant Transformation:</strong> 
+                  <a href="${change.transformation.url}">${change.transformation.title}</a>
+                </div>
+              `;
+            }
+            return `
+              <li>
+                <a href="${change.url}">${change.title}</a>
+                ${transformationHtml}
+              </li>
+            `;
+          }).join('')}</ul>
+          <p class="transformation-request">
+            To request additional transformations to be built into the Migration Assistant, 
+            open a github issue <a href="https://github.com/opensearch-project/opensearch-migrations/issues">here</a>.
+          </p>
+        `;
+      } else {
+        elements.resultsContainer.innerHTML = `
+          <p>No specific breaking changes found for your selection.</p>
+          <p class="transformation-request">
+            To request additional transformations to be built into the Migration Assistant, 
+            open a github issue <a href="https://github.com/opensearch-project/opensearch-migrations/issues">here</a>.
+          </p>
+        `;
+      }
+    }
+  };
+
+  // Public API
+  return {
+    UIManager
+  };
+})();
+
+// Export for ES modules
+export default BreakingChangesUI;

--- a/_migration-assistant/assets/js/breaking-changes-ui.js
+++ b/_migration-assistant/assets/js/breaking-changes-ui.js
@@ -39,6 +39,10 @@ const BreakingChangesUI = (function() {
         return;
       }
       
+      // Store original values before populating dropdowns
+      const originalSourceValue = elements.sourceSelect.value;
+      const originalTargetValue = elements.targetSelect.value;
+      
       // Set up event listeners
       this.setupEventListeners();
       
@@ -51,8 +55,24 @@ const BreakingChangesUI = (function() {
       // Set up component checkboxes
       this.setupComponentCheckboxes();
       
+      // Restore original values if they were set (e.g., when navigating back to the page)
+      if (originalSourceValue && originalTargetValue) {
+        console.log('Restoring pre-selected values:', originalSourceValue, originalTargetValue);
+        elements.sourceSelect.value = originalSourceValue;
+        elements.targetSelect.value = originalTargetValue;
+      }
+      
       // Initialize results
       this.updateResults();
+      
+      // Use requestAnimationFrame to wait for the next rendering cycle
+      // This ensures the DOM has been updated before we check for selected values
+      requestAnimationFrame(() => {
+        if (elements.sourceSelect.value && elements.targetSelect.value) {
+          console.log('Selected values detected, updating results after DOM update');
+          this.updateResults();
+        }
+      });
     },
 
     /**
@@ -114,8 +134,23 @@ const BreakingChangesUI = (function() {
      * @param {Array} versions - Array of version strings
      */
     populateVersionDropdowns(versions) {
+      // Populate source dropdown with all versions
       this.populateDropdown(elements.sourceSelect, versions, 'Select Source');
-      this.populateDropdown(elements.targetSelect, versions, 'Select Target');
+      
+      // For target dropdown, only show versions that are targets for any source
+      const allTargetVersions = new Set();
+      
+      // Collect all target versions from the migration map
+      Object.values(MIGRATION_MAP.sourceToTargets).forEach(targets => {
+        targets.forEach(target => allTargetVersions.add(target));
+      });
+      
+      // Convert Set to Array
+      const targetVersions = Array.from(allTargetVersions);
+      console.log('Filtered target versions:', targetVersions);
+      
+      // Populate target dropdown with filtered versions
+      this.populateDropdown(elements.targetSelect, targetVersions, 'Select Target');
     },
 
     /**

--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -16,19 +16,38 @@ There are also tools available for migrating cluster configuration, templates, a
 
 ## Migration paths
 
-| **Source Version**          | **Target Version**               |
-|-----------------------------|----------------------------------|
-| Elasticsearch 5.6           | OpenSearch 1.3                   |
-| Elasticsearch 5.6           | OpenSearch 2.19                  |
-| Elasticsearch 6.8           | OpenSearch 1.3                   |
-| Elasticsearch 6.8           | OpenSearch 2.19                  |
-| Elasticsearch 7.10.2        | OpenSearch 1.3                   |
-| Elasticsearch 7.10.2        | OpenSearch 2.19                  |
-| Elasticsearch 7.17          | OpenSearch 1.3                   |
-| Elasticsearch 7.17          | OpenSearch 2.19                  |
-| OpenSearch 1.3              | OpenSearch 2.19                  |
+{% comment %}First, collect all unique target versions{% endcomment %}
+{% assign all_targets = "" | split: "" %}
+{% for path in site.data.migration-assistant.valid_migrations.migration_paths %}
+  {% for target in path.targets %}
+    {% assign all_targets = all_targets | push: target %}
+  {% endfor %}
+{% endfor %}
+{% assign unique_targets = all_targets | uniq | sort %}
 
- 
+<table class="migration-matrix">
+  <thead>
+    <tr>
+      <th></th>
+      {% for target in unique_targets %}
+        <th>{{ target }}</th>
+      {% endfor %}
+    </tr>
+  </thead>
+  <tbody>
+    {% for path in site.data.migration-assistant.valid_migrations.migration_paths %}
+      <tr>
+        <th>{{ path.source }}</th>
+        {% for target_version in unique_targets %}
+          <td>
+            {% if path.targets contains target_version %}✓{% endif %}
+          </td>
+        {% endfor %}
+      </tr>
+    {% endfor %}
+  </tbody>
+</table>
+
 {: .note}
 
 ### Supported source and target platforms

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -14,19 +14,38 @@ The goal of the Migration Assistant is to streamline the process of migrating fr
 
 ## Understanding breaking changes
 
-Before performing any upgrade or migration, you should review any documentation of breaking changes.  Even if the cluster is migrated there might be changes required for clients to connect to the new cluster
+Before performing any upgrade or migration, you should review any documentation of breaking changes. Even if the cluster is migrated there might be changes required for clients to connect to the new cluster
 
-## Upgrade and breaking changes guides
+<link rel="stylesheet" href="{{site.url}}{{site.baseurl}}/migration-assistant/assets/css/breaking-changes-selector.css">
 
-For migrations paths between Elasticsearch 6.8 and OpenSearch 2.x users should be familiar with documentation in the links below that apply to their specific case:
+<div class="breaking-changes-selector">
+  <h4>Find Breaking Changes for Your Migration Path</h4>
+  
+  <div>
+    <label for="source-version">Source:</label>
+    <select id="source-version">
+      <option value="">Select</option>
+      <!-- Source versions will be populated by JavaScript -->
+    </select>
+    
+    <label for="target-version">Target:</label>
+    <select id="target-version">
+      <option value="">Select</option>
+      <!-- Target versions will be populated by JavaScript -->
+    </select>
+  </div>
+  
+  <div>
+    <label>Components:</label>
+    <!-- Components will be populated by JavaScript -->
+    <span id="component-checkboxes"></span>
+  </div>
+  
+  <div id="breaking-changes-results"></div>
+</div>
 
-* [Upgrading Amazon Service Domains](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/version-migration.html).
-
-* [Changes from Elasticsearch to OpenSearch fork](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/rename.html).
-
-* [OpenSearch Breaking Changes]({{site.url}}{{site.baseurl}}/breaking-changes/).
-
-The next step is to set up a proper test bed to verify that your applications will work as expected on the target version.
+<script src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-data.js"></script>
+<script src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-filter.js"></script>
 
 ## Impact of data transformations
 
@@ -46,5 +65,8 @@ We recommend running production-like queries against the target cluster before s
 
 For complex migrations involving multiple transformations or breaking changes, we highly recommend performing a trial migration with representative, non-production data (e.g., in a staging environment) to fully test client compatibility with the target cluster.
 
+## Included transformations
 
+The following transformations are included in the Migration Assistant. They can be enabled, combined, and configured to tailor a migration to your needs. To request additional transformations to be built into the Migration Assistant, open a github issue [here](https://github.com/opensearch-project/opensearch-migrations/issues).
 
+- [Type Mapping Deprecation](../handling-type-mapping-deprecation)

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -14,12 +14,12 @@ The goal of the Migration Assistant is to streamline the process of migrating fr
 
 ## Understanding breaking changes
 
-Before performing any upgrade or migration, you should review any breaking changes that might exist between version, because there might be changes required for clients to connect to the new cluster:
+Before performing any upgrade or migration, you should review any breaking changes that might exist between version because there may be changes required in order for clients to connect to the new cluster. Use the following tool by selecting the versions in your migration path. The tool will respond with any breaking changes you should note when migrating:
 
 <link rel="stylesheet" href="{{site.url}}{{site.baseurl}}/migration-assistant/assets/css/breaking-changes-selector.css">
 
 <div class="breaking-changes-selector">
-  <h4>Find breaking changes for your migration path</h4>
+  <h4>Find a list of breaking changes for your migration path</h4>
   
   <div>
     <label for="source-version">Source:</label>
@@ -71,6 +71,6 @@ For complex migrations involving multiple transformations or breaking changes, w
 
 ## Supported transformations
 
-The following transformations are included in the Migration Assistant. They can be enabled, combined, and configured to tailor a migration to your needs. To request additional transformations to be built into the Migration Assistant, open a GitHub issue [in the OpenSearch migrations repository](https://github.com/opensearch-project/opensearch-migrations/issues).
+The following [transformations]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/live-traffic-migration/using-traffic-replayer/#transformations) are included in Migration Assistant. They can be enabled, combined, and configured to customize a migration for your use case. To request additional Migration Assistant transformations , create a GitHub issue [in the OpenSearch migrations repository](https://github.com/opensearch-project/opensearch-migrations/issues).
 
 - [Type mapping deprecation]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/)

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -36,13 +36,17 @@ Before performing any upgrade or migration, you should review any documentation 
   </div>
   
   <div>
-    <label>Components:</label>
+    <label>Include Optional Components:</label><br>
     <!-- Components will be populated by JavaScript -->
     <span id="component-checkboxes"></span>
   </div>
   
   <div id="breaking-changes-results"></div>
 </div>
+
+<div id="migration-data" 
+     data-migration-paths="{{ site.data.migration-assistant.valid_migrations.migration_paths | jsonify | escape }}" 
+     style="display:none;"></div>
 
 <script src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-data.js"></script>
 <script src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-filter.js"></script>
@@ -69,4 +73,4 @@ For complex migrations involving multiple transformations or breaking changes, w
 
 The following transformations are included in the Migration Assistant. They can be enabled, combined, and configured to tailor a migration to your needs. To request additional transformations to be built into the Migration Assistant, open a github issue [here](https://github.com/opensearch-project/opensearch-migrations/issues).
 
-- [Type Mapping Deprecation](../handling-type-mapping-deprecation)
+- [Type Mapping Deprecation]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation)

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -14,12 +14,12 @@ The goal of the Migration Assistant is to streamline the process of migrating fr
 
 ## Understanding breaking changes
 
-Before performing any upgrade or migration, you should review any documentation of breaking changes. Even if the cluster is migrated there might be changes required for clients to connect to the new cluster
+Before performing any upgrade or migration, you should review any breaking changes that might exist between version, because there might be changes required for clients to connect to the new cluster:
 
 <link rel="stylesheet" href="{{site.url}}{{site.baseurl}}/migration-assistant/assets/css/breaking-changes-selector.css">
 
 <div class="breaking-changes-selector">
-  <h4>Find Breaking Changes for Your Migration Path</h4>
+  <h4>Find breaking changes for your migration path</h4>
   
   <div>
     <label for="source-version">Source:</label>
@@ -69,8 +69,8 @@ We recommend running production-like queries against the target cluster before s
 
 For complex migrations involving multiple transformations or breaking changes, we highly recommend performing a trial migration with representative, non-production data (e.g., in a staging environment) to fully test client compatibility with the target cluster.
 
-## Included transformations
+## Supported transformations
 
-The following transformations are included in the Migration Assistant. They can be enabled, combined, and configured to tailor a migration to your needs. To request additional transformations to be built into the Migration Assistant, open a github issue [here](https://github.com/opensearch-project/opensearch-migrations/issues).
+The following transformations are included in the Migration Assistant. They can be enabled, combined, and configured to tailor a migration to your needs. To request additional transformations to be built into the Migration Assistant, open a GitHub issue [in the OpenSearch migrations repository](https://github.com/opensearch-project/opensearch-migrations/issues).
 
-- [Type Mapping Deprecation]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation)
+- [Type mapping deprecation]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/)

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -45,7 +45,8 @@ Before performing any upgrade or migration, you should review any documentation 
 </div>
 
 <div id="migration-data" 
-     data-migration-paths="{{ site.data.migration-assistant.valid_migrations.migration_paths | jsonify | escape }}" 
+     data-migration-paths="{{ site.data.migration-assistant.valid_migrations.migration_paths | jsonify | escape }}"
+     data-breaking-changes="{{ site.data.migration-assistant.breaking-changes.breaking_changes | jsonify | escape }}"
      style="display:none;"></div>
 
 <script type="module" src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-index.js"></script>

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -48,8 +48,7 @@ Before performing any upgrade or migration, you should review any documentation 
      data-migration-paths="{{ site.data.migration-assistant.valid_migrations.migration_paths | jsonify | escape }}" 
      style="display:none;"></div>
 
-<script src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-data.js"></script>
-<script src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-filter.js"></script>
+<script type="module" src="{{site.url}}{{site.baseurl}}/migration-assistant/assets/js/breaking-changes-index.js"></script>
 
 ## Impact of data transformations
 


### PR DESCRIPTION
### Description
Add Breaking Changes viewer for migration assistant assessment with links for transformations.

Aligns migration paths with supported migrations in a generated table 

### Issues Resolved
Closes [MIGRATIONS-2416](https://opensearch.atlassian.net/browse/MIGRATIONS-2416)

### Version
Migration Assistant

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

https://github.com/user-attachments/assets/813fa59f-226f-47d9-81b7-c9ddf631e5e1


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
