### PR TITLE
removing alerting comments experimental banner

### DIFF
--- a/_observing-your-data/alerting/api.md
+++ b/_observing-your-data/alerting/api.md
@@ -2329,8 +2329,6 @@ POST _plugins/_alerting/destinations/email_groups/_search
 </details>
 
 ## Create comment
-This is an experimental feature and is not recommended for use in a production environment.   
-{: .warning}
 
 Add comments to a specific alert, providing additional context or notes related to that alert, using the following request.
 
@@ -2371,8 +2369,6 @@ POST _plugins/_alerting/comments/<alert-id>
 </details>
 
 ## Update comment
-This is an experimental feature and is not recommended for use in a production environment.   
-{: .warning}
 
 Modify the content of a previously added comment associated with an alert using the following request.
 
@@ -2414,8 +2410,6 @@ PUT _plugins/_alerting/comments/<comment-id>
 </details>
 
 ## Search comment
-This is an experimental feature and is not recommended for use in a production environment.   
-{: .warning}
 
 Query and retrieve existing comments associated with alerts using the following request.
 
@@ -2496,8 +2490,6 @@ GET _plugins/_alerting/comments/_search
 </details>
 
 ## Delete comment
-This is an experimental feature and is not recommended for use in a production environment.   
-{: .warning}
 
 Remove a specific comment associated with an alert using the following request.
 

--- a/_observing-your-data/alerting/comments.md
+++ b/_observing-your-data/alerting/comments.md
@@ -10,9 +10,6 @@ redirect_from:
 
 # Adding comments
 
-This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch-Dashboards/issues/6999).
-{: .warning}
-
 When an alert is generated, add comments to share information about its root cause and facilitate resolution. Comments are enabled by setting `plugins.alerting.comments_enabled` to `true` using the [`cluster/settings` API]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/settings/).
 
 Comments can be accessed through the alerts table view by selecting the comment icon within an alert's row. From there, comments can be added, edited, or deleted. An Alerting Comments API is also available for programmatic comment management. For more information, see [Alerting API]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/api/).


### PR DESCRIPTION
### Description
Removes experimental banner for Alerting plugin's Comments feature

### Issues Resolved
None

### Version
2.15 and above

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
