### PR TITLE
Add support for a ForkJoinPool type - 18674

### DIFF
--- a/_install-and-configure/configuring-opensearch/thread-pool-settings.md
+++ b/_install-and-configure/configuring-opensearch/thread-pool-settings.md
@@ -61,7 +61,9 @@ Scaling thread pools support the following settings:
 
 - `thread_pool.<pool_name>.keep_alive` (Static, time unit): Determines how long idle threads are kept in the pool before being terminated. Threads above the core size are terminated after this period of inactivity.
 
-### ForkJoin thread pool (New in OpenSearch 3.2)
+### Fork-join thread pool
+**Introduced 3.2**
+{: .label .label-purple }
 
 Fork-join thread pools use the Java `ForkJoinPool` to provide efficient parallelism for workloads that benefit from work stealing and task splitting. This is useful for compute-intensive operations. In OpenSearch, fork-join thread pools support features that rely on parallel computation, such as the [OpenSearch jVector plugin](https://github.com/opensearch-project/opensearch-jvector), which accelerates index builds.
 


### PR DESCRIPTION
### Description
This PR updates the documentation to include information about the new ForkJoinPool thread pool type in OpenSearch. It explains the purpose, configuration options, and use cases for ForkJoinPool, which is now supported as a thread pool type for components that benefit from parallelism, such as jVector. 

### Issues Resolved
Closes #18664
Closes https://github.com/opensearch-project/OpenSearch/issues/18674

### Version
Applies to OpenSearch version 3.2 and later.

### Frontend features
N/A (documentation only)

### Checklist
- [X ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
