### PR TITLE
Add experimental warning to Search Relevance Workbench

### DIFF
--- a/_search-plugins/search-relevance/compare-query-sets.md
+++ b/_search-plugins/search-relevance/compare-query-sets.md
@@ -10,6 +10,9 @@ has_toc: false
 
 # Comparing query sets
 
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
+
 To compare the results of two different search configurations, you can run a pairwise experiment. To achieve this, you need two search configurations and a query set to use for the search configuration.
 
 

--- a/_search-plugins/search-relevance/comparing-search-results.md
+++ b/_search-plugins/search-relevance/comparing-search-results.md
@@ -10,6 +10,9 @@ has_toc: false
 
 # Comparing search results
 
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
+
 Comparing search results, also called a _pairwise experiment_, in OpenSearch Dashboards allows you to compare results of multiple search configurations. Using this tool helps assess how results change when applying different search configurations to queries.
 
 For example, you can see how results change when you apply one of the following query changes:

--- a/_search-plugins/search-relevance/evaluate-search-quality.md
+++ b/_search-plugins/search-relevance/evaluate-search-quality.md
@@ -10,6 +10,9 @@ has_toc: false
 
 # Evaluating search quality
 
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
+
 Search Relevance Workbench can run pointwise experiments to evaluate search configuration quality using provided queries and relevance judgments.
 
 For more information about creating a query set, see [Query sets]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/query-sets/).

--- a/_search-plugins/search-relevance/judgments.md
+++ b/_search-plugins/search-relevance/judgments.md
@@ -10,6 +10,9 @@ has_toc: false
 
 # Judgments
 
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
+
 A judgment is a relevance rating assigned to a specific document in the context of a particular query. Multiple judgments are grouped together into judgment lists.
 Typically, judgments are categorized into two types---implicit and explicit:
 

--- a/_search-plugins/search-relevance/optimize-hybrid-search.md
+++ b/_search-plugins/search-relevance/optimize-hybrid-search.md
@@ -10,6 +10,9 @@ has_toc: false
 
 # Optimizing hybrid search
 
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
+
 A key challenge of using hybrid search in OpenSearch is combining results from lexical and vector-based search effectively. OpenSearch provides different techniques and various parameters you can experiment with to find the best setup for your application. What works best, however, depends heavily on your data, user behavior, and application domain—there is no one-size-fits-all solution.
 
 Search Relevance Workbench helps you systematically find the ideal set of parameters for your needs.

--- a/_search-plugins/search-relevance/query-sets.md
+++ b/_search-plugins/search-relevance/query-sets.md
@@ -10,6 +10,9 @@ has_toc: false
 
 # Query sets
 
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
+
 A query set is a collection of queries. These queries are used in experiments for search relevance evaluation. Search Relevance Workbench offers different sampling techniques for creating query sets from real user data that adheres to the [User Behavior Insights (UBI)]({{site.url}}{{site.baseurl}}/search-plugins/ubi/schemas/) specification.
 Additionally, Search Relevance Workbench allows you to import a query set.
 

--- a/_search-plugins/search-relevance/search-configurations.md
+++ b/_search-plugins/search-relevance/search-configurations.md
@@ -10,6 +10,9 @@ has_toc: false
 
 # Search configurations
 
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
+
 A search configuration defines the query pattern used to run experiments, specifying how queries should be constructed and executed.
 
 ## Creating search configurations

--- a/_search-plugins/search-relevance/using-search-relevance-workbench.md
+++ b/_search-plugins/search-relevance/using-search-relevance-workbench.md
@@ -8,6 +8,8 @@ has_toc: false
 ---
 
 # Search Relevance Workbench
+Introduced 3.1
+{: .label .label-purple }
 
 This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
 {: .warning}

--- a/_search-plugins/search-relevance/using-search-relevance-workbench.md
+++ b/_search-plugins/search-relevance/using-search-relevance-workbench.md
@@ -1,15 +1,16 @@
 ---
 layout: default
-title: Using Search Relevance Workbench
+title: Search Relevance Workbench
 nav_order: 10
 parent: Search relevance
 has_children: true
 has_toc: false
 ---
 
+# Search Relevance Workbench
 
-
-# Using Search Relevance Workbench
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/17735).    
+{: .warning}
 
 In search applications, tuning relevance is a constant, iterative exercise intended to provide the right search results to your end users. The tooling in Search Relevance Workbench helps search relevance engineers and business users create the best search experience possible for application users. It does this without hiding internal information, enabling engineers to experiment and investigate details as necessary.
 


### PR DESCRIPTION
Add experimental warning to Search Relevance Workbench except the Compare Search Results page, which was GA previously.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
