### PR TITLE
Correct example URL for synchronous provisioning

### DIFF
--- a/_automating-configurations/api/provision-workflow.md
+++ b/_automating-configurations/api/provision-workflow.md
@@ -51,7 +51,7 @@ POST /_plugins/_flow_framework/workflow/8xL8bowB8y25Tqfenm50/_provision
 The following request performs a synchronous provisioning call, waiting for up to 2 seconds for completion:
 
 ```json
-POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision&wait_for_completion_timeout=2s
+POST /_plugins/_flow_framework/workflow/<workflow_id>/_provision?wait_for_completion_timeout=2s
 ```
 {% include copy-curl.html %}
 


### PR DESCRIPTION
### Description

Fixes the sample URL for synchronous provisioning to use `?` rather than `&` which only applies if there are other params.

### Issues Resolved

Fixes https://github.com/opensearch-project/flow-framework/issues/1187#issuecomment-3071367748

### Version
2.19 and later

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
