### PR TITLE
Add documentation for percentile agg percents field

### DIFF
--- a/_aggregations/metric/percentile.md
+++ b/_aggregations/metric/percentile.md
@@ -72,3 +72,23 @@ GET opensearch_dashboards_sample_data_ecommerce/_search
   }
 }
 ```
+
+The default percentiles returned are `1, 5, 25, 50, 75, 95, 99`. You can specify other percentiles with the optional `percents` field. For example, to get the 99.9th and 99.99th percentiles, run the following: 
+
+```json
+GET opensearch_dashboards_sample_data_ecommerce/_search
+{
+  "size": 0,
+  "aggs": {
+    "percentile_taxful_total_price": {
+      "percentiles": {
+        "field": "taxful_total_price",
+        "percents": [99.9, 99.99]
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+This overrides the default percentiles, so only the percentiles you specify are returned. 


### PR DESCRIPTION
### Description
Add documentation for the `percents` field in the percentile aggregation. 

### Issues Resolved
Did not raise an issue for this minor change. 

### Version
All

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
