### PR TITLE
[Rule based auto tagging] Update 'Create workload group rules'

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api.md
+++ b/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api.md
@@ -29,8 +29,8 @@ POST /_rules/{feature_type}
 Use the following endpoint to modify an existing rule by specifying both the feature type and rule ID in the path parameters:
 
 ```json
-PUT /_rules/{feature_type}/{_id}
-POST /_rules/{feature_type}/{_id}
+PUT /_rules/{feature_type}/{id}
+POST /_rules/{feature_type}/{id}
 ```
 
 ### Get a rule
@@ -38,7 +38,7 @@ POST /_rules/{feature_type}/{_id}
 Use the following endpoint to retrieve either a specific rule by ID or list all rules for a feature type:
 
 ```json
-GET /_rules/{feature_type}/{_id}
+GET /_rules/{feature_type}/{id}
 GET /_rules/{feature_type}
 ```
 
@@ -47,17 +47,17 @@ GET /_rules/{feature_type}
 Use the following endpoint to remove a rule by specifying both the feature type and rule ID:
 
 ```json
-DELETE /_rules/{feature_type}/{_id}
+DELETE /_rules/{feature_type}/{id}
 ```
 
 ## Path parameters
 
 The following table lists the available path parameters.
 
-| Parameter | Data type | Description  |
-| :--- | :--- | :--- |
+| Parameter      | Data type | Description  |
+|:---------------| :--- | :--- |
 | `feature_type` | String    | The category of the rule that defines the type of feature, such as `workload_group`. |
-| `_id`          | String    | The unique identifier for the rule. Required for `UPDATE`, `GET`, and `DELETE` operations. |
+| `id`           | String    | The unique identifier for the rule. Required for `UPDATE`, `GET`, and `DELETE` operations. |
 
 ## Query parameters
 
@@ -119,7 +119,7 @@ You can't change the `feature_type`. Fields that are not updated can be omitted.
 The following request retrieves a rule by ID:
 
 ```json
-GET /_rules/{feature_type}/{_id}
+GET /_rules/{feature_type}/{id}
 ```
 {% include copy-curl.html %}
 
@@ -157,7 +157,7 @@ The following example continues the search for all rules of the `workload_group`
 
 ```json
 {
-  "_id": "wi6VApYBoX5wstmtU_8l",
+  "id": "wi6VApYBoX5wstmtU_8l",
   "description": "description for rule",
   "index_pattern": ["log*", "event*"],
   "workload_group": "EITBzjFkQ6CA-semNWGtRQ",
@@ -178,7 +178,7 @@ The following example continues the search for all rules of the `workload_group`
 {
   "rules": [
     {
-      "_id": "z1MJApUB0zgMcDmz-UQq",
+      "id": "z1MJApUB0zgMcDmz-UQq",
       "description": "Rule for tagging workload_group_id to index123",
       "index_pattern": ["index123"],
       "workload_group": "workload_group_id",
@@ -198,11 +198,11 @@ To retrieve the next page, include the `search_after` value in the next `GET` re
 
 ## Response body fields
 
-| Field | Data type | Description |
-| :--- | :--- | :--- |
-| `_id` | String | The unique identifier for the rule. |
-| `description` | String | The explanation or purpose of the rule. |
-| `updated_at` | String | The timestamp of the most recent update to the rule in UTC format. |
+| Field             | Data type | Description |
+|:------------------| :--- | :--- |
+| `id`              | String | The unique identifier for the rule. |
+| `description`     | String | The explanation or purpose of the rule. |
+| `updated_at`      | String | The timestamp of the most recent update to the rule in UTC format. |
 | `<attribute_key>` | Array | The attribute values used to match incoming queries. |
-| `<feature_type>` | String | The value assigned to the feature type if the rule matches. |
-| `search_after` | Array | The token for paginating additional results. Present only if more results exist. |
+| `<feature_type>`  | String | The value assigned to the feature type if the rule matches. |
+| `search_after`    | Array | The token for paginating additional results. Present only if more results exist. |

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/create-workload-group-rules-api.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/create-workload-group-rules-api.md
@@ -92,7 +92,7 @@ The following request provides the next page of rules from the same workload gro
 
 ### Delete a rule
 
-The following request deletes a rule with the specified id.
+The following request deletes a rule using the rule's ID:
 
 ```json
 DELETE /_rules/workload_group/{id}

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/create-workload-group-rules-api.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/create-workload-group-rules-api.md
@@ -62,7 +62,7 @@ You can retrieve rules created using the Create Workload Group Rules API by rule
 The following request retrieves a rule by ID for the `workload_group` feature type:
 
 ```json
-GET /_rules/workload_group/{_id}
+GET /_rules/workload_group/{id}
 ```
 {% include copy-curl.html %}
 
@@ -90,6 +90,15 @@ The following request provides the next page of rules from the same workload gro
 ```
 {% include copy-curl.html %}
 
+### Delete a rule
+
+The following request deletes a rule with the specified id.
+
+```json
+DELETE /_rules/workload_group/{id}
+```
+{% include copy-curl.html %}
+
 ## Example responses
 
 <details open markdown="block"> 
@@ -100,7 +109,7 @@ The following request provides the next page of rules from the same workload gro
 
 ```json
 {
-  "_id": "wi6VApYBoX5wstmtU_8l",
+  "id": "wi6VApYBoX5wstmtU_8l",
   "description": "description for rule",
   "index_pattern": ["log*", "event*"],
   "workload_group": "EITBzjFkQ6CA-semNWGtRQ",
@@ -121,7 +130,7 @@ The following request provides the next page of rules from the same workload gro
 {
   "rules": [
     {
-      "_id": "z1MJApUB0zgMcDmz-UQq",
+      "id": "z1MJApUB0zgMcDmz-UQq",
       "description": "Rule for tagging workload_group_id to index123",
       "index_pattern": ["index123"],
       "workload_group": "workload_group_id",
@@ -137,3 +146,17 @@ If the `search_after` field is present in the response, more results are availab
 To retrieve the next page, include the `search_after` value in the next `GET` request as a query parameter, such as `GET /_rules/{feature_type}?search_after=z1MJApUB0zgMcDmz-UQq`.
 
 </details>
+
+
+<details markdown="block"> 
+  <summary> 
+    Response: Delete rules 
+  </summary> 
+  {: .text-delta }
+
+```json
+{ "acknowledged": true }
+```
+
+</details>
+


### PR DESCRIPTION
### Description
The previous 'Create workload group rules' page is missing description for the delete rule api. This PR adds it in.
This PR also changes `_id` to `id` to reflect the up-to-date api structure.

### Issues Resolved
Closes #[_delete this text, including the brackets, and replace with the issue number_]

### Version
3.1+

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
