### PR TITLE
#10056 clarify that exactly one of minimum_should_match_field or script must be provided in terms_set query

### DIFF
--- a/_query-dsl/term/terms-set.md
+++ b/_query-dsl/term/terms-set.md
@@ -162,6 +162,8 @@ GET _search
 
 The `<field>` accepts the following parameters. All parameters except `terms` are optional.
 
+The required number of matching terms must be specified using either the `minimum_should_match_field` or `minimum_should_match_script` parameter. Exactly one of these parameters must be provided—not both.
+
 Parameter | Data type | Description
 :--- | :--- | :---
 `terms` | Array of strings | The array of terms to search for in the field specified in `<field>`. A document is returned in the results only if the required number of terms matches the document's field values exactly, with the correct spacing and capitalization.


### PR DESCRIPTION
### Description
This change updates the `terms_set` query documentation to clarify that **exactly one** of `minimum_should_match_field` or `minimum_should_match_script` must be provided. This aligns the documentation with the actual validation logic in OpenSearch (`TermsSetQueryBuilder`), which throws an exception if both or neither are specified.

### Issues Resolved
Closes [opensearch-project/OpenSearch#18261](https://github.com/opensearch-project/OpenSearch/issues/18261)  
Closes [opensearch-project/documentation-website#10056](https://github.com/opensearch-project/documentation-website/issues/10056)

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
