### PR TITLE
doc(gen-ai/rag,vector-search/semantic-search): generate tmp AWS role creds programmatically

### DIFF
--- a/_tutorials/gen-ai/rag/rag-deepseek-chat.md
+++ b/_tutorials/gen-ai/rag/rag-deepseek-chat.md
@@ -120,7 +120,7 @@ Create an IAM role named `my_create_deepseek_connector_role` with the following 
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 4.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 4.
 
 - Permissions:
 
@@ -162,28 +162,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the DeepSeek chat model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 4.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 3.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step3.1 --role-session-name your_session_name
-```
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step3.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step3.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step3.1
-```
-{% include copy.html %}
-
-### Step 4.2: Create a connector
-
-Add the DeepSeek API endpoint to the trusted URL list:
+- Add the DeepSeek API endpoint to the trusted URL list:
 
 ```json
 PUT /_cluster/settings
@@ -197,7 +176,7 @@ PUT /_cluster/settings
 ```
 {% include copy-curl.html %}
 
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+- Run the following Python code with the temporary credentials fetched from AWS.
  
 ```python
 import boto3
@@ -208,8 +187,12 @@ host = 'your_amazon_opensearch_domain_endpoint'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step3.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path

--- a/_tutorials/gen-ai/rag/rag-deepseek-r1-bedrock.md
+++ b/_tutorials/gen-ai/rag/rag-deepseek-r1-bedrock.md
@@ -107,7 +107,7 @@ Create an IAM role named `my_create_bedrock_deepseek_connector_role` with the fo
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.
 
 - Permissions:
 
@@ -149,28 +149,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the DeepSeek-R1 model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 3.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 2.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step2.1 --role-session-name your_session_name
-```
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step2.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step2.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step2.1
-```
-{% include copy.html %}
-
-### Step 3.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the temporary credentials fetched from AWS.
 
 ```python
 import boto3
@@ -181,8 +160,12 @@ host = 'your_amazon_opensearch_domain_endpoint'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step2.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path

--- a/_tutorials/gen-ai/rag/rag-deepseek-r1-sagemaker.md
+++ b/_tutorials/gen-ai/rag/rag-deepseek-r1-sagemaker.md
@@ -111,7 +111,7 @@ Create an IAM role named `my_create_sagemaker_deepseek_connector_role` with the 
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.
 
 - Permissions:
 
@@ -153,28 +153,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the DeepSeek-R1 model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 3.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 2.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step2.1 --role-session-name your_session_name
-```
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step2.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step2.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step2.1
-```
-{% include copy.html %}
-
-### Step 3.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the one-time temporary credentials.
 
 ```python
 import boto3
@@ -185,8 +164,12 @@ host = 'your_amazon_opensearch_domain_endpoint'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step2.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 
 path = '/_plugins/_ml/connectors/_create'

--- a/_tutorials/reranking/reranking-by-field.md
+++ b/_tutorials/reranking/reranking-by-field.md
@@ -195,29 +195,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 1.4.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 3.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step3.1 --role-session-name your_session_name
-```
-
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step3.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step3.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step3.1
-```
-{% include copy.html %}
-
-### Step 1.4.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the temporary credentials fetched from AWS.
  
 ```python
 import boto3
@@ -228,8 +206,13 @@ host = 'your_amazon_opensearch_domain_endpoint_created_in_step0'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step1.3.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path
@@ -280,7 +263,7 @@ Note the connector ID; you'll use it in the next step.
 
 After successfully creating a connector using either the self-managed OpenSearch or Amazon OpenSearch Service method, you can register the Cohere Rerank model. 
 
-Use the connector ID from Step 1 to create a model:
+Use the connector ID from Step 1.4 to create a model:
 
 ```json
 POST /_plugins/_ml/models/_register?deploy=true

--- a/_tutorials/vector-search/semantic-search/semantic-search-bedrock-cohere.md
+++ b/_tutorials/vector-search/semantic-search/semantic-search-bedrock-cohere.md
@@ -107,7 +107,7 @@ Create an IAM role named `my_create_bedrock_cohere_connector_role` with the foll
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.
 
 - Permissions:
 
@@ -149,28 +149,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 3.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 2.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step2.1 --role-session-name your_session_name
-```
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step2.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step2.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step2.1
-```
-{% include copy.html %}
-
-### Step 3.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the temporary credentials fetched from AWS.
 
 ```python
 import boto3
@@ -181,8 +160,12 @@ host = 'your_amazon_opensearch_domain_endpoint'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step2.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path

--- a/_tutorials/vector-search/semantic-search/semantic-search-bedrock-titan-other.md
+++ b/_tutorials/vector-search/semantic-search/semantic-search-bedrock-titan-other.md
@@ -158,7 +158,7 @@ Create an IAM role named `my_create_connector_role_accountA` with the following 
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.
 
 - Permissions:
 
