### PR TITLE
Revert spec insert changes

### DIFF
--- a/spec-insert/lib/doc_processor.rb
+++ b/spec-insert/lib/doc_processor.rb
@@ -46,7 +46,7 @@ class DocProcessor
                          .filter { |line, _index| line.match?(START_MARKER) }
                          .map { |_line, index| index }
     end_indices = start_indices.map do |index|
-      (index..(lines.length - 1)).find { |i| lines[i].match?(END_MARKER) }
+      (index..lines.length - 1).find { |i| lines[i].match?(END_MARKER) }
     end.compact
 
     validate_markers!(start_indices, end_indices)

--- a/spec-insert/lib/renderers/path_parameters.rb
+++ b/spec-insert/lib/renderers/path_parameters.rb
@@ -11,7 +11,7 @@ class PathParameters < BaseMustacheRenderer
     ParameterTableRenderer.new(params, @args).render
   end
 
-  def optional?
+  def optional
     params.none?(&:required)
   end
 

--- a/spec-insert/lib/renderers/query_parameters.rb
+++ b/spec-insert/lib/renderers/query_parameters.rb
@@ -11,7 +11,7 @@ class QueryParameters < BaseMustacheRenderer
     ParameterTableRenderer.new(params, @args).render
   end
 
-  def optional?
+  def optional
     params.none?(&:required)
   end
 

--- a/spec-insert/lib/reports/dry_run_report.rb
+++ b/spec-insert/lib/reports/dry_run_report.rb
@@ -17,7 +17,7 @@ class DryRunReport < Mustache
     generate_dry_runs
   end
 
-  def any_errors?
+  def any_errors
     @errors_report.keys.any?
   end
 

--- a/spec-insert/spec/_fixtures/expected_output/url_params_tables.md
+++ b/spec-insert/spec/_fixtures/expected_output/url_params_tables.md
@@ -6,7 +6,7 @@ component: path_parameters
 -->
 ## Path parameters
 
-The following table lists the available path parameters.
+The following table lists the available path parameters. All path parameters are optional.
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |


### PR DESCRIPTION
PR https://github.com/opensearch-project/documentation-website/pull/10324 contained some spec insert changes, which resulted in spec-insert producing incorrect autocut PRs (ex: https://github.com/opensearch-project/documentation-website/pull/10696)

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
