### PR TITLE
Remove since because from TERMS.md

### DIFF
--- a/TERMS.md
+++ b/TERMS.md
@@ -704,10 +704,6 @@ A piece of an index that consumes CPU and memory. Operates as a full Lucene inde
 
 Don't use. Both *simple* and *simply* are not neutral in tone and might sound condescending to some users. If you mean *only*, use *only* instead.
 
-**since**
-
-Use only to describe time events. Don't use in place of *because*.
-
 **slave**
 
 Do not use. Use *replica*, *secondary*, or *standby* instead.


### PR DESCRIPTION
### Description
Removes guidance differentiating between "since" and "because" from TERMS.md.

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
