### PR TITLE
Document ISM transition conditions `no_alias` and `min_state_age`

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -636,7 +636,8 @@ Parameter | Description | Type | Required
 `cron.cron.expression` | The `cron` expression that triggers the transition. | `string` | Yes
 `cron.cron.timezone` | The timezone that triggers the transition. | `string` | Yes
 
-**Note:** All time-based values (`min_index_age`, `min_rollover_age`, `min_state_age`) use [standard OpenSearch time units](https://docs.opensearch.org/latest/api-reference/common-parameters/#time-units).
+All time-based values (`min_index_age`, `min_rollover_age`, `min_state_age`) use [standard OpenSearch time units]({{site.url}}{{site.baseurl}}/api-reference/common-parameters/#time-units).
+{: .note}
 
 
 The following example transitions the index to a `cold` state after a period of 30 days:


### PR DESCRIPTION
This commit updates the Index State Management (ISM) documentation to include two new transition conditions added in [PR #1440](https://github.com/opensearch-project/index-management/pull/1440):

- `no_alias`: Enables alias-aware transitions. When set to `true`, the index must not be associated with any aliases. When set to `false`, it must have at least one alias. 

- `min_state_age`: Allows transitions only after the index has spent a minimum duration in the current ISM state. 

These enhancements are scheduled to be released as part of **OpenSearch ISM version 3.2**. The documentation aligns them with the existing transition condition format and improves policy flexibility for production workloads.

### Description
_Describe what this change achieves._

### Issues Resolved
Closes #10453

### Version
3.2 and above


### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
