### PR TITLE
Add more security configuration APIs

### DIFF
--- a/_api-reference/security/configuration/get-configuration.md
+++ b/_api-reference/security/configuration/get-configuration.md
@@ -10,7 +10,7 @@ nav_order: 40
 **Introduced 1.0**
 {: .label .label-purple }
 
-The Get Security Configuration API retrieves the current Security configuration. This configuration includes authentication domains and other security-related configurations.
+The Get Security Configuration API retrieves the current security configuration. This configuration includes authentication domains and other security-related configurations.
 
 <!-- spec_insert_start
 api: security.get_configuration
@@ -75,7 +75,7 @@ GET /_plugins/_security/api/securityconfig
 
 ## Response body fields
 
-The response body is a JSON object with the following fields:
+The response body is a JSON object with the following fields.
 
 | Property | Data type | Description |
 | :--- | :--- | :--- |
@@ -87,7 +87,7 @@ The response body is a JSON object with the following fields:
   </summary>
   {: .text-delta}
 
-`config` is a JSON object that contains the following fields:
+`config` is a JSON object that contains the following fields.
 
 | Property | Data type | Description |
 | :--- | :--- | :--- |
@@ -101,7 +101,7 @@ The Get Configuration API provides a way to inspect the current security configu
 
 - **Read-only operation**: This API only retrieves the configuration and does not modify it.
 
-- **Access control**: Access to this API should be restricted to administrators, as the configuration contains sensitive information about your security setup.
+- **Access control**: Access to this API should be restricted to administrators because the configuration contains sensitive information about your security setup.
 
 ## Security considerations
 
@@ -112,4 +112,4 @@ The security configuration contains sensitive information about your authenticat
 
 ## Permissions
 
-Any users with roles defined in the `plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]` have access to this API.
+Any users with roles defined in `plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]` have access to this API.

--- a/_api-reference/security/configuration/get-configuration.md
+++ b/_api-reference/security/configuration/get-configuration.md
@@ -1,0 +1,120 @@
+---
+layout: default
+title: Get Configuration API
+parent: Configuration APIs
+grand_parent: Security APIs
+nav_order: 40
+---
+
+# Get Security Configuration API
+**Introduced 1.0**
+{: .label .label-purple }
+
+The Get Security Configuration API retrieves the current Security plugin configuration. This configuration includes authentication domains, authorization settings, and other security-related configurations that determine how users and requests are authenticated and authorized in your OpenSearch cluster.
+
+<!-- spec_insert_start
+api: security.get_configuration
+component: endpoints
+-->
+## Endpoints
+```json
+GET /_plugins/_security/api/securityconfig
+```
+<!-- spec_insert_end -->
+
+## Example request
+
+```bash
+GET /_plugins/_security/api/securityconfig
+```
+{% include copy-curl.html %}
+
+## Example response
+
+```json
+{
+  "config": {
+    "dynamic": {
+      "authc": {
+        "basic_internal_auth_domain": {
+          "http_enabled": true,
+          "transport_enabled": true,
+          "order": 0,
+          "http_authenticator": {
+            "challenge": true,
+            "type": "basic",
+            "config": {}
+          },
+          "authentication_backend": {
+            "type": "internal",
+            "config": {}
+          }
+        }
+      },
+      "authz": {
+        "roles_from_myldap": {
+          "http_enabled": true,
+          "transport_enabled": true,
+          "authorization_backend": {
+            "type": "ldap",
+            "config": {
+              "roles_search_filter": "(uniqueMember={0})",
+              "host": "ldap.example.com",
+              "port": 389
+            }
+          }
+        }
+      },
+      "multi_rolespan_enabled": true,
+      "hosts_resolver_mode": "ip-only",
+      "do_not_fail_on_forbidden": false
+    }
+  }
+}
+```
+
+## Response body fields
+
+The response body is a JSON object with the following fields:
+
+| Property | Data type | Description |
+| :--- | :--- | :--- |
+| `config` | Object | The root object containing the security configuration. |
+
+<details markdown="block">
+  <summary>
+    Response body fields: <code>config</code>
+  </summary>
+  {: .text-delta}
+
+`config` is a JSON object that contains the following fields:
+
+| Property | Data type | Description |
+| :--- | :--- | :--- |
+| `dynamic` | Object | The main configuration object containing all security configuration settings. Includes authentication domains (`authc`), authorization settings (`authz`), and various security behaviors. |
+
+</details>
+
+## Usage notes
+
+The Get Configuration API provides a way to inspect the current security configuration. When using the API, remember the following usage notes:
+
+- **Read-only operation**: This API only retrieves the configuration and does not modify it.
+
+- **Access control**: Access to this API should be restricted to administrators, as the configuration contains sensitive information about your security setup.
+
+## Security considerations
+
+The security configuration contains sensitive information about your authentication mechanisms, LDAP settings, and security policies. Consider the following security best practices:
+
+- Restrict access to this API to administrators only.
+- Be cautious about storing or logging the output from this API, as it may contain sensitive configuration details.
+- Use HTTPS/TLS when interacting with this API to prevent information disclosure.
+
+## Enabling this API
+
+By default, access to this API is restricted. To enable it, you need to:
+
+1. Update the `config.yml` file of the Security plugin.
+2. Add the setting `plugins.security.restapi.endpoints_disabled.securityconfig: "false"`. 
+3. Restart your OpenSearch cluster.

