### PR TITLE
Update plugin list

### DIFF
--- a/_install-and-configure/additional-plugins/index.md
+++ b/_install-and-configure/additional-plugins/index.md
@@ -23,8 +23,8 @@ There are many more plugins available in addition to those provided by the stand
 | `discovery-ec2`                                                                                                          | 1.0.0                      |
 | `discovery-gce`                                                                                                          | 1.0.0                      |
 | [`ingest-attachment`]({{site.url}}{{site.baseurl}}/install-and-configure/additional-plugins/ingest-attachment-plugin/) | 1.0.0                      |
-| `ingest-kafka` | 3.0.0                      |
-| `ingest-kinesis` | 3.0.0                      |
+| `ingestion-kafka`                                                                                                         | 3.0.0                      |
+| `ingestion-kinesis`                                                                                                       | 3.0.0                      |
 | `mapper-annotated-text`                                                                                                  | 1.0.0                      |
 | `mapper-murmur3`                                                                                                         | 1.0.0                      |
 | [`mapper-size`]({{site.url}}{{site.baseurl}}/install-and-configure/additional-plugins/mapper-size-plugin/)             | 1.0.0                      |


### PR DESCRIPTION
**Modify the plugin name (ingest-kafka, ingest-kinesis) for pull-based ingestion in OpenSearch 3.0+**

### Description

This PR corrects the plugin names (`ingest-kafka`, `ingest-kinesis`) used in the documentation for setting up [pull-based ingestion](https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion/), a new experimental feature introduced in OpenSearch 3.0 and later.
This change ensures users can accurately install the required plugins during testing and evaluation of the [pull-based ingestion](https://docs.opensearch.org/docs/latest/api-reference/document-apis/pull-based-ingestion/) functionality.

### Issues Resolved

Closes #\[*replace with issue number if applicable*]

### Version

3.0+

### Frontend features

*N/A*

### Checklist

* [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
  For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

