### PR TITLE
Update minimum length of `plugins.security.compliance.salt` parameter as in implementation

### DIFF
--- a/_security/access-control/field-masking.md
+++ b/_security/access-control/field-masking.md
@@ -32,7 +32,7 @@ Field masking works alongside field-level security on the same per-role, per-ind
 
 You can set the salt (a random string used to hash your data) in `opensearch.yml` using the optional `plugins.security.compliance.salt` setting. The salt value must fulfill the following requirements:
 
-- Must be at least 32 characters.
+- Must be at least 16 characters.
 - Use only ASCII characters.
 
 The following example shows a salt value:

--- a/_security/access-control/field-masking.md
+++ b/_security/access-control/field-masking.md
@@ -38,7 +38,7 @@ You can set the salt (a random string used to hash your data) in `opensearch.yml
 The following example shows a salt value:
 
 ```yml
-plugins.security.compliance.salt: abcdefghijklmnopqrstuvqxyz1234567890
+plugins.security.compliance.salt: abcdefghijklmnop
 ```
 
 Although setting the salt is optional, it is highly recommended.


### PR DESCRIPTION
### Description
Updates minimum length of `plugins.security.compliance.salt` parameter.

According to implementation the length of salt must be at least 16 chars https://github.com/opensearch-project/security/blob/975377dc82c2e1ba4ba997408424bb8290a22702/src/main/java/org/opensearch/security/configuration/Salt.java#L34

When length is greater than 16 chars  - there are warning log that only first 16 bytes will be used https://github.com/opensearch-project/security/blob/975377dc82c2e1ba4ba997408424bb8290a22702/src/main/java/org/opensearch/security/configuration/Salt.java#L58

There are unit tests as well for 16 char length salt https://github.com/opensearch-project/security/blob/975377dc82c2e1ba4ba997408424bb8290a22702/src/test/java/org/opensearch/security/configuration/SaltTest.java#L47

### Issues Resolved
None

### Version
All documentation.

### Frontend features
Not applicable.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
