### PR TITLE
Update sm-api.md to include snapshot pattern deletion feature

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/snapshots/sm-api.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/sm-api.md
@@ -71,7 +71,8 @@ POST _plugins/_sm/policies/daily-policy
       "max_count": 21,
       "min_count": 7
     },
-    "time_limit": "1h"
+    "time_limit": "1h",
+    "snapshot_pattern": "external-backup-*"
   },
   "snapshot_config": {
     "date_format": "yyyy-MM-dd-HH:mm",
@@ -132,7 +133,8 @@ POST _plugins/_sm/policies/daily-policy
         "min_count" : 7,
         "max_count" : 21
       },
-      "time_limit" : "1h"
+      "time_limit" : "1h",
+      "snapshot_pattern" : "external-backup-*"
     },
     "snapshot_config" : {
       "indices" : "*",
@@ -188,7 +190,7 @@ Parameter | Type | Description
 `snapshot_config.include_global_state` | Boolean | Do you want to include cluster state? Optional. Default is `true` because of [Security plugin considerations]({{site.url}}{{site.baseurl}}/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore#security-considerations).
 `snapshot_config.partial` | Boolean | Do you want to allow partial snapshots? Optional. Default is `false`.
 `snapshot_config.metadata` | Object | Metadata in the form of key/value pairs. Optional.
-`creation` | Object | Configuration for snapshot creation. Required.
+`creation` | Object | Configuration for snapshot creation. Optional. (This parameter is optional only for OpenSearch 3.3 and later; it should not be left unset until all nodes are upgraded to 3.3 or later.)
 `creation.schedule` | String | The cron schedule used to create snapshots. Required.
 `creation.time_limit` | String | Sets the maximum time to wait for snapshot creation to finish. If time_limit is longer than the scheduled time interval for taking snapshots, no scheduled snapshots are taken until time_limit elapses. For example, if time_limit is set to 35 minutes and snapshots are taken every 30 minutes starting at midnight, the snapshots at 00:00 and 01:00 are taken, but the snapshot at 00:30 is skipped. Optional. 
 `deletion` | Object | Configuration for snapshot deletion. Optional. Default is to retain all snapshots.
@@ -198,6 +200,7 @@ Parameter | Type | Description
 `deletion.delete_condition.max_count` | Integer | The maximum number of snapshots to be retained. Optional.
 `deletion.delete_condition.max_age` | String | The maximum time a snapshot is retained. Optional.
 `deletion.delete_condition.min_count` | Integer | The minimum number of snapshots to be retained. Optional. Default is `1`.
+`deletion.snapshot_pattern` | String | Additional snapshot patterns to include in deletion. This allows deletion of snapshots that match the specified pattern in addition to the policy's own snapshots. Supports wildcards (`*`). Optional.
 `notification` | Object | Defines notifications for SM events. Optional.
 `notification.channel` | Object | Defines a channel for notifications. You must [create and configure a notification channel]({{site.url}}{{site.baseurl}}/notifications-plugin/api) before setting up SM notifications. Required.
 `notification.channel.id` | String | The channel ID of the channel used for notifications. To get the channel IDs of all created channels, use `GET _plugins/_notifications/configs`. Required.
@@ -271,7 +274,8 @@ GET _plugins/_sm/policies/daily-policy
         "min_count" : 7,
         "max_count" : 21
       },
-      "time_limit" : "1h"
+      "time_limit" : "1h",
+      "snapshot_pattern" : "external-backup-*"
     },
     "snapshot_config" : {
       "metadata" : {


### PR DESCRIPTION
### Description
This PR updates snapshot management API docs according to feature added in [this PR](https://github.com/opensearch-project/index-management/pull/1452 ). This change is for opensearch 3.3. This feature introduces a new `snapshot_pattern` field in deletion and make `creation` optional.

### Issues Resolved
Closes #11130 

### Version
Opensearch 3.3 and above 

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