@@ -200,29 +200,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 3.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 2.2 to assume the role:
-
-```bash
-aws sts assume-role --role-arn arn:aws:iam::<your_aws_account_A>:role/my_create_connector_role_accountA --role-session-name your_session_name
-```
-
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step2.2
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step2.2
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step2.2
-```
-{% include copy.html %}
-
-### Step 3.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the temporary credentials fetched from AWS.
  
 ```python
 import boto3
@@ -233,8 +211,12 @@ host = 'your_amazon_opensearch_domain_endpoint_created'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step2.2",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path

--- a/_tutorials/vector-search/semantic-search/semantic-search-bedrock-titan.md
+++ b/_tutorials/vector-search/semantic-search/semantic-search-bedrock-titan.md
@@ -104,7 +104,7 @@ Create an IAM role named `my_create_bedrock_connector_role` with the following t
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.
 
 - Permissions:
 
@@ -146,28 +146,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 3.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 2.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step2.1 --role-session-name your_session_name
-```
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step2.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step2.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step2.1
-```
-{% include copy.html %}
-
-### Step 3.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the temporary credentials fetched from AWS.
  
 ```python
 import boto3
@@ -178,8 +157,12 @@ host = 'your_amazon_opensearch_domain_endpoint_created'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step2.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path

--- a/_tutorials/vector-search/semantic-search/semantic-search-openai.md
+++ b/_tutorials/vector-search/semantic-search/semantic-search-openai.md
@@ -114,7 +114,7 @@ Create an IAM role named `my_create_openai_connector_role` with the following tr
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 4.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 4.
 
 - Permissions:
 
@@ -156,28 +156,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the OpenAI model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 4.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 3.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step3.1 --role-session-name your_session_name
-```
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step3.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step3.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step3.1
-```
-{% include copy.html %}
-
-### Step 4.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the temporary credentials fetched from AWS.
  
 ```python
 import boto3
@@ -188,8 +167,12 @@ host = 'your_amazon_opensearch_domain_endpoint_created'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step3.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path

--- a/_tutorials/vector-search/semantic-search/semantic-search-sagemaker.md
+++ b/_tutorials/vector-search/semantic-search/semantic-search-sagemaker.md
@@ -202,7 +202,7 @@ Create an IAM role named `my_create_sagemaker_connector_role` with the following
 ```
 {% include copy.html %}
 
-You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.1.
+You'll use the `your_iam_user_arn` IAM user to assume the role in Step 3.
 
 - Permissions:
 
@@ -244,28 +244,7 @@ The IAM role is now successfully configured in your OpenSearch cluster.
 
 Follow these steps to create a connector for the model. For more information about creating a connector, see [Connectors]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/).
 
-### Step 3.1: Get temporary credentials
-
-Use the credentials of the IAM user specified in Step 2.1 to assume the role:
-
-```bash
-aws sts assume-role --role-arn your_iam_role_arn_created_in_step2.1 --role-session-name your_session_name
-```
-{% include copy.html %}
-
-Copy the temporary credentials from the response and configure them in `~/.aws/credentials`:
-
-```ini
-[default]
-AWS_ACCESS_KEY_ID=your_access_key_of_role_created_in_step2.1
-AWS_SECRET_ACCESS_KEY=your_secret_key_of_role_created_in_step2.1
-AWS_SESSION_TOKEN=your_session_token_of_role_created_in_step2.1
-```
-{% include copy.html %}
-
-### Step 3.2: Create a connector
-
-Run the following Python code with the temporary credentials configured in `~/.aws/credentials`:
+Run the following Python code with the temporary credentials fetched from AWS.
  
 ```python
 import boto3
@@ -276,9 +255,12 @@ host = 'your_amazon_opensearch_domain_endpoint'
 region = 'your_amazon_opensearch_domain_region'
 service = 'es'
 
-credentials = boto3.Session().get_credentials()
-awsauth = AWS4Auth(credentials.access_key, credentials.secret_key, region, service, session_token=credentials.token)
-
+assume_role_response = boto3.Session().client('sts').assume_role(
+  RoleArn="your_iam_role_arn_created_in_step2.1",
+  RoleSessionName="your_session_name"
+)
+credentials = assume_role_response["Credentials"]
+awsauth = AWS4Auth(credentials["AccessKeyId"], credentials["SecretAccessKey"], region, service, session_token=credentials["SessionToken"])
 
 path = '/_plugins/_ml/connectors/_create'
 url = host + path


### PR DESCRIPTION

### Description

All credit to @tavsec. 
Better user onboarding experience for semantic search and vector search to AI models in AWS OpenSearch Service. 

### Issues Resolved
Closes #9979 

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

2.19--3.2

Before
<img width="1502" height="879" alt="image" src="https://github.com/user-attachments/assets/a2e713c0-9984-485b-8af4-afa24e7f4e94" />


After
<img width="1502" height="879" alt="image" src="https://github.com/user-attachments/assets/d56c6d91-7b34-420e-9ee4-62e816062e1e" />

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
