### PR TITLE
fix instruction for terms query with roaring bitmap #8379

### DIFF
--- a/_query-dsl/term/terms.md
+++ b/_query-dsl/term/terms.md
@@ -272,7 +272,7 @@ PUT /products
 {
   "mappings": {
     "properties": {
-      "product_id": { "type": "keyword" }
+      "product_id": { "type": "integer" }
     }
   }
 }
@@ -285,7 +285,7 @@ Next, index three documents that correspond to products:
 PUT /products/_doc/1
 {
   "name": "Product 1",
-  "product_id" : "111"
+  "product_id" : 111
 }
 ```
 {% include copy-curl.html %}
@@ -294,7 +294,7 @@ PUT /products/_doc/1
 PUT /products/_doc/2
 {
   "name": "Product 2",
-  "product_id" : "222"
+  "product_id" : 222
 }
 ```
 {% include copy-curl.html %}
@@ -303,7 +303,7 @@ PUT /products/_doc/2
 PUT /products/_doc/3
 {
   "name": "Product 3",
-  "product_id" : "333"
+  "product_id" : 333
 }
 ```
 {% include copy-curl.html %}
@@ -382,7 +382,9 @@ POST /products/_search
 {
   "query": {
     "terms": {
-      "product_id": "OjAAAAEAAAAAAAIAEAAAAG8A3gBNAQ==",
+      "product_id": [
+        "OjAAAAEAAAAAAAIAEAAAAG8A3gBNAQ=="
+      ],
       "value_type": "bitmap"
     }
   }


### PR DESCRIPTION
### Description
Instruction for terms query with roaring bitmap introduced since 2.17 does not work appropriately. For more details of issue, please refer from https://forum.opensearch.org/t/bitmap-search-not-working/21631

### Issues Resolved
Closes #8379 

### Version
2.17-

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
