### PR TITLE
Update security-settings.md

### DIFF
--- a/_install-and-configure/configuring-opensearch/security-settings.md
+++ b/_install-and-configure/configuring-opensearch/security-settings.md
@@ -392,7 +392,7 @@ The Security plugin supports the following transport layer security settings:
 plugins.security.nodes_dn:
   - "CN=*.example.com, OU=SSL, O=Test, L=Test, C=DE"
   - "CN=node.other.com, OU=SSL, O=Test, L=Test, C=DE"
-  - "CN=node.example.com, OU=SSL\, Inc., L=Test, C=DE" # escape additional comma with `\`
+  - "CN=node.example.com, OU=SSL\\, Inc., L=Test, C=DE" # escape additional comma with `\\`
 plugins.security.authcz.admin_dn:
   - CN=kirk,OU=client,O=client,L=test, C=de
 plugins.security.roles_mapping_resolution: MAPPING_ONLY


### PR DESCRIPTION
A single backslash escape character would cause YAML parsing error.

### Description
A single backsplash escape character would cause YAML parsing error and failure to start OpenSearch service. A double backslash escape character would need to be used, if part of DN contains comma.

### Issues Resolved
Example update

### Version
all

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
