### PR TITLE
Add PyPI to using gRPC APIs section

### DIFF
--- a/_api-reference/grpc-apis/index.md
+++ b/_api-reference/grpc-apis/index.md
@@ -111,6 +111,7 @@ To submit gRPC requests, you must have a set of protobufs on the client side. Yo
 
 - **Raw protobufs**: Download the raw protobuf schema from the [OpenSearch Protobufs GitHub repository (v0.6.0)](https://github.com/opensearch-project/opensearch-protobufs/releases/tag/0.6.0). You can then generate client-side code using the protocol buffer compilers for the [supported languages](https://grpc.io/docs/languages/).
 - **Java client-side programs only**: Download the `opensearch-protobufs` jar from the [Maven Central repository](https://repo1.maven.org/maven2/org/opensearch/protobufs/0.6.0).
+- **Python client-side programs only**: Download the `opensearch-protobufs` package from the [PyPI repository](https://pypi.org/project/opensearch-protobufs/).
 
 ## Supported APIs
 


### PR DESCRIPTION
### Description
opensearch-protobufs now has python libraries available for use in client side applications.
Changes add these to `Using gRPC APIs` section alongside java client libraries.

### Issues Resolved
N/A

### Version
3.3

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
