### PR TITLE
Corrects the documentation for the otel_trace processor

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/otel-traces.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-traces.md
@@ -12,7 +12,7 @@ The `otel_trace` processor completes trace-group-related fields in all incoming 
 
 ## Usage
 
-This processor adds the following fields to span events.
+This processor adds the following fields to span events:
 
 * `traceGroup`: Root span name
 * `endTime`: End time of the entire trace in International Organization for Standardization (ISO) 8601 format

--- a/_data-prepper/pipelines/configuration/processors/otel-traces.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-traces.md
@@ -10,9 +10,9 @@ nav_order: 260
 
 The `otel_trace` processor completes trace-group-related fields in all incoming OpenSearch Data Prepper span records by state caching the root span information for each `traceId`. 
 
-## Parameters
+## Usage
 
-This processor includes the following parameters.
+This processor adds the following fields to span events.
 
 * `traceGroup`: Root span name
 * `endTime`: End time of the entire trace in International Organization for Standardization (ISO) 8601 format


### PR DESCRIPTION
### Description

The Data Prepper `otel_trace` processor adds fields to events. But, the documentation indicates that these are parameters. This PR corrects that.

### Issues Resolved

N/A

### Version

Data Prepper - all versions

### Frontend features
N/A

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
