### PR TITLE
Add documentation for http.max_header_size

### DIFF
--- a/_install-and-configure/configuring-opensearch/network-settings.md
+++ b/_install-and-configure/configuring-opensearch/network-settings.md
@@ -39,7 +39,7 @@ OpenSearch supports the following advanced network settings for HTTP communicati
 
 - `http.compression` (Static, Boolean): Enables support for compression using `Accept-Encoding` when applicable. When `HTTPS` is enabled, the default is `false`, otherwise, the default is `true`. Disabling compression for HTTPS helps mitigate potential security risks, such as `BREACH` attacks. To enable compression for HTTPS traffic, explicitly set `http.compression` to `true`.
 
-- `http.max_header_size`: (Static, string) The maximum size of all allowed headers. Defaults to `16KB`.
+- `http.max_header_size`: (Static, string) The maximum combined size of all HTTP headers allowed in a request. Default is `16KB`.
 
 ## Advanced transport settings
 

--- a/_install-and-configure/configuring-opensearch/network-settings.md
+++ b/_install-and-configure/configuring-opensearch/network-settings.md
@@ -39,6 +39,8 @@ OpenSearch supports the following advanced network settings for HTTP communicati
 
 - `http.compression` (Static, Boolean): Enables support for compression using `Accept-Encoding` when applicable. When `HTTPS` is enabled, the default is `false`, otherwise, the default is `true`. Disabling compression for HTTPS helps mitigate potential security risks, such as `BREACH` attacks. To enable compression for HTTPS traffic, explicitly set `http.compression` to `true`.
 
+- `http.max_header_size`: (Static, string) The maximum size of all allowed headers. Defaults to `16KB`.
+
 ## Advanced transport settings
 
 OpenSearch supports the following advanced network settings for transport communication:


### PR DESCRIPTION
### Description

Add documentation for http.max_header_size 
related pr : https://github.com/opensearch-project/OpenSearch/pull/18024/files

### Issues Resolved
Closes #9676 

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
