### PR TITLE
Add skip_list parameter to numeric field type (default: false)

### DIFF
--- a/_field-types/supported-field-types/numeric.md
+++ b/_field-types/supported-field-types/numeric.md
@@ -59,6 +59,37 @@ PUT testindex/_doc/1
 ```
 {% include copy-curl.html %}
 
+## Skip list example
+
+Create a mapping with skip list indexing enabled for better range query performance:
+
+```json
+PUT testindex_skiplist
+{
+  "mappings" : {
+    "properties" :  {
+      "price" : {
+        "type" : "double",
+        "skip_list" : true
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Index documents with numeric values:
+
+```json
+PUT testindex_skiplist/_doc/1
+{
+  "price" : 19.99
+}
+```
+{% include copy-curl.html %}
+
+The `skip_list` parameter is particularly beneficial for fields that are frequently used in range queries or aggregations, as it allows the query engine to skip over document ranges that don't match the query criteria.
+
 ## Scaled float field type
 
 A scaled float field type is a floating-point value that is multiplied by the scale factor and stored as a long value. It takes all optional parameters taken by number field types, plus an additional scaling_factor parameter. The scale factor is required when creating a scaled float. 
@@ -110,6 +141,7 @@ Parameter | Description
 `index` | A Boolean value that specifies whether the field should be searchable. Default is `true`. 
 `meta` | Accepts metadata for this field.
 [`null_value`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/index#null-value) | A  value to be used in place of `null`. Must be of the same type as the field. If this parameter is not specified, the field is treated as missing when its value is `null`. Default is `null`.
+`skip_list` | A Boolean value that specifies whether to enable skip list indexing for doc values. When enabled, this creates indexed doc values that can improve performance for range queries and aggregations by allowing the query engine to skip over irrelevant document ranges. Default is `false`.
 `store` | A Boolean value that specifies whether the field value should be stored and can be retrieved separately from the _source field. Default is `false`. 
 
 Scaled float has an additional required parameter: `scaling_factor`.


### PR DESCRIPTION
### Description

* Added Parameter Documentation
* Added Practical Example, and when its useful to enable 
* Applies to all numeric field types (byte, short, integer, long, float, double, half_float, unsigned_long)

### Issues Resolved
Closes #[17965]

### Version
OS 3.2

### Frontend features
n/a

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
