### PR TITLE
Fix documentation for derived source with respect to wildcard field type

### DIFF
--- a/_field-types/metadata-fields/source.md
+++ b/_field-types/metadata-fields/source.md
@@ -99,7 +99,7 @@ If this setting is used, you may notice differences in the `_source` content for
 
 Derived source uses [`doc_values`]({{site.url}}{{site.baseurl}}/field-types/mapping-parameters/doc-values/) and [`stored_fields`]({{site.url}}{{site.baseurl}}/field-types/mapping-parameters/store/) to reconstruct the document at query time. Because of the implementation of `doc_values`, the dynamically generated `_source` may differ in format or precision from the original ingested document.
 
-Derived source supports the following field types without requiring any changes to field mappings (with some [limitations](#limitations)):
+Derived source supports the following field types, with most of them not requiring any changes to field mappings (with some [limitations](#limitations)):
 
 - [`boolean`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/boolean/)
 - [`byte`, `double`, `float`, `half_float`, `integer`, `long`, `short`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/numeric/)
@@ -114,6 +114,9 @@ Derived source supports the following field types without requiring any changes 
 - [`wildcard`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/wildcard/)
 
 For a [`text`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/text/) field with derived source enabled, the field value is stored as a stored field by default. You do not need to set the `store` mapping parameter to `true`.
+{: .note}
+
+For [`wildcard`]({{site.url}}{{site.baseurl}}/field-types/supported-field-types/wildcard/) field with derived source, it requires mapping parameter [`doc_values`]({{site.url}}{{site.baseurl}}/field-types/mapping-parameters/doc-values/) to be set as `true`.
 {: .note}
 
 ### Limitations


### PR DESCRIPTION
### Description
Fix documentation for derived source with respect to wildcard field type as for wildcard we need to explicitly enabled doc values for derived source to be supported

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
