### PR TITLE
Update the `search_only` mode section with more details and recovery scenarios

### DIFF
--- a/_tuning-your-cluster/seperate-index-and-search-workloads.md
+++ b/_tuning-your-cluster/seperate-index-and-search-workloads.md
@@ -148,11 +148,12 @@ The `cluster.routing.search_replica.strict` setting supports the following optio
 
 Use the `auto_expand_search_replicas` index setting to automatically scale search replicas based on the number of available search nodes in the cluster. For more information, see [Index settings]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/index-settings/#dynamic-index-level-index-settings).
 
-### Turn off write workloads
+### Turn off write workloads: The `search_only` mode
 
 You can use the `_scale` API to turn off primary shards and write replicas if you don't expect any writes to an index. In write-once, read-many scenarios (like log analytics), you can scale down primary and write replicas, leaving only search replicas active to free up resources.
 
 The following [scale]({{site.url}}{{site.baseurl}}/api-reference/index-apis/scale/) request turns off write replicas:
+
 
 ```json
 POST my_index/_scale 
@@ -171,3 +172,27 @@ POST my_index/_scale
 }
 ```
 {% include copy-curl.html %}
+
+**Important NOTE**
+
+Along with the above prerequisites it is recommended to set the remote store state setting to true (`cluster.remote_store.state.enabled, true`) before enabling the `search_only` mode. Please check the following Search Replica Recovery Scenarios during `search_only` mode for more details. 
+
+### Search Replica Recovery Scenarios during `search_only` mode
+
+Depending on your configuration, OpenSearch handles recovery of search replicas in `search_only` mode differently. Below are scenarios that illustrate how search only replicas behave during restart or recovery operations.
+
+**Scenario 1: With persistent data directory and remote store state set to false:**
+
+With persistent data and `cluster.remote_store.state.enabled: false`, search only replicas recover after node restarts.
+
+**Scenario 2: Remote store state enabled and no persistent data directory:**
+
+Search only replicas recover without primaries and replica. Since `cluster.remote_store.state.enabled: true`, OpenSearch remembers the index exists after restart. The allocation logic skips checking for an active primary for search only replicas, the search replicas will be allocated and search queries remain functional.
+
+**Scenario 3: Remote store state enabled with persistent data directory — seamless recovery**
+
+In `search_only` mode with persistent data directoy and `cluster.remote_store.state.enabled: true`, OpenSearch correctly brings up only search replicas without primary and regular replicas.
+
+**Scenario 4: No persistent data directory and remote store state set to false: — Index is lost after restart**
+
+Without persistent data directory and `cluster.remote_store.state.enabled: false`, restarting OpenSearch loses all local state and the index becomes unrecoverable. This is because OpenSearch has no metadata reference and local state is wiped.

--- a/_tuning-your-cluster/seperate-index-and-search-workloads.md
+++ b/_tuning-your-cluster/seperate-index-and-search-workloads.md
@@ -178,7 +178,7 @@ POST my_index/_scale
 
 #### Search replica recovery scenarios
 
-OpenSearch handles recovery of search replicas in search-only mode differently depending on the configuration:
+OpenSearch handles recovery of search replicas in search-only mode differently depending on the configuration.
 
 ##### Scenario 1: Persistent data directory with remote store state disabled
 
