### PR TITLE
Add `false_allow_templates` as a dynamic mapping option

### DIFF
--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -398,7 +398,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-Indexing succeeds because the new field `room` matches the dynamic templates.
+The new field `room` is indexed because matches the dynamic templates.
 
 3. Indexing also succeeds when the new field `floor` is added even though it does not match any properties or dynamic tamplates. However mappings will not be created for `floor` and so queries such as `{"match": {"floor": "1"}}` will not return the doc.
 

--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -400,7 +400,7 @@ PUT testindex1/_doc/1
 
 The new field `room` is indexed because matches the dynamic templates.
 
-3. Indexing also succeeds when the new field `floor` is added even though it does not match any properties or dynamic tamplates. However mappings will not be created for `floor` and so queries such as `{"match": {"floor": "1"}}` will not return the doc.
+If you add a new field `floor`, it is indexed even though it does not match any mapping properties or dynamic templates. However, mappings are not created for the `floor` field. Thus, queries such as `{"match": {"floor": "1"}}` do not return this document:
 
 ```json
 PUT testindex1/_doc/1

--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -413,3 +413,4 @@ PUT testindex1/_doc/1
   "floor": "1"
 }
 ```
+{% include copy-curl.html %}

--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -344,3 +344,72 @@ PUT testindex1/_doc/1
   "floor": "1"
 }
 ```
+
+---
+
+## Example: Create an index with `dynamic` set to `false_allow_templates`
+
+1. Create an index with predefined dynamic templates and `dynamic` set to `false_allow_templates` by sending the following request: 
+
+```json
+PUT testindex1
+{
+  "mappings": {
+    "dynamic": "false_allow_templates",
+    "dynamic_templates": [
+      {
+        "strings": {
+          "match": "room*",
+          "match_mapping_type": "string",
+          "mapping": {
+            "type": "keyword"
+          }
+        }
+      }
+    ],
+    "properties": {
+      "patient": {
+        "properties": {
+          "id": {
+            "type": "keyword"
+          },
+          "name": {
+            "type": "keyword"
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+2. Index a document with an object field `patient` containing two string fields and a new field `room` that matches one of the dynamic templates by sending the following request:
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  },
+  "room": "room1"
+}
+```
+{% include copy-curl.html %}
+
+Indexing succeeds because the new field `room` matches the dynamic templates.
+
+3. Indexing also succeeds when the new field `floor` is added even though it does not match any properties or dynamic tamplates. However mappings will not be created for `floor` and so queries such as `{"match": {"floor": "1"}}` will not return the doc.
+
+```json
+PUT testindex1/_doc/1
+{ 
+  "patient": { 
+    "name" : "John Doe",
+    "id" : "123456"
+  },
+  "room": "room1",
+  "floor": "1"
+}
+```

--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -398,7 +398,7 @@ PUT testindex1/_doc/1
 ```
 {% include copy-curl.html %}
 
-The new field `room` is indexed because matches the dynamic templates.
+The new field `room` is indexed because it matches the dynamic templates.
 
 If you add a new field `floor`, it is indexed even though it does not match any mapping properties or dynamic templates. However, mappings are not created for the `floor` field. Thus, queries such as `{"match": {"floor": "1"}}` do not return this document:
 

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -310,7 +310,7 @@ The following table lists the parameters accepted by object field types. All par
 
 Parameter | Description 
 :--- | :--- 
-[`dynamic`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/object#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to the object. Valid values are `true`, `false`, `strict`, and `strict_allow_templates`. Default is `true`.
+[`dynamic`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/object#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to the object. Valid values are `true`, `false`, `strict`, `strict_allow_templates`, and `false_allow_templates`. Default is `true`.
 `include_in_parent` | A Boolean value that specifies whether all fields in the child nested object should also be added to the parent document in flattened form. Default is `false`.
 `include_in_root` | A Boolean value that specifies whether all fields in the child nested object should also be added to the root document in flattened form. Default is `false`.
 `properties` | Fields of this object, which can be of any supported type. New properties can be dynamically added to this object if `dynamic` is set to `true`.

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -75,7 +75,7 @@ The following table lists the parameters accepted by object field types. All par
 
 Parameter | Description 
 :--- | :--- 
-[`dynamic`](#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to the object. Valid values are `true`, `false`, `strict`, and `strict_allow_templates`. Default is `true`.
+[`dynamic`](#the-dynamic-parameter) | Specifies whether new fields can be dynamically added to the object. Valid values are `true`, `false`, `strict`, `strict_allow_templates`, and `false_allow_templates`. Default is `true`.
 `enabled` | A Boolean value that specifies whether the JSON contents of the object should be parsed. If `enabled` is set to `false`, the object's contents are not indexed or searchable, but they are still retrievable from the _source field. Default is `true`.
 `properties` | Fields of this object, which can be of any supported type. New properties can be dynamically added to this object if `dynamic` is set to `true`.
 
@@ -152,6 +152,7 @@ Value | Description
 `false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the _source field. 
 `strict` | When new fields are added to the mapping dynamically, an exception is thrown. To add a new field to an object, you have to add it to the mapping first.
 `strict_allow_templates` | If the newly detected fields match any of the predefined dynamic templates in the mapping, then they are added to the mapping; if they do not match any of them, then an exception is thrown.
+`false_allow_templates` | If the newly detected fields match any of the predefined dynamic templates in the mapping, then they are added to the mapping; only fields matching dynamic templates or properties are indexed.
 
 Inner objects inherit the `dynamic` parameter value from their parent unless they declare their own `dynamic` parameter value.
 {: .note }

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -152,7 +152,7 @@ Value | Description
 `false` | New fields cannot be added to the mapping dynamically. If a new field is detected, it is not indexed or searchable. However, it is still retrievable from the _source field. 
 `strict` | When new fields are added to the mapping dynamically, an exception is thrown. To add a new field to an object, you have to add it to the mapping first.
 `strict_allow_templates` | If the newly detected fields match any of the predefined dynamic templates in the mapping, then they are added to the mapping; if they do not match any of them, then an exception is thrown.
-`false_allow_templates` | If the newly detected fields match any of the predefined dynamic templates in the mapping, then they are added to the mapping; only fields matching dynamic templates or properties are indexed.
+`false_allow_templates` | If the newly detected fields match any of the predefined dynamic templates in the mapping, then they are added to the mapping. Only fields matching dynamic templates or mapping properties are indexed.
 
 Inner objects inherit the `dynamic` parameter value from their parent unless they declare their own `dynamic` parameter value.
 {: .note }


### PR DESCRIPTION
### Description
In this [PR](https://github.com/opensearch-project/OpenSearch/pull/18825), we add support for `false_allow_templates` as a dynamic mapping option. This PR adds documentation for that. Will hold off on merging until the PR to the main project has merged.

### Issues Resolved
Closes #10389
Original OpenSearch project issue: https://github.com/opensearch-project/OpenSearch/issues/18617#issuecomment-3070419493

### Version
3.2.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
