### PR TITLE
Typo fix in terms query docs

### DIFF
--- a/_query-dsl/term/terms.md
+++ b/_query-dsl/term/terms.md
@@ -265,7 +265,7 @@ The `terms` query can filter for multiple terms simultaneously. However, when th
 
 The following example assumes that you have two indexes: a `products` index, which contains all the products sold by a company, and a `customers` index, which stores filters representing customers who own specific products.
 
-First, create a `products` index and map `product_id` as a `keyword`:
+First, create a `products` index and map `product_id` as an integer:
 
 ```json
 PUT /products


### PR DESCRIPTION
The field is mapped as an integer, not keyword.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
