### PR TITLE
Update ingestion tooling support for 3.x

### DIFF
--- a/_tools/index.md
+++ b/_tools/index.md
@@ -26,7 +26,7 @@ For information about Data Prepper, the server-side data collector for filtering
 
 Historically, many multiple popular agents and ingestion tools have worked with Elasticsearch OSS, such as Beats, Logstash, Fluentd, FluentBit, and OpenTelemetry. OpenSearch aims to continue to support a broad set of agents and ingestion tools, but not all have been tested or have explicitly added OpenSearch compatibility.
 
-As an intermediate compatibility solution, OpenSearch has a setting that instructs the cluster to return version 7.10.2 rather than its actual version.
+As an intermediate compatibility solution, OpenSearch 1.x and 2.x have a setting that instructs the cluster to return version 7.10.2 rather than its actual version.
 
 If you use clients that include a version check, such as versions of Logstash OSS or Filebeat OSS between 7.x - 7.12.x, enable the setting:
 
@@ -84,6 +84,7 @@ Some users report compatibility issues with ingest pipelines on these versions o
 | ODFE 1.0 to 1.12 | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
 | ODFE 1.13 | *Yes* | *Yes* | *No* | *Yes* | *Yes* |
 | OpenSearch 1.x to 2.x | Yes via version setting | Yes via version setting | *No* | *Yes* | Yes, with Elastic Common Schema Setting |
+| OpenSearch 3.x | *No * | *No* | *No* | *Yes* | Yes, with Elastic Common Schema Setting |
 
 \* Most current compatible version with Elasticsearch OSS.
 


### PR DESCRIPTION
Related to https://github.com/opensearch-project/OpenSearch/issues/18228

I need a subject matter expert on these ingestion tools to confirm the compatibility matrix is correct. OpenSearch 3.0 does not support the `override_main_response_version` setting.

### Version
3.0+

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