@@ -186,11 +186,11 @@ When you use a persistent data directory and set `cluster.remote_store.state.ena
 
 ##### Scenario 2: Remote store state enabled without a persistent data directory
 
-When `cluster.remote_store.state.enabled` is `true` and there is no persistent data directory, OpenSearch recovers search replicas without requiring primaries or write replicas. Because remote store state is enabled, OpenSearch retains the index metadata after a restart. The allocation logic skips the active primary check for search replicas, allowing them to be allocated so search queries remain functional.
+When `cluster.remote_store.state.enabled` is set to `true` and there is no persistent data directory, OpenSearch recovers search replicas without requiring primaries or write replicas. Because remote store state is enabled, OpenSearch retains the index metadata after a restart. The allocation logic skips the active primary check for search replicas, allowing them to be allocated so that search queries remain functional.
 
 ##### Scenario 3: Remote store state enabled with a persistent data directory
 
-This configuration provides seamless recovery. In search-only mode, with both a persistent data directory and `cluster.remote_store.state.enabled` set to `true`, OpenSearch starts only search replicas—excluding primaries and write replicas—ensuring the index remains queryable after restart.
+This configuration provides seamless recovery. In search-only mode, with both a persistent data directory and `cluster.remote_store.state.enabled` set to `true`, OpenSearch starts only search replicas—excluding primaries and write replicas—ensuring the index can be queried after restart.
 
 ##### Scenario 4: No persistent data directory and remote store state disabled
 

--- a/_tuning-your-cluster/seperate-index-and-search-workloads.md
+++ b/_tuning-your-cluster/seperate-index-and-search-workloads.md
@@ -57,6 +57,10 @@ node.attr.remote_store.repository.my-repository.settings.region: <Region>
 
 For more information, see [Remote-backed storage]({{site.url}}{{site.baseurl}}/tuning-your-cluster/availability-and-recovery/remote-store/index/).
 
+**Important NOTE**
+
+Before enabling [search-only mode](#turn-off-write-workloads-with-search-only-mode), we recommend setting `cluster.remote_store.state.enabled` to `true`. For more information about recovery scenarios, see [Search replica recovery scenarios](#search-replica-recovery-scenarios).
+
 ### Step 3: Add search replicas to an index
 
 After configuring your nodes and the remote store, you need to set up search replicas for your indexes. Search replicas are copies of your index that are dedicated to handling search requests, allowing you to scale your search capacity independently of your indexing capacity.
@@ -151,8 +155,6 @@ Use the `auto_expand_search_replicas` index setting to automatically scale searc
 ### Turn off write workloads with search-only mode
 
 You can use the `_scale` API to turn off primary shards and write replicas for an index when you don't need to write to it. This approach works well for write-once, read-many scenarios like log analytics, where you can reduce resource usage by keeping only search replicas active.
-
-Before enabling search-only mode, we recommend setting `cluster.remote_store.state.enabled` to `true`. For more information about recovery scenarios, see [Search replica recovery scenarios](#search-replica-recovery-scenarios).
 
 The following request turns on search-only mode by deactivating write replicas:
 

--- a/_tuning-your-cluster/seperate-index-and-search-workloads.md
+++ b/_tuning-your-cluster/seperate-index-and-search-workloads.md
@@ -57,9 +57,8 @@ node.attr.remote_store.repository.my-repository.settings.region: <Region>
 
 For more information, see [Remote-backed storage]({{site.url}}{{site.baseurl}}/tuning-your-cluster/availability-and-recovery/remote-store/index/).
 
-**Important NOTE**
-
-When separating index and search workloads, we recommend setting `cluster.remote_store.state.enabled` to `true` as part of your initial setup. This ensures that OpenSearch persists index metadata in the remote store, enabling seamless recovery of search replicas during [search-only mode](#turn-off-write-workloads-with-search-only-mode). For more information about recovery scenarios, see [Search replica recovery scenarios](#search-replica-recovery-scenarios).
+When separating index and search workloads, set `cluster.remote_store.state.enabled` to `true` during initial setup. This setting ensures that OpenSearch stores index metadata in the remote store, enabling seamless recovery of search replicas in [search-only mode](#turn-off-write-workloads-with-search-only-mode). For more information, see [Search replica recovery scenarios](#search-replica-recovery-scenarios).
+{: .note}
 
 
 ### Step 3: Add search replicas to an index
@@ -179,20 +178,21 @@ POST my_index/_scale
 
 #### Search replica recovery scenarios
 
-OpenSearch handles recovery of search replicas in search-only mode differently depending on your configuration:
+OpenSearch handles recovery of search replicas in search-only mode differently depending on the configuration:
 
-**Scenario 1: Persistent data directory with remote store state disabled**
+##### Scenario 1: Persistent data directory with remote store state disabled
 
-When you have persistent data and `cluster.remote_store.state.enabled` set to `false`, search replicas recover automatically after node restarts.
+When you use a persistent data directory and set `cluster.remote_store.state.enabled` to `false`, search replicas recover automatically after node restarts.
 
-**Scenario 2: Remote store state enabled without persistent data directory**
+##### Scenario 2: Remote store state enabled without a persistent data directory
 
-When `cluster.remote_store.state.enabled` is `true` but you don't have a persistent data directory, search replicas recover without primaries and write replicas. Because remote store state is enabled, OpenSearch remembers that the index exists after restart. The allocation logic skips checking for an active primary for search replicas, so search replicas are allocated and search queries remain functional.
+When `cluster.remote_store.state.enabled` is `true` and there is no persistent data directory, OpenSearch recovers search replicas without requiring primaries or write replicas. Because remote store state is enabled, OpenSearch retains the index metadata after a restart. The allocation logic skips the active primary check for search replicas, allowing them to be allocated so search queries remain functional.
 
-**Scenario 3: Remote store state enabled with persistent data directory**
+##### Scenario 3: Remote store state enabled with a persistent data directory
 
-This configuration provides seamless recovery. In search-only mode with a persistent data directory and `cluster.remote_store.state.enabled` set to `true`, OpenSearch correctly brings up only search replicas without primary and regular replicas.
+This configuration provides seamless recovery. In search-only mode, with both a persistent data directory and `cluster.remote_store.state.enabled` set to `true`, OpenSearch starts only search replicas—excluding primaries and write replicas—ensuring the index remains queryable after restart.
 
-**Scenario 4: No persistent data directory and remote store state disabled**
+##### Scenario 4: No persistent data directory and remote store state disabled
 
-Without a persistent data directory and with `cluster.remote_store.state.enabled` set to `false`, restarting OpenSearch loses all local state and the index becomes unrecoverable because OpenSearch has no metadata reference and local state is wiped.
+When both the persistent data directory is missing and `cluster.remote_store.state.enabled` is set to `false`, all local state is lost on restart. OpenSearch has no metadata reference, so the index becomes unrecoverable.
+

--- a/_tuning-your-cluster/seperate-index-and-search-workloads.md
+++ b/_tuning-your-cluster/seperate-index-and-search-workloads.md
@@ -59,7 +59,8 @@ For more information, see [Remote-backed storage]({{site.url}}{{site.baseurl}}/t
 
 **Important NOTE**
 
-Before enabling [search-only mode](#turn-off-write-workloads-with-search-only-mode), we recommend setting `cluster.remote_store.state.enabled` to `true`. For more information about recovery scenarios, see [Search replica recovery scenarios](#search-replica-recovery-scenarios).
+When separating index and search workloads, we recommend setting `cluster.remote_store.state.enabled` to `true` as part of your initial setup. This ensures that OpenSearch persists index metadata in the remote store, enabling seamless recovery of search replicas during [search-only mode](#turn-off-write-workloads-with-search-only-mode). For more information about recovery scenarios, see [Search replica recovery scenarios](#search-replica-recovery-scenarios).
+
 
 ### Step 3: Add search replicas to an index
 


### PR DESCRIPTION
### Description
Update the `search_only` mode section with more details and recovery scenarios.

### Issues Resolved
- Part of https://github.com/opensearch-project/documentation-website/issues/9641
- Related PR: https://github.com/opensearch-project/OpenSearch/pull/17299.
- Related Issue from OpenSearch for search only mode with all the design and implementation details https://github.com/opensearch-project/OpenSearch/issues/16720.

### Version
3.0.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
