### PR TITLE
Added documentation for settings limiting total shards and primary shards per node at both cluster and index level.

### DIFF
--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -108,7 +108,7 @@ OpenSearch supports the following cluster-level routing and shard allocation set
 
 - `cluster.routing.allocation.total_shards_per_node` (Dynamic, integer): The maximum combined total number of primary and replica shards that can be allocated to a single node. Default is `-1` (unlimited). Helps distribute shards evenly across nodes by limiting the total number of shards per node. Use with caution because shards may remain unallocated if nodes reach their configured limits.
 
-- `cluster.routing.allocation.total_primary_shards_per_node` (Dynamic, integer): Maximum number of primary shards that can be allocated on a single node. This setting is applicable only for remote-backed clusters. Defaults to `-1`(unlimited). Helps distribute primary shards evenly across nodes by limiting primary shards per node. Use with caution as primary shards may remain unallocated if nodes reach their configured limits.
+- `cluster.routing.allocation.total_primary_shards_per_node` (Dynamic, integer): The maximum number of primary shards that can be allocated to a single node. This setting is applicable only for remote-backed clusters. Default is `-1`(unlimited). Helps distribute primary shards evenly across nodes by limiting the number of primary shards per node. Use with caution because primary shards may remain unallocated if nodes reach their configured limits.
 
 ## Cluster-level shard, block, and task settings
 

--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -106,7 +106,7 @@ OpenSearch supports the following cluster-level routing and shard allocation set
 
 - `cluster.allocator.existing_shards_allocator.batch_enabled` (Static, Boolean): Enables batch allocation of unassigned shards that already exist on the disk, as opposed to allocating one shard at a time. This reduces memory and transport overhead by fetching any unassigned shard metadata in a batch call. Default is `false`.
 
-- `cluster.routing.allocation.total_shards_per_node` (Dynamic, integer): Maximum number of primary and replica shards (total) that can be allocated on a single node. Defaults to `-1` (unlimited). Helps distribute shards evenly across nodes by limiting the total number of shards per node. Use with caution as shards may remain unallocated if nodes reach their configured limits.
+- `cluster.routing.allocation.total_shards_per_node` (Dynamic, integer): The maximum combined total number of primary and replica shards that can be allocated to a single node. Default is `-1` (unlimited). Helps distribute shards evenly across nodes by limiting the total number of shards per node. Use with caution because shards may remain unallocated if nodes reach their configured limits.
 
 - `cluster.routing.allocation.total_primary_shards_per_node` (Dynamic, integer): Maximum number of primary shards that can be allocated on a single node. This setting is applicable only for remote-backed clusters. Defaults to `-1`(unlimited). Helps distribute primary shards evenly across nodes by limiting primary shards per node. Use with caution as primary shards may remain unallocated if nodes reach their configured limits.
 

--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -106,6 +106,10 @@ OpenSearch supports the following cluster-level routing and shard allocation set
 
 - `cluster.allocator.existing_shards_allocator.batch_enabled` (Static, Boolean): Enables batch allocation of unassigned shards that already exist on the disk, as opposed to allocating one shard at a time. This reduces memory and transport overhead by fetching any unassigned shard metadata in a batch call. Default is `false`.
 
+- `cluster.routing.allocation.total_shards_per_node` (Dynamic, integer): Maximum number of primary and replica shards (total) that can be allocated on a single node. Defaults to `-1` (unlimited). Helps distribute shards evenly across nodes by limiting the total number of shards per node. Use with caution as shards may remain unallocated if nodes reach their configured limits.
+
+- `cluster.routing.allocation.total_primary_shards_per_node` (Dynamic, integer): Maximum number of primary shards that can be allocated on a single node. This setting is applicable only for remote-backed clusters. Defaults to `-1`(unlimited). Helps distribute primary shards evenly across nodes by limiting primary shards per node. Use with caution as primary shards may remain unallocated if nodes reach their configured limits.
+
 ## Cluster-level shard, block, and task settings
 
 OpenSearch supports the following cluster-level shard, block, and task settings:

--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -257,7 +257,7 @@ OpenSearch supports the following dynamic index-level index settings:
 
 - `index.optimize_doc_id_lookup.fuzzy_set.false_positive_probability` (Double): Sets the false-positive probability for the underlying `fuzzy_set` (that is, the Bloom filter). A lower false-positive probability ensures higher throughput for upsert and get operations but results in increased storage and memory use. Allowed values range between `0.01` and `0.50`. Default is `0.20`.
 
