### PR TITLE
Modify docker compose reference in quickstart and correct curl to http

### DIFF
--- a/_getting-started/quickstart.md
+++ b/_getting-started/quickstart.md
@@ -67,7 +67,7 @@ You should get a response that looks like this:
 
 ## Option 2: Set up a custom Docker cluster
 
-Use Docker Compose to run a local multi-node OpenSearch and OpenSearch Dashboards cluster:
+Use [Docker Compose](https://docs.docker.com/compose/) to run a local multi-node OpenSearch and OpenSearch Dashboards cluster:
 
 - [Set up a cluster without security](#set-up-a-cluster-without-security-for-local-development) -- Best for local development.
 - [Set up a cluster with security](#set-up-a-cluster-with-security-recommended-for-most-use-cases) -- Try OpenSearch with security by installing it with default certificates.
@@ -107,7 +107,7 @@ This configuration disables security and should only be used in test environment
 1. To verify that OpenSearch is running, send the following request: 
 
     ```bash
-    curl https://localhost:9200
+    curl http://localhost:9200
     ```
     {% include copy.html %}
 
@@ -211,14 +211,6 @@ Eliminate the need for running your Docker commands with `sudo` by adding your u
 ```bash
 sudo usermod -aG docker $USER
 ```
-
-### Error message: "-bash: docker-compose: command not found"
-
-If you installed Docker Desktop, then Docker Compose is already installed on your machine. Try `docker compose` (without the hyphen) instead of `docker-compose`. See [Use Docker Compose](https://docs.docker.com/get-started/08_using_compose/).
-
-### Error message: "docker: 'compose' is not a docker command."
-
-If you installed Docker Engine, then you must install Docker Compose separately, and you will use the command `docker-compose` (with a hyphen). See [Docker Compose](https://github.com/docker/compose).
 
 ### Error message: "max virtual memory areas vm.max_map_count [65530] is too low"
 

--- a/_vector-search/getting-started/index.md
+++ b/_vector-search/getting-started/index.md
@@ -35,7 +35,7 @@ docker pull opensearchproject/opensearch:latest && docker run -it -p 9200:9200 -
 OpenSearch is now running on port 9200. To verify that OpenSearch is running, send the following request: 
 
 ```bash
-curl https://localhost:9200
+curl http://localhost:9200
 ```
 {% include copy.html %}
 


### PR DESCRIPTION
- Remove reference to standalone Docker Compose because it's bundled in Docker 
- Correct curl requests to use http without security

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