--- a/_api-reference/security/configuration/get-configuration.md
+++ b/_api-reference/security/configuration/get-configuration.md
@@ -10,7 +10,7 @@ nav_order: 40
 **Introduced 1.0**
 {: .label .label-purple }
 
-The Get Security Configuration API retrieves the current Security plugin configuration. This configuration includes authentication domains, authorization settings, and other security-related configurations that determine how users and requests are authenticated and authorized in your OpenSearch cluster.
+The Get Security Configuration API retrieves the current Security configuration. This configuration includes authentication domains and other security-related configurations.
 
 <!-- spec_insert_start
 api: security.get_configuration
@@ -107,14 +107,9 @@ The Get Configuration API provides a way to inspect the current security configu
 
 The security configuration contains sensitive information about your authentication mechanisms, LDAP settings, and security policies. Consider the following security best practices:
 
-- Restrict access to this API to administrators only.
 - Be cautious about storing or logging the output from this API, as it may contain sensitive configuration details.
 - Use HTTPS/TLS when interacting with this API to prevent information disclosure.
 
-## Enabling this API
+## Permissions
 
-By default, access to this API is restricted. To enable it, you need to:
-
-1. Update the `config.yml` file of the Security plugin.
-2. Add the setting `plugins.security.restapi.endpoints_disabled.securityconfig: "false"`. 
-3. Restart your OpenSearch cluster.
+Any users with roles defined in the `plugins.security.restapi.roles_enabled: ["all_access", "security_rest_api_access"]` have access to this API.

--- a/_api-reference/security/configuration/index.md
+++ b/_api-reference/security/configuration/index.md
@@ -34,11 +34,11 @@ Use the Configuration APIs to perform the following actions:
 
 - [Upgrade Perform API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/upgrade-perform/): Applies updates to the security configuration, based on the results of the Upgrade Check API.
 
-- [Update Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/update-configuration/): Creates or updates the Security configuration.
+- [Update Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/update-configuration/): Creates or updates the security configuration.
 
-- [Patch Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/patch-configuration/): Update specific fields of the Security configuration without replacing the entire configuration document. 
+- [Patch Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/patch-configuration/): Updates specific fields of the security configuration without replacing the entire configuration document. 
 
-- [Get Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/get-configuration/): Retrieves the current Security configuration.
+- [Get Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/get-configuration/): Retrieves the current security configuration.
 
 ## `authc`
 
@@ -95,12 +95,12 @@ You can then use the extracted backend roles in role mappings. The following con
 
 ## `authz`
 
-The `authz` section handles authorization by retrieving backend roles from external sources such as LDAP. This allows OpenSearch to authenticate users using one method (for example, basic authentication or SAML) and authorize them based on role information stored in a separate directory.
+The `authz` section handles authorization by retrieving backend roles from external sources such as LDAP. This allows OpenSearch to authenticate users through one method (for example, basic authentication or SAML) and authorize them based on role information stored in a separate directory.
 
-A typical authz configuration includes the following elements:
+A typical `authz` configuration includes the following elements:
 
 - `roles_search_filter`: The LDAP search filter used to find roles for a user
-- `rolebase`: The DN (Distinguished Name) where to search for roles
+- `rolebase`: The Distinguished Name (DN) to search for roles
 - `rolesearch`: The search pattern to use when looking for roles
 - `rolename`: The attribute that contains the role name
 
@@ -132,7 +132,7 @@ The following example connects to an LDAP directory, uses the `rolesearch` filte
 {% include copy.html %}
 
 
