### PR TITLE
Remove OpenSearch 3 as valid migration source in Migration Assistant Documentation

### DIFF
--- a/_data/migration-assistant/valid_migrations.yml
+++ b/_data/migration-assistant/valid_migrations.yml
@@ -27,6 +27,3 @@ migration_paths:
     targets:
       - "OpenSearch 2.x"
       - "OpenSearch 3.x"
-  - source: "OpenSearch 3.x"
-    targets:
-      - "OpenSearch 3.x"


### PR DESCRIPTION
### Description
Remove OpenSearch 3 as valid migration source in Migration Assistant Documentation

### Issues Resolved
Aligns with https://github.com/orgs/opensearch-project/projects/229/views/1?pane=issue&itemId=117495207 which is not supported today

### Version
Migration Assistant

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
