### PR TITLE
Fix typo in Get Workflow Steps API

### DIFF
--- a/_automating-configurations/api/get-workflow-steps.md
+++ b/_automating-configurations/api/get-workflow-steps.md
@@ -31,7 +31,7 @@ This API returns a list of workflow steps, including their required inputs, outp
 
 ```json
 GET /_plugins/_flow_framework/workflow/_steps
-GET /_plugins/_flow_framework/workflow/_step?workflow_step=<step_name>
+GET /_plugins/_flow_framework/workflow/_steps?workflow_step=<step_name>
 ``` 
 
 ## Query parameters
@@ -54,7 +54,7 @@ GET /_plugins/_flow_framework/workflow/_steps
 To fetch specific workflow steps, pass the step names to the request as a query parameter:
 
 ```json
-GET /_plugins/_flow_framework/workflow/_step?workflow_step=create_connector,delete_model,deploy_model
+GET /_plugins/_flow_framework/workflow/_step?workflow_steps=create_connector,delete_model,deploy_model
 ```
 {% include copy-curl.html %}
 


### PR DESCRIPTION
### Description

An `s` was inadertently left off in the Get Workflow Steps API documentation for the case where the `workflow_step` parameter was used.

### Issues Resolved

N/A, typo fix.

### Version

All

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
