### PR TITLE
Add documentation for agentic search processors

### DIFF
--- a/_query-dsl/specialized/agentic.md
+++ b/_query-dsl/specialized/agentic.md
@@ -1,0 +1,57 @@
+---
+layout: default
+title: Agentic
+parent: Specialized queries
+nav_order: 2
+---
+
+# Agentic query
+**Introduced 3.2**
+{: .label .label-purple }
+
+Use the `agentic` query to ask questions in natural language and have OpenSearch automatically plan and execute the retrieval. The `agentic` query works in conjunction with a preconfigured agent that reads the question, plans the search, and returns relevant results. For more information about agentic search, see [Agentic search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/).
+
+**Prerequisite**<br>
+Before using an `agentic` query, you must configure an agent with the [`QueryPlanningTool`]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/tools/query-planning-tool/) and create a search pipeline with an `agentic_query_translator` search request processor.
+{: .note}
+
+## Request body fields
+
+The `agentic` query accepts the following fields.
+
+Field | Data type | Required/Optional | Description
+:--- | :--- | :--- | :---
+`query_text` | String | Required | The natural language question or request.
+`query_fields` | Array | Optional | A list of fields that the agent should consider when generating the search query. If not provided, the agent considers all available fields in the index mapping.
+
+## Example
+
+The following example uses an `agentic` query that asks a natural language question about flowers in an `iris` dataset. In this example, `query_text` contains the natural language question, `query_fields` specifies the fields to use when generating the query, and the `search-pipeline` query parameter specifies the search pipeline containing the agentic query translator processor:
+
+```json
+GET /iris-index/_search?search_pipeline=agentic-pipeline
+{
+  "query": {
+    "agentic": {
+      "query_text": "List all the flowers present",
+      "query_fields": ["species", "petal_length_in_cm"]
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+When executed, the agentic search request performs the following steps:
+
+1. Sends the natural language question, along with the index mapping and a default prompt, to a large language model (LLM).
+2. The LLM generates a query domain-specific language (DSL) query based on the input.
+3. The generated DSL query is executed as a search request in OpenSearch.
+4. Returns the search results based on the generated query.
+
+For a complete example, see [Agentic search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/).
+
+## Next steps
+
+- Learn how to set up agentic search in [Agentic search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/).
+- Learn about configuring agents in [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/).
+- Learn about the [QueryPlanningTool]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/tools/query-planning-tool/).

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -14,7 +14,7 @@ OpenSearch supports the following specialized queries:
 
 - [`agentic`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/agentic/): Uses natural language questions that are automatically planned and executed by an agent with a large language model.
 
-- `distance_feature`: Calculates document scores based on the dynamically calculated distance between the origin and a document's `date`, `date_nanos`, or `geo_point` fields. This query can skip non-competitive hits.
+- [`distance_feature`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/distance-feature/): Calculates document scores based on the dynamically calculated distance between the origin and a document's `date`, `date_nanos`, or `geo_point` fields. This query can skip non-competitive hits.
 
 - [`knn`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/k-nn/): Used for searching raw vectors during [vector search]({{site.url}}{{site.baseurl}}/vector-search/).
 
@@ -32,6 +32,6 @@ OpenSearch supports the following specialized queries:
 
 - [`script_score`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script-score/): Calculates a custom score for matching documents using a script.
 
-- `template`: Allows you to use mustache templating in queries.
+- [`template`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/template/): Allows you to use mustache templating in queries.
 
 - [`wrapper`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/wrapper/): Accepts other queries as JSON or YAML strings.

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -12,11 +12,13 @@ redirect_from:
 
 OpenSearch supports the following specialized queries:
 
+- [`agentic`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/agentic/): Uses natural language questions that are automatically planned and executed by an agent with a large language model.
+
 - `distance_feature`: Calculates document scores based on the dynamically calculated distance between the origin and a document's `date`, `date_nanos`, or `geo_point` fields. This query can skip non-competitive hits.
 
-- [`more_like_this`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/more-like-this/): Finds documents similar to the provided text, document, or collection of documents.
-
 - [`knn`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/k-nn/): Used for searching raw vectors during [vector search]({{site.url}}{{site.baseurl}}/vector-search/).
+
+- [`more_like_this`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/more-like-this/): Finds documents similar to the provided text, document, or collection of documents.
 
 - [`neural`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/neural/): Used for searching by text or image in [vector search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/).
 
@@ -29,5 +31,7 @@ OpenSearch supports the following specialized queries:
 - [`script`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script/): Uses a script as a filter.
 
 - [`script_score`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script-score/): Calculates a custom score for matching documents using a script.
+
+- `template`: Allows you to use mustache templating in queries.
 
 - [`wrapper`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/wrapper/): Accepts other queries as JSON or YAML strings.

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -32,6 +32,6 @@ OpenSearch supports the following specialized queries:
 
 - [`script_score`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script-score/): Calculates a custom score for matching documents using a script.
 
-- [`template`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/template/): Allows you to use mustache templating in queries.
+- [`template`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/template/): Allows you to use Mustache templating in queries.
 
 - [`wrapper`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/wrapper/): Accepts other queries as JSON or YAML strings.

--- a/_query-dsl/specialized/k-nn/index.md
+++ b/_query-dsl/specialized/k-nn/index.md
@@ -3,7 +3,7 @@ layout: default
 title: k-NN
 parent: Specialized queries
 has_children: true
-nav_order: 10
+nav_order: 15
 redirect_from:
   - /query-dsl/specialized/k-nn/
 ---

--- a/_search-plugins/search-pipelines/agentic-context-processor.md
+++ b/_search-plugins/search-pipelines/agentic-context-processor.md
@@ -35,6 +35,7 @@ When enabled, the processor adds the following fields to the search response ext
 Field | Description
 :--- | :---
 `agent_steps_summary` | A summary of the steps that the agent took to translate the natural language query (included when `agent_steps_summary` is `true`).
+`memory_id` | The conversation memory ID for maintaining context across queries. Only provide this in the agentic query if you want to continue the previous conversation.
 `dsl_query` | The generated DSL query that was executed (included when `dsl_query` is `true`).
 
 ## Example

--- a/_search-plugins/search-pipelines/agentic-context-processor.md
+++ b/_search-plugins/search-pipelines/agentic-context-processor.md
@@ -11,7 +11,7 @@ grand_parent: Search pipelines
 **Introduced 3.3**
 {: .label .label-purple }
 
-The `agentic_context` search response processor adds agent execution context information to search response extensions. This processor works in conjunction with the [agentic query translator]({{site.url}}{{site.baseurl}}/search-plugins/agentic-query-translator/) to expose the agent's query translation process and maintain conversation continuity:
+The `agentic_context` search response processor adds agent execution context information to search response extensions. This processor works in conjunction with the [agentic query translator]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) to expose the agent's query translation process and maintain conversation continuity:
 
 1. The processor retrieves agent context information from the pipeline processing context.
 2. Based on the processor configuration, it selectively includes agent steps summary and DSL query in the response.

--- a/_search-plugins/search-pipelines/agentic-context-processor.md
+++ b/_search-plugins/search-pipelines/agentic-context-processor.md
@@ -1,17 +1,23 @@
 ---
 layout: default
 title: Agentic context
-nav_order: 70
+nav_order: 2
 has_children: false
 parent: Search processors
 grand_parent: Search pipelines
 ---
 
 # Agentic context processor
-Introduced 3.3
+**Introduced 3.3**
 {: .label .label-purple }
 
-The `agentic_context` search response processor adds agent execution context information to search response extensions. This processor works in conjunction with the [agentic query translator]({{site.url}}{{site.baseurl}}/search-plugins/agentic-query-translator/) to provide transparency into the agent's query translation process and maintain conversation continuity.
+The `agentic_context` search response processor adds agent execution context information to search response extensions. This processor works in conjunction with the [agentic query translator]({{site.url}}{{site.baseurl}}/search-plugins/agentic-query-translator/) to expose the agent's query translation process and maintain conversation continuity:
+
+1. The processor retrieves agent context information from the pipeline processing context.
+2. Based on the processor configuration, it selectively includes agent steps summary and DSL query in the response.
+3. The memory ID is always included when available for conversation continuity.
+4. The context information is added to the search response extensions.
+5. Type validation ensures that all context attributes are strings.
 
 ## Request body fields
 
@@ -24,12 +30,12 @@ Field | Data type | Description
 
 ## Response fields
 
-When enabled, the processor adds the following fields to the search response extensions:
+When enabled, the processor adds the following fields to the search response extensions.
 
 Field | Description
 :--- | :---
-`agent_steps_summary` | A summary of the steps the agent took to translate the natural language query (included when `agent_steps_summary` is `true`)
-`dsl_query` | The generated DSL query that was executed (included when `dsl_query` is `true`)
+`agent_steps_summary` | A summary of the steps that the agent took to translate the natural language query (included when `agent_steps_summary` is `true`).
+`dsl_query` | The generated DSL query that was executed (included when `dsl_query` is `true`).
 
 ## Example
 
@@ -57,9 +63,7 @@ PUT /_search/pipeline/agentic_pipeline
 ```
 {% include copy-curl.html %}
 
