### PR TITLE
Update the doc with `search_only` block which is part of OpenSearch Reader/Writer Separation 

### DIFF
--- a/_api-reference/index-apis/blocks.md
+++ b/_api-reference/index-apis/blocks.md
@@ -23,7 +23,7 @@ PUT /<index>/_block/<block>
 | Parameter | Data type | Description |
 :--- | :--- | :---
 | `index` | String | A comma-delimited list of index names. Wildcard expressions (`*`) are supported. To target all data streams and indexes in a cluster, use `_all` or `*`. Optional. |
-| <block> | String | Specifies the type of block to apply to the index. Valid values are: <br> - metadata: Blocks metadata changes, such as closing the index. <br> - read: Blocks read operations. <br> - read_only: Blocks write operations and metadata changes. <br> - write: Blocks write operations but allows metadata changes. <br> - search_only: Blocks indexing and write operations while allowing read-only access through search replicas. <br> OpenSearch automatically manages this block through the Scale API as part of the reader-writer separation mechanism. Therefore, do not set this block manually. |
+| <block> | String | Specifies the type of block to apply to the index. Valid values are: <br> - metadata: Blocks metadata changes, such as closing the index. <br> - read: Blocks read operations. <br> - read_only: Blocks write operations and metadata changes. <br> - write: Blocks write operations but allows metadata changes. <br> - search_only: Blocks indexing and write operations while allowing read-only access through search replicas. <br> OpenSearch automatically manages this block through the Scale API as part of the reader-writer separation mechanism. Therefore, do not set this parameter manually. |
 
 ## Query parameters
 

--- a/_api-reference/index-apis/blocks.md
+++ b/_api-reference/index-apis/blocks.md
@@ -23,7 +23,7 @@ PUT /<index>/_block/<block>
 | Parameter | Data type | Description |
 :--- | :--- | :---
 | `index` | String | A comma-delimited list of index names. Wildcard expressions (`*`) are supported. To target all data streams and indexes in a cluster, use `_all` or `*`. Optional. |
-| `<block>` | String | Specifies the type of block to apply to the index. Valid values are: <br> `metadata`: Disables all metadata changes, such as closing the index. <br> `read`: Disables any read operations. <br> `read_only`: Disables any write operations and metadata changes. <br> `write`: Disables write operations. However, metadata changes are still allowed. <br> `search_only`: Disables all indexing and write operations while allowing read-only access through search replicas. Note: Do not set this block manually—OpenSearch automatically manages the `search_only` block via the `_scale` API as part of the reader-writer separation mechanism. |
+| <block> | String | Specifies the type of block to apply to the index. Valid values are: <br> - metadata: Blocks metadata changes, such as closing the index. <br> - read: Blocks read operations. <br> - read_only: Blocks write operations and metadata changes. <br> - write: Blocks write operations but allows metadata changes. <br> - search_only: Blocks indexing and write operations while allowing read-only access through search replicas. <br> OpenSearch automatically manages this block through the Scale API as part of the reader-writer separation mechanism. Therefore, do not set this block manually. |
 
 ## Query parameters
 

--- a/_api-reference/index-apis/blocks.md
+++ b/_api-reference/index-apis/blocks.md
@@ -23,7 +23,7 @@ PUT /<index>/_block/<block>
 | Parameter | Data type | Description |
 :--- | :--- | :---
 | `index` | String | A comma-delimited list of index names. Wildcard expressions (`*`) are supported. To target all data streams and indexes in a cluster, use `_all` or `*`. Optional. |
-| `<block>` | String | Specifies the type of block to apply to the index. Valid values are: <br> - metadata: Blocks metadata changes, such as closing the index. <br> - read: Blocks read operations. <br> - read_only: Blocks write operations and metadata changes. <br> - write: Blocks write operations but allows metadata changes. <br> - search_only: Blocks indexing and write operations while allowing read-only access through search replicas. <br> OpenSearch automatically manages this block through the Scale API as part of the reader-writer separation mechanism. Therefore, do not set this parameter manually. |
+| `<block>` | String | Specifies the type of block to apply to the index. Valid values are: <br> - `metadata`: Blocks metadata changes, such as closing the index. <br> - `read`: Blocks read operations. <br> - `read_only`: Blocks write operations and metadata changes. <br> - `write`: Blocks write operations but allows metadata changes. <br> - `search_only`: Blocks indexing and write operations while allowing read-only access through search replicas. <br> OpenSearch automatically manages this block through the Scale API as part of the reader-writer separation mechanism. Therefore, do not set this parameter manually. |
 
 ## Query parameters
 

