### PR TITLE
add redline test flags to documentation

### DIFF
--- a/_benchmark/reference/commands/redline-test.md
+++ b/_benchmark/reference/commands/redline-test.md
@@ -65,7 +65,7 @@ opensearch-benchmark execute-test \
 
 ## Results
 
-At the end of a redline test, OpenSearch Benchmark logs the maximum number of clients that your cluster supported without request errors.
+During a redline test, OpenSearch Benchmark provides detailed logs with scaling decisions and request failures during the test. At the end of a redline test, OpenSearch Benchmark logs the maximum number of clients that your cluster supported without request errors.
 
 The following example log output indicates that the redline test detected a `15%` error rate for the keyword-terms operation and determined that the cluster's maximum stable client load before errors occurred was `410`:
 
@@ -78,6 +78,7 @@ Redline test finished. Maximum stable client number reached: 410
 
 Use the following options and behaviors to better understand and customize redline test execution:
 
-- To set a custom client limit, use `--redline-test=<int>`. For example, `--redline-test=1500` sets the maximum to `1500` clients.
-- When errors are detected, the `FeedbackActor` pauses execution and waits 30 seconds before retrying.
-- OpenSearch Benchmark provides detailed logs with scaling decisions and request failures during the test.
+- `--redline-scale-step`: Specifies the number of clients to unpause in each scaling iteration.
+- `--redline-scaledown-percentage`: Specifies the percentage of clients to pause when an error occurs.
+- `--redline-post-scaledown-sleep`: Specifies the number of seconds the feedback actor waits before initiating a scale-up after scaling down.
+- `--redline-max-clients`: Specifies the maximum number of clients allowed during redline testing. If unset, OpenSearch Benchmark defaults to the number of clients defined in the test procedure.


### PR DESCRIPTION
### Description
Adds CLI arguments for redline testing, added in [this PR](https://github.com/opensearch-project/opensearch-benchmark/pull/835). Replaces `--redline-test=1500`

### Issues Resolved
Closes #[_delete this text, including the brackets, and replace with the issue number_]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
