### PR TITLE
Update cluster manager task throttling documentation to reflect enabled-by-default behavior (previously disabled)

### DIFF
--- a/_tuning-your-cluster/cluster-manager-task-throttling.md
+++ b/_tuning-your-cluster/cluster-manager-task-throttling.md
@@ -11,7 +11,7 @@ For many cluster state updates, such as defining a mapping or creating an index,
 
 The first line of defense is to implement mechanisms in the caller nodes to avoid task overload on the cluster manager. However, even with those mechanisms in place, the cluster manager needs a built-in way to protect itself: cluster manager task throttling.
 
-To turn on cluster manager task throttling, you need to set throttling limits. The cluster manager uses the throttling limits to determine whether to reject a task. 
+By default, the cluster manager uses predefined throttling limits to determine whether to reject a task. You can modify these limits or disable throttling for specific task types.
 
 The cluster manager rejects a task based on its type. For any incoming task, the cluster manager evaluates the total number of tasks of the same type in the pending task queue. If this number exceeds the threshold for this task type, the cluster manager rejects the incoming task. Rejecting a task does not affect tasks of a different type. For example, if the cluster manager rejects a `put-mapping` task, it can still accept a subsequent `create-index` task. 
 
@@ -21,7 +21,7 @@ When the cluster manager rejects a task, the node performs retries with exponent
 
 You can set throttling limits by specifying them in the `cluster_manager.throttling.thresholds` object and updating the [OpenSearch cluster settings]({{site.url}}{{site.baseurl}}/api-reference/cluster-settings). The setting is dynamic, so you can change the behavior of this feature without restarting your cluster.
 
-By default, throttling is disabled for all task types.
+By default, throttling is enabled for all task types. To disable throttling for a specific task type, set its threshold value to `-1`.
 {: .note}
 
 The request has the following format:
@@ -43,45 +43,52 @@ The following table describes the `cluster_manager.throttling.thresholds` object
 
 Field Name | Description
 :--- | :---
-task-type | The task type. See [supported task types](#supported-task-types) for a list of valid values.
-value | The maximum number of tasks of the `task-type` type in the cluster manager's pending task queue. Default is `-1` (no task throttling).  
+task-type | The task type. See [supported task types and default thresholds](#supported-task-types-and-default-thresholds) for a list of valid values.
+value | The maximum number of tasks of the `task-type` type in the cluster manager's pending task queue. <br> The default values can be found in the [supported task types and default thresholds](#supported-task-types-and-default-thresholds) section.
 
-## Supported task types
+## Supported task types and default thresholds
 
-The following task types are supported:
+The following table lists all supported task types and their default threshold values:
 
-- `create-index` 
-- `update-settings` 
-- `cluster-update-settings` 
-- `auto-create` 
-- `delete-index` 
-- `delete-dangling-index` 
-- `create-data-stream` 
-- `remove-data-stream` 
-- `rollover-index` 
-- `index-aliases` 
-- `put-mapping` 
-- `create-index-template` 
-- `remove-index-template` 
-- `create-component-template` 
-- `remove-component-template` 
-- `create-index-template-v2` 
-- `remove-index-template-v2` 
-- `put-pipeline` 
-- `delete-pipeline` 
-- `create-persistent-task` 
-- `finish-persistent-task` 
-- `remove-persistent-task` 
-- `update-task-state` 
-- `put-script` 
-- `delete-script` 
-- `put-repository` 
-- `delete-repository` 
-- `create-snapshot` 
-- `delete-snapshot` 
-- `update-snapshot-state` 
-- `restore-snapshot` 
-- `cluster-reroute-api`
+Task Type | Threshold
+:--- | :---
+create-index | 50
+update-settings | 50
+cluster-update-settings | 50
+auto-create | 200
+delete-index | 50
+delete-dangling-index | 50
+create-data-stream | 50
+remove-data-stream | 50
+rollover-index | 200
+index-aliases | 200
+put-mapping | 10000
+create-index-template | 50
+remove-index-template | 50
+create-component-template | 50
+remove-component-template | 50
+create-index-template-v2 | 50
+remove-index-template-v2 | 50
+put-pipeline | 50
+delete-pipeline | 50
+put-search-pipeline | 50
+delete-search-pipeline | 50
+create-persistent-task | 50
+finish-persistent-task | 50
+remove-persistent-task | 50
+update-task-state | 50
+create-query-group | 50
+delete-query-group | 50
+update-query-group | 50
+put-script | 50
+delete-script | 50
+put-repository | 50
+delete-repository | 50
+create-snapshot | 50
+delete-snapshot | 50
+update-snapshot-state | 5000
+restore-snapshot | 50
+cluster-reroute-api | 50
 
 #### Example request
 
@@ -99,9 +106,6 @@ PUT _cluster/settings
   }
 }
 ```
-
-Set the threshold to `-1` to disable throttling for a task type. 
-{: .note}
 
 
 

--- a/_tuning-your-cluster/cluster-manager-task-throttling.md
+++ b/_tuning-your-cluster/cluster-manager-task-throttling.md
@@ -32,65 +32,65 @@ PUT _cluster/settings
   "persistent": {
     "cluster_manager.throttling.thresholds" : {
       "<task-type>" : {
-          "value" : <threshold limit>
+          "value" : <threshold>
       }
     }
   }
 }
 ```
 