-- `index.routing.allocation.total_shards_per_node` (Integer): Maximum number of primary and replica shards (total) from a single index that can be allocated on a single node. Defaults to `-1` (unlimited). Helps control per-index shard distribution across nodes by limiting shards per node. Use with caution as shards from this index may remain unallocated if nodes reach their configured limits.
+- `index.routing.allocation.total_shards_per_node` (Integer): The maximum combined total number of primary and replica shards from a single index that can be allocated to a single node. Default is `-1` (unlimited). Helps control per-index shard distribution across nodes by limiting the number of shards per node. Use with caution because shards from this index may remain unallocated if nodes reach their configured limits.
 
 - `index.routing.allocation.total_primary_shards_per_node` (Integer): Maximum number of primary shards from a single index that can be allocated on a single node. This setting is applicable only for remote-backed clusters. Defaults to `-1` (unlimited). Helps control per-index primary shard distribution across nodes by limiting primary shards per node. Use with caution as primary shards from this index may remain unallocated if nodes reach their configured limits.
 

--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -257,6 +257,10 @@ OpenSearch supports the following dynamic index-level index settings:
 
 - `index.optimize_doc_id_lookup.fuzzy_set.false_positive_probability` (Double): Sets the false-positive probability for the underlying `fuzzy_set` (that is, the Bloom filter). A lower false-positive probability ensures higher throughput for upsert and get operations but results in increased storage and memory use. Allowed values range between `0.01` and `0.50`. Default is `0.20`.
 
+- `index.routing.allocation.total_shards_per_node` (Integer): Maximum number of primary and replica shards (total) from a single index that can be allocated on a single node. Defaults to `-1` (unlimited). Helps control per-index shard distribution across nodes by limiting shards per node. Use with caution as shards from this index may remain unallocated if nodes reach their configured limits.
+
+- `index.routing.allocation.total_primary_shards_per_node` (Integer): Maximum number of primary shards from a single index that can be allocated on a single node. This setting is applicable only for remote-backed clusters. Defaults to `-1` (unlimited). Helps control per-index primary shard distribution across nodes by limiting primary shards per node. Use with caution as primary shards from this index may remain unallocated if nodes reach their configured limits.
+
 ### Updating a dynamic index setting
 
 You can update a dynamic index setting at any time through the API. For example, to update the refresh interval, use the following request:

--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -259,7 +259,7 @@ OpenSearch supports the following dynamic index-level index settings:
 
 - `index.routing.allocation.total_shards_per_node` (Integer): The maximum combined total number of primary and replica shards from a single index that can be allocated to a single node. Default is `-1` (unlimited). Helps control per-index shard distribution across nodes by limiting the number of shards per node. Use with caution because shards from this index may remain unallocated if nodes reach their configured limits.
 
-- `index.routing.allocation.total_primary_shards_per_node` (Integer): Maximum number of primary shards from a single index that can be allocated on a single node. This setting is applicable only for remote-backed clusters. Defaults to `-1` (unlimited). Helps control per-index primary shard distribution across nodes by limiting primary shards per node. Use with caution as primary shards from this index may remain unallocated if nodes reach their configured limits.
+- `index.routing.allocation.total_primary_shards_per_node` (Integer): The maximum number of primary shards from a single index that can be allocated to a single node. This setting is applicable only for remote-backed clusters. Default is `-1` (unlimited). Helps control per-index primary shard distribution across nodes by limiting the number of primary shards per node. Use with caution because primary shards from this index may remain unallocated if nodes reach their configured limits.
 
 ### Updating a dynamic index setting
 


### PR DESCRIPTION
### Description
Adding documentation for four important OpenSearch routing allocation settings. These settings control total and primary shard distribution across nodes and help prevent uneven shard allocation:

`index.routing.allocation.total_primary_shards_per_node`: Index-level setting that limits the number of primary shards per node for a specific index
`index.routing.allocation.total_shards_per_node`: Index-level setting that limits the total number of shards per node for a specific index for remote store enabled clusters.
`cluster.routing.allocation.total_primary_shards_per_node`: Cluster-level setting that sets a global limit on primary shards per node
`cluster.routing.allocation.total_primary_shards_per_node`: Cluster-level setting that sets a global limit on total shards per node for remote store enabled clusters.

This documentation will help users:

->Better understand shard allocation controls
->Implement more balanced shard distribution strategies
->Prevent node overload from excessive primary shard allocation
->Configure these settings at both index and cluster levels
->The documentation will include setting descriptions, usage examples, and best practices for primary shard allocation management.

### Issues Resolved
Closes ##9301

### Version
OpenSearch version 3.0.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [✅ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
