### PR TITLE
Rename "REST API reference" page to "API reference"

### DIFF
--- a/_api-reference/index.md
+++ b/_api-reference/index.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: REST API reference
+title: API reference
 nav_order: 1
 has_toc: false
 has_children: true


### PR DESCRIPTION
### Description
Since the API reference page now includes both REST and GRPC APIs, fixing the title of the page to say just "API reference". 
https://docs.opensearch.org/docs/latest/api-reference/ 
<img width="1460" alt="Screenshot 2025-05-09 at 3 31 13 PM" src="https://github.com/user-attachments/assets/b8e825b7-8319-45a1-ae73-9c7cb94d05dd" />

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/9591 

### Version
3.0 and beyond

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