-The following table describes the `cluster_manager.throttling.thresholds` object.
+The `cluster_manager.throttling.thresholds` object contains the following fields.
 
-Field Name | Description
+Field name | Description
 :--- | :---
-task-type | The task type. See [supported task types and default thresholds](#supported-task-types-and-default-thresholds) for a list of valid values.
-value | The maximum number of tasks of the `task-type` type in the cluster manager's pending task queue. <br> The default values can be found in the [supported task types and default thresholds](#supported-task-types-and-default-thresholds) section.
+`<task-type>` | The task type. For a list of valid task types, see [supported task types and default thresholds](#supported-task-types-and-default-thresholds).
+`<task-type>.value` | The maximum number of tasks of the `task-type` type in the cluster manager's pending task queue. <br> For default thresholds for each task type, see [Supported task types and default thresholds](#supported-task-types-and-default-thresholds).
 
 ## Supported task types and default thresholds
 
-The following table lists all supported task types and their default threshold values:
+The following table lists all supported task types and their default throttling threshold values.
 
-Task Type | Threshold
+Task type | Threshold
 :--- | :---
-create-index | 50
-update-settings | 50
-cluster-update-settings | 50
-auto-create | 200
-delete-index | 50
-delete-dangling-index | 50
-create-data-stream | 50
-remove-data-stream | 50
-rollover-index | 200
-index-aliases | 200
-put-mapping | 10000
-create-index-template | 50
-remove-index-template | 50
-create-component-template | 50
-remove-component-template | 50
-create-index-template-v2 | 50
-remove-index-template-v2 | 50
-put-pipeline | 50
-delete-pipeline | 50
-put-search-pipeline | 50
-delete-search-pipeline | 50
-create-persistent-task | 50
-finish-persistent-task | 50
-remove-persistent-task | 50
-update-task-state | 50
-create-query-group | 50
-delete-query-group | 50
-update-query-group | 50
-put-script | 50
-delete-script | 50
-put-repository | 50
-delete-repository | 50
-create-snapshot | 50
-delete-snapshot | 50
-update-snapshot-state | 5000
-restore-snapshot | 50
-cluster-reroute-api | 50
+`create-index `| 50
+`update-settings` | 50
+`cluster-update-settings` | 50
+`auto-create` | 200
+`delete-index` | 50
+`delete-dangling-index `| 50
+`create-data-stream` | 50
+`remove-data-stream` | 50
+`rollover-index` | 200
+`index-aliases` | 200
+`put-mapping` | 10000
+`create-index-template` | 50
+`remove-index-template` | 50
+`create-component-template` | 50
+`remove-component-template` | 50
+`create-index-template-v2` | 50
+`remove-index-template-v2` | 50
+`put-pipeline` | 50
+`delete-pipeline` | 50
+`put-search-pipeline` | 50
+`delete-search-pipeline` | 50
+`create-persistent-task` | 50
+`finish-persistent-task` | 50
+`remove-persistent-task` | 50
+`update-task-state` | 50
+`create-query-group` | 50
+`delete-query-group` | 50
+`update-query-group` | 50
+`put-script` | 50
+`delete-script` | 50
+`put-repository` | 50
+`delete-repository` | 50
+`create-snapshot` | 50
+`delete-snapshot` | 50
+`update-snapshot-state` | 5000
+`restore-snapshot` | 50
+`cluster-reroute-api` | 50
 
-#### Example request
+## Example request
 
 The following request sets the throttling threshold for the `put-mapping` task type to 100:
 

--- a/_tuning-your-cluster/cluster-manager-task-throttling.md
+++ b/_tuning-your-cluster/cluster-manager-task-throttling.md
@@ -106,6 +106,4 @@ PUT _cluster/settings
   }
 }
 ```
-
-
-
+{% include copy-curl.html %}


### PR DESCRIPTION
### Description
Updates cluster manager task throttling documentation to reflect enabled-by-default behavior (previously disabled)

### Issues Resolved
Closes #9517

### Version
- 3.0+


~~### Frontend features~~
~~If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will~~ ~~interact with the UI step by step. A voiceover is optional.~~

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
