### PR TITLE
Delete the content of convert-index-to-remote operation about index-management plugin , because now  this operation is not exist in 2.19

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -109,7 +109,6 @@ ISM supports the following operations:
 - [rollover](#rollover)
 - [notification](#notification)
 - [snapshot](#snapshot)
-- [convert-index-to-remote](#convert_index_to_remote)
 - [index_priority](#index_priority)
 - [allocation](#allocation)
 - [rollup](#rollup)
@@ -407,33 +406,6 @@ Parameter | Description | Type | Required | Default
   }
 }
 ```
-
-### convert_index_to_remote
-
-Converts an index from a local snapshot repository to a remote repository.
-
-The `convert_index_to_remote` operation has the following parameters.
-
-Parameter | Description | Type | Required | Default
-:--- | :--- |:--- |:--- |
-`repository` | The repository name registered through the native snapshot API operations.  | `string` | Yes | N/A
-`snapshot` | The snapshot name created through the snapshot action.  | `string` | Yes | N/A
-
-Make sure that the repository name used in the `convert_index_to_remote` operation matches the repository name specified during the snapshot action. Additionally, you can reference the snapshot using `{{ctx.index}}`, as shown in the following example policy:
-
-```json
-{
-   "snapshot": {
-      "repository": "my_backup",
-      "snapshot": "{{ctx.index}}"
-   }, 
-   "convert_index_to_remote": {
-      "repository": "my_backup",
-      "snapshot": "{{ctx.index}}"
-   }
-}
-```
-{% include copy.html %}
 
 ### index_priority
 


### PR DESCRIPTION
…anagement plugin , because now  this operation is not exist in 2.19

### Description
The convert-index-to-remote operation of  index-management plugin is not exist in the version 2.19 ，but the document of 2.19 have the related content. So should we delete it from the version 2.19?

### Issues Resolved
Closes #10025 

### Version
2.19

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
