### PR TITLE
Add sparse_embedding_format param for sparse_encoding/sparse_tokenize model

### DIFF
--- a/_ml-commons-plugin/pretrained-models.md
+++ b/_ml-commons-plugin/pretrained-models.md
@@ -286,9 +286,9 @@ The response contains text embeddings for the provided sentence:
 }
 ```
 
-### Sparse encoding model, sparse tokenize model
+### Sparse encoding model or sparse tokenizer
 
-For a sparse encoding model or sparse tokenize model, send the following request:
+For a sparse encoding model or sparse tokenizer, send the following request:
 
 ```json
 POST /_plugins/_ml/_predict/sparse_encoding/cleMb4kBJ1eYAeTMFFg4
@@ -298,7 +298,7 @@ POST /_plugins/_ml/_predict/sparse_encoding/cleMb4kBJ1eYAeTMFFg4
 ```
 {% include copy-curl.html %}
 
-The response contains the tokens and weights:
+The response contains the extracted tokens and their corresponding weights:
 
 ```json
 {
@@ -323,9 +323,7 @@ The response contains the tokens and weights:
 }
 ```
 
-You can control the output key format by setting `parameters.sparse_embedding_format` to `lexical` (default) or `token_id`.
-
-Example request (token ID keys):
+The preceding example uses the default `lexical` output format, which returns strings as keys. You can control the output key format by setting `parameters.sparse_embedding_format` to `lexical` (returns string tokens) or `token_id` (returns integer token IDs). The following example sets the `sparse_embedding_format` to `token_id`:
 
 ```json
 POST /_plugins/_ml/_predict/sparse_encoding/cleMb4kBJ1eYAeTMFFg4
@@ -338,7 +336,7 @@ POST /_plugins/_ml/_predict/sparse_encoding/cleMb4kBJ1eYAeTMFFg4
 ```
 {% include copy-curl.html %}
 
-Example response (token ID keys):
+The response contains the token IDs and their corresponding token weights:
 
 ```json
 {

--- a/_ml-commons-plugin/pretrained-models.md
+++ b/_ml-commons-plugin/pretrained-models.md
@@ -286,9 +286,9 @@ The response contains text embeddings for the provided sentence:
 }
 ```
 
-### Sparse encoding model
+### Sparse encoding model, sparse tokenize model
 
-For a sparse encoding model, send the following request:
+For a sparse encoding model or sparse tokenize model, send the following request:
 
 ```json
 POST /_plugins/_ml/_predict/sparse_encoding/cleMb4kBJ1eYAeTMFFg4
@@ -320,6 +320,44 @@ The response contains the tokens and weights:
           }
         }
     }
+}
+```
+
+You can control the output key format by setting `parameters.sparse_embedding_format` to `lexical` (default) or `token_id`.
+
+Example request (token ID keys):
+
+```json
+POST /_plugins/_ml/_predict/sparse_encoding/cleMb4kBJ1eYAeTMFFg4
+{
+  "text_docs": ["hello world"],
+  "parameters": {
+    "sparse_embedding_format": "token_id"
+  }
+}
+```
+{% include copy-curl.html %}
+
+Example response (token ID keys):
+
+```json
+{
+  "inference_results": [
+    {
+      "output": [
+        {
+          "dataAsMap": {
+            "response": [
+              {
+                "2088": 3.4208686,
+                "7592": 6.9377565
+              }
+            ]
+          }
+        }
+      ]
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
### Description
Add sparse_embedding_format param for sparse_encoding/sparse_tokenize model

### Issues Resolved
https://github.com/opensearch-project/ml-commons/pull/3963

### Version
3.3

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
