### PR TITLE
fix(search): forward to search result page to avoid redirection 

### DIFF
--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -253,7 +253,7 @@
 
         const navToResultsPage = () => {
             const query = encodeURIComponent(elInput.value);
-            window.location.href = `/docs/${docsVersion}/search.html?q=${query}`;
+            window.location.href = `/${docsVersion}/search.html?q=${query}`;
         }
 
         const navToResult = () => {


### PR DESCRIPTION
### Description
_Describe what this change achieves._

- Implemented a TODO item since the criteria is met; it sits at [94%](https://caniuse.com/?search=replaceChildren) now :D
- Remove the `/docs` prefix when navigating to search result page

Before
<img width="1377" height="98" alt="image" src="https://github.com/user-attachments/assets/df15c851-3777-481a-81a4-6bfe4ddd7197" />

After
<img width="1377" height="98" alt="image" src="https://github.com/user-attachments/assets/50e18613-d702-4938-8c41-750bac3bb8db" />


### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

Closes #10703

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

Latest and all

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
