### PR TITLE
TLS settings for gRPC

### DIFF
--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -317,7 +317,7 @@ gRPC supports encryption in transit only. Trust stores and certificates configur
 
 You can configure TLSon the optional gRPC transport in `opensearch.yml`. For more information about using  gRPC plugin, see [Enabling the plugin]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/index/#enabling-the-plugin).
 
-### Pemkey settings (X.509 PEM certificates and PKCS #8 keys)
+### PEM key settings (X.509 PEM certificates and PKCS #8 keys)
 
 The following table lists the available gRPC PEM key settings.
 

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -324,7 +324,7 @@ The following table lists the available gRPC PEM key settings.
 Name | Description
 :--- | :---
 `plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.
-`plugins.security.ssl.aux.secure-transport-grpc.pemkey_filepath` | Path to the certificate's key file (PKCS \#8), which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.pemkey_filepath` | The path to the certificate's key file (PKCS #8), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.pemkey_password` | The key password. Omit this setting if the key has no password. Optional.
 `plugins.security.ssl.aux.secure-transport-grpc.pemcert_filepath` | Path to the X.509 node certificate chain (PEM format), which must be under the `config` directory, specified using a relative path. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.pemtrustedcas_filepath` | Path to the root CAs (PEM format), which must be under the `config` directory, specified using a relative path. Required.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -329,7 +329,7 @@ Name | Description
 `plugins.security.ssl.aux.secure-transport-grpc.pemcert_filepath` | The path to the X.509 node certificate chain (in PEM format), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.pemtrustedcas_filepath` | The path to the root CAs (in PEM format), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 
-### Keystore and trustore
+### Keystore and truststore
 
 Name | Description
 :--- | :---

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -326,7 +326,7 @@ Name | Description
 `plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.
 `plugins.security.ssl.aux.secure-transport-grpc.pemkey_filepath` | The path to the certificate's key file (PKCS #8), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.pemkey_password` | The key password. Omit this setting if the key has no password. Optional.
-`plugins.security.ssl.aux.secure-transport-grpc.pemcert_filepath` | Path to the X.509 node certificate chain (PEM format), which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.pemcert_filepath` | The path to the X.509 node certificate chain (in PEM format), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.pemtrustedcas_filepath` | Path to the root CAs (PEM format), which must be under the `config` directory, specified using a relative path. Required.
 
 ### Keystore and trustore

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -335,7 +335,7 @@ Name | Description
 :--- | :---
 `plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_type` | The type of the keystore file, JKS or PKCS12/PFX. Optional. Default is JKS.
-`plugins.security.ssl.aux.secure-transport-grpc.keystore_filepath` | Path to the keystore file, which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.keystore_filepath` | The path to the keystore file, specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_alias` | The alias name of the keystore. Optional. Default is the first alias.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_password` | The password for the keystore. Default is `changeit`.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_type` | The type of the truststore file, JKS or PKCS12/PFX. Default is JKS.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -319,6 +319,8 @@ You can configure TLSon the optional gRPC transport in `opensearch.yml`. For mor
 
 ### Pemkey settings (X.509 PEM certificates and PKCS #8 keys)
 
+The following table lists the available gRPC PEM key settings.
+
 Name | Description
 :--- | :---
 `plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -331,6 +331,8 @@ Name | Description
 
 ### Keystore and truststore
 
+The following table lists the available gRPC keystore and truststore settings.
+
 Name | Description
 :--- | :---
 `plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -327,7 +327,7 @@ Name | Description
 `plugins.security.ssl.aux.secure-transport-grpc.pemkey_filepath` | The path to the certificate's key file (PKCS #8), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.pemkey_password` | The key password. Omit this setting if the key has no password. Optional.
 `plugins.security.ssl.aux.secure-transport-grpc.pemcert_filepath` | The path to the X.509 node certificate chain (in PEM format), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
-`plugins.security.ssl.aux.secure-transport-grpc.pemtrustedcas_filepath` | Path to the root CAs (PEM format), which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.pemtrustedcas_filepath` | The path to the root CAs (in PEM format), specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 
 ### Keystore and trustore
 

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -310,6 +310,33 @@ You should receive the following response:
 { "message": "successfully updated http certs"}
 ```
 
