### PR TITLE
Add bring your own snapshot documentation to configuration-options.md

### DIFF
--- a/_migration-assistant/deploying-migration-assistant/configuration-options.md
+++ b/_migration-assistant/deploying-migration-assistant/configuration-options.md
@@ -170,6 +170,47 @@ The `serviceSigningName` can be `es` for an Elasticsearch or OpenSearch domain, 
 
 All of these authentication options apply to both source and target clusters.
 
+## Bring your own snapshot options
+
+An existing snapshot can alternatively be used to perform metadata as well as backfill migrations, instead of using the Migration Assistant to create a snapshot.
+
+```json
+    "snapshot": {
+        "snapshotName": "my-snapshot-name",
+        "s3Uri": "s3://my-s3-bucket-name/my-bucket-path-to-snapshot-repo",
+        "s3Region": "us-east-2"
+    }
+```
+{% include copy.html %}
+
+As a default, S3 buckets will automatically allow roles in the same account (with the appropriate `s3:*` permissions) to access the S3 bucket regardless of region. So if the external S3 bucket being utilized is in the same account as the Migration Assistant deployment, no IAM configuration may be required to access this bucket.
+If a custom permission model has been used with S3, or if the S3 bucket is in a separate account from the Migration Assistant deployment, a custom bucket policy (similar to below) or ACL will be needed to allow access to the Migration Assistant.
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowExternalAccountReadAccessToBucket",
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::<ACCOUNT_ID>:root"
+      },
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:GetBucketLocation"
+      ],
+      "Resource": [
+        "arn:aws:s3:::my-s3-bucket-name",
+        "arn:aws:s3:::my-s3-bucket-name/*"
+      ]
+    }
+  ]
+}
+```
+{% include copy.html %}
+
 ## Network configuration
 
 The migration tooling expects the source cluster, target cluster, and migration resources to exist in the same VPC. If this is not the case, manual networking setup outside of this documentation is likely required.


### PR DESCRIPTION
### Description
Add details for new feature to allow bringing your own snapshot with Migration Assistant, and selecting the proper configuration options

### Issues Resolved
Closes https://opensearch.atlassian.net/browse/MIGRATIONS-2219

### Version
Migration Assistant

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
