### PR TITLE
remove experimental for batch_predict and deprecate the async batch i…

### DIFF
--- a/_ml-commons-plugin/api/async-batch-ingest.md
+++ b/_ml-commons-plugin/api/async-batch-ingest.md
@@ -12,6 +12,7 @@ nav_order: 35
 {: .label .label-red }
 
 This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
+{: .warning}
 
 Use the Asynchronous Batch Ingestion API to ingest data into your OpenSearch cluster from your files on remote file servers, such as Amazon Simple Storage Service (Amazon S3) or OpenAI. For detailed configuration steps, see [Asynchronous batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/async-batch-ingestion/).
 

--- a/_ml-commons-plugin/api/async-batch-ingest.md
+++ b/_ml-commons-plugin/api/async-batch-ingest.md
@@ -14,6 +14,8 @@ nav_order: 35
 This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 {: .warning}
 
+{: .warning}
+
 Use the Asynchronous Batch Ingestion API to ingest data into your OpenSearch cluster from your files on remote file servers, such as Amazon Simple Storage Service (Amazon S3) or OpenAI. For detailed configuration steps, see [Asynchronous batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/async-batch-ingestion/).
 
 ## Endpoints

--- a/_ml-commons-plugin/api/async-batch-ingest.md
+++ b/_ml-commons-plugin/api/async-batch-ingest.md
@@ -14,7 +14,6 @@ nav_order: 35
 This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 {: .warning}
 
-{: .warning}
 
 Use the Asynchronous Batch Ingestion API to ingest data into your OpenSearch cluster from your files on remote file servers, such as Amazon Simple Storage Service (Amazon S3) or OpenAI. For detailed configuration steps, see [Asynchronous batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/async-batch-ingestion/).
 

--- a/_ml-commons-plugin/api/async-batch-ingest.md
+++ b/_ml-commons-plugin/api/async-batch-ingest.md
@@ -11,7 +11,7 @@ nav_order: 35
 **Deprecated 3.0**
 {: .label .label-red }
 
