### PR TITLE
add documentation for skip_existing feature for text embedding processor

### DIFF
--- a/_ingest-pipelines/processors/text-embedding.md
+++ b/_ingest-pipelines/processors/text-embedding.md
@@ -45,6 +45,7 @@ The following table lists the required and optional parameters for the `text_emb
 `if` | String containing a Boolean expression | Optional | A condition for running the processor.|
 `ignore_failure` | Boolean | Optional | Specifies whether the processor continues execution even if it encounters an error. If set to `true`, the processor failure is ignored. Default is `false`.|
 `on_failure` | List | Optional | A list of processors to run if the processor fails. |
+`skip_existing` | Boolean | Optional | Specifies whether the processor skips making inference call for fields that already have embeddings. If set to `true`, the processor will not make inference call on fields where the embeddings haven't changed. Default is `false`.|
 
 ## Using the processor
 

--- a/_ingest-pipelines/processors/text-embedding.md
+++ b/_ingest-pipelines/processors/text-embedding.md
@@ -45,7 +45,7 @@ The following table lists the required and optional parameters for the `text_emb
 `if` | String containing a Boolean expression | Optional | A condition for running the processor.|
 `ignore_failure` | Boolean | Optional | Specifies whether the processor continues execution even if it encounters an error. If set to `true`, the processor failure is ignored. Default is `false`.|
 `on_failure` | List | Optional | A list of processors to run if the processor fails. |
-`skip_existing` | Boolean | Optional | Specifies whether the processor skips making inference call for fields that already have embeddings. If set to `true`, the processor will not make inference call on fields where the embeddings haven't changed. Default is `false`.|
+`skip_existing` | Boolean | Optional | When `true`, the processor does not make inference calls for fields that already contain embeddings, leaving existing embeddings unchanged. Default is `false`.|
 
 ## Using the processor
 


### PR DESCRIPTION
### Description
Adds documentation for "skip_existing" feature in text embedding processor

### Issues Resolved
Closes #9482 

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
