### PR TITLE
Update MCP connector settings for OpenSearch 3.1

### DIFF
--- a/_ml-commons-plugin/agents-tools/mcp/mcp-connector.md
+++ b/_ml-commons-plugin/agents-tools/mcp/mcp-connector.md
@@ -23,7 +23,7 @@ Before using MCP tools, you must complete the following prerequisites.
 
 ### Enable MCP and configure trusted connector endpoints
 
-- Enable the MCP protocol by configuring the `plugins.ml_commons.mcp_feature_enabled` setting.
+- Enable the MCP protocol by configuring the `plugins.ml_commons.mcp_connector_enabled` setting.
 - Configure trusted connector endpoints in the `plugins.ml_commons.trusted_connector_endpoints_regex` setting. For security purposes, this setting uses regex patterns to define which MCP server URLs are allowed.
 
 To configure both settings, send the following request:
@@ -35,7 +35,7 @@ POST /_cluster/settings/
     "plugins.ml_commons.trusted_connector_endpoints_regex": [
       "<mcp server url>"
     ],
-    "plugins.ml_commons.mcp_feature_enabled": "true"
+    "plugins.ml_commons.mcp_connector_enabled": "true"
   }
 }
 ```


### PR DESCRIPTION
### Description

This PR updates the documentation and guidance for enabling the MCP protocol in OpenSearch 3.1.
Previously, documentation referred to `plugins.ml_commons.mcp_feature_enabled`, which is no longer recognized. The correct persistent setting is now `plugins.ml_commons.mcp_connector_enabled`.

### Issues Resolved

No issue related

### Version

Applies to OpenSearch 3.1 and later

### Frontend features

*No frontend changes; this is a documentation and configuration update.*

### Checklist

* [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [[Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin)](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

---

### Example cluster settings update

```json
PUT _cluster/settings
{
  "transient": {},
  "persistent": {
    "plugins.ml_commons.mcp_connector_enabled": "true",
    "plugins.ml_commons.trusted_connector_endpoints_regex": [
      "http://opensearch-mcp:9900"
    ]
  }
}
```

This replaces the previously suggested (but invalid) setting:

```json
"plugins.ml_commons.mcp_feature_enabled": "true"
```

Documentation link: [[Connecting to an external MCP server](https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/mcp/mcp-connector/)](https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/mcp/mcp-connector/)
