### PR TITLE
Fix URI paths for cluster stats filtering

### DIFF
--- a/_api-reference/cluster-api/cluster-stats.md
+++ b/_api-reference/cluster-api/cluster-stats.md
@@ -61,8 +61,8 @@ Metric | Description
 To filter the information returned for the `indices` metric, you can use specific `index_metric` values. These values are only supported when using the following query types:
 
 ```json
-GET _cluster/stats/_all/<index_metric>/_nodes/<node-filters>
-GET _cluster/stats/indices/<index_metric>/_nodes/<node-filters>
+GET _cluster/stats/_all/<index_metric>/nodes/<node-filters>
+GET _cluster/stats/indices/<index_metric>/nodes/<node-filters>
 ```
 
 The following index metrics are supported:
@@ -80,7 +80,7 @@ The following index metrics are supported:
 For example, the following query requests statistics for `docs` and `search`:
 
 ```json
-GET _cluster/stats/indices/docs,segments/_nodes/_all
+GET _cluster/stats/indices/docs,segments/nodes/_all
 ```
 {% include copy-curl.html %}
 


### PR DESCRIPTION
### Description
As part of PR https://github.com/opensearch-project/documentation-website/issues/8527 filterning support for cluster/stats API was added. The documentation has incorrect URI examples in https://github.com/opensearch-project/documentation-website/issues/8527.

Incorrect URL
```
   "error": "no handler found for uri [/_cluster/stats/indices/docs/_nodes/_all] and method [GET]"
```

The correct URL is
```
GET _cluster/stats/indices/docs/nodes/_all
``` 


### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/9518

### Version
2.17 and above

### Frontend features
No

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
