### PR TITLE
Change intro sentence from Docker compose to Docker

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,7 +102,7 @@ Follow these steps to set up your local copy of the repository:
 
 ##### Building by using containerization
 
-Assuming you have `docker-compose` installed, run the following command:
+Assuming you have Docker installed, run the following command:
 
    ```
    docker compose -f docker-compose.dev.yml up


### PR DESCRIPTION
Compose is now a subcommand of Docker, so changing the intro sentence to reflect that. For more info, see #9645 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
