### PR TITLE
Update persian.md to Remove Norwegian, add keywords.

### DIFF
--- a/_analyzers/language-analyzers/persian.md
+++ b/_analyzers/language-analyzers/persian.md
@@ -59,6 +59,7 @@ The `persian` analyzer is built using the following components:
   - decimal_digit
   - normalization (Arabic)
   - normalization (Persian)
+  - stop (Persian)
   - keyword
 
 ## Custom Persian analyzer


### PR DESCRIPTION
### Description
Persian Analyzer docs currently reference Norwegian stemmer but not the Persian stopword filter, and do not include `persian_keywords`, which is configured, but not used. Remove Norwegian stemmer from text and add Persian stopwords, and add `persian_keywords` to sample unpacked analyzer config.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
