### PR TITLE
Added GPU-Access to systemd-Service Definition

### DIFF
--- a/_ml-commons-plugin/gpu-acceleration.md
+++ b/_ml-commons-plugin/gpu-acceleration.md
@@ -71,7 +71,7 @@ If you run OpenSearch natively (without Docker) using the packaged version of Op
 
 To allow OpenSearch to use the GPU, update the `systemd` service by adding the following configuration:
 
-```
+```ini
 systemctl edit opensearch.service
 
 [Service]


### PR DESCRIPTION
Added a case where you run opensearch ml-node natively without docker. Systemd prevents you from accessing the gpu.

### Description
_Describe what this change achieves._

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