-The following example shows how to map an LDAP group to an OpenSearch role. If a user belongs to the LDAP group `cn=analysts,ou=groups,dc=example,dc=com`, the backend role analysts is extracted and mapped to the `data_access_role`:
+The following example shows how to map an LDAP group to an OpenSearch role. If a user belongs to the LDAP group `cn=analysts,ou=groups,dc=example,dc=com`, the backend role `analysts` is extracted and mapped to the `data_access_role`:
 
 ```json
 {

--- a/_api-reference/security/configuration/index.md
+++ b/_api-reference/security/configuration/index.md
@@ -34,6 +34,116 @@ Use the Configuration APIs to perform the following actions:
 
 - [Upgrade Perform API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/upgrade-perform/): Applies updates to the security configuration, based on the results of the Upgrade Check API.
 
+- [Update Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/update-configuration/): Creates or updates the Security configuration.
+
+- [Patch Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/patch-configuration/): Update specific fields of the Security configuration without replacing the entire configuration document. 
+
+- [Get Security Configuration API]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/get-configuration/): Retrieves the current Security configuration.
+
+## `authc`
+
+When configuring authentication domains (`authc`), you define how OpenSearch extracts user information and backend roles from the authentication response. This is especially important when integrating with external systems such as SAML, OIDC, or custom authentication backends.
+
+To support role mapping, use the following configuration keys:
+
+- `subject_key`: Specifies where to find the user identifier in the authentication response
+- `roles_key`: Indicates where to find the backend roles in the authentication response
+
+OpenSearch uses the extracted backend roles in role mappings to assign roles to users.
+
+The following example shows how to configure an authentication domain to extract the username from `"preferred_username"` and backend roles from `"groups"` in a JWT token:
+
+```json
+{
+  "authc": {
+    "oidc_auth_domain": {
+      "http_enabled": true,
+      "transport_enabled": false,
+      "order": 1,
+      "http_authenticator": {
+        "type": "openid",
+        "challenge": false,
+        "config": {
+          "subject_key": "preferred_username",
+          "roles_key": "groups",
+          "openid_connect_url": "https://identity.example.com/.well-known/openid-configuration"
+        }
+      },
+      "authentication_backend": {
+        "type": "noop",
+        "config": {}
+      }
+    }
+  }
+}
+```
+{% include copy.html %}
+
+You can then use the extracted backend roles in role mappings. The following configuration assigns the `analyst_role` to users whose authentication response includes either `analyst_group` or `data_scientist_group`:
+
+```json
+{
+  "role_mappings": {
+    "analyst_role": {
+      "backend_roles": ["analyst_group", "data_scientist_group"]
+    }
+  }
+}
+```
+{% include copy.html %}
+
+
+## `authz`
+
+The `authz` section handles authorization by retrieving backend roles from external sources such as LDAP. This allows OpenSearch to authenticate users using one method (for example, basic authentication or SAML) and authorize them based on role information stored in a separate directory.
+
+A typical authz configuration includes the following elements:
+
+- `roles_search_filter`: The LDAP search filter used to find roles for a user
+- `rolebase`: The DN (Distinguished Name) where to search for roles
+- `rolesearch`: The search pattern to use when looking for roles
+- `rolename`: The attribute that contains the role name
+
+This setup is useful in enterprise environments where identities are managed in one system and roles in another.
+
+The following example connects to an LDAP directory, uses the `rolesearch` filter to find user groups, and extracts each group as a backend role using the `rolename` attribute:
+
+```json
+{
+  "authz": {
+    "ldap_role_authz": {
+      "http_enabled": true,
+      "transport_enabled": true,
+      "authorization_backend": {
+        "type": "ldap",
+        "config": {
+          "rolebase": "ou=groups,dc=example,dc=com",
+          "rolesearch": "(uniqueMember={0})",
+          "rolename": "cn",
+          "userbase": "ou=people,dc=example,dc=com",
+          "usersearch": "(uid={0})",
+          "username_attribute": "uid"
+        }
+      }
+    }
+  }
+}
+```
+{% include copy.html %}
+
+
+The following example shows how to map an LDAP group to an OpenSearch role. If a user belongs to the LDAP group `cn=analysts,ou=groups,dc=example,dc=com`, the backend role analysts is extracted and mapped to the `data_access_role`:
+
+```json
+{
+  "role_mappings": {
+    "data_access_role": {
+      "backend_roles": ["analysts", "researchers"]
+    }
+  }
+}
+```
+
 ## Configuration components
 
 These APIs manage the following configuration components:

--- a/_api-reference/security/configuration/patch-configuration.md
+++ b/_api-reference/security/configuration/patch-configuration.md
@@ -27,11 +27,11 @@ PATCH /_plugins/_security/api/securityconfig
 
 ## Request body fields
 
-The request body is **required**. It is an **array of JSON objects** (NDJSON). Each object has the following fields:
+The request body is **required**. It is an **array of JSON objects** (NDJSON). Each object has the following fields.
 
 | Property | Required | Data type | Description |
 | :--- | :--- | :--- | :--- |
-| `op` | **Required** | String | The operation to perform. Valid values are: `add`, `remove`, `replace`, `move`, `copy`, and `test`. |
+| `op` | **Required** | String | The operation to perform. Valid values are `add`, `remove`, `replace`, `move`, `copy`, and `test`. |
 | `path` | **Required** | String | The JSON pointer path to the location in the configuration to modify. |
 | `value` | Optional | Object | The value to use for the operation. Required for `add`, `replace`, and `test` operations. |
 
@@ -91,7 +91,7 @@ PATCH /_plugins/_security/api/securityconfig
 
 ## Response body fields
 
-The response body is a JSON object with the following fields:
+The response body is a JSON object with the following fields.
 
 | Property | Data type | Description |
 | :--- | :--- | :--- |
@@ -111,7 +111,7 @@ The API supports the following JSON patch operations:
 
 ## Usage notes
 
-The Patch Configuration API provides more granular control over configuration updates than the Update Configuration API, but still comes with significant risks:
+The Patch Configuration API provides more granular control over configuration updates than the Update Configuration API but still comes with potential risks:
 
 - **Path format**: Paths start with `/config` followed by the JSON pointer path to the specific configuration element you want to modify.
 
@@ -119,20 +119,20 @@ The Patch Configuration API provides more granular control over configuration up
 
 - **Backup configuration**: Always back up your current security configuration before making changes.
 
-- **Testing**: Test configuration changes in a development environment before applying to production.
+- **Testing**: Test configuration changes in a development environment before deploying them to production.
 
 ## Enabling this API
 
 By default, this API is disabled for security reasons. To enable it, perform the following steps:
 
-1. Update the `opensearch.yml` file with:
+1. Update the `opensearch.yml` file with the following:
 
    ```
    plugins.security.unsupported.restapi.allow_securityconfig_modification: true
    ```
    {% include copy.html %}
 
-2. Update the Security plugin's `config.yml` file with:
+2. Update the Security plugin's `config.yml` file with the following:
 
    ```
    plugins.security.restapi.endpoints_disabled.securityconfig: "false"

--- a/_api-reference/security/configuration/patch-configuration.md
+++ b/_api-reference/security/configuration/patch-configuration.md
@@ -1,0 +1,140 @@
+---
+layout: default
+title: Patch Configuration API
+parent: Configuration APIs
+grand_parent: Security APIs
+nav_order: 50
+---
+
+# Patch Configuration API
+**Introduced 1.0**
+{: .label .label-purple }
+
+The Patch Configuration API allows you to update specific parts of the Security plugin configuration without replacing the entire configuration document. 
+
+This operation can easily break your existing security configuration. We strongly recommend using the `securityadmin.sh` script instead, which includes validations and safeguards to prevent misconfiguration.
+{: .warning}
+
+<!-- spec_insert_start
+api: security.patch_configuration
+component: endpoints
+-->
+## Endpoints
+```json
+PATCH /_plugins/_security/api/securityconfig
+```
+<!-- spec_insert_end -->
+
+## Request body fields
+
+The request body is **required**. It is an **array of JSON objects** (NDJSON). Each object has the following fields:
+
+| Property | Required | Data type | Description |
+| :--- | :--- | :--- | :--- |
+| `op` | **Required** | String | The operation to perform. Valid values are: `add`, `remove`, `replace`, `move`, `copy`, and `test`. |
+| `path` | **Required** | String | The JSON pointer path to the location in the configuration to modify. |
+| `value` | Optional | Object | The value to use for the operation. Required for `add`, `replace`, and `test` operations. |
+
+## Example request
+
+The following example adds a new authentication domain and modifies an existing setting:
+
+```json
+PATCH /_plugins/_security/api/securityconfig
+[
+  {
+    "op": "add",
+    "path": "/config/dynamic/authc/saml_auth_domain",
+    "value": {
+      "http_enabled": true,
+      "transport_enabled": false,
+      "order": 1,
+      "http_authenticator": {
+        "type": "saml",
+        "challenge": false,
+        "config": {
+          "idp": {
+            "metadata_url": "https://idp.example.com/saml/metadata"
+          },
+          "sp": {
+            "entity_id": "opensearch"
+          }
+        }
+      },
+      "authentication_backend": {
+        "type": "noop",
+        "config": {}
+      }
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/config/dynamic/multi_rolespan_enabled",
+    "value": true
+  },
+  {
+    "op": "remove",
+    "path": "/config/dynamic/authc/legacy_auth_domain"
+  }
+]
+```
+{% include copy-curl.html %}
+
+## Example response
+
+```json
+{
+  "status": "OK",
+  "message": "Configuration updated."
+}
+```
+
+## Response body fields
+
+The response body is a JSON object with the following fields:
+
+| Property | Data type | Description |
+| :--- | :--- | :--- |
+| `status` | String | The status of the request. A successful request returns "OK". |
+| `message` | String | A message describing the result of the operation. |
+
+## JSON Patch operations
+
+The API supports the following JSON Patch operations:
+
+- **add**: Adds a value to an object or inserts it into an array. For existing properties, the value is replaced.
+- **remove**: Removes a value from an object or array.
+- **replace**: Replaces a value. 
+- **move**: Moves a value from one location to another.
+- **copy**: Copies a value from one location to another.
+- **test**: Tests that a value at the target location is equal to the specified value.
+
+## Usage notes
+
+The Patch Configuration API provides more granular control over configuration updates than the Update Configuration API, but still comes with significant risks:
+
+- **Path format**: Paths start with `/config` followed by the JSON pointer path to the specific configuration element you want to modify.
+
+- **Validation**: Limited validation is performed on the patched configuration, which may lead to security vulnerabilities if misconfigured.
+
+- **Backup configuration**: Always back up your current security configuration before making changes.
+
+- **Testing**: Test configuration changes in a development environment before applying to production.
+
+## Enabling this API
+
+By default, this API is disabled for security reasons. To enable it, you need to:
+
+1. Update the `opensearch.yml` file with:
+   ```
+   plugins.security.unsupported.restapi.allow_securityconfig_modification: true
+   ```
+
+2. Update the Security plugin's `config.yml` file with:
+   ```
+   plugins.security.restapi.endpoints_disabled.securityconfig: "false"
+   ```
+
+3. Restart your OpenSearch cluster
+
+Due to the potential security implications, enabling this API is generally not recommended for production environments.

