### PR TITLE
Derived Source is Enabled By Default from 3.0.0

### DIFF
--- a/_vector-search/settings.md
+++ b/_vector-search/settings.md
@@ -41,7 +41,7 @@ Setting | Static/Dynamic | Default | Description
 `index.knn.algo_param.ef_search` | Dynamic | `100`   | `ef` (or `efSearch`) represents the size of the dynamic list for the nearest neighbors used during a search. Higher `ef` values lead to a more accurate but slower search. `ef` cannot be set to a value lower than the number of queried nearest neighbors, `k`. `ef` can take any value between `k` and the size of the dataset. 
 `index.knn.advanced.approximate_threshold` | Dynamic | `15000` | The number of vectors that a segment must have before creating specialized data structures for ANN search. Set to `-1` to disable building vector data structures and to `0` to always build them.
 `index.knn.advanced.filtered_exact_search_threshold`| Dynamic | None    | The filtered ID threshold value used to switch to exact search during filtered ANN search. If the number of filtered IDs in a segment is lower than this setting's value, then exact search will be performed on the filtered IDs.
-`index.knn.derived_source.enabled` | Static | `true` | Removes vectors from `_source` storage, reducing overall disk consumption for vector indexes.
+`index.knn.derived_source.enabled` | Static | `true` | Prevents vectors from being stored in `_source`, reducing disk usage for vector indexes.
 
 An index created in OpenSearch version 2.11 or earlier will still use the previous `ef_construction` and `ef_search` values (`512`).
 {: .note}

--- a/_vector-search/settings.md
+++ b/_vector-search/settings.md
@@ -41,7 +41,7 @@ Setting | Static/Dynamic | Default | Description
 `index.knn.algo_param.ef_search` | Dynamic | `100`   | `ef` (or `efSearch`) represents the size of the dynamic list for the nearest neighbors used during a search. Higher `ef` values lead to a more accurate but slower search. `ef` cannot be set to a value lower than the number of queried nearest neighbors, `k`. `ef` can take any value between `k` and the size of the dataset. 
 `index.knn.advanced.approximate_threshold` | Dynamic | `15000` | The number of vectors that a segment must have before creating specialized data structures for ANN search. Set to `-1` to disable building vector data structures and to `0` to always build them.
 `index.knn.advanced.filtered_exact_search_threshold`| Dynamic | None    | The filtered ID threshold value used to switch to exact search during filtered ANN search. If the number of filtered IDs in a segment is lower than this setting's value, then exact search will be performed on the filtered IDs.
-`index.knn.derived_source.enabled` (Experimental) | Static | `false` | Removes vectors from `_source` storage, reducing overall disk consumption for vector indexes. Only supported for non-nested fields. This feature is experimental in OpenSearch 2.19. It is not recommended for production use. Backward compatibility is not guaranteed.
+`index.knn.derived_source.enabled` | Static | `true` | Removes vectors from `_source` storage, reducing overall disk consumption for vector indexes.
 
 An index created in OpenSearch version 2.11 or earlier will still use the previous `ef_construction` and `ef_search` values (`512`).
 {: .note}


### PR DESCRIPTION
### Description
In 2.19 we launched derived source feature which was experimental and was behind index setting which was false, but from 3.0.0 this will be enabled by default. 

### Issues Resolved
Closes #[_delete this text, including the brackets, and replace with the issue number_]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
