### PR TITLE
Documented path option for data prepper http sink

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/http.md
+++ b/_data-prepper/pipelines/configuration/sources/http.md
@@ -15,6 +15,7 @@ The `http` plugin accepts HTTP requests from clients. The following table descri
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
 port | No | Integer | The port that the source is running on. Default value is `2021`. Valid options are between `0` and `65535`.
+path | No | String | The  URI path for log ingestion and it should start with `/`. Path can contain `${pipelineName}` placeholder which will be replaced with pipeline name. Default value is `/log/ingest`. Path example `/${pipelineName}/logs`
 health_check_service | No | Boolean | Enables the health check service on the `/health` endpoint on the defined port. Default value is `false`.
 unauthenticated_health_check | No | Boolean | Determines whether or not authentication is required on the health check endpoint. OpenSearch Data Prepper ignores this option if no authentication is defined. Default value is `false`.
 request_timeout | No | Integer | The request timeout, in milliseconds. Default value is `10000`.


### PR DESCRIPTION
### Description
Documented the missing `path` option for data prepper `http` sink

### Issues Resolved
Closes https://github.com/opensearch-project/data-prepper/issues/4732

### Version
all

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