--- a/_api-reference/security/configuration/patch-configuration.md
+++ b/_api-reference/security/configuration/patch-configuration.md
@@ -98,9 +98,9 @@ The response body is a JSON object with the following fields:
 | `status` | String | The status of the request. A successful request returns "OK". |
 | `message` | String | A message describing the result of the operation. |
 
-## JSON Patch operations
+## JSON patch operations
 
-The API supports the following JSON Patch operations:
+The API supports the following JSON patch operations:
 
 - **add**: Adds a value to an object or inserts it into an array. For existing properties, the value is replaced.
 - **remove**: Removes a value from an object or array.

--- a/_api-reference/security/configuration/patch-configuration.md
+++ b/_api-reference/security/configuration/patch-configuration.md
@@ -123,18 +123,22 @@ The Patch Configuration API provides more granular control over configuration up
 
 ## Enabling this API
 
-By default, this API is disabled for security reasons. To enable it, you need to:
+By default, this API is disabled for security reasons. To enable it, perform the following steps:
 
 1. Update the `opensearch.yml` file with:
+
    ```
    plugins.security.unsupported.restapi.allow_securityconfig_modification: true
    ```
+   {% include copy.html %}
 
 2. Update the Security plugin's `config.yml` file with:
+
    ```
    plugins.security.restapi.endpoints_disabled.securityconfig: "false"
    ```
+   {% include copy.html %}
 
-3. Restart your OpenSearch cluster
+3. Restart your OpenSearch cluster.
 
 Due to the potential security implications, enabling this API is generally not recommended for production environments.

--- a/_api-reference/security/configuration/update-configuration.md
+++ b/_api-reference/security/configuration/update-configuration.md
@@ -46,7 +46,6 @@ The request body is **required**. It is a JSON object with the following fields:
 | `auth_failure_listeners` | Object | The configuration for handling authentication failures, including thresholds and actions. |
 | `authc` | Object | The authentication configuration domains, defining how users are authenticated. For more information, see [authc]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authc). |
 | `authz` | Object | The authorization configuration, defining how to extract backend roles when using LDAP for authentication. For more information, see [authz]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authz). |
-| `disable_rest_auth` | Boolean | When `true`, disables authentication for REST API requests (dangerous). |
 | `do_not_fail_on_forbidden` | Boolean | When `true`, returns empty results instead of a forbidden error settings the user is not authorized to access. Instead, failures are stored in the application logs. |
 | `do_not_fail_on_forbidden_empty` | Boolean | Similar to `do_not_fail_on_forbidden` but with specific behavior for empty results. |
 | `filtered_alias_mode` | String | Controls how document field filtering is applied on aliases. |

