### PR TITLE
Fix 'stored_fields' parameter on GetDocument API 

### DIFF
--- a/_api-reference/document-apis/get-documents.md
+++ b/_api-reference/document-apis/get-documents.md
@@ -3,7 +3,7 @@ layout: default
 title: Get document
 parent: Document APIs
 nav_order: 5
-redirect_from: 
+redirect_from:
  - /opensearch/rest-api/document-apis/get-documents/
 ---
 
@@ -47,7 +47,7 @@ preference | String | Specifies a preference of which shard to retrieve results 
 realtime | Boolean | Specifies whether the operation should run in realtime. If false, the operation waits for the index to refresh to analyze the source to retrieve data, which makes the operation near-realtime. Default is `true`.
 refresh | Boolean | If true, OpenSearch refreshes shards to make the get operation available to search results. Valid options are `true`, `false`, and `wait_for`, which tells OpenSearch to wait for a refresh before executing the operation. Default is `false`.
 routing | String | A value used to route the operation to a specific shard.
-stored_fields | Boolean | Whether the get operation should retrieve fields stored in the index. Default is `false`.
+stored_fields | List | A comma-separated list of fields stored in the index that should be retrieved. Default is no stored fields will be returned.
 _source | String | Whether to include the `_source` field in the response body. Default is `true`.
 _source_excludes | String | A comma-separated list of source fields to exclude in the query response.
 _source_includes | String | A comma-separated list of source fields to include in the query response.
@@ -56,7 +56,7 @@ version_type | Enum | Retrieves a specifically typed document. Available options
 
 ### Real time
 
-The OpenSearch Get Document API operates in real time by default, which means that it retrieves the latest version of the document regardless of the index's refresh rate or the rate at which new data becomes searchable. However, if you request stored fields (using the `stored_fields` parameter) for a document that has been updated but not yet refreshed, then the Get Document API parses and analyzes the document's source to extract those stored fields. 
+The OpenSearch Get Document API operates in real time by default, which means that it retrieves the latest version of the document regardless of the index's refresh rate or the rate at which new data becomes searchable. However, if you request stored fields (using the `stored_fields` parameter) for a document that has been updated but not yet refreshed, then the Get Document API parses and analyzes the document's source to extract those stored fields.
 
 To disable the real-time behavior and retrieve the document based on the last refreshed state of the index, set the `realtime` parameter to `false`.
 
@@ -70,7 +70,7 @@ GET test-index/_doc/0?_source=false
 
 #### `source` includes and excludes
 
-If you only want to retrieve specific fields from the source, use the `_source_includes` or `_source_excludes` parameters to include or exclude particular fields, respectively. This can be beneficial for large documents because retrieving only the required fields can reduce network overhead. 
+If you only want to retrieve specific fields from the source, use the `_source_includes` or `_source_excludes` parameters to include or exclude particular fields, respectively. This can be beneficial for large documents because retrieving only the required fields can reduce network overhead.
 
 Both parameters accept a comma-separated list of fields and wildcard expressions, as shown in the following example, where any `_source` that contains `*.play` is included in the response but sources with the field `entities` are excluded:
 


### PR DESCRIPTION
### Description
The `stored_fields` parameter in the Get Document API is not a boolean but a list. 

Tested via: 
1. Created an index `my_index` with  index mapping as following (notably `store: true` on the `author` and `title` fields)
```
{
  "my_index": {
    "mappings": {
      "properties": {
        "author": {
          "type": "keyword",
          "store": true
        },
        "price": {
          "type": "double"
        },
        "publication_date": {
          "type": "date"
        },
        "title": {
          "type": "text",
          "store": true
        },
        "year": {
          "type": "long"
        }
      }
    }
  }
}
```
2. Ingested a document with ID=1, with contents:
```
{
    "title": "OpenSearch Basics",
    "author": "John Doe",
    "publication_date": "2022-01-01",
    "price": 29.99
  }
```
3. Retrieved the document with ID=1, using `stored_fields=true` in the parameters. Doesn't return any `stored_fields`.
<img width="971" alt="Screenshot 2025-03-24 at 11 14 08 AM" src="https://github.com/user-attachments/assets/591f831b-0391-4f2f-b142-a6125fd0ea48" />

4. Retrieved for the document, using `stored_fields=title,author`. Returns the selected stored_fields. 
<img width="967" alt="Screenshot 2025-03-24 at 11 14 21 AM" src="https://github.com/user-attachments/assets/3d814b2b-d510-40a5-9b26-9a71b3862a68" />


### Issues Resolved
See description above 

### Version
Appears to be for all OpenSearch versions. 

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