-## Usage
-
-When you perform a search with the configured pipeline, the response will include agent context information:
+Perform a search using the configured pipeline:
 
 ```json
 POST /your-index/_search?search_pipeline=agentic_search_pipeline
@@ -74,7 +78,7 @@ POST /your-index/_search?search_pipeline=agentic_search_pipeline
 ```
 {% include copy-curl.html %}
 
-### Example response
+The response contains the steps taken by the agent to translate the query, the memory ID, and the rewritten DSL query:
 
 ```json
 {
@@ -91,10 +95,8 @@ POST /your-index/_search?search_pipeline=agentic_search_pipeline
 }
 ```
 
-## How it works
+## Related articles
 
-1. The processor retrieves agent context information from the pipeline processing context
-2. Based on configuration, it selectively includes agent steps summary and DSL query
-3. Memory ID is always included when available for conversation continuity
-4. The context information is added to the search response extensions
-5. Type validation ensures all context attributes are strings
+- [Agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search)
+- [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/index/)
+- [Agentic query translator processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/)

--- a/_search-plugins/search-pipelines/agentic-context-processor.md
+++ b/_search-plugins/search-pipelines/agentic-context-processor.md
@@ -14,8 +14,8 @@ grand_parent: Search pipelines
 The `agentic_context` search response processor adds agent execution context information to search response extensions. This processor works in conjunction with the [agentic query translator]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) to expose the agent's query translation process and maintain conversation continuity:
 
 1. The processor retrieves agent context information from the pipeline processing context.
