### PR TITLE
Fix commands to start local website in docker 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -105,7 +105,7 @@ Follow these steps to set up your local copy of the repository:
 Assuming you have `docker-compose` installed, run the following command:
 
    ```
-   docker compose -f docker-compose.dev.yml up
+   docker-compose -f docker-compose.dev.yml up
    ```
 
 #### Troubleshooting
@@ -176,5 +176,3 @@ ruby -v
 ## Getting help
 
 For help with the contribution process, reach out to one of the [points of contact](README.md#points-of-contact).
-
-

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -9,4 +9,4 @@ services:
     command: bash -c "bundler install && bash build.sh"
     environment:
       BUNDLE_PATH: /app/vendor/bundle  # Avoid installing gems globally.
-      DOCKER_BUILD: true               # Signify build.sh to bind to 0.0.0.0 for effective doc access from host.
+      DOCKER_BUILD: 'true'             # Signify build.sh to bind to 0.0.0.0 for effective doc access from host.


### PR DESCRIPTION
### Description
1. Missing `-` in `docker-compose` command in the DEVELOPER_GUIDE.md 
2. `DOCKER_BUILD` expects a string
```
docker-compose -f docker-compose.dev.yml up

ERROR: The Compose file './docker-compose.dev.yml' is invalid because:
services.doc_builder.environment.DOCKER_BUILD contains true, which is an invalid type, it should be a string, number, or a null
```
### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
