### PR TITLE
Update documentation for msearch and search include_named_queries_score

### DIFF
--- a/_api-reference/search-apis/multi-search.md
+++ b/_api-reference/search-apis/multi-search.md
@@ -38,7 +38,7 @@ cancel_after_time_interval | Time | The time after which the search request will
 css_minimize_roundtrips | Boolean | Whether OpenSearch should try to minimize the number of network round trips between the coordinating node and remote clusters (only applicable to cross-cluster search requests). Default is `true`. | No
 expand_wildcards | Enum | Expands wildcard expressions to concrete indexes. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. Default is `open`. | Yes
 ignore_unavailable | Boolean | If an index or shard from the indexes list doesn’t exist, whether to ignore it rather than fail the query. Default is `false`. | Yes
-include_named_queries_score | Boolean | Whether to return scores with named queries. Default is `false`. | No
+include_named_queries_score | Boolean | Whether to return scores for named queries. Default is `false`. | No
 max_concurrent_searches | Integer | The maximum number of concurrent searches. The default depends on your node count and search thread pool size. Higher values can improve performance, but risk overloading the cluster. | No
 max_concurrent_shard_requests | Integer | Maximum number of concurrent shard requests that each search executes per node. Default is 5. Higher values can improve performance, but risk overloading the cluster. | No
 pre_filter_shard_size | Integer | Default is 128. | No

--- a/_api-reference/search-apis/multi-search.md
+++ b/_api-reference/search-apis/multi-search.md
@@ -38,6 +38,7 @@ cancel_after_time_interval | Time | The time after which the search request will
 css_minimize_roundtrips | Boolean | Whether OpenSearch should try to minimize the number of network round trips between the coordinating node and remote clusters (only applicable to cross-cluster search requests). Default is `true`. | No
 expand_wildcards | Enum | Expands wildcard expressions to concrete indexes. Combine multiple values with commas. Supported values are `all`, `open`, `closed`, `hidden`, and `none`. Default is `open`. | Yes
 ignore_unavailable | Boolean | If an index or shard from the indexes list doesn’t exist, whether to ignore it rather than fail the query. Default is `false`. | Yes
+include_named_queries_score | Boolean | Whether to return scores with named queries. Default is `false`. | No
 max_concurrent_searches | Integer | The maximum number of concurrent searches. The default depends on your node count and search thread pool size. Higher values can improve performance, but risk overloading the cluster. | No
 max_concurrent_shard_requests | Integer | Maximum number of concurrent shard requests that each search executes per node. Default is 5. Higher values can improve performance, but risk overloading the cluster. | No
 pre_filter_shard_size | Integer | Default is 128. | No

--- a/_api-reference/search-apis/search.md
+++ b/_api-reference/search-apis/search.md
@@ -45,7 +45,7 @@ explain | Boolean | Whether to return details about how OpenSearch computed the 
 from | Integer | The starting index to search from. Default is 0.
 ignore_throttled | Boolean | Whether to ignore concrete, expanded, or indexes with aliases if indexes are frozen. Default is `true`.
 ignore_unavailable | Boolean | Specifies whether to include missing or closed indexes in the response and ignores unavailable shards during the search request. Default is `false`.
-include_named_queries_score | Boolean | Whether to return scores with named queries. Default is `false`.
+include_named_queries_score | Boolean | Whether to return scores for named queries. Default is `false`.
 lenient | Boolean | Specifies whether OpenSearch should accept requests if queries have format errors (for example, querying a text field for an integer). Default is `false`.
 max_concurrent_shard_requests | Integer | How many concurrent shard requests this request should execute on each node. Default is 5.
 phase_took | Boolean | Whether to return phase-level `took` time values in the response. Default is `false`.
@@ -101,7 +101,7 @@ docvalue_fields | Array of objects | The fields that OpenSearch should return us
 fields | Array | The fields to search for in the request. Specify a format to return results in a certain format, such as date and time.
 explain | String | Whether to return details about how OpenSearch computed the document's score. Default is `false`.
 from | Integer | The starting index to search from. Default is 0.
-include_named_queries_score | Boolean | Whether to return scores with named queries.
+include_named_queries_score | Boolean | Whether to return scores for named queries.
 indices_boost | Array of objects | Values used to boost the score of specified indexes. Specify in the format of &lt;index&gt; : &lt;boost-multiplier&gt;
 min_score | Integer | Specify a score threshold to return only documents above the threshold.
 query | Object | The [DSL query]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/index/) to use in the request.

--- a/_api-reference/search-apis/search.md
+++ b/_api-reference/search-apis/search.md
@@ -45,6 +45,7 @@ explain | Boolean | Whether to return details about how OpenSearch computed the 
 from | Integer | The starting index to search from. Default is 0.
 ignore_throttled | Boolean | Whether to ignore concrete, expanded, or indexes with aliases if indexes are frozen. Default is `true`.
 ignore_unavailable | Boolean | Specifies whether to include missing or closed indexes in the response and ignores unavailable shards during the search request. Default is `false`.
+include_named_queries_score | Boolean | Whether to return scores with named queries. Default is `false`.
 lenient | Boolean | Specifies whether OpenSearch should accept requests if queries have format errors (for example, querying a text field for an integer). Default is `false`.
 max_concurrent_shard_requests | Integer | How many concurrent shard requests this request should execute on each node. Default is 5.
 phase_took | Boolean | Whether to return phase-level `took` time values in the response. Default is `false`.
@@ -74,7 +75,6 @@ track_scores | Boolean | Whether to return document scores. Default is `false`.
 track_total_hits | Boolean or Integer | Whether to return how many documents matched the query.
 typed_keys | Boolean | Whether returned aggregations and suggested terms should include their types in the response. Default is `true`.
 version | Boolean | Whether to include the document version as a match.
-include_named_queries_score | Boolean | Whether to return scores with named queries. Default is `false`.
 
 ### The `preference` query parameter
 
@@ -101,6 +101,7 @@ docvalue_fields | Array of objects | The fields that OpenSearch should return us
 fields | Array | The fields to search for in the request. Specify a format to return results in a certain format, such as date and time.
 explain | String | Whether to return details about how OpenSearch computed the document's score. Default is `false`.
 from | Integer | The starting index to search from. Default is 0.
+include_named_queries_score | Boolean | Whether to return scores with named queries.
 indices_boost | Array of objects | Values used to boost the score of specified indexes. Specify in the format of &lt;index&gt; : &lt;boost-multiplier&gt;
 min_score | Integer | Specify a score threshold to return only documents above the threshold.
 query | Object | The [DSL query]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/index/) to use in the request.


### PR DESCRIPTION
### Description
Updates the documentation for the `include_named_queries_score` parameter for the `msearch` and `search` endpoints, to go along with this PR https://github.com/opensearch-project/OpenSearch/pull/19241

### Issues Resolved
N/A

### Version
I presume just the latest version?

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
