### PR TITLE
Update Migration Assistant support for OpenSearch 3.0

### DIFF
--- a/_data/migration-assistant/breaking-changes.yml
+++ b/_data/migration-assistant/breaking-changes.yml
@@ -28,6 +28,10 @@ breaking_changes:
     transformation:
       title: "Type Mapping Deprecation"
       url: "/docs/latest/migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/"
+  - title: "OpenSearch 3.0: Breaking Changes"
+    url: "/docs/latest/breaking-changes/#300"
+    introducedIn: "OpenSearch 3.0"
+    comp: []
   - title: "OpenSearch Notifications Plugins"
     url: "/breaking-changes/#add-opensearch-notifications-plugins"
     introducedIn: "OpenSearch 2.19"

--- a/_data/migration-assistant/valid_migrations.yml
+++ b/_data/migration-assistant/valid_migrations.yml
@@ -4,21 +4,30 @@ migration_paths:
     targets: 
       - "OpenSearch 1.3"
       - "OpenSearch 2.19"
+      - "OpenSearch 3.0"
   - source: "Elasticsearch 6.8"
     targets:
       - "OpenSearch 1.3"
       - "OpenSearch 2.19"
+      - "OpenSearch 3.0"
   - source: "Elasticsearch 7.10"
     targets:
       - "OpenSearch 1.3"
       - "OpenSearch 2.19"
+      - "OpenSearch 3.0"
   - source: "Elasticsearch 7.17"
     targets:
       - "OpenSearch 1.3"
       - "OpenSearch 2.19"
+      - "OpenSearch 3.0"
   - source: "OpenSearch 1.3"
     targets:
       - "OpenSearch 2.19"
+      - "OpenSearch 3.0"
   - source: "OpenSearch 2.19"
     targets:
       - "OpenSearch 2.19"
+      - "OpenSearch 3.0"
+  - source: "OpenSearch 3.0"
+    targets:
+      - "OpenSearch 3.0"


### PR DESCRIPTION
### Description
Migration Assistant supports newly released OpenSearch 3.0, added to the supported list of targets, tested locally, here are screenshots:

![image](https://github.com/user-attachments/assets/f4e8c2a0-c623-4dcc-86c2-d6d1b993d6ad)
![image](https://github.com/user-attachments/assets/cc75ca45-8a50-4ec4-9024-6fd91a337a1d)

### Issues Resolved
- Resolves https://opensearch.atlassian.net/browse/MIGRATIONS-2426

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
