### PR TITLE
Alerting plugin - Callout that per doc monitors don't support cross-cluster search.

### DIFF
--- a/_observing-your-data/alerting/per-document-monitors.md
+++ b/_observing-your-data/alerting/per-document-monitors.md
@@ -17,6 +17,9 @@ Per document monitors are a type of alert monitor that can be used to identify a
 - Enforce data quality policies, such as ensuring all documents contain a certain field or that values in a field are within a certain range. 
 - Track changes to a specific document over time, which can be helpful for auditing and compliance purposes
 
+Per document monitors do not support cross-cluster searching.
+{: .note} 
+
 ## Defining queries
 
 Per document monitors allow you to define up to 10 queries that compare a selected field with a desired value. You can define supported field data types using the following operators:


### PR DESCRIPTION
### Description
Callout that per doc monitors don't support cross-cluster search.

### Issues Resolved
Closes #[_delete this text, including the brackets, and replace with the issue number_]

### Version
Please backport to v2.12+.

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
