### PR TITLE
Extend _cluster docs for _cluster/reroute and _cluster/state

### DIFF
--- a/_api-reference/cluster-api/cluster-reroute.md
+++ b/_api-reference/cluster-api/cluster-reroute.md
@@ -1,0 +1,63 @@
+---
+layout: default
+title: Cluster reroute
+nav_order: 45
+parent: Cluster APIs
+redirect_from:
+  - /api-reference/cluster-reroute/
+  - /opensearch/rest-api/cluster-reroute/
+---
+
+# Cluster reroute
+**Introduced 1.0**
+{: .label .label-purple }
+
+The cluster reroute operation lets you manually initiate a rerouting within the cluster.
+> Note: The cluster will perform a rebalancing within the cluster based on it's `cluster.routing.rebalance` settings after completion.
+
+## Endpoints
+
+```json
+POST _cluster/reroute
+```
+
+## Path parameters
+
+All parameters are optional.
+
+Parameter | Data type | Description
+:--- | :--- | :---
+| `dry_run` | Boolean | When `true`, will simulate the state of the cluster after applying the command. Default is `false`. |
+| `explain` | Boolean | When `true`, will explain why the action can or cannot be performed. Default: `false`|
+| `metric` | Array of strings | Allows you to limit the output provided to the given metric type, such as `routing_table`. |
+| `retry_failed` | Boolean | This let's you initiate a manual retry to fix a a failed allocation due to too many allocation failures. |
+
+## Example requests
+
+The following example requests show how to use the cluster reroute API.
+
+### Dry-run reroute command
+
+A manual reroute command with dry-run enabled to see what the impact would be.
+
+```json
+POST _cluster/reroute?dry_run=true&metric=routing_table
+```
+
+{% include copy-curl.html %}
+
+### Initiate a retry of failed shard
+
+This command will do a one-time retry of a failed shard.
+
+```json
+POST _cluster/reroute?retry_failed=true
+```
+
+{% include copy-curl.html %}
+
+A common follow-up will be to check the allocation command to see the status.
+
+```json
+GET _cluster/allocation/explain
+```

--- a/_api-reference/cluster-api/cluster-state.md
+++ b/_api-reference/cluster-api/cluster-state.md
@@ -28,11 +28,10 @@ Parameter | Data type | Description
 :--- | :--- | :---
 | `allow_no_indices` | Boolean | When `false`, the Refresh Index API returns an error when a wildcard expression, index alias, or `_all` targets only closed or missing indexes, even when the request is made against open indexes. Default is `true`. |
 | `ignore_unavailable` | Boolean | When `false`, the request returns an error when it target gets an error returned. Default is `false`.
-| `expand_wildcards` | String | Option to expand wildcard patterns from (hidden) datastreams. Supports comma-separated values, such as `open,hidden`. Valid values are `all`, `open`, `closed`, `hidden`, and `none`. |
+| `expand_wildcards` | String | Option to expand wildcard patterns |
 | `flat_settings` | Boolean | Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`.
 | `master_timeout` | Time unit | The amount of time to wait in total for the response.
 | `cluster_manager_timeout` | Time unit | The amount of time to wait for a response from the cluster manager node. Default is `30 seconds`.
-timeout (PUT only) | Time unit | The amount of time to wait for a response from the cluster. Default is `30 seconds`.
 
 ## Example requests
 

--- a/_api-reference/cluster-api/cluster-state.md
+++ b/_api-reference/cluster-api/cluster-state.md
@@ -1,0 +1,55 @@
+---
+layout: default
+title: Cluster state
+nav_order: 55
+parent: Cluster APIs
+redirect_from:
+  - /api-reference/cluster-state/
+  - /opensearch/rest-api/cluster-state/
+---
+
+# Cluster state
+**Introduced 1.0**
+{: .label .label-purple }
+
+The cluster state operation lets you dump the cluster state for review or monitoring purposes.
+
+## Endpoints
+
+```json
+GET _cluster/state
+```
+
+## Path parameters
+
+All parameters are optional.
+
+Parameter | Data type | Description
+:--- | :--- | :---
+| `allow_no_indices` | Boolean | When `false`, the Refresh Index API returns an error when a wildcard expression, index alias, or `_all` targets only closed or missing indexes, even when the request is made against open indexes. Default is `true`. |
+| `ignore_unavailable` | Boolean | When `false`, the request returns an error when it target gets an error returned. Default is `false`.
+| `expand_wildcards` | String | Option to expand wildcard patterns from (hidden) datastreams. Supports comma-separated values, such as `open,hidden`. Valid values are `all`, `open`, `closed`, `hidden`, and `none`. |
+| `flat_settings` | Boolean | Whether to return settings in the flat form, which can improve readability, especially for heavily nested settings. For example, the flat form of `"cluster": { "max_shards_per_node": 500 }` is `"cluster.max_shards_per_node": "500"`.
+| `master_timeout` | Time unit | The amount of time to wait in total for the response.
+| `cluster_manager_timeout` | Time unit | The amount of time to wait for a response from the cluster manager node. Default is `30 seconds`.
+timeout (PUT only) | Time unit | The amount of time to wait for a response from the cluster. Default is `30 seconds`.
+
+## Example requests
+
+The following example requests show how to use the cluster state API.
+
+### Check cluster status
+
+The following will show the entire cluster state of all components:
+
+```json
+GET _cluster/state?flat_settings=true
+```
+{% include copy-curl.html %}
+
+Using filter_path, you can only return specific components, for example `nodes`:
+
+```json
+GET _cluster/state?flat_settings=true&filter_path=nodes
+```
+{% include copy-curl.html %}


### PR DESCRIPTION
### Description
Added docs for _cluster/state and _cluster/reroute.
In particular _cluster/reroute is useful for people once they run into failed allocations.
(Which was how I found out that it's missing in the docs)

### Issues Resolved
Does not close a whole issue, but part of #3614
 