### PR TITLE
[Pull-based Ingestion] Update pull-based ingestion metrics and reset settings

### DIFF
--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -79,7 +79,7 @@ The following table lists the available query parameters. All query parameters a
 | `cluster_manager_timeout` | Time units | The amount of time to wait for a connection to the cluster manager node. Default is `30s`. |
 | `timeout` | Time units | The amount of time to wait for a response from the cluster. Default is `30s`. |
 
-### Request body
+### Request body fields
 
 A list of reset settings can be provided for all or a subset of shards that need to be reset. This is optional.
 

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -53,7 +53,8 @@ POST /my-index/ingestion/_pause
 ## Resume ingestion
 
 Resumes ingestion for one or more indexes. When resumed, OpenSearch continues consuming data from the streaming source for all shards in the specified indexes.
-As part of the resume operation, the stream consumer can optionally be reset to start reading from a particular offset or timestamp. If reset settings are provided, all consumers for specified shards will first be reset before applying the resume operation on the index. Note that consumer reset will internally trigger a flush to persist the changes. 
+
+As part of the resume operation, you can optionally reset the stream consumer to start reading from a specific offset or timestamp. If reset settings are specified, all consumers for the selected shards are reset before the resume operation is applied to the index. Resetting a consumer also triggers an internal flush to persist the changes.
 
 ### Endpoint
 

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -87,7 +87,7 @@ A list of reset settings can be provided for all or a subset of shards that need
 | :--- | :--- | :--- | :--- |
 | `reset_settings` | Array | Optional | A list of reset settings for each shard. If not provided, OpenSearch resumes ingestion from the last committed position for each shard in the specified index. |
 | `reset_settings.shard` | Integer | Required | The shard to reset. |
-| `mode` | String | Required | Reset mode. Allowed values are `offset` and `timestamp`. |
+| `reset_settings.mode` | String | Required | The reset mode. Valid values are `offset` and `timestamp`. |
 | `value` | String | Required | &ensp;&#x2022; `offset`: Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: Unix timestamp in milliseconds |
 
 ```json

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -85,7 +85,8 @@ A list of reset settings can be provided for all or a subset of shards that need
 
 | Field | Data type | Required/Optional | Description |
 | :--- | :--- | :--- | :--- |
-| `shard` | Number | Required | The shard to reset. |
+| `reset_settings` | Array | Optional | A list of reset settings for each shard. If not provided, OpenSearch resumes ingestion from the last committed position for each shard in the specified index. |
+| `reset_settings.shard` | Integer | Required | The shard to reset. |
 | `mode` | String | Required | Reset mode. Allowed values are `offset` and `timestamp`. |
 | `value` | String | Required | &ensp;&#x2022; `offset`: Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: Unix timestamp in milliseconds |
 

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -88,7 +88,7 @@ The following table lists the available request body fields.
 | `reset_settings` | Array | Optional | A list of reset settings for each shard. If not provided, OpenSearch resumes ingestion from the current position for each shard in the specified index. |
 | `reset_settings.shard` | Integer | Required | The shard to reset. |
 | `reset_settings.mode` | String | Required | The reset mode. Valid values are `offset` (a positive integer offset) and `timestamp` (a Unix timestamp in milliseconds). |
-| `reset_settings.value` | String | Required | &ensp;&#x2022; `offset`: The Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: A Unix timestamp in milliseconds |
+| `reset_settings.value` | String | Required | &ensp;&#x2022; `offset`: The Apache Kafka offset or Amazon Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: A Unix timestamp in milliseconds. |
 
 ### Example request
 

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -88,7 +88,7 @@ The following table lists the available request body fields.
 | `reset_settings` | Array | Optional | A list of reset settings for each shard. If not provided, OpenSearch resumes ingestion from the last committed position for each shard in the specified index. |
 | `reset_settings.shard` | Integer | Required | The shard to reset. |
 | `reset_settings.mode` | String | Required | The reset mode. Valid values are `offset` and `timestamp`. |
-| `value` | String | Required | &ensp;&#x2022; `offset`: Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: Unix timestamp in milliseconds |
+| `reset_settings.value` | String | Required | &ensp;&#x2022; `offset`: The Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: A Unix timestamp in milliseconds |
 
 ```json
 {

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -81,7 +81,7 @@ The following table lists the available query parameters. All query parameters a
 
 ### Request body fields
 
-A list of reset settings can be provided for all or a subset of shards that need to be reset. This is optional.
+The following table lists the available request body fields.
 
 | Field | Data type | Required/Optional | Description |
 | :--- | :--- | :--- | :--- |

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -85,7 +85,7 @@ The following table lists the available request body fields.
 
 | Field | Data type | Required/Optional | Description |
 | :--- | :--- | :--- | :--- |
-| `reset_settings` | Array | Optional | A list of reset settings for each shard. If not provided, OpenSearch resumes ingestion from the last committed position for each shard in the specified index. |
+| `reset_settings` | Array | Optional | A list of reset settings for each shard. If not provided, OpenSearch resumes ingestion from the current position for each shard in the specified index. |
 | `reset_settings.shard` | Integer | Required | The shard to reset. |
 | `reset_settings.mode` | String | Required | The reset mode. Valid values are `offset` and `timestamp`. |
 | `reset_settings.value` | String | Required | &ensp;&#x2022; `offset`: The Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: A Unix timestamp in milliseconds |

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -87,7 +87,7 @@ The following table lists the available request body fields.
 | :--- | :--- | :--- | :--- |
 | `reset_settings` | Array | Optional | A list of reset settings for each shard. If not provided, OpenSearch resumes ingestion from the current position for each shard in the specified index. |
 | `reset_settings.shard` | Integer | Required | The shard to reset. |
-| `reset_settings.mode` | String | Required | The reset mode. Valid values are `offset` and `timestamp`. |
+| `reset_settings.mode` | String | Required | The reset mode. Valid values are `offset` (a positive integer offset) and `timestamp` (a Unix timestamp in milliseconds). |
 | `reset_settings.value` | String | Required | &ensp;&#x2022; `offset`: The Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: A Unix timestamp in milliseconds |
 
 ### Example request

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -53,6 +53,7 @@ POST /my-index/ingestion/_pause
 ## Resume ingestion
 
 Resumes ingestion for one or more indexes. When resumed, OpenSearch continues consuming data from the streaming source for all shards in the specified indexes.
+As part of the resume operation, the stream consumer can optionally be reset to start reading from a particular offset or timestamp. If reset settings are provided, all consumers for specified shards will first be reset before applying the resume operation on the index. 
 
 ### Endpoint
 
@@ -77,10 +78,48 @@ The following table lists the available query parameters. All query parameters a
 | `cluster_manager_timeout` | Time units | The amount of time to wait for a connection to the cluster manager node. Default is `30s`. |
 | `timeout` | Time units | The amount of time to wait for a response from the cluster. Default is `30s`. |
 
-### Example request
+### Request body
+
+A list of reset settings can be provided for all or a subset of shards that need to be reset. This is optional.
+
+| Field | Data type | Required/Optional | Description |
+| :--- | :--- | :--- | :--- |
+| `shard` | Number | Required | The shard to reset. |
+| `mode` | String | Required | Reset mode. Allowed values are `offset` and `timestamp`. |
+| `value` | String | Required | &ensp;&#x2022; `offset`: Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: Unix timestamp in milliseconds |
 
 ```json
+{
+  "reset_settings": [
+    {
+      "shard": "shard number",
+      "mode": "offset" or "timestamp",
+      "value": "offset/timestamp value"
+    }
+  ]
+}
+```
+
+### Example request
+
+Resume without reset settings:
+```json
 POST /my-index/ingestion/_resume
+```
+{% include copy-curl.html %}
+
+Resume with reset settings:
+```json
+POST /my-index/ingestion/_resume
+{
+  "reset_settings": [
+    {
+      "shard": 0,
+      "mode": "offset",
+      "value": "1"
+    }
+  ]
+}
 ```
 {% include copy-curl.html %}
 

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -90,18 +90,6 @@ The following table lists the available request body fields.
 | `reset_settings.mode` | String | Required | The reset mode. Valid values are `offset` and `timestamp`. |
 | `reset_settings.value` | String | Required | &ensp;&#x2022; `offset`: The Kafka offset or Kinesis sequence number<br>&ensp;&#x2022; `timestamp`: A Unix timestamp in milliseconds |
 
-```json
-{
-  "reset_settings": [
-    {
-      "shard": "shard number",
-      "mode": "offset" or "timestamp",
-      "value": "offset/timestamp value"
-    }
-  ]
-}
-```
-
 ### Example request
 
 To resume ingestion without specifying reset settings, send the following request:
@@ -111,7 +99,8 @@ POST /my-index/ingestion/_resume
 ```
 {% include copy-curl.html %}
 
-Resume with reset settings:
+To provide reset settings when resuming ingestion, send the following request:
+
 ```json
 POST /my-index/ingestion/_resume
 {

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -53,7 +53,7 @@ POST /my-index/ingestion/_pause
 ## Resume ingestion
 
 Resumes ingestion for one or more indexes. When resumed, OpenSearch continues consuming data from the streaming source for all shards in the specified indexes.
-As part of the resume operation, the stream consumer can optionally be reset to start reading from a particular offset or timestamp. If reset settings are provided, all consumers for specified shards will first be reset before applying the resume operation on the index. 
+As part of the resume operation, the stream consumer can optionally be reset to start reading from a particular offset or timestamp. If reset settings are provided, all consumers for specified shards will first be reset before applying the resume operation on the index. Note that consumer reset will internally trigger a flush to persist the changes. 
 
 ### Endpoint
 

--- a/_api-reference/document-apis/pull-based-ingestion-management.md
+++ b/_api-reference/document-apis/pull-based-ingestion-management.md
@@ -104,7 +104,8 @@ The following table lists the available request body fields.
 
 ### Example request
 
-Resume without reset settings:
+To resume ingestion without specifying reset settings, send the following request:
+
 ```json
 POST /my-index/ingestion/_resume
 ```

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -131,7 +131,7 @@ Each data unit in the streaming source (Kafka message or Kinesis record) must in
 | :--- | :--- | :--- | :--- |
 | `_id` | String | No | A unique identifier for a document. If not provided, OpenSearch auto-generates an ID. Required for document updates or deletions. |
 | `_version` | Long | No | A document version number, which must be maintained externally. If provided, OpenSearch drops messages with versions earlier than the current document version. If not provided, no version checking occurs. |
-| `_op_type` | String | No | The operation to perform. Valid values are:<br>- `index`: Creates a new document or updates an existing one<br>- `create`: Create a new document in append-mode. Note that this will not update existing documents. <br>- `delete`: Soft deletes a document |
+| `_op_type` | String | No | The operation to perform. Valid values are:<br>- `index`: Creates a new document or updates an existing one.<br>- `create`: Create a new document in append-mode. Note that this will not update existing documents. <br>- `delete`: Soft deletes a document. |
 | `_source` | Object | Yes | The message payload containing the document data. |
 
 ## Pull-based ingestion metrics

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -147,7 +147,7 @@ The following table lists the available `polling_ingest_stats` metrics.
 | `message_processor_stats.total_version_conflicts_count` | The number of version conflicts due to which older version message will be dropped. |
 | `message_processor_stats.total_failed_count` | The total number of failed messages, which error out during processing. |
 | `message_processor_stats.total_failures_dropped_count` | The total number of failed messages, which are dropped after exhausting retries. Note that messages are only dropped when DROP error policy is used. |
-| `message_processor_stats.total_processor_thread_interrupt_count` | Indicates number of thread interruptions on the processor thread. |
+| `message_processor_stats.total_processor_thread_interrupt_count` | Indicates the number of thread interruptions on the processor thread. |
 | `consumer_stats.total_polled_count` | The total number of messages polled from the stream consumer. |
 | `consumer_stats.total_consumer_error_count` | The total number of fatal consumer read errors. |
 | `consumer_stats.total_poller_message_failure_count` | The total number of failed messages on the poller. |

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -144,7 +144,7 @@ The following table lists the available `polling_ingest_stats` metrics.
 | :--- | :--- |
 | `message_processor_stats.total_processed_count` | The total number of messages processed by the message processor. |
 | `message_processor_stats.total_invalid_message_count` | The number of invalid messages encountered. |
-| `message_processor_stats.total_version_conflicts_count` | The number of version conflicts due to which older version message will be dropped. |
+| `message_processor_stats.total_version_conflicts_count` | The number of version conflicts due to which older version messages will be dropped. |
 | `message_processor_stats.total_failed_count` | The total number of failed messages, which error out during processing. |
 | `message_processor_stats.total_failures_dropped_count` | The total number of failed messages, which are dropped after exhausting retries. Note that messages are only dropped when DROP error policy is used. |
 | `message_processor_stats.total_processor_thread_interrupt_count` | Indicates the number of thread interruptions on the processor thread. |

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -88,7 +88,7 @@ The following table provides the valid `pointer.init.reset` values and their cor
 | `latest`             | The current end of the stream | None | 
 | `reset_by_offset`    | A specific offset in the stream | A positive integer offset. Required. | 
 | `reset_by_timestamp` | A specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |
-| `none`               | Last committed position for existing indexes | None | 
+| `none`               | The last committed position for existing indexes | None | 
 
 ### Stream partitioning
 

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -131,7 +131,7 @@ Each data unit in the streaming source (Kafka message or Kinesis record) must in
 | :--- | :--- | :--- | :--- |
 | `_id` | String | No | A unique identifier for a document. If not provided, OpenSearch auto-generates an ID. Required for document updates or deletions. |
 | `_version` | Long | No | A document version number, which must be maintained externally. If provided, OpenSearch drops messages with versions earlier than the current document version. If not provided, no version checking occurs. |
-| `_op_type` | String | No | The operation to perform. Valid values are:<br>- `index`: Creates a new document or updates an existing one.<br>- `create`: Create a new document in append-mode. Note that this will not update existing documents. <br>- `delete`: Soft deletes a document. |
+| `_op_type` | String | No | The operation to perform. Valid values are:<br>- `index`: Creates a new document or updates an existing one.<br>- `create`: Creates a new document in append mode. Note that this will not update existing documents. <br>- `delete`: Soft deletes a document. |
 | `_source` | Object | Yes | The message payload containing the document data. |
 
 ## Pull-based ingestion metrics
@@ -146,12 +146,12 @@ The following table lists the available `polling_ingest_stats` metrics.
 | `message_processor_stats.total_invalid_message_count` | The number of invalid messages encountered. |
 | `message_processor_stats.total_version_conflicts_count` | The number of version conflicts due to which older version messages will be dropped. |
 | `message_processor_stats.total_failed_count` | The total number of failed messages, which error out during processing. |
-| `message_processor_stats.total_failures_dropped_count` | The total number of failed messages, which are dropped after exhausting retries. Note that messages are only dropped when DROP error policy is used. |
+| `message_processor_stats.total_failures_dropped_count` | The total number of failed messages, which are dropped after exhausting retries. Note that messages are only dropped when the DROP error policy is used. |
 | `message_processor_stats.total_processor_thread_interrupt_count` | Indicates the number of thread interruptions on the processor thread. |
 | `consumer_stats.total_polled_count` | The total number of messages polled from the stream consumer. |
 | `consumer_stats.total_consumer_error_count` | The total number of fatal consumer read errors. |
 | `consumer_stats.total_poller_message_failure_count` | The total number of failed messages on the poller. |
-| `consumer_stats.total_poller_message_dropped_count` | The total number of failed messages on the poller that are dropped. |
+| `consumer_stats.total_poller_message_dropped_count` | The total number of failed messages on the poller that were dropped. |
 | `consumer_stats.total_duplicate_message_skipped_count` | The total number of skipped messages that were previously processed. |
 | `consumer_stats.lag_in_millis` | Lag in milliseconds, computed as the time elapsed since the last processed message timestamp. |
 

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -85,7 +85,7 @@ The following table provides the valid `pointer.init.reset` values and their cor
 | `pointer.init.reset` | Starting ingestion point | `pointer.init.reset.value` | 
 | :--- | :--- | :--- | 
 | `earliest`           | The beginning of the stream | None | 
-| `latest`             | Current end of stream | None | 
+| `latest`             | The current end of the stream | None | 
 | `reset_by_offset`    | Specific offset in the stream | A positive integer offset. Required. | 
 | `reset_by_timestamp` | Specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |
 | `none`               | Last committed position for existing indexes | None | 

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -68,8 +68,8 @@ The `ingestion_source` parameters control how OpenSearch pulls data from the str
 | Parameter | Description |
 | :--- | :--- |
 | `type` | The streaming source type. Required. Valid values are `kafka` or `kinesis`. |
-| `pointer.init.reset` | Determines where to start reading from the stream. Optional. Valid values are `earliest`, `latest`, `rewind_by_offset`, `rewind_by_timestamp`, or `none`. See [Stream position](#stream-position). |
-| `pointer.init.reset.value` | Required only for `rewind_by_offset` or `rewind_by_timestamp`. Specifies the offset value or timestamp in milliseconds. See [Stream position](#stream-position). |
+| `pointer.init.reset` | Determines where to start reading from the stream. Optional. Valid values are `earliest`, `latest`, `reset_by_offset`, `reset_by_timestamp`, or `none`. See [Stream position](#stream-position). |
+| `pointer.init.reset.value` | Required only for `reset_by_offset` or `reset_by_timestamp`. Specifies the offset value or timestamp in milliseconds. See [Stream position](#stream-position). |
 | `error_strategy` | How to handle failed messages. Optional. Valid values are `DROP` (failed messages are skipped and ingestion continues) and `BLOCK` (when a message fails, ingestion stops). Default is `DROP`. We recommend using `DROP` for the current experimental release. |
 | `max_batch_size` | The maximum number of records to retrieve in each poll operation. Optional. |
 | `poll.timeout` | The maximum time to wait for data in each poll operation. Optional. |
@@ -84,11 +84,11 @@ The following table provides the valid `pointer.init.reset` values and their cor
 
 | `pointer.init.reset` | Starting ingestion point | `pointer.init.reset.value` | 
 | :--- | :--- | :--- | 
-| `earliest` | Beginning of stream | None | 
-| `latest` | Current end of stream | None | 
-| `rewind_by_offset` | Specific offset in the stream | A positive integer offset. Required. | 
-| `rewind_by_timestamp` | Specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |
-| `none` | Last committed position for existing indexes | None | 
+| `earliest`           | Beginning of stream | None | 
+| `latest`             | Current end of stream | None | 
+| `reset_by_offset`    | Specific offset in the stream | A positive integer offset. Required. | 
+| `reset_by_timestamp` | Specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |
+| `none`               | Last committed position for existing indexes | None | 
 
 ### Stream partitioning
 
@@ -131,7 +131,7 @@ Each data unit in the streaming source (Kafka message or Kinesis record) must in
 | :--- | :--- | :--- | :--- |
 | `_id` | String | No | A unique identifier for a document. If not provided, OpenSearch auto-generates an ID. Required for document updates or deletions. |
 | `_version` | Long | No | A document version number, which must be maintained externally. If provided, OpenSearch drops messages with versions earlier than the current document version. If not provided, no version checking occurs. |
-| `_op_type` | String | No | The operation to perform. Valid values are:<br>- `index`: Creates a new document or updates an existing one<br>- `delete`: Soft deletes a document |
+| `_op_type` | String | No | The operation to perform. Valid values are:<br>- `index`: Creates a new document or updates an existing one<br>- `create`: Create a new document in append-mode. Note that this will not update existing documents. <br>- `delete`: Soft deletes a document |
 | `_source` | Object | Yes | The message payload containing the document data. |
 
 ## Pull-based ingestion metrics
@@ -143,7 +143,17 @@ The following table lists the available `polling_ingest_stats` metrics.
 | Metric | Description |
 | :--- | :--- |
 | `message_processor_stats.total_processed_count` | The total number of messages processed by the message processor. |
+| `message_processor_stats.total_invalid_message_count` | The number of invalid messages encountered. |
+| `message_processor_stats.total_version_conflicts_count` | The number of version conflicts due to which older version message will be dropped. |
+| `message_processor_stats.total_failed_count` | The total number of failed messages, which error out during processing. |
+| `message_processor_stats.total_failures_dropped_count` | The total number of failed messages, which are dropped after exhausting retries. Note that messages are only dropped when DROP error policy is used. |
+| `message_processor_stats.total_processor_thread_interrupt_count` | Indicates number of thread interruptions on the processor thread. |
 | `consumer_stats.total_polled_count` | The total number of messages polled from the stream consumer. |
+| `consumer_stats.total_consumer_error_count` | The total number of fatal consumer read errors. |
+| `consumer_stats.total_poller_message_failure_count` | The total number of failed messages on the poller. |
+| `consumer_stats.total_poller_message_dropped_count` | The total number of failed messages on the poller that are dropped. |
+| `consumer_stats.total_duplicate_message_skipped_count` | The total number of skipped messages which were previously processed. |
+| `consumer_stats.lag_in_millis` | Lag in milliseconds, computed as the time elapsed since the last processed message timestamp. |
 
 To retrieve shard-level pull-based ingestion metrics, use the [Nodes Stats API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/update-settings/):
 

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -68,7 +68,7 @@ The `ingestion_source` parameters control how OpenSearch pulls data from the str
 | Parameter | Description |
 | :--- | :--- |
 | `type` | The streaming source type. Required. Valid values are `kafka` or `kinesis`. |
-| `pointer.init.reset` | Determines where to start reading from the stream. Optional. Valid values are `earliest`, `latest`, `reset_by_offset`, `reset_by_timestamp`, or `none`. See [Stream position](#stream-position). |
+| `pointer.init.reset` | Determines the stream location from which to start reading. Optional. Valid values are `earliest`, `latest`, `reset_by_offset`, `reset_by_timestamp`, or `none`. See [Stream position](#stream-position). |
 | `pointer.init.reset.value` | Required only for `reset_by_offset` or `reset_by_timestamp`. Specifies the offset value or timestamp in milliseconds. See [Stream position](#stream-position). |
 | `error_strategy` | How to handle failed messages. Optional. Valid values are `DROP` (failed messages are skipped and ingestion continues) and `BLOCK` (when a message fails, ingestion stops). Default is `DROP`. We recommend using `DROP` for the current experimental release. |
 | `max_batch_size` | The maximum number of records to retrieve in each poll operation. Optional. |

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -152,7 +152,7 @@ The following table lists the available `polling_ingest_stats` metrics.
 | `consumer_stats.total_consumer_error_count` | The total number of fatal consumer read errors. |
 | `consumer_stats.total_poller_message_failure_count` | The total number of failed messages on the poller. |
 | `consumer_stats.total_poller_message_dropped_count` | The total number of failed messages on the poller that are dropped. |
-| `consumer_stats.total_duplicate_message_skipped_count` | The total number of skipped messages which were previously processed. |
+| `consumer_stats.total_duplicate_message_skipped_count` | The total number of skipped messages that were previously processed. |
 | `consumer_stats.lag_in_millis` | Lag in milliseconds, computed as the time elapsed since the last processed message timestamp. |
 
 To retrieve shard-level pull-based ingestion metrics, use the [Nodes Stats API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/update-settings/):

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -86,7 +86,7 @@ The following table provides the valid `pointer.init.reset` values and their cor
 | :--- | :--- | :--- | 
 | `earliest`           | The beginning of the stream | None | 
 | `latest`             | The current end of the stream | None | 
-| `reset_by_offset`    | Specific offset in the stream | A positive integer offset. Required. | 
+| `reset_by_offset`    | A specific offset in the stream | A positive integer offset. Required. | 
 | `reset_by_timestamp` | Specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |
 | `none`               | Last committed position for existing indexes | None | 
 

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -87,7 +87,7 @@ The following table provides the valid `pointer.init.reset` values and their cor
 | `earliest`           | The beginning of the stream | None | 
 | `latest`             | The current end of the stream | None | 
 | `reset_by_offset`    | A specific offset in the stream | A positive integer offset. Required. | 
-| `reset_by_timestamp` | Specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |
+| `reset_by_timestamp` | A specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |
 | `none`               | Last committed position for existing indexes | None | 
 
 ### Stream partitioning

--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -84,7 +84,7 @@ The following table provides the valid `pointer.init.reset` values and their cor
 
 | `pointer.init.reset` | Starting ingestion point | `pointer.init.reset.value` | 
 | :--- | :--- | :--- | 
-| `earliest`           | Beginning of stream | None | 
+| `earliest`           | The beginning of the stream | None | 
 | `latest`             | Current end of stream | None | 
 | `reset_by_offset`    | Specific offset in the stream | A positive integer offset. Required. | 
 | `reset_by_timestamp` | Specific point in time | A Unix timestamp in milliseconds. Required. <br> For Kafka streams, defaults to Kafka's `auto.offset.reset` policy if no messages are found for the given timestamp. |


### PR DESCRIPTION
### Description
This PR updates the pull-based ingestion documentation with newly added metrics and updates Resume API spec to include reset settings. This PR also renames `rewind` to `reset` which is a backward incompatible change that will be introduced in the next OS release (3.1.0).

### Issues Resolved
Follow up of #9545

### Version
OS 3.1.0 and beyond (experimental feature as of now)

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