--- a/_api-reference/security/configuration/update-configuration.md
+++ b/_api-reference/security/configuration/update-configuration.md
@@ -1,0 +1,154 @@
+---
+layout: default
+title: Update Security Configuration API
+parent: Configuration APIs
+grand_parent: Security APIs
+nav_order: 30
+---
+
+# Update Security Configuration API
+**Introduced 1.0**
+{: .label .label-purple }
+
+The Update Security Configuration API creates or updates the Security plugin's configuration directly through the REST API. This configuration manages core security settings including authentication methods, authorization rules, and access controls.
+
+This operation can easily break your existing security configuration. We strongly recommend using the `securityadmin.sh` script instead, which includes validations and safeguards to prevent misconfiguration.
+{: .warning}
+
+<!-- spec_insert_start
+api: security.update_configuration
+component: endpoints
+-->
+## Endpoints
+```json
+PUT /_plugins/_security/api/securityconfig/config
+```
+<!-- spec_insert_end -->
+
+## Request body fields
+
+The request body is **required**. It is a JSON object with the following fields:
+
+| Property | Required | Data type | Description |
+| :--- | :--- | :--- | :--- |
+| `dynamic` | **Required** | Object | The main configuration object containing all security configuration settings. |
+
+<details markdown="block">
+  <summary>
+    Request body fields: <code>dynamic</code>
+  </summary>
+  {: .text-delta}
+
+`dynamic` is a JSON object with the following fields:
+
+| Property | Data type | Description |
+| :--- | :--- | :--- |
+| `auth_failure_listeners` | Object | Configuration for handling authentication failures, including thresholds and actions. |
+| `authc` | Object | Authentication configuration domains, defining how users are authenticated. |
+| `authz` | Object | Authorization configuration, defining how permissions are evaluated. |
+| `disable_intertransport_auth` | Boolean | When `true`, disables authentication for internal node-to-node communication. |
+| `disable_rest_auth` | Boolean | When `true`, disables authentication for REST API requests (dangerous). |
+| `do_not_fail_on_forbidden` | Boolean | When `true`, returns empty results instead of forbidden error for unauthorized access. |
+| `do_not_fail_on_forbidden_empty` | Boolean | Similar to `do_not_fail_on_forbidden` but with specific behavior for empty results. |
+| `filtered_alias_mode` | String | Controls how document field filtering is applied on aliases. |
+| `hosts_resolver_mode` | String | Determines how hostname resolution is performed for security operations. |
+| `http` | Object | HTTP-specific security configurations. |
+| `kibana` | Object | Legacy settings for Kibana integration (deprecated). |
+| `multi_rolespan_enabled` | Boolean | When `true`, enables spanning permissions across multiple roles. |
+| `on_behalf_of` | Object | Configuration for trusted users to impersonate other users (advanced). |
+| `opensearch-dashboards` | Object | Configuration for OpenSearch Dashboards integration. |
+| `respect_request_indices_options` | Boolean | When `true`, respects index options specified in requests. |
+
+</details>
+
+## Example request
+
+The following example updates the security configuration to configure basic authentication and internal user database:
+
+```json
+PUT /_plugins/_security/api/securityconfig/config
+PUT _plugins/_security/api/securityconfig/config
+{
+  "dynamic": {
+    "filtered_alias_mode": "warn",
+    "disable_rest_auth": false,
+    "disable_intertransport_auth": false,
+    "respect_request_indices_options": false,
+    "opensearch-dashboards": {
+      "multitenancy_enabled": true,
+      "server_username": "kibanaserver",
+      "index": ".opensearch-dashboards"
+    },
+    "http": {
+      "anonymous_auth_enabled": false
+    },
+    "authc": {
+      "basic_internal_auth_domain": {
+        "http_enabled": true,
+        "transport_enabled": true,
+        "order": 0,
+        "http_authenticator": {
+          "challenge": true,
+          "type": "basic",
+          "config": {}
+        },
+        "authentication_backend": {
+          "type": "intern",
+          "config": {}
+        },
+        "description": "Authenticate via HTTP Basic against internal users database"
+      }
+    },
+    "auth_failure_listeners": {},
+    "do_not_fail_on_forbidden": false,
+    "multi_rolespan_enabled": true,
+    "hosts_resolver_mode": "ip-only",
+    "do_not_fail_on_forbidden_empty": false
+  }
+}
+```
+{% include copy-curl.html %}
+
+## Example response
+
+```json
+{
+  "status": "OK",
+  "message": "Configuration updated."
+}
+```
+
+## Response body fields
+
+The response body is a JSON object with the following fields:
+
+| Property | Data type | Description |
+| :--- | :--- | :--- |
+| `status` | String | Status of the request. A successful request returns "OK". |
+| `message` | String | A message describing the result of the operation. |
+
+## Usage notes
+
+The Update Configuration API provides direct access to modify the Security plugin's core configuration, but comes with significant risks:
+
+- **Prefer `securityadmin.sh`**: In most cases, you should use the `securityadmin.sh` script instead, which includes validation and safeguards.
+  
+- **Backup configuration**: Always back up your current security configuration before making changes.
+  
+- **Access control**: Enable access to this API only for trusted administrators, as it can potentially disable security for your entire cluster.
+  
+- **Testing**: Test the security configuration changes in a development environment before applying to production.
+
+- **Complete configuration**: You must provide a complete configuration when updating, as partial updates will replace the entire configuration.
+  
+- **Validation**: This API has minimal validation, so incorrect configurations might not be caught until they cause operational issues.
+
+## Enabling this API
+
+By default, this API is disabled for security reasons. To enable it, you need to:
+
+1. Update the `config.yml` file of the Security plugin.
+2. Add the setting `plugins.security.restapi.endpoints_disabled.securityconfig: "false"`.  
+3. Restart your OpenSearch cluster.
+
+Due to the potential security implications, enabling this API is generally not recommended for production environments.