-This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
+This feature is deprecated. For similar functionality, use [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [create an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 {: .warning}
 
 

--- a/_ml-commons-plugin/api/async-batch-ingest.md
+++ b/_ml-commons-plugin/api/async-batch-ingest.md
@@ -8,8 +8,11 @@ nav_order: 35
 ---
 
 # Asynchronous batch ingestion
-**Introduced 2.17**
+**Deprecated 3.0**
 {: .label .label-purple }
+
+This feature has been deprecated. Please use DataPrepper for similar functionality. To request reinstatement of this feature, open an issue at 
+https://github.com/opensearch-project/ml-commons/issues 
 
 Use the Asynchronous Batch Ingestion API to ingest data into your OpenSearch cluster from your files on remote file servers, such as Amazon Simple Storage Service (Amazon S3) or OpenAI. For detailed configuration steps, see [Asynchronous batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/async-batch-ingestion/).
 

--- a/_ml-commons-plugin/api/async-batch-ingest.md
+++ b/_ml-commons-plugin/api/async-batch-ingest.md
@@ -9,10 +9,9 @@ nav_order: 35
 
 # Asynchronous batch ingestion
 **Deprecated 3.0**
-{: .label .label-purple }
+{: .label .label-red }
 
-This feature has been deprecated. Please use DataPrepper for similar functionality. To request reinstatement of this feature, open an issue at 
-https://github.com/opensearch-project/ml-commons/issues 
+This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 
 Use the Asynchronous Batch Ingestion API to ingest data into your OpenSearch cluster from your files on remote file servers, such as Amazon Simple Storage Service (Amazon S3) or OpenAI. For detailed configuration steps, see [Asynchronous batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/async-batch-ingestion/).
 

--- a/_ml-commons-plugin/api/model-apis/batch-predict.md
+++ b/_ml-commons-plugin/api/model-apis/batch-predict.md
@@ -8,9 +8,6 @@ nav_order: 65
 
 # Batch predict
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/ml-commons/issues/2488).
-{: .warning}
-
 ML Commons can perform inference on large datasets in an offline asynchronous mode using a model deployed on external model servers. To use the Batch Predict API, you must provide the `model_id` for an externally hosted model. Amazon SageMaker, Cohere, and OpenAI are currently the only verified external servers that support this API.
 
 For information about user access for this API, see [Model access control considerations]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/model-apis/index/#model-access-control-considerations).

--- a/_ml-commons-plugin/remote-models/async-batch-ingestion.md
+++ b/_ml-commons-plugin/remote-models/async-batch-ingestion.md
@@ -12,6 +12,7 @@ grand_parent: Integrating ML models
 {: .label .label-red }
 
 This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
+{: .warning}
 
 [Batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/batch-ingestion/) configures an ingest pipeline, which processes documents one by one. For each document, batch ingestion calls an externally hosted model to generate text embeddings from the document text and then ingests the document, including text and embeddings, into an OpenSearch index.
 

--- a/_ml-commons-plugin/remote-models/async-batch-ingestion.md
+++ b/_ml-commons-plugin/remote-models/async-batch-ingestion.md
@@ -11,7 +11,7 @@ grand_parent: Integrating ML models
 **Deprecated 3.0**
 {: .label .label-red }
 
-This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
+This feature is deprecated. For similar functionality, use [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [create an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 {: .warning}
 
 

--- a/_ml-commons-plugin/remote-models/async-batch-ingestion.md
+++ b/_ml-commons-plugin/remote-models/async-batch-ingestion.md
@@ -9,10 +9,9 @@ grand_parent: Integrating ML models
 
 # Asynchronous batch ingestion
 **Deprecated 3.0**
-{: .label .label-purple }
+{: .label .label-red }
 
-This feature has been deprecated. Please use DataPrepper for similar functionality. To request reinstatement of this feature, open an issue at 
-https://github.com/opensearch-project/ml-commons/issues 
+This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 
 [Batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/batch-ingestion/) configures an ingest pipeline, which processes documents one by one. For each document, batch ingestion calls an externally hosted model to generate text embeddings from the document text and then ingests the document, including text and embeddings, into an OpenSearch index.
 

--- a/_ml-commons-plugin/remote-models/async-batch-ingestion.md
+++ b/_ml-commons-plugin/remote-models/async-batch-ingestion.md
@@ -8,8 +8,11 @@ grand_parent: Integrating ML models
 
 
 # Asynchronous batch ingestion
-**Introduced 2.17**
+**Deprecated 3.0**
 {: .label .label-purple }
+
+This feature has been deprecated. Please use DataPrepper for similar functionality. To request reinstatement of this feature, open an issue at 
+https://github.com/opensearch-project/ml-commons/issues 
 
 [Batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/batch-ingestion/) configures an ingest pipeline, which processes documents one by one. For each document, batch ingestion calls an externally hosted model to generate text embeddings from the document text and then ingests the document, including text and embeddings, into an OpenSearch index.
 

--- a/_ml-commons-plugin/remote-models/async-batch-ingestion.md
+++ b/_ml-commons-plugin/remote-models/async-batch-ingestion.md
@@ -14,6 +14,8 @@ grand_parent: Integrating ML models
 This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 {: .warning}
 
+{: .warning}
+
 [Batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/batch-ingestion/) configures an ingest pipeline, which processes documents one by one. For each document, batch ingestion calls an externally hosted model to generate text embeddings from the document text and then ingests the document, including text and embeddings, into an OpenSearch index.
 
 An alternative to this real-time process, _asynchronous_ batch ingestion, ingests both documents and their embeddings generated outside of OpenSearch and stored on a remote file server, such as Amazon Simple Storage Service (Amazon S3) or OpenAI. Asynchronous ingestion returns a task ID and runs asynchronously to ingest data offline into your k-NN cluster for neural search. You can use asynchronous batch ingestion together with the [Batch Predict API]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/model-apis/batch-predict/) to perform inference asynchronously. The batch predict operation takes an input file containing documents and calls an externally hosted model to generate embeddings for those documents in an output file. You can then use asynchronous batch ingestion to ingest both the input file containing documents and the output file containing their embeddings into an OpenSearch index.

--- a/_ml-commons-plugin/remote-models/async-batch-ingestion.md
+++ b/_ml-commons-plugin/remote-models/async-batch-ingestion.md
@@ -14,7 +14,6 @@ grand_parent: Integrating ML models
 This feature is deprecated. For similar functionality, use [Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). If you'd like to see this feature reinstated, [open an issue](https://github.com/opensearch-project/ml-commons/issues) in the ML Commons repository.
 {: .warning}
 
-{: .warning}
 
 [Batch ingestion]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/batch-ingestion/) configures an ingest pipeline, which processes documents one by one. For each document, batch ingestion calls an externally hosted model to generate text embeddings from the document text and then ingests the document, including text and embeddings, into an OpenSearch index.
 


### PR DESCRIPTION
…ngestion API in ml-commons

### Description
The batch_predict API is in GA status as it's in use by DataPrepper, so the experimental statement can be removed. The async batch ingestion API can be deprecated in favor of the similar functionalities in DataPrepper.

### Issues Resolved
Closes #[_delete this text, including the brackets, and replace with the issue number_]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