-2. Based on the processor configuration, it selectively includes agent steps summary and DSL query in the response.
-3. The memory ID is always included when available for conversation continuity.
+2. Based on the processor configuration, it selectively includes the agent steps summary and the query domain-specific language (DSL) query in the response.
+3. The memory ID is always included, when available, for conversation continuity.
 4. The context information is added to the search response extensions.
 5. Type validation ensures that all context attributes are strings.
 
@@ -35,7 +35,7 @@ When enabled, the processor adds the following fields to the search response ext
 Field | Description
 :--- | :---
 `agent_steps_summary` | A summary of the steps that the agent took to translate the natural language query (included when `agent_steps_summary` is `true`).
-`memory_id` | The conversation memory ID for maintaining context across queries. Only provide this in the agentic query if you want to continue the previous conversation.
+`memory_id` | The conversation memory ID for maintaining context across queries. Only provide this in the `agentic` query if you want to continue the previous conversation.
 `dsl_query` | The generated DSL query that was executed (included when `dsl_query` is `true`).
 
 ## Example
@@ -96,7 +96,7 @@ The response contains the steps taken by the agent to translate the query, the m
 }
 ```
 
-## Related articles
+## Related pages
 
 - [Agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search)
 - [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/index/)

--- a/_search-plugins/search-pipelines/agentic-context-processor.md
+++ b/_search-plugins/search-pipelines/agentic-context-processor.md
@@ -1,0 +1,100 @@
+---
+layout: default
+title: Agentic context
+nav_order: 70
+has_children: false
+parent: Search processors
+grand_parent: Search pipelines
+---
+
+# Agentic context processor
+Introduced 3.3
+{: .label .label-purple }
+
+The `agentic_context` search response processor adds agent execution context information to search response extensions. This processor works in conjunction with the [agentic query translator]({{site.url}}{{site.baseurl}}/search-plugins/agentic-query-translator/) to provide transparency into the agent's query translation process and maintain conversation continuity.
+
+## Request body fields
+
+The following table lists all available request fields.
+
+Field | Data type | Description
+:--- | :--- | :---
+`agent_steps_summary` | Boolean | Whether to include the agent's execution steps summary in the response. Default is `false`. Optional.
+`dsl_query` | Boolean | Whether to include the generated DSL query in the response. Default is `false`. Optional.
+
+## Response fields
+
+When enabled, the processor adds the following fields to the search response extensions:
+
+Field | Description
+:--- | :---
+`agent_steps_summary` | A summary of the steps the agent took to translate the natural language query (included when `agent_steps_summary` is `true`)
+`dsl_query` | The generated DSL query that was executed (included when `dsl_query` is `true`)
+
+## Example
+
+The following example request creates a search pipeline with an `agentic_context` response processor:
+
+```json
+PUT /_search/pipeline/agentic_pipeline
+{
+  "request_processors": [
+    {
+      "agentic_query_translator": {
+        "agent_id": "your-agent-id"
+      }
+    }
+  ],
+  "response_processors": [
+    {
+      "agentic_context": {
+        "agent_steps_summary": true,
+        "dsl_query": true
+      }
+    }
+  ]
+}
+```
+{% include copy-curl.html %}
+
+## Usage
+
+When you perform a search with the configured pipeline, the response will include agent context information:
+
+```json
+POST /your-index/_search?search_pipeline=agentic_search_pipeline
+{
+    "query": {
+        "agentic": {
+            "query_text": "Show me shoes in white color",
+            "memory_id": "your memory id"
+        }
+    }
+}
+```
+{% include copy-curl.html %}
+
+### Example response
+
+```json
+{
+  "took": 15,
+  "hits": {
+    "_shards": {...},
+    "hits": [...]
+  },
+   "ext": {
+        "agent_steps_summary": "I have these tools available: [ListIndexTool, IndexMappingTool, query_planner_tool]\\nFirst I used: ListIndexTool — input: \"\"; context gained: \"Discovered products-index which seems relevant for products and pricing context\"\\nSecond I used: IndexMappingTool — input: \"products-index\"; context gained: \"Confirmed presence of category and price fields in products-index\"\\nThird I used: query_planner_tool — qpt.question: \"Show me shoes that cost exactly 100 dollars.\"; index_name_provided: \"products-index\"\\nValidation: qpt output is valid and accurately reflects the request for shoes priced at 100 dollars.",
+        "memory_id": "WVhHiJkBnqovov2plcDH",
+        "dsl_query": "{\"query\":{\"bool\":{\"filter\":[{\"term\":{\"category\":\"shoes\"}},{\"term\":{\"price\":100.0}}]}}}"
+    }
+}
+```
+
+## How it works
+
+1. The processor retrieves agent context information from the pipeline processing context
+2. Based on configuration, it selectively includes agent steps summary and DSL query
+3. Memory ID is always included when available for conversation continuity
+4. The context information is added to the search response extensions
+5. Type validation ensures all context attributes are strings

--- a/_search-plugins/search-pipelines/agentic-query-translator-processor.md
+++ b/_search-plugins/search-pipelines/agentic-query-translator-processor.md
@@ -11,9 +11,9 @@ grand_parent: Search pipelines
 **Introduced 3.2**
 {: .label .label-purple }
 
-The `agentic_query_translator` search request processor enables natural language search by translating user queries into OpenSearch DSL queries using machine learning agents. It works with [agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search) to provide conversational search capabilities:
+The `agentic_query_translator` search request processor enables natural language search by translating user queries into OpenSearch query domain-specific language (DSL) queries using machine learning (ML) agents. It works with [agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search) to provide conversational search capabilities:
 
-1. The processor sends the user’s natural language query to the specified ML agent.
+1. The processor sends the user's natural language query to the specified ML agent.
 2. The agent translates the query into OpenSearch DSL.
 3. The original query is replaced with the generated DSL query.
 
@@ -22,7 +22,7 @@ This processor only works with the `agentic` query type as the top-level query.
 
 ## Prerequisites
 
-Before using the agentic query translator processor, you must have either a conversational or flow agent configured. For more information, see [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/index/).
+Before using the `agentic_query_translator` processor, you must have either a conversational or flow agent configured. For more information, see [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/index/).
 
 ## Request body fields
 
@@ -125,7 +125,7 @@ The response contains the matching documents:
 }
 ```
 
