### PR TITLE
Add AWS Lambda client configuration options to documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/processors/aws-lambda.md
@@ -31,6 +31,14 @@ Field                | Type    | Required | Description
 `tags_on_match_failure` | List | Optional |  A list of tags to add to events when Lambda matching fails or encounters an unexpected error.
 `sdk_timeout`        | Duration| Optional | Configures the SDK's client connection timeout period. Default is `60s`. 
 `response_events_match` | Boolean | Optional | Specifies how Data Prepper interprets and processes Lambda function responses. Default is `false`.
+ `client`            | Object  | Optional | Client configuration
+`api_call_timeout`   | Duration | Optional | Api call timeout defines the time sdk maintains the api call to complete before timing out.
+`base_delay`         | Duration | Optional | Base delay for exponential backoff.
+`connection_timeout` | Duration | Optional | sdk timeout defines the time sdk maintains the connection to the client before timing out.
+`max_backoff`        | Duration | Optional | Maximum backoff time for exponential backoff. 
+`max_concurrency`    | Integer  | Optional | Max concurrency defined from the client side. 
+`max_retries`        | Integer | Optional | Total retries we want before failing`.  
+
 
 #### Example configuration
 
@@ -40,6 +48,9 @@ processors:
       function_name: "my-lambda-function"
       invocation_type: "request-response"
       response_events_match: false
+      client:
+        connection_timeout: PT5M
+        api_call_timeout: PT5M
       aws:
         region: "us-east-1"
         sts_role_arn: "arn:aws:iam::123456789012:role/my-lambda-role"


### PR DESCRIPTION


### Description
Added client configuration fields including:

api_call_timeout for SDK API call timeout
base_delay for exponential backoff
connection_timeout for SDK connection timeout
max_backoff for maximum backoff time
max_concurrency for client-side concurrency limit
max_retries for retry attempts
<img width="996" height="1226" alt="Screenshot 2025-07-21 at 11 56 33 AM" src="https://github.com/user-attachments/assets/e3263051-4a4c-4090-84ac-a66d5e91adf8" />


### Issues Resolved
Closes #[_delete this text, including the brackets, and replace with the issue number_]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