--- a/_api-reference/security/configuration/update-configuration.md
+++ b/_api-reference/security/configuration/update-configuration.md
@@ -10,7 +10,7 @@ nav_order: 30
 **Introduced 1.0**
 {: .label .label-purple }
 
-The Update Security Configuration API creates or updates the Security plugin's configuration directly through the REST API. This configuration manages core security settings including authentication methods, authorization rules, and access controls.
+The Update Security Configuration API creates or updates the Security plugin's configuration directly through the REST API. This configuration manages core security settings, including authentication methods, authorization rules, and access controls.
 
 This operation can easily break your existing security configuration. We strongly recommend using the `securityadmin.sh` script instead, which includes validations and safeguards to prevent misconfiguration.
 {: .warning}
@@ -27,7 +27,7 @@ PUT /_plugins/_security/api/securityconfig/config
 
 ## Request body fields
 
-The request body is **required**. It is a JSON object with the following fields:
+The request body is **required**. It is a JSON object with the following fields.
 
 | Property | Required | Data type | Description |
 | :--- | :--- | :--- | :--- |
@@ -39,16 +39,16 @@ The request body is **required**. It is a JSON object with the following fields:
   </summary>
   {: .text-delta}
 
-`dynamic` is a JSON object with the following fields:
+`dynamic` is a JSON object with the following fields.
 
 | Property | Data type | Description |
 | :--- | :--- | :--- |
 | `auth_failure_listeners` | Object | The configuration for handling authentication failures, including thresholds and actions. |
-| `authc` | Object | The authentication configuration domains, defining how users are authenticated. For more information, see [authc]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authc). |
-| `authz` | Object | The authorization configuration, defining how to extract backend roles when using LDAP for authentication. For more information, see [authz]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authz). |
-| `do_not_fail_on_forbidden` | Boolean | When `true`, returns empty results instead of a forbidden error settings the user is not authorized to access. Instead, failures are stored in the application logs. |
+| `authc` | Object | The authentication configuration domains that define how users are authenticated. For more information, see [authc]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authc). |
+| `authz` | Object | The authorization configuration that defines how to extract backend roles when using LDAP for authentication. For more information, see [authz]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authz). |
+| `do_not_fail_on_forbidden` | Boolean | When `true`, returns empty results instead of a forbidden error. Instead, failures are stored in the application logs. |
 | `do_not_fail_on_forbidden_empty` | Boolean | Similar to `do_not_fail_on_forbidden` but with specific behavior for empty results. |
-| `filtered_alias_mode` | String | Controls how document field filtering is applied on aliases. |
+| `filtered_alias_mode` | String | Controls how document field filtering is applied to aliases. |
 | `hosts_resolver_mode` | String | Determines how hostname resolution is performed for security operations. |
 | `http` | Object | The HTTP-specific security configurations. |
 | `on_behalf_of` | Object | Configures a temporary access token for the duration of a user's session (advanced). |
@@ -61,7 +61,7 @@ The request body is **required**. It is a JSON object with the following fields:
 
 ## Example request
 
