### PR TITLE
Fix missing API header in hybrid collapse documentation

### DIFF
--- a/_vector-search/ai-search/hybrid-search/collapse.md
+++ b/_vector-search/ai-search/hybrid-search/collapse.md
@@ -55,6 +55,7 @@ PUT /bakery-items
 Ingest documents into the index:
 
 ```json
+POST /bakery-items/_bulk
 { "index": {} }
 { "item": "Chocolate Cake", "category": "cakes", "price": 15, "baked_date": "2023-07-01T00:00:00Z" }
 { "index": {} }


### PR DESCRIPTION
### Description
Adds a missing API header for the hybrid collapse documentation


### Version
3.1

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
