### PR TITLE
adding read-only explanation to split and shrink API docs

### DIFF
--- a/_api-reference/index-apis/shrink-index.md
+++ b/_api-reference/index-apis/shrink-index.md
@@ -11,7 +11,10 @@ redirect_from:
 **Introduced 1.0**
 {: .label .label-purple }
 
-The shrink index API operation moves all of your data in an existing index into a new index with fewer primary shards.
+The shrink index API operation moves all of your data in an existing read-only index into a new index with fewer primary shards.
+
+Index is read-only when the `index.blocks.write` in index settings is set to `true`.
+{: .note}
 
 
 ## Endpoints

--- a/_api-reference/index-apis/split.md
+++ b/_api-reference/index-apis/split.md
@@ -13,6 +13,9 @@ redirect_from:
 
 The split index API operation splits an existing read-only index into a new index, cutting each primary shard into some amount of primary shards in the new index.
 
+Index is read-only when the `index.blocks.write` in index settings is set to `true`.
+{: .note}
+
 ## Example
 
 ```json

--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -209,6 +209,8 @@ OpenSearch supports the following dynamic index-level index settings:
 
    For example, if you have 5 data nodes and set `index.auto_expand_search_replicas` to `0-3`, the index can have up to 3 search replicas and the cluster does not automatically add another search replica shard. However, if you set `index.auto_expand_search_replicas` to `0-all` and add 2 more nodes, for a total of 7, the cluster will expand to now have 7 search replica shards. This setting is disabled by default.
 
+- `index.blocks.write` (Boolean): Controls whether the index is read-only. `true` blocks all the write requests and sets the index as read-only. Defaults is `false`.
+
 - `index.search.idle.after` (Time unit): The amount of time a shard should wait for a search or get request until it goes idle. Default is `30s`.
 
 - `index.search.default_pipeline` (String): The name of the search pipeline that is used if no pipeline is explicitly set when searching an index. If a default pipeline is set and the pipeline doesn't exist, then the index requests fail. Use the pipeline name `_none` to specify no default search pipeline. For more information, see [Default search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/using-search-pipeline/#default-search-pipeline).


### PR DESCRIPTION
### Description
adding read-only explanation to split and shrink API docs

### Issues Resolved
Closes #10521

### Version
all

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
