### PR TITLE
Fix removal version for Java high level rest client

### DIFF
--- a/_clients/java-rest-high-level.md
+++ b/_clients/java-rest-high-level.md
@@ -6,7 +6,7 @@ nav_order: 20
 
 # Java high-level REST client
 
-The OpenSearch Java high-level REST client is deprecated. Support will be removed in OpenSearch version 3.0.0. We recommend switching to the [Java client]({{site.url}}{{site.baseurl}}/clients/java/) instead.
+The OpenSearch Java high-level REST client is deprecated. Support will be removed in a future version. We recommend switching to the [Java client]({{site.url}}{{site.baseurl}}/clients/java/) instead.
 {: .warning}
 
 The OpenSearch Java high-level REST client lets you interact with your OpenSearch clusters and indexes through Java methods and data structures rather than HTTP methods and JSON.


### PR DESCRIPTION
This client will not be removed in 3.0. There is no specific timeline for removal yet, so changing the text to reflect that.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
