### PR TITLE
chore(assets/js): null checks before adding event listener to `Contribute` button in Home page

### DIFF
--- a/assets/js/home-listener.js
+++ b/assets/js/home-listener.js
@@ -1,5 +1,7 @@
 const contributeButton = document.getElementById('contribute');
 
-contributeButton.addEventListener('click', function(event) {
-    window.open('https://github.com/opensearch-project', '_blank');
-});
+if (contributeButton && contributeButton.addEventListener) {
+    contributeButton.addEventListener('click', function(event) {
+        window.open('https://github.com/opensearch-project', '_blank');
+    });
+}


### PR DESCRIPTION

### Description
_Describe what this change achieves._

Fixes a browser console error in Search page when opened in Edge

<img width="1319" height="485" alt="image" src="https://github.com/user-attachments/assets/44bb4bee-2f71-4c65-87b9-7aa28c6b9f8b" />


### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

N/A

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

To all published versions

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
