### PR TITLE
Add a rule to replace old-style doc links with variables

### DIFF
--- a/spec-insert/config.yml
+++ b/spec-insert/config.yml
@@ -11,5 +11,7 @@ param_table:
 text_replacements:
   - replace: "https://docs.opensearch.org/latest"
     with: "{{site.url}}{{site.baseurl}}"
+  - replace: "https://opensearch.org/docs/latest"
+    with: "{{site.url}}{{site.baseurl}}"
   - replace: "\n"
     with: " "


### PR DESCRIPTION
For spec-insert tool, add a rule to replace old-style doc links with variables because api-spec repo uses old-style links.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
