### PR TITLE
Fix Spec insert bug

### DIFF
--- a/_api-reference/security/authentication/change-password.md
+++ b/_api-reference/security/authentication/change-password.md
@@ -22,10 +22,6 @@ PUT /_plugins/_security/api/account
 ```
 <!-- spec_insert_end -->
 
-<!-- spec_insert_start
-api: security.change_password
-component: query_parameters
--->
 
 <!-- spec_insert_start
 api: security.change_password
@@ -39,6 +35,8 @@ The request body is __required__. It is a JSON object with the following fields.
 | :--- | :--- | :--- | :--- |
 | `current_password` | **Required** | String | The current password. |
 | `password` | **Required** | String | The new password to set. |
+
+<!-- spec_insert_end -->
 
 ## Example request
 


### PR DESCRIPTION
Fixes a bug where a `spen-insert` marker was missing an end marker.
### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
