### PR TITLE
Add command reference for CURL also fix headings across the file

### DIFF
--- a/_migration-assistant/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant/migration-console/migration-console-commands-references.md
@@ -36,6 +36,58 @@ console clusters cat-indices
 ```
 {% include copy.html %}
 
+### Execute HTTP requests against clusters
+
+Run OpenSearch/Elasticsearch APIs directly against the configured source or target cluster using a `curl`-like interface. Authentication, TLS, and endpoints are taken from your console configuration.
+
+```sh
+console clusters curl <source_cluster|target_cluster> <path> [OPTIONS]
+```
+{% include copy.html %}
+
+#### Arguments
+
+* `<source_cluster|target_cluster>` — Which cluster to call.
+* `<path>` — The API path to call on the cluster (e.g., `/_cat/indices`, `/my-index/_search`).
+
+#### Options
+
+* `--json <JSON_DATA>` — Send a JSON body and automatically set `Content-Type: application/json`.
+* `-X, --request <METHOD>` — HTTP method (GET, POST, PUT, DELETE, HEAD). Default: GET.
+* `-H, --header <HEADER>` — Custom header (repeatable). Example: `-H 'Accept: application/json'`.
+* `-d, --data <DATA>` — Raw request body.
+
+#### Examples
+
+*Get cluster health:*
+
+```sh
+console clusters curl source_cluster /_cluster/health
+```
+{% include copy.html %}
+
+*List indices as JSON:*
+
+```sh
+console clusters curl source_cluster "/_cat/indices?format=json&v=true"
+```
+{% include copy.html %}
+
+*Create an index:*
+
+```sh
+console clusters curl target_cluster /my-new-index --json '{"settings":{"number_of_shards":3,"number_of_replicas":1}}'
+```
+{% include copy.html %}
+
+*Search with a body:*
+
+```sh
+console clusters curl source_cluster /_search --json '{"query":{"match_all":{}}}'
+```
+{% include copy.html %}
+
+
 ### Create a snapshot
 
 Creates a snapshot of the source cluster and stores it in a preconfigured Amazon Simple Storage Service (Amazon S3) bucket.
@@ -45,34 +97,37 @@ console snapshot create
 ```
 {% include copy.html %}
 
-## Check snapshot status
+### Check snapshot status
 
 Runs a detailed check on the snapshot creation status, including estimated completion time:
 
 ```sh
 console snapshot status --deep-check
 ```
+
 {% include copy.html %}
 
-## Evaluate metadata
+### Evaluate metadata
 
 Performs a dry run of metadata migration, showing which indexes, templates, and other objects will be migrated to the target cluster.
 
 ```sh
 console metadata evaluate
 ```
+
 {% include copy.html %}
 
-## Migrate metadata
+### Migrate metadata
 
 Migrates the metadata from the source cluster to the target cluster.
 
 ```sh
 console metadata migrate
 ```
+
 {% include copy.html %}
 
-## Start a backfill
+### Start a backfill
 
 If `Reindex-From-Snapshot` (RFS) is enabled, this command starts an instance of the service to begin moving documents to the target cluster:
 
@@ -84,12 +139,16 @@ console backfill start
 ```
 {% include copy.html %}
 
-## Check backfill status
+### Check backfill status
 
 Gets the current status of the backfill migration, including the number of operating instances and the progress of the shards.
 
+```sh
+console backfill status
+```
+{% include copy.html %}
 
-## Start Traffic Replayer
+### Start Traffic Replayer
 
 If Traffic Replayer is enabled, this command starts an instance of Traffic Replayer to begin replaying traffic against the target cluster.
 The `stop` command stops all active instances.
@@ -99,7 +158,7 @@ console replay start
 ```
 {% include copy.html %}
 
-## Read logs
+### Read logs
 
 Reads any logs that exist when running Traffic Replayer. Use tab completion on the path to fill in the available `NODE_IDs` and, if applicable, log file names. The tuple logs roll over at a certain size threshold, so there may be many files named with timestamps. The `jq` command pretty-prints each line of the tuple output before writing it to file.
 
@@ -108,7 +167,7 @@ console tuples show --in /shared-logs-output/traffic-replayer-default/[NODE_ID]/
 ```
 {% include copy.html %}
 
-## Show version
+### Show version
 
 Displays the version of the currently installed Migration Assistant.
 
@@ -117,11 +176,11 @@ console --version
 ```
 {% include copy.html %}
 
-## Help option
+### Help option
 
 All commands and options can be explored within the tool itself by using the `--help` option, either for the entire `console` application or for individual components (for example, `console backfill --help`). For example:
 
-```bash
+```sh
 $ console --help
 Usage: console [OPTIONS] COMMAND [ARGS]...
 


### PR DESCRIPTION
### Description
Add command reference for CURL also fix headings across the file

### Issues Resolved
- Closes [[MIGRATIONS-2629 | Document the console clusters curl command]](https://opensearch.atlassian.net/browse/MIGRATIONS-2629)

### Version
_All versions of the Migration Assistant_

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