-## Related articles
+## Related pages
 
 - [Agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search)
 - [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/index/)

--- a/_search-plugins/search-pipelines/agentic-query-translator-processor.md
+++ b/_search-plugins/search-pipelines/agentic-query-translator-processor.md
@@ -1,22 +1,28 @@
 ---
 layout: default
 title: Agentic query translator
-nav_order: 60
+nav_order: 5
 has_children: false
 parent: Search processors
 grand_parent: Search pipelines
 ---
 
 # Agentic query translator processor
-Introduced 3.2
+**Introduced 3.2**
 {: .label .label-purple }
 
-The `agentic_query_translator` search request processor enables natural language search by translating user queries into OpenSearch DSL queries using machine learning agents. This processor works with [agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search) to provide conversational search capabilities.
+The `agentic_query_translator` search request processor enables natural language search by translating user queries into OpenSearch DSL queries using machine learning agents. It works with [agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search) to provide conversational search capabilities:
+
+1. The processor sends the user’s natural language query to the specified ML agent.
+2. The agent translates the query into OpenSearch DSL.
+3. The original query is replaced with the generated DSL query.
+
+This processor only works with the `agentic` query type as the top-level query.
+{: .note}
 
 ## Prerequisites
 
-- A configured ML agent (conversational or flow type) must be available
-- The processor only works with `agentic` query type as the top-level query
+Before using the agentic query translator processor, you must have either a conversational or flow agent configured. For more information, see [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/index/).
 
 ## Request body fields
 
