### PR TITLE
Fix python snippets to work with opensearch-py v3

### DIFF
--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -188,7 +188,7 @@ index_body = {
   }
 }
 
-response = client.indices.create(index_name, body=index_body)
+response = client.indices.create(index=index_name, body=index_body)
 ```
 {% include copy.html %}
 
@@ -219,7 +219,7 @@ You can perform several operations at the same time by using the `bulk()` method
 ```python
 movies = '{ "index" : { "_index" : "my-dsl-index", "_id" : "2" } } \n { "title" : "Interstellar", "director" : "Christopher Nolan", "year" : "2014"} \n { "create" : { "_index" : "my-dsl-index", "_id" : "3" } } \n { "title" : "Star Trek Beyond", "director" : "Justin Lin", "year" : "2015"} \n { "update" : {"_id" : "3", "_index" : "my-dsl-index" } } \n { "doc" : {"year" : "2016"} }'
 
-client.bulk(movies)
+client.bulk(body=movies)
 ```
 {% include copy.html %}
 
@@ -309,7 +309,7 @@ index_body = {
   }
 }
 
-response = client.indices.create(index_name, body=index_body)
+response = client.indices.create(index=index_name, body=index_body)
 print('\nCreating index:')
 print(response)
 
@@ -335,7 +335,7 @@ print(response)
 
 movies = '{ "index" : { "_index" : "my-dsl-index", "_id" : "2" } } \n { "title" : "Interstellar", "director" : "Christopher Nolan", "year" : "2014"} \n { "create" : { "_index" : "my-dsl-index", "_id" : "3" } } \n { "title" : "Star Trek Beyond", "director" : "Justin Lin", "year" : "2015"} \n { "update" : {"_id" : "3", "_index" : "my-dsl-index" } } \n { "doc" : {"year" : "2016"} }'
 
-client.bulk(movies)
+client.bulk(body=movies)
 
 # Search for the document.
 q = 'miller'


### PR DESCRIPTION
opensearch-py v3 has introduced a breaking change, introduced [here](https://github.com/opensearch-project/opensearch-py/pull/907). Due to the change, one has to mandatorily specify argument names on all APIs.

### Description
Current examples of python code do not work, due to the above breaking change on opensearch-py v3 library.

### Issues Resolved
Closes #10752 

### Version
3.0 and up.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
