### PR TITLE
10553 - [DOC]- Fix the Links Under Resources on the Footer

### DIFF
--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -19,22 +19,22 @@ columns:
     links:
       - 
         title: About
-        url: '/about.html'
+        url: 'https://opensearch.org/about/'
       - 
         title: Release Schedule
-        url: '/releases.html'
+        url: 'https://opensearch.org/releases/#release-schedule'
       - 
         title: Maintenance Policy
-        url: '/releases.html#maintenance-policy'
+        url: 'https://opensearch.org/releases/#maintenance-policy'
       - 
         title: FAQ
-        url: '/faq/'
+        url: 'https://opensearch.org/faq/'
       -
         title: 'Testimonials'
-        url: '/testimonials/'
+        url: 'https://opensearch.org/testimonials/
       -
         title: 'Trademark and Brand Policy'
-        url: '/trademark-brand-policy.html'
+        url: 'https://opensearch.org/trademark-brand-policy/'
       -
         title: 'Privacy'
         url: 'https://aws.amazon.com/privacy/'

--- a/_data/footer.yml
+++ b/_data/footer.yml
@@ -31,7 +31,7 @@ columns:
         url: 'https://opensearch.org/faq/'
       -
         title: 'Testimonials'
-        url: 'https://opensearch.org/testimonials/
+        url: 'https://opensearch.org/testimonials/'
       -
         title: 'Trademark and Brand Policy'
         url: 'https://opensearch.org/trademark-brand-policy/'


### PR DESCRIPTION
### Description
Fixed the links under the Resource section on the footer

<img width="290" height="364" alt="Screenshot 2025-08-01 at 2 11 53 PM" src="https://github.com/user-attachments/assets/2c2496f9-abb2-4925-bffb-96be231c395c" />

### Issues Resolved

Closes #10553

### Version

Documentation Website https://docs.opensearch.org/latest/

### Frontend features
NA

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
