### PR TITLE
Field collapsing supports search_after parameter

### DIFF
--- a/_search-plugins/searching-data/collapse-search.md
+++ b/_search-plugins/searching-data/collapse-search.md
@@ -166,7 +166,7 @@ The `collapse` parameter affects only the top search results and does not change
 
 You can paginate collapsed search results using the `search_after` parameter. The collapsed field and sort field must be the same, and only one sort field can be specified.
 
-The following example shows how to use collapse with `search_after`:
+The following example shows how to use `collapse` with `search_after`:
 
 ```json
 GET /bakery-items/_search


### PR DESCRIPTION
### Description
Field collapsing supports search_after parameter.

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/10896

### Version
3.3.0


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
