### PR TITLE
[DOC] Document the property for replication of delete index

### DIFF
--- a/_tuning-your-cluster/replication-plugin/settings.md
+++ b/_tuning-your-cluster/replication-plugin/settings.md
@@ -37,4 +37,5 @@ Setting | Default | Description
 `plugins.replication.follower.metadata_sync_interval` | 60s | How often the follower cluster polls the leader cluster for updated index metadata.
 `plugins.replication.translog.retention_lease.pruning.enabled` | true | If enabled, prunes the translog based on retention leases on the leader index.
 `plugins.replication.translog.retention_size` | 512 MB | Controls the size of the translog on the leader index.
+`plugins.replication.replicate.delete_index` | false | If enabled, the follower index is automatically deleted whenever the corresponding leader index is deleted.
 


### PR DESCRIPTION
### Description
Added the documentation of proprty plugins.replication.replicate.delete_index replication-plugin settings page.

### Issues Resolved
Resolves #10728

### Version
3.3

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
