### PR TITLE
Fix Terms, Term, MatchAll, MatchNone public docs

### DIFF
--- a/_query-dsl/match-all.md
+++ b/_query-dsl/match-all.md
@@ -29,3 +29,13 @@ GET _search
 }
 ```
 {% include copy-curl.html %}
+
+
+## Parameters
+
+Both the matchall and match none queries accepts the following parameters. All parameters are optional.
+
+Parameter | Data type | Description
+:--- | :--- | :---
+`boost` | Floating-point | A floating-point value that specifies the weight of this field toward the relevance score. Values above 1.0 increase the field’s relevance. Values between 0.0 and 1.0 decrease the field’s relevance. Default is 1.0.
+`_name` | String | The name of the query for query tagging. Optional.

--- a/_query-dsl/term/term.md
+++ b/_query-dsl/term/term.md
@@ -98,4 +98,5 @@ Parameter | Data type | Description
 :--- | :--- | :---
 `value` | String | The term to search for in the field specified in `<field>`. A document is returned in the results only if its field value exactly matches the term, with the correct spacing and capitalization.
 `boost` | Floating-point | A floating-point value that specifies the weight of this field toward the relevance score. Values above 1.0 increase the field’s relevance. Values between 0.0 and 1.0 decrease the field’s relevance. Default is 1.0.
+`_name` | String | The name of the query for query tagging. Optional.
 `case_insensitive` | Boolean | If `true`, allows case-insensitive matching of the value with the indexed field values. Default is `false` (case sensitivity is determined by the field's mapping).

--- a/_query-dsl/term/terms.md
+++ b/_query-dsl/term/terms.md
@@ -39,6 +39,7 @@ Parameter | Data type | Description
 :--- | :--- | :---
 `<field>` | String | The field in which to search. A document is returned in the results only if its field value exactly matches at least one term, with the correct spacing and capitalization.
 `boost` | Floating-point | A floating-point value that specifies the weight of this field toward the relevance score. Values above 1.0 increase the field’s relevance. Values between 0.0 and 1.0 decrease the field’s relevance. Default is 1.0.
+`_name` | String | The name of the query for query tagging. Optional.
 `value_type` | String | Specifies the types of values used for filtering. Valid values are `default` and `bitmap`. If omitted, the value defaults to `default`.
 
 ## Terms lookup
@@ -250,7 +251,6 @@ Parameter | Data type | Description
 `id` | String | The document ID of the document from which to fetch field values. Required.
 `path` | String | The name of the field from which to fetch field values. Specify nested fields using dot path notation. Required.
 `routing` | String | Custom routing value of the document from which to fetch field values. Optional. Required if a custom routing value was provided when the document was indexed.
-`boost` | Floating-point | A floating-point value that specifies the weight of this field toward the relevance score. Values above 1.0 increase the field’s relevance. Values between 0.0 and 1.0 decrease the field’s relevance. Default is 1.0.
 
 ## Bitmap filtering
 **Introduced 2.17**


### PR DESCRIPTION
### Description
1. Add `name` and `boost` field to all 4 queries
2. Remove `boost` from the terms query  terms lookup parameters.
3. `store` field was added in https://github.com/opensearch-project/OpenSearch/pull/14774/files to  terms query  terms lookup parameters.
4. `ValueType` was added in 2.17 per https://opensearch.org/docs/latest/query-dsl/term/terms/#bitmap-filtering 

### Issues Resolved
Part of [#30](https://github.com/opensearch-project/opensearch-protobufs/issues/30)
 
### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
