### PR TITLE
Update JDK version for 3.2 distributions

### DIFF
--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -32,6 +32,7 @@ OpenSearch Version | Compatible Java Versions | Bundled Java Version
 1.3.x          | 8, 11, 14  | 11.0.25+9
 2.0.0--2.11.x    | 11, 17     | 17.0.2+8
 2.12.0+        | 11, 17, 21 | 21.0.5+11
+3.2.0+        | 11, 17, 21 | 24.0.2+12
 
 To use a different Java installation, set the `OPENSEARCH_JAVA_HOME` or `JAVA_HOME` environment variable to the Java install location. For example:
 ```bash


### PR DESCRIPTION
### Description
- According to https://github.com/opensearch-project/common-utils/pull/848/files, the [documentation](https://docs.opensearch.org/3.2/install-and-configure/install-opensearch/index/#java-compatibility) explaining the java compatibility with OpenSearch needs to be fixed. ([source](https://github.com/opensearch-project/documentation-website/blob/3.2/_install-and-configure/install-opensearch/index.md?plain=1#L25-L34))
```
### OpenSearch 3.1.0 (Docker)
➜ docker exec -it ef158537b656a39d932de166c9ddb4d504296c1db6ced45aa935161422b5f354 /bin/bash
[opensearch@ef158537b656 ~]$ java --version
openjdk 21.0.7 2025-04-15 LTS
OpenJDK Runtime Environment Temurin-21.0.7+6 (build 21.0.7+6-LTS)
OpenJDK 64-Bit Server VM Temurin-21.0.7+6 (build 21.0.7+6-LTS, mixed mode, sharing)

### OpenSearch 3.2.0 (Docker)
➜ docker exec -it 75f0e5a4f9efe059bcb249aa0d8588f440b9882b3631d5e8668f2fe877360930 /bin/bash
[opensearch@75f0e5a4f9ef ~]$ java --version
openjdk 24.0.2 2025-07-15
OpenJDK Runtime Environment Temurin-24.0.2+12 (build 24.0.2+12)
OpenJDK 64-Bit Server VM Temurin-24.0.2+12 (build 24.0.2+12, mixed mode, sharing)
```
- [trivial] Even though the documentation for OpenSearch 3.1.0 specifies Java version 21.0.5+11, I'm currently using 21.0.7+6-LTS. Is it really necessary to be so specific about these minor version updates in the compatibility documentation?


### Issues Resolved
Closes #10820 
- https://github.com/opensearch-project/documentation-website/issues/10820

### Version
- OpenSearch `>=3.2.0`


### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
