### PR TITLE
Remove unused openssl security settings for 3.0.0

### DIFF
--- a/_install-and-configure/configuring-opensearch/security-settings.md
+++ b/_install-and-configure/configuring-opensearch/security-settings.md
@@ -307,16 +307,6 @@ The Security plugin supports the following REST layer TLS key store and trust st
 
 For more information, see [REST layer TLS]({{site.url}}{{site.baseurl}}/security/configuration/tls/#rest-layer-tls-1).
 
-## OpenSSL settings
-
-The Security plugin supports the following OpenSSL settings:
-
-- `plugins.security.ssl.transport.enable_openssl_if_available` (Static): Enables OpenSSL on the transport layer if available. Optional. Default is `true`.
-
-- `plugins.security.ssl.http.enable_openssl_if_available` (Static): Enables OpenSSL on the REST layer if available. Optional. Default is `true`.
-
-For more information, see [OpenSSL]({{site.url}}{{site.baseurl}}/security/configuration/tls/#advanced-openssl).
-
 ## X.509 PEM certificates and PKCS #8 keys---transport layer TLS settings
 
 The Security plugin supports the following transport layer TLS settings related to X.509 PEM certificates and PKCS #8 keys:

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -140,29 +140,6 @@ For security reasons, you cannot use wildcards or regular expressions as values 
 For more information about admin and super admin user roles, see [Admin and super admin roles]({{site.url}}{{site.baseurl}}/security/access-control/users-roles/#admin-and-super-admin-roles). 
 
 
-## (Advanced) OpenSSL
-
-The Security plugin supports OpenSSL, but we only recommend it if you use Java 8. If you use Java 11, we recommend the default configuration.
-
-To use OpenSSL, you must install OpenSSL, the Apache Portable Runtime, and a Netty version with OpenSSL support matching your platform on all nodes.
-
-If OpenSSL is enabled, but for one reason or another the installation does not work, the Security plugin falls back to the Java JCE as the security engine.
-
-Name | Description
-:--- | :---
-`plugins.security.ssl.transport.enable_openssl_if_available` | Enable OpenSSL on the transport layer if available. Optional. Default is `true`.
-`plugins.security.ssl.http.enable_openssl_if_available` | Enable OpenSSL on the REST layer if available. Optional. Default is `true`.
-
-{% comment %}
-1. Install [OpenSSL 1.1.0](https://www.openssl.org/community/binaries.html) on every node.
-1. Install [Apache Portable Runtime](https://apr.apache.org) on every node:
-
-  ```
-  sudo yum install apr
-  ```
-{% endcomment %}
-
-
 ## (Advanced) Hostname verification and DNS lookup
 
 In addition to verifying the TLS certificates against the root CA and/or intermediate CA(s), the Security plugin can apply additional checks on the transport layer.


### PR DESCRIPTION
### Description

Remove unused openssl security settings for 3.0.0

Associated security PR: https://github.com/opensearch-project/security/pull/5220

### Version

These settings will be removed in 3.0.0 because it requires Java < 12, but 3.0.0 has minimum java compatibility of JDK 21.

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