+#### Configuring TLS certificates for gRPC
 
+gRPC supports encryption in transit with only. Trust stores and certificates configured as root CAs in PEM format are used only for the purpose of TLS client auth. Role based access is not available for gRPC endpoints. This feature is a work in progress, please see the associated GitHub issue for updates.
+{: .warning}
 
+TLS may be configured on the optional gRPC transport with `opensearch.yml`. To install and enable the gRPC endpoint see [enabling-the-plugin]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/index/#enabling-the-plugin).
 
+### Pemkey settings (X.509 PEM certificates and PKCS #8 keys)
+
+Name | Description
+:--- | :---
+`plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.
+`plugins.security.ssl.aux.secure-transport-grpc.pemkey_filepath` | Path to the certificate's key file (PKCS \#8), which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.pemkey_password` | The key password. Omit this setting if the key has no password. Optional.
+`plugins.security.ssl.aux.secure-transport-grpc.pemcert_filepath` | Path to the X.509 node certificate chain (PEM format), which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.pemtrustedcas_filepath` | Path to the root CAs (PEM format), which must be under the `config` directory, specified using a relative path. Required.
+
+### Keystore and trustore
+
+Name | Description
+:--- | :---
+`plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.
+`plugins.security.ssl.aux.secure-transport-grpc.keystore_type` | The type of the keystore file, JKS or PKCS12/PFX. Optional. Default is JKS.
+`plugins.security.ssl.aux.secure-transport-grpc.keystore_filepath` | Path to the keystore file, which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.keystore_alias` | The alias name of the keystore. Optional. Default is the first alias.
+`plugins.security.ssl.aux.secure-transport-grpc.keystore_password` | The password for the keystore. Default is `changeit`.
+`plugins.security.ssl.aux.secure-transport-grpc.truststore_type` | The type of the truststore file, JKS or PKCS12/PFX. Default is JKS.
+`plugins.security.ssl.aux.secure-transport-grpc.truststore_filepath` | Path to the truststore file, which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.truststore_alias` | The alias name of the truststore. Optional. Default is all certificates.
+`plugins.security.ssl.aux.secure-transport-grpc.truststore_password` | The password for the truststore. Default is `changeit`.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -312,7 +312,7 @@ You should receive the following response:
 
 #### Configuring TLS certificates for gRPC
 
-gRPC supports encryption in transit with only. Trust stores and certificates configured as root CAs in PEM format are used only for the purpose of TLS client auth. Role based access is not available for gRPC endpoints. This feature is a work in progress, please see the associated GitHub issue for updates.
+gRPC supports encryption in transit only. Trust stores and certificates configured as root CAs in PEM format are used only for the purpose of TLS client authorization. Role-based access is not available for gRPC endpoints. 
 {: .warning}
 
 TLS may be configured on the optional gRPC transport with `opensearch.yml`. To install and enable the gRPC endpoint see [enabling-the-plugin]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/index/#enabling-the-plugin).

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -339,6 +339,6 @@ Name | Description
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_alias` | The alias name of the keystore. Optional. Default is the first alias.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_password` | The password for the keystore. Default is `changeit`.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_type` | The type of the truststore file, JKS or PKCS12/PFX. Default is JKS.
-`plugins.security.ssl.aux.secure-transport-grpc.truststore_filepath` | Path to the truststore file, which must be under the `config` directory, specified using a relative path. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.truststore_filepath` | The path to the truststore file, , specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_alias` | The alias name of the truststore. Optional. Default is all certificates.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_password` | The password for the truststore. Default is `changeit`.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -338,9 +338,9 @@ Name | Description
 `plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_type` | The type of the keystore file, JKS or PKCS12/PFX. Optional. Default is JKS.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_filepath` | The path to the keystore file, specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
-`plugins.security.ssl.aux.secure-transport-grpc.keystore_alias` | The alias name of the keystore. Optional. Default is the first alias.
+`plugins.security.ssl.aux.secure-transport-grpc.keystore_alias` | The alias of the key-pair to use from the provided keystore. Optional. Defaults to the first key-pair added to the keystore.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_password` | The password for the keystore. Default is `changeit`.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_type` | The type of the truststore file, JKS or PKCS12/PFX. Default is JKS.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_filepath` | The path to the truststore file, , specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
-`plugins.security.ssl.aux.secure-transport-grpc.truststore_alias` | The alias name of the truststore. Optional. Default is all certificates.
+`plugins.security.ssl.aux.secure-transport-grpc.truststore_alias` | The alias of the certificate to use from the provided truststore. Optional. Default is all certificates.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_password` | The password for the truststore. Default is `changeit`.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -310,7 +310,7 @@ You should receive the following response:
 { "message": "successfully updated http certs"}
 ```
 
