### PR TITLE
Vector search docs: missing method object for space_type

### DIFF
--- a/_vector-search/getting-started/index.md
+++ b/_vector-search/getting-started/index.md
@@ -80,7 +80,10 @@ PUT /hotels-index
       "location": {
         "type": "knn_vector",
         "dimension": 2,
-        "space_type": "l2"
+        "method": {
+          "name": "hnsw",
+          "space_type": "l2"
+        }
       }
     }
   }


### PR DESCRIPTION
### Description
fixes errors when following the knn example due to missing `method` object:

- https://docs.opensearch.org/docs/2.19/field-types/supported-field-types/knn-methods-engines/#method-definition-example

```
curl . . .  /hotels-index" -H 'Content-Type: application/json' -d'
{
  "settings": {
    "index.knn": true
  },
  "mappings": {
    "properties": {
      "location": {
        "type": "knn_vector",
        "dimension": 2,
        "space_type": "l2"
      }
    }
  }
}
' | jq
{
  "error": {
    "root_cause": [
      {
        "type": "mapper_parsing_exception",
        "reason": "unknown parameter [space_type] on mapper [location] of type [knn_vector]"
      }
    ],
    "type": "mapper_parsing_exception",
    "reason": "Failed to parse mapping [_doc]: unknown parameter [space_type] on mapper [location] of type [knn_vector]",
    "caused_by": {
      "type": "mapper_parsing_exception",
      "reason": "unknown parameter [space_type] on mapper [location] of type [knn_vector]"
    }
  },
  "status": 400
}

```


### Version
all



### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
