### PR TITLE
Improve percentiles agg documentation

### DIFF
--- a/_aggregations/metric/percentile-ranks.md
+++ b/_aggregations/metric/percentile-ranks.md
@@ -45,11 +45,11 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
 }
 ```
 
-This response means the value `10` is at the `5.5`th percentile, and the value `15` is at the `8.3`rd percentile. 
+This response indicates that the value `10` is at the `5.5`th percentile and the value `15` is at the `8.3`rd percentile. 
 
 As with the `percentiles` aggregation, you can control the level of approximation by setting the optional `tdigest.compression` field. A larger value increases the precision of the approximation but uses more heap space. The default value is 100.
 
-For example, to set compression to 200: 
+For example, use the following request to set `compression` to `200`: 
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search

--- a/_aggregations/metric/percentile-ranks.md
+++ b/_aggregations/metric/percentile-ranks.md
@@ -44,3 +44,29 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
  }
 }
 ```
+
+This response means the value `10` is at the `5.5`th percentile, and the value `15` is at the `8.3`rd percentile. 
+
+Like in the percentiles aggregation, you can control the level of approximation using the optional `tdigest.compression` field. A larger value means the data structure that approximates percentiles is more accurate, but uses more heap space. The default value is 100. 
+
+For example, to set compression to 200: 
+
+```json
+GET opensearch_dashboards_sample_data_ecommerce/_search
+{
+  "size": 0,
+  "aggs": {
+    "percentile_rank_taxful_total_price": {
+      "percentile_ranks": {
+        "field": "taxful_total_price",
+        "values": [
+          10,
+          15
+        ],
+        "tdigest": { 
+          "compression": 200
+        }
+      }
+    }
+  }
+}

--- a/_aggregations/metric/percentile-ranks.md
+++ b/_aggregations/metric/percentile-ranks.md
@@ -47,7 +47,7 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
 
 This response means the value `10` is at the `5.5`th percentile, and the value `15` is at the `8.3`rd percentile. 
 
-Like in the percentiles aggregation, you can control the level of approximation using the optional `tdigest.compression` field. A larger value means the data structure that approximates percentiles is more accurate, but uses more heap space. The default value is 100. 
+As with the `percentiles` aggregation, you can control the level of approximation by setting the optional `tdigest.compression` field. A larger value increases the precision of the approximation but uses more heap space. The default value is 100.
 
 For example, to set compression to 200: 
 

--- a/_aggregations/metric/percentile.md
+++ b/_aggregations/metric/percentile.md
@@ -51,3 +51,24 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
  }
 }
 ```
+
+You can control the level of approximation using the optional `tdigest.compression` field. A larger value means the data structure that approximates percentiles is more accurate, but uses more heap space. The default value is 100. 
+
+For example, to set compression to 200: 
+
+```json
+GET opensearch_dashboards_sample_data_ecommerce/_search
+{
+  "size": 0,
+  "aggs": {
+    "percentile_taxful_total_price": {
+      "percentiles": {
+        "field": "taxful_total_price",
+        "tdigest": { 
+          "compression": 200
+        }
+      }
+    }
+  }
+}
+```

--- a/_aggregations/metric/percentile.md
+++ b/_aggregations/metric/percentile.md
@@ -52,9 +52,9 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
 }
 ```
 
-You can control the level of approximation using the optional `tdigest.compression` field. A larger value means the data structure that approximates percentiles is more accurate, but uses more heap space. The default value is 100. 
+You can control the level of approximation using the optional `tdigest.compression` field. A larger value indicates that the data structure that approximates percentiles is more accurate but uses more heap space. The default value is 100. 
 
-For example, to set compression to 200: 
+For example, use the following request to set `compression` to `200`: 
 
 ```json
 GET opensearch_dashboards_sample_data_ecommerce/_search


### PR DESCRIPTION
### Description
Adds documentation for the optional "tdigest.compression" field for percentiles aggregations. Also clarifies what the results for percentile_ranks mean. 

### Issues Resolved
Did not raise an issue for this minor addition.

### Version
I believe this applies to all versions.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
