### PR TITLE
Add useSimilarity parameter to keyword mapping documentation

### DIFF
--- a/_field-types/supported-field-types/keyword.md
+++ b/_field-types/supported-field-types/keyword.md
@@ -57,7 +57,138 @@ Parameter | Description
 [`normalizer`]({{site.url}}{{site.baseurl}}/analyzers/normalizers/) | Specifies how to preprocess this field before indexing (for example, make it lowercase). Default is `null` (no preprocessing).
 `norms` | A Boolean value that specifies whether the field length should be used when calculating relevance scores. Default is `false`.
 [`null_value`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/index#null-value) | A value to be used in place of `null`. Must be of the same type as the field. If this parameter is not specified, the field is treated as missing when its value is `null`. Default is `null`.
-`similarity` | The ranking algorithm for calculating relevance scores. Default is `BM25`. 
+`similarity` | The ranking algorithm for calculating relevance scores. Default is index default, which is `BM25`.
+`useSimilarity` | With default of `false`, constant_score is used that leads to lower latency. Set this to `true` if you old behavior of scoring, but expect worse search latency. See example below.
 `split_queries_on_whitespace` | A Boolean value that specifies whether full-text queries should be split on white space. Default is `false`.
 `store` | A Boolean value that specifies whether the field value should be stored and can be retrieved separately from the `_source` field. Default is `false`. 
 
+#### Example term search with useSimilarity set to false (Default) - Took time is 10ms, all scores are 1.0. 
+
+```json
+curl - X POST "http://localhost:9200/big5/_search?pretty=true"\ -
+    H "Content-Type: application/json"\ -
+    d '{"size":3, "explain": false,
+"query": {
+    "term": {
+        "process.name": "kernel"
+    }
+}, "_source": false
+}
+' {
+"took": 10,
+"timed_out": false,
+"_shards": {
+    "total": 1,
+    "successful": 1,
+    "skipped": 0,
+    "failed": 0
+},
+"hits": {
+    "total": {
+        "value": 10000,
+        "relation": "gte"
+    },
+    "max_score": 1.0,
+    "hits": [{
+            "_index": "big5",
+            "_id": "xDoCtJQBE3c7bAfikzbk",
+            "_score": 1.0
+        },
+        {
+            "_index": "big5",
+            "_id": "xzoCtJQBE3c7bAfikzbk",
+            "_score": 1.0
+        },
+        {
+            "_index": "big5",
+            "_id": "yDoCtJQBE3c7bAfikzbk",
+            "_score": 1.0
+        }
+    ]
+}
+}
+```
+
+#### Example term search with useSimilarity set to true - took time 200ms, scores are based on BM25
+
+Set the parameter and check
+```json
+curl -X PUT "http://localhost:9200/big5/_mapping?pretty" \
+-H "Content-Type: application/json" \
+-d '{
+  "properties": {
+    "process.name": {
+       "type":"keyword", "useSimilarity": true
+    }
+  }
+}'
+{
+  "acknowledged" : true
+}
+
+GET "http://localhost:9200/big5/_mapping/field/process.name?pretty=true"
+{
+  "big5" : {
+    "mappings" : {
+      "process.name" : {
+        "full_name" : "process.name",
+        "mapping" : {
+          "name" : {
+            "type" : "keyword",
+            "useSimilarity" : true
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+Took 200ms
+```json
+curl -X POST "http://localhost:9200/big5/_search?pretty=true" \
+-H "Content-Type: application/json" \
+-d '{"size":3, "explain": false,
+  "query": {
+    "term": {
+      "process.name": "kernel"
+    }
+  },"_source":false
+}'
+{
+  "took" : 200,
+  "timed_out" : false,
+  "_shards" : {
+    "total" : 1,
+    "successful" : 1,
+    "skipped" : 0,
+    "failed" : 0
+  },
+  "hits" : {
+    "total" : {
+      "value" : 10000,
+      "relation" : "gte"
+    },
+    "max_score" : 0.8844931,
+    "hits" : [
+      {
+        "_index" : "big5",
+        "_id" : "xDoCtJQBE3c7bAfikzbk",
+        "_score" : 0.8844931
+      },
+      {
+        "_index" : "big5",
+        "_id" : "xzoCtJQBE3c7bAfikzbk",
+        "_score" : 0.8844931
+      },
+      {
+        "_index" : "big5",
+        "_id" : "yDoCtJQBE3c7bAfikzbk",
+        "_score" : 0.8844931
+      }
+    ]
+  }
+}
+
+
+```


### PR DESCRIPTION

### Description
Add useSimilarity parameter to keyword mapping documentation


### Issues Resolved
Closes #[[17823](https://github.com/opensearch-project/OpenSearch/issues/17823)]

### Version
3.0.0


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