-The following example updates the security configuration to configure basic authentication and internal user database:
+The following example updates the security configuration to configure basic authentication and an internal user database:
 
 ```json
 PUT /_plugins/_security/api/securityconfig/config
@@ -117,34 +117,34 @@ PUT /_plugins/_security/api/securityconfig/config
 
 ## Response body fields
 
-The response body is a JSON object with the following fields:
+The response body is a JSON object with the following fields.
 
 | Property | Data type | Description |
 | :--- | :--- | :--- |
-| `status` | String | Status of the request. A successful request returns "OK". |
+| `status` | String | The status of the request. A successful request returns "OK". |
 | `message` | String | A message describing the result of the operation. |
 
 ## Usage notes
 
-The Update Configuration API provides direct access to modify the Security plugin's core configuration, but comes with significant risks:
+The Update Configuration API allows you to directly modify the Security plugin's core configuration but comes with potential risks:
 
-- **Prefer `securityadmin.sh`**: In most cases, you should use the `securityadmin.sh` script instead, which includes validation and safeguards.
+- **Prefer `securityadmin.sh`**: In most cases, you should use the `securityadmin.sh` script instead, which includes validations and safeguards to prevent misconfiguration.
   
 - **Backup configuration**: Always back up your current security configuration before making changes.
   
-- **Access control**: Enable access to this API only for trusted administrators, as it can potentially disable security for your entire cluster.
+- **Access control**: Enable access to this API only for trusted administrators, as it can potentially disable the security configuration for your entire cluster.
   
-- **Testing**: Test the security configuration changes in a development environment before applying to production.
+- **Testing**: Test the security configuration changes in a development environment before deploying them to production.
 
 - **Complete configuration**: You must provide a complete configuration when updating, as partial updates will replace the entire configuration.
   
-- **Validation**: This API has minimal validation, so incorrect configurations might not be caught until they cause operational issues.
+- **Validation**: This API has minimal validation, so incorrect configurations might not be identified until they cause operational issues.
 
 ## Enabling this API
 
 By default, this API is disabled for security reasons. To enable it, you need to:
 
-1. Update the `config.yml` file of the Security plugin.
+1. Update the Security plugin's `config.yml` file.
 2. Add the setting `plugins.security.restapi.endpoints_disabled.securityconfig: "false"`.  
 3. Restart your OpenSearch cluster.
 

--- a/_api-reference/security/configuration/update-configuration.md
+++ b/_api-reference/security/configuration/update-configuration.md
@@ -43,23 +43,22 @@ The request body is **required**. It is a JSON object with the following fields:
 
 | Property | Data type | Description |
 | :--- | :--- | :--- |
-| `auth_failure_listeners` | Object | Configuration for handling authentication failures, including thresholds and actions. |
-| `authc` | Object | Authentication configuration domains, defining how users are authenticated. |
-| `authz` | Object | Authorization configuration, defining how permissions are evaluated. |
-| `disable_intertransport_auth` | Boolean | When `true`, disables authentication for internal node-to-node communication. |
+| `auth_failure_listeners` | Object | The configuration for handling authentication failures, including thresholds and actions. |
+| `authc` | Object | The authentication configuration domains, defining how users are authenticated. For more information, see [authc]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authc). |
+| `authz` | Object | The authorization configuration, defining how to extract backend roles when using LDAP for authentication. For more information, see [authz]({{site.url}}{{site.baseurl}}/api-reference/security/configuration/index/#authz). |
 | `disable_rest_auth` | Boolean | When `true`, disables authentication for REST API requests (dangerous). |
-| `do_not_fail_on_forbidden` | Boolean | When `true`, returns empty results instead of forbidden error for unauthorized access. |
+| `do_not_fail_on_forbidden` | Boolean | When `true`, returns empty results instead of a forbidden error settings the user is not authorized to access. Instead, failures are stored in the application logs. |
 | `do_not_fail_on_forbidden_empty` | Boolean | Similar to `do_not_fail_on_forbidden` but with specific behavior for empty results. |
 | `filtered_alias_mode` | String | Controls how document field filtering is applied on aliases. |
 | `hosts_resolver_mode` | String | Determines how hostname resolution is performed for security operations. |
-| `http` | Object | HTTP-specific security configurations. |
-| `kibana` | Object | Legacy settings for Kibana integration (deprecated). |
-| `multi_rolespan_enabled` | Boolean | When `true`, enables spanning permissions across multiple roles. |
-| `on_behalf_of` | Object | Configuration for trusted users to impersonate other users (advanced). |
-| `opensearch-dashboards` | Object | Configuration for OpenSearch Dashboards integration. |
+| `http` | Object | The HTTP-specific security configurations. |
+| `on_behalf_of` | Object | Configures a temporary access token for the duration of a user's session (advanced). |
+| `kibana` | Object | The configuration for OpenSearch Dashboards integration. |
 | `respect_request_indices_options` | Boolean | When `true`, respects index options specified in requests. |
 
+
 </details>
+
 
 ## Example request
 
@@ -67,7 +66,6 @@ The following example updates the security configuration to configure basic auth
 
 ```json
 PUT /_plugins/_security/api/securityconfig/config
-PUT _plugins/_security/api/securityconfig/config
 {
   "dynamic": {
     "filtered_alias_mode": "warn",


### PR DESCRIPTION
### Description

Adds more security configuration APIs. Will reconcile with the Access Control API list in a separate PR.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
