### PR TITLE
Remove polyfill.io link from head custom

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -3,7 +3,6 @@
 {% endif %}
 
 {% if page.has_math == true %}
-  <script src="https://polyfill.io/v3/polyfill.min.js?features=es6"></script>
   <script id="MathJax-script" async src="https://cdn.jsdelivr.net/npm/mathjax@3.0.1/es5/tex-mml-chtml.js"></script>
 {% endif %}
 


### PR DESCRIPTION
Removes polyfill.io link as unnecessary for MathJax (see https://groups.google.com/g/mathjax-users/c/BC8xyt6Ph0g?pli=1). 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
