### PR TITLE
Fix an incorrect url path

### DIFF
--- a/_vector-search/creating-vector-index.md
+++ b/_vector-search/creating-vector-index.md
@@ -155,6 +155,6 @@ OpenSearch also supports sparse vectors. For more information, see [Neural spars
 
 ## Next steps
 
-- [Ingesting data into a vector index]({{site.url}}{{site.baseurl}}/vector-search/searching-data/)
+- [Ingesting data into a vector index]({{site.url}}{{site.baseurl}}/vector-search/ingesting-data/)
 - [k-NN vector]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/knn-vector/)
 - [Methods and engines]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/knn-methods-engines/)


### PR DESCRIPTION
### Description
There is a url named "Ingesting data into a vector index", but its actual path is "Searching vector data".

### Issues Resolved
None.

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
None

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