--- a/_api-reference/index-apis/blocks.md
+++ b/_api-reference/index-apis/blocks.md
@@ -44,6 +44,7 @@ The following example request disables any `write` operations made to the test i
 ```json
 PUT /test-index/_block/write
 ```
+{% include copy.html %}
 
 ## Example response
 

--- a/_api-reference/index-apis/blocks.md
+++ b/_api-reference/index-apis/blocks.md
@@ -23,7 +23,7 @@ PUT /<index>/_block/<block>
 | Parameter | Data type | Description |
 :--- | :--- | :---
 | `index` | String | A comma-delimited list of index names. Wildcard expressions (`*`) are supported. To target all data streams and indexes in a cluster, use `_all` or `*`. Optional. |
-| `<block>` | String | Specifies the type of block to apply to the index. Valid values are: <br> `metadata`: Disables all metadata changes, such as closing the index. <br> `read`: Disables any read operations. <br> `read_only`: Disables any write operations and metadata changes. <br> `write`: Disables write operations. However, metadata changes are still allowed. |
+| `<block>` | String | Specifies the type of block to apply to the index. Valid values are: <br> `metadata`: Disables all metadata changes, such as closing the index. <br> `read`: Disables any read operations. <br> `read_only`: Disables any write operations and metadata changes. <br> `write`: Disables write operations. However, metadata changes are still allowed. <br> `search_only`: Disables all indexing and write operations while allowing read-only access through search replicas. Note: Do not set this block manually—OpenSearch automatically manages the `search_only` block via the `_scale` API as part of the reader-writer separation mechanism. |
 
 ## Query parameters
 

--- a/_api-reference/index-apis/blocks.md
+++ b/_api-reference/index-apis/blocks.md
@@ -23,7 +23,7 @@ PUT /<index>/_block/<block>
 | Parameter | Data type | Description |
 :--- | :--- | :---
 | `index` | String | A comma-delimited list of index names. Wildcard expressions (`*`) are supported. To target all data streams and indexes in a cluster, use `_all` or `*`. Optional. |
-| <block> | String | Specifies the type of block to apply to the index. Valid values are: <br> - metadata: Blocks metadata changes, such as closing the index. <br> - read: Blocks read operations. <br> - read_only: Blocks write operations and metadata changes. <br> - write: Blocks write operations but allows metadata changes. <br> - search_only: Blocks indexing and write operations while allowing read-only access through search replicas. <br> OpenSearch automatically manages this block through the Scale API as part of the reader-writer separation mechanism. Therefore, do not set this parameter manually. |
+| `<block>` | String | Specifies the type of block to apply to the index. Valid values are: <br> - metadata: Blocks metadata changes, such as closing the index. <br> - read: Blocks read operations. <br> - read_only: Blocks write operations and metadata changes. <br> - write: Blocks write operations but allows metadata changes. <br> - search_only: Blocks indexing and write operations while allowing read-only access through search replicas. <br> OpenSearch automatically manages this block through the Scale API as part of the reader-writer separation mechanism. Therefore, do not set this parameter manually. |
 
 ## Query parameters
 


### PR DESCRIPTION
### Description
Update the doc with `search_only` block which is part of OpenSearch Reader/Writer Separation 

### Issues Resolved
- Part of https://github.com/opensearch-project/documentation-website/issues/9641
- Related PR: https://github.com/opensearch-project/OpenSearch/pull/17299.
- Related Issue from OpenSearch for search only mode with all the design and implementation details https://github.com/opensearch-project/OpenSearch/issues/16720.


### Version
3.0.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
