### PR TITLE
Add version command for migration console command reference

### DIFF
--- a/_migration-assistant/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant/migration-console/migration-console-commands-references.md
@@ -107,6 +107,13 @@ console tuples show --in /shared-logs-output/traffic-replayer-default/[NODE_ID]/
 ```
 {% include copy.html %}
 
+## Show version
+Displays the version of the currently installed Migration Assistant.
+```sh
+console --version
+```
+{% include copy.html %}
+
 ## Help option
 
 All commands and options can be explored within the tool itself by using the `--help` option, either for the entire `console` application or for individual components (for example, `console backfill --help`). For example:
@@ -120,6 +127,7 @@ Options:
   --json
   -v, --verbose       Verbosity level. Default is warn, -v is info, -vv is
                       debug.
+  --version           Show the Migration Assistant version.
   --help              Show this message and exit.
 
 Commands:


### PR DESCRIPTION
### Description
Adds a command reference for showing Migration Assistant version, and updates help message output

### Issues Resolved
Documentation counterpart to change here: https://github.com/opensearch-project/opensearch-migrations/pull/1712 (Already merged)

### Version
Migration Assistant

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
