### PR TITLE
Add link to tutorial from UBI index page

### DIFF
--- a/_search-plugins/ubi/index.md
+++ b/_search-plugins/ubi/index.md
@@ -36,7 +36,8 @@ Advanced features in OpenSearch, such as the [Search Relevance Workbench]({{site
   <tr style="vertical-align: top;">
     <td>
       <h2>Tutorials</h2>
-      <ul>                                        
+      <ul>    
+        <li><a href="{{site.url}}{{site.baseurl}}/search-plugins/ubi/ubi-aws-managed-services-tutorial/">Learn to use AWS OpenSearch Ingestion</a> pipelines for gathering UBI query and event data.</li>        
         <li><a href="{{site.url}}{{site.baseurl}}/search-plugins/ubi/ubi-dashboard-tutorial/">Learn to create custom dashboards</a> for visualizing UBI data.</li>    
         <li> Based on <a href="https://github.com/o19s/chorus-opensearch-edition">Chorus for OpenSearch</a> demo:
           <ul>


### PR DESCRIPTION
### Description
Tutorial is in left nav, but on index we have our internal doc links, and this should be listed under Tutorial.

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
all

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