@@ -45,9 +51,9 @@ PUT /_search/pipeline/agentic_search_pipeline
 ```
 {% include copy-curl.html %}
 
-## Usage with agentic search query
+## Usage
 
-To use the processor, send a search request with an `agentic` query:
+To use the processor, run an `agentic` query:
 
 ```json
 POST /your-index/_search?search_pipeline=agentic_search_pipeline
@@ -59,8 +65,9 @@ POST /your-index/_search?search_pipeline=agentic_search_pipeline
     }
 }
 ```
+{% include copy-curl.html %}
 
-returns
+The response contains the matching documents:
 
 ```json
 {
@@ -118,8 +125,8 @@ returns
 }
 ```
 
-## How it works
+## Related articles
 
-1. The processor calls the specified ML agent with the natural language query
-2. The agent translates the query into proper OpenSearch DSL
-3. The original query is replaced with the generated DSL query
+- [Agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search)
+- [Agents]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/agents/index/)
+- [Agentic context processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-context-processor/)

--- a/_search-plugins/search-pipelines/agentic-query-translator-processor.md
+++ b/_search-plugins/search-pipelines/agentic-query-translator-processor.md
@@ -1,0 +1,125 @@
+---
+layout: default
+title: Agentic query translator
+nav_order: 60
+has_children: false
+parent: Search processors
+grand_parent: Search pipelines
+---
+
+# Agentic query translator processor
+Introduced 3.2
+{: .label .label-purple }
+
+The `agentic_query_translator` search request processor enables natural language search by translating user queries into OpenSearch DSL queries using machine learning agents. This processor works with [agentic search queries]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search) to provide conversational search capabilities.
+
+## Prerequisites
+
+- A configured ML agent (conversational or flow type) must be available
+- The processor only works with `agentic` query type as the top-level query
+
+## Request body fields
+
+The following table lists all available request fields.
+
+Field | Data type | Description
+:--- | :--- | :---
+`agent_id` | String | The ID of the ML agent that will translate natural language queries into DSL queries. Required.
+
+
+## Example
+
+The following example request creates a search pipeline with an `agentic_query_translator` processor:
+
+```json
+PUT /_search/pipeline/agentic_search_pipeline
+{
+  "request_processors": [
+    {
+      "agentic_query_translator": {
+        "agent_id": "your-agent-id-here"
+      }
+    }
+  ]
+}
+```
+{% include copy-curl.html %}
+
+## Usage with agentic search query
+
+To use the processor, send a search request with an `agentic` query:
+
+```json
+POST /your-index/_search?search_pipeline=agentic_search_pipeline
+{
+    "query": {
+        "agentic": {
+            "query_text": "Show me shoes in white color"
+        }
+    }
+}
+```
+
+returns
+
+```json
+{
+    "took": 6031,
+    "timed_out": false,
+    "_shards": {
+        "total": 8,
+        "successful": 8,
+        "skipped": 0,
+        "failed": 0
+    },
+    "hits": {
+        "total": {
+            "value": 8,
+            "relation": "eq"
+        },
+        "max_score": 0.0,
+        "hits": [
+            {
+                "_index": "products-index",
+                "_id": "43",
+                "_score": 0.0,
+                "_source": {
+                    "product_name": "Nike Air Max white",
+                    "description": "Red cushioned sneakers",
+                    "price": 140.0,
+                    "currency": "USD",
+                    "in_stock": true,
+                    "color": "white",
+                    "size": "10",
+                    "product_id": "P6001",
+                    "category": "shoes",
+                    "brand": "Nike"
+                }
+            },
+            {
+                "_index": "products-index",
+                "_id": "45",
+                "_score": 0.0,
+                "_source": {
+                    "product_name": "Adidas Superstar white",
+                    "description": "Classic black sneakers",
+                    "price": 100.0,
+                    "currency": "USD",
+                    "in_stock": true,
+                    "color": "white",
+                    "size": "8",
+                    "product_id": "P6003",
+                    "category": "shoes",
+                    "brand": "Adidas"
+                }
+            }
+        ]
+    }
+}
+```
+
+## How it works
+
+1. The processor calls the specified ML agent with the natural language query
+2. The agent translates the query into proper OpenSearch DSL
+3. The original query is replaced with the generated DSL query

--- a/_search-plugins/search-pipelines/search-processors.md
+++ b/_search-plugins/search-pipelines/search-processors.md
@@ -22,7 +22,7 @@ The following table lists all supported search request processors.
 
 Processor | Description | Earliest available version
 :--- | :--- | :---
-[`agentic_query_translator`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) | Translates `agentic` queries into OpenSearch query DSL and executes an agent to process the query. | 3.2
+[`agentic_query_translator`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) | Translates `agentic` queries into OpenSearch query domain-specific language (DSL) and executes an agent to process the query. | 3.2
 [`filter_query`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/filter-query-processor/) | Adds a filtering query that is used to filter requests. | 2.8
 [`ml_inference`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/ml-inference-search-request/) | Invokes registered machine learning (ML) models in order to rewrite queries. | 2.16 
 [`neural_query_enricher`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/neural-query-enricher/) | Sets a default model for neural search and neural sparse search at the index or field level. | 2.11 (neural), 2.13 (neural sparse)

--- a/_search-plugins/search-pipelines/search-processors.md
+++ b/_search-plugins/search-pipelines/search-processors.md
@@ -28,6 +28,7 @@ Processor | Description | Earliest available version
 [`neural_sparse_two_phase_processor`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/neural-sparse-query-two-phase-processor/) | Accelerates the neural sparse query. | 2.15
 [`oversample`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/oversample-processor/) | Increases the search request `size` parameter, storing the original value in the pipeline state.  | 2.12
 [`script`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/script-processor/) | Adds a script that is run on newly indexed documents. | 2.8
+[`agentic_query_translator`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) | Executes agent for agentic query | 3.2
 
 ## Search response processors
 
@@ -47,6 +48,7 @@ Processor | Description | Earliest available version
 [`sort`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/sort-processor/)| Sorts an array of items in either ascending or descending order. | 2.16
 [`split`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/split-processor/)| Splits a string field into an array of substrings based on a specified delimiter. | 2.17
 [`truncate_hits`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/truncate-hits-processor/)| Discards search hits after a specified target count is reached. Can undo the effect of the `oversample` request processor.  | 2.12
+[`agentic_context`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-context-processor/)| Used for agentic query to return agent summary, generated query and memory id | 3.3
 
 
 ## Search phase results processors

--- a/_search-plugins/search-pipelines/search-processors.md
+++ b/_search-plugins/search-pipelines/search-processors.md
@@ -22,13 +22,13 @@ The following table lists all supported search request processors.
 
 Processor | Description | Earliest available version
 :--- | :--- | :---
+[`agentic_query_translator`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) | Translates `agentic` queries into OpenSearch query DSL and executes an agent to process the query. | 3.2
 [`filter_query`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/filter-query-processor/) | Adds a filtering query that is used to filter requests. | 2.8
 [`ml_inference`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/ml-inference-search-request/) | Invokes registered machine learning (ML) models in order to rewrite queries. | 2.16 
 [`neural_query_enricher`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/neural-query-enricher/) | Sets a default model for neural search and neural sparse search at the index or field level. | 2.11 (neural), 2.13 (neural sparse)
 [`neural_sparse_two_phase_processor`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/neural-sparse-query-two-phase-processor/) | Accelerates the neural sparse query. | 2.15
 [`oversample`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/oversample-processor/) | Increases the search request `size` parameter, storing the original value in the pipeline state.  | 2.12
 [`script`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/script-processor/) | Adds a script that is run on newly indexed documents. | 2.8
-[`agentic_query_translator`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) | Executes agent for agentic query | 3.2
 
 ## Search response processors
 
@@ -38,6 +38,7 @@ The following table lists all supported search response processors.
 
 Processor | Description | Earliest available version
 :--- | :--- | :---
+[`agentic_context`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-context-processor/)| Returns the agent summary, generated query, and memory ID for an `agentic` query. | 3.3
 [`collapse`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/collapse-processor/)| Deduplicates search hits based on a field value, similarly to `collapse` in a search request. | 2.12
 [`hybrid_score_explanation`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/explanation-processor/)| Adds detailed scoring information to search results when the `explain` parameter is enabled, providing information about score normalization, combination techniques, and individual score calculations in hybrid queries.  | 2.19
 [`ml_inference`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/ml-inference-search-response/) | Invokes registered machine learning (ML) models in order to incorporate model output as additional search response fields. | 2.16 
@@ -48,8 +49,6 @@ Processor | Description | Earliest available version
 [`sort`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/sort-processor/)| Sorts an array of items in either ascending or descending order. | 2.16
 [`split`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/split-processor/)| Splits a string field into an array of substrings based on a specified delimiter. | 2.17
 [`truncate_hits`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/truncate-hits-processor/)| Discards search hits after a specified target count is reached. Can undo the effect of the `oversample` request processor.  | 2.12
-[`agentic_context`]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-context-processor/)| Used for agentic query to return agent summary, generated query and memory id | 3.3
-
 
 ## Search phase results processors
 

--- a/_vector-search/ai-search/agentic-search.md
+++ b/_vector-search/ai-search/agentic-search.md
@@ -7,10 +7,11 @@ has_children: false
 ---
 
 # Agentic search
+
 This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).    
 {: .warning}
 
-Introduced 3.2
+**Introduced 3.2**
 {: .label .label-purple }
 
 Agentic search lets users ask questions in natural language and have OpenSearch plan and execute the retrieval automatically. A preconfigured **agent** reads the question, plans the search, and returns relevant results.

--- a/_vector-search/api/neural.md
+++ b/_vector-search/api/neural.md
@@ -20,7 +20,7 @@ By default, the Neural Search Stats API is disabled through a cluster setting. T
 PUT /_cluster/settings
 {
   "persistent": {
-    "plugins.neural_search.stats_enabled": "true"
+    "plugins.neural_search.stats_enabled": true
   }
 }
 ```


### PR DESCRIPTION
### Description
Add documentation for agentic search processors
- Agentic Query Translator - Request Processor
- Agentic Context - Response Processor

### Issues Resolved
Part of https://github.com/opensearch-project/documentation-website/issues/11026

### Version
3.3

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