-#### Configuring TLS certificates for gRPC
+## Configuring TLS certificates for gRPC
 
 gRPC supports encryption in transit only. Trust stores and certificates configured as root CAs in PEM format are used only for the purpose of TLS client authorization. Role-based access is not available for gRPC endpoints. 
 {: .warning}

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -315,7 +315,7 @@ You should receive the following response:
 gRPC supports encryption in transit only. Trust stores and certificates configured as root CAs in PEM format are used only for the purpose of TLS client authorization. Role-based access is not available for gRPC endpoints. 
 {: .warning}
 
-You can configure TLSon the optional gRPC transport in `opensearch.yml`. For more information about using  gRPC plugin, see [Enabling the plugin]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/index/#enabling-the-plugin).
+You can configure TLS on the optional gRPC transport in `opensearch.yml`. For more information about using the gRPC plugin, see [Enabling the plugin]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/index/#enabling-the-plugin).
 
 ### PEM key settings (X.509 PEM certificates and PKCS #8 keys)
 
@@ -338,9 +338,9 @@ Name | Description
 `plugins.security.ssl.aux.secure-transport-grpc.enabled` | Whether to enable TLS for gRPC. If enabled, only HTTPS is allowed. Optional. Default is `false`.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_type` | The type of the keystore file, JKS or PKCS12/PFX. Optional. Default is JKS.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_filepath` | The path to the keystore file, specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
-`plugins.security.ssl.aux.secure-transport-grpc.keystore_alias` | The alias of the key-pair to use from the provided keystore. Optional. Defaults to the first key-pair added to the keystore.
+`plugins.security.ssl.aux.secure-transport-grpc.keystore_alias` | The alias of the key pair to use from the provided keystore. Optional. Defaults to the first key pair added to the keystore.
 `plugins.security.ssl.aux.secure-transport-grpc.keystore_password` | The password for the keystore. Default is `changeit`.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_type` | The type of the truststore file, JKS or PKCS12/PFX. Default is JKS.
-`plugins.security.ssl.aux.secure-transport-grpc.truststore_filepath` | The path to the truststore file, , specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
+`plugins.security.ssl.aux.secure-transport-grpc.truststore_filepath` | The path to the truststore file, specified as a relative path from the `config` directory. The file must reside within the `config` directory. Required.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_alias` | The alias of the certificate to use from the provided truststore. Optional. Default is all certificates.
 `plugins.security.ssl.aux.secure-transport-grpc.truststore_password` | The password for the truststore. Default is `changeit`.

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -315,7 +315,7 @@ You should receive the following response:
 gRPC supports encryption in transit only. Trust stores and certificates configured as root CAs in PEM format are used only for the purpose of TLS client authorization. Role-based access is not available for gRPC endpoints. 
 {: .warning}
 
-TLS may be configured on the optional gRPC transport with `opensearch.yml`. To install and enable the gRPC endpoint see [enabling-the-plugin]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/index/#enabling-the-plugin).
+You can configure TLSon the optional gRPC transport in `opensearch.yml`. For more information about using  gRPC plugin, see [Enabling the plugin]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/index/#enabling-the-plugin).
 
 ### Pemkey settings (X.509 PEM certificates and PKCS #8 keys)
 


### PR DESCRIPTION
### Description
Adds settings for configuring encryption in transit with TLS for gRPC plugin.
Includes settings for Pem and truststore/keystore formats.

Places a warning at the top to make it clear authn/authz are not provided at this time. Only encryption in transit is supported for this feature.

### Issues Resolved
Closes #10592

### Version
3.2

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
