### PR TITLE
Add principal attributes description to Rule-based Auto-tagging documentation

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
+++ b/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
@@ -29,7 +29,7 @@ Rule-based auto-tagging provides a flexible framework for implementing feature-s
 Before reviewing the rule configuration and behavior, it's important to understand the following key components of rule-based auto-tagging:
 
 * **Rule**: Defines matching criteria (attributes) and the value to assign.
-* **Attributes**: Key-value pairs used to match rules (such as index patterns, user roles, or request types).
+* **Attributes**: Key-value pairs used to match rules (such as index patterns, username, user roles, or request types).
 * **Feature-specific value**: The value assigned when a rule matches.
 * **Pattern matching**: The matching behavior (exact or pattern based) for attribute values.
 
@@ -44,7 +44,11 @@ The following rule schema includes matching attributes and a feature-specific va
 ```json
 {
   "_id": "fwehf8302582mglfio349==",  
-  "index_pattern": ["logs-prod-*"],  
+  "index_pattern": ["logs-prod-*"],
+  "principal": {
+    "username": ["admin"],
+    "role": ["all_access"]
+  },
   "other_attribute": ["value1", "value2"],
   "workload_group": "production_workload_id",
   "updated_at": 1683256789000
@@ -167,7 +171,7 @@ When creating rules, the following issues can occur:
 
 * **Unexpected value**: This can happen when multiple rules are defined with overlapping or conflicting conditions.  
   For example, consider the following rules:
-  1. `{ "username": ["dev*"], "index_pattern": ["logs*"] }`
+  1. `{ principal: {"username": ["dev*"]}, "index_pattern": ["logs*"] }`
   2. `{ "index_pattern": ["logs*", "events*"] }`
 
   If a user with the username `dev_john` sends a search request to `logs_q1_25`, it will match the first rule based on the `username` and `index_pattern` attributes. The request will not match the second rule, even though the `index_pattern` also qualifies.

--- a/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api.md
+++ b/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/rule-lifecycle-api.md
@@ -85,13 +85,17 @@ The following example demonstrates how to use the Rules API to create a rule.
 
 ### Create a rule
 
-The following request creates a rule that assigns a `workload_group` value based on matching `index_pattern` attributes:
+The following request creates a rule that assigns a `workload_group` value based on matching `index_pattern` and principal attributes:
 
 ```json
 PUT _rules/workload_group
 {
   "description": "description for rule",
   "index_pattern": ["log*", "event*"],
+  "principal": {
+    "username": ["admin"],
+    "role": ["all_access"]
+  },
   "workload_group": "EITBzjFkQ6CA-semNWGtRQ"
 }
 ```
@@ -106,6 +110,10 @@ PUT _rules/workload_group/0A6RULxkQ9yLqn4r8LPrIg
 {
   "description": "updated_description for rule",
   "index_pattern": ["log*"],
+  "principal": {
+    "username": ["admin"],
+    "role": ["all_access"]
+  },
   "workload_group": "EITBzjFkQ6CA-semNWGtRQ"
 }
 ```
@@ -130,10 +138,10 @@ GET /_rules/{feature_type}
 ```
 {% include copy-curl.html %}
 
-The following request returns all rules of the feature type `workload_group` that contain the attribute `index_pattern` with values `a` or `b`:
+The following request returns all rules of the feature type `workload_group` that contain the attribute `index_pattern` with values `a` or `b` and `principal.username` with value admin:
 
 ```json
-GET /_rules/workload_group?index_pattern=a,b
+GET /_rules/workload_group?index_pattern=a,b&principal.username=admin
 ```
 {% include copy-curl.html %}
 
@@ -160,6 +168,10 @@ GET /_rules/workload_group?index_pattern=a,b&search_after=z1MJApUB0zgMcDmz-UQq
   "id": "wi6VApYBoX5wstmtU_8l",
   "description": "description for rule",
   "index_pattern": ["log*", "event*"],
+  "principal": {
+    "username": ["admin"],
+    "role": ["all_access"]
+  },
   "workload_group": "EITBzjFkQ6CA-semNWGtRQ",
   "updated_at": "2025-04-04T20:54:22.406Z"
 }
@@ -181,6 +193,10 @@ GET /_rules/workload_group?index_pattern=a,b&search_after=z1MJApUB0zgMcDmz-UQq
       "id": "z1MJApUB0zgMcDmz-UQq",
       "description": "Rule for tagging workload_group_id to index123",
       "index_pattern": ["index123"],
+      "principal": {
+        "username": ["admin"],
+        "role": ["all_access"]
+      },
       "workload_group": "workload_group_id",
       "updated_at": "2025-02-14T01:19:22.589Z"
     },

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
@@ -14,13 +14,16 @@ Workload group rules allow you to automatically assign workload group IDs to inc
 
 ## Creating a rule
 
-To create a rule for a workload group, provide the workload group ID in the `workload_group` parameter. The following request creates a rule that assigns the specified workload group to requests for the matching `index_pattern`:
+To create a rule for a workload group, provide the workload group ID in the `workload_group` parameter. The following request creates a rule that assigns the specified workload group to requests for the matching `index_pattern` and `principal.username`:
 
 ```json
 PUT _rules/workload_group
 {
   "description": "description for rule",
   "index_pattern": ["test*"],
+  "principal": {
+    "username": ["admin"]
+  },
   "workload_group": "wfbdJoDAS0mYiLbEAjd1sA"
 }
 ```
@@ -32,23 +35,35 @@ The response contains the rule ID:
 {
   "id": "176fd554-43e7-39eb-92cc-56615d287eae",
   "description": "description for rule",
-  "index_pattern": [
-    "test*"
-  ],
+  "index_pattern": ["test*"],
+  "principal": {
+    "username": ["admin"]
+  },
   "workload_group": "wfbdJoDAS0mYiLbEAjd1sA",
   "updated_at": "2025-08-06T15:12:44.791Z"
 }
 ```
 
+## Attributes
+
+The `workload_group` feature type contains the following attributes. Each rule should contain as least one of the attributes below.
+A priority value of 1 represents the highest priority. When multiple rules match a single request, the rule with the higher-priority attributes is selected.
+
+| Attribute            | Data type | Description                                                                                                                                                                                    | Priority |
+|:---------------------|:----------|:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:---------|
+| `principal.username` | List      | A list of strings used to specify the usernames that should be matched to this rule. This attribute can only be used when the domain enables security plugin.                                  | 1        |
+| `principal.role`     | List      | A list of strings used to specify the roles that should be matched to this rule. This attribute can only be used when the domain enables security plugin.                                      | 2        |
+| `index_pattern`      | List      | A list of strings used to specify the target indexes of incoming queries. Each string can be an exact index name or a prefix ending in `*` to support wildcard matching, for example, `logs*`. | 3        |
+
 ## Parameters
 
-The `workload_group` feature type requires the following parameters.
+The `workload_group` feature type contains the following parameters.
 
-| Attribute  | Data type | Description  |
-| :--- | :--- | :--- |
-| `index_pattern` | List      | A list of strings used to match the target indexes of incoming queries. Each string can be an exact index name or a prefix ending in `*` to support wildcard matching, for example, `logs*`. |
-| `description` | String      | A description of the rule. |
-| `workload_group` | String      | The workload group ID to apply to the requests matching this rule. |
+| Parameter        | Data type | Description                                                                                             |
+|:-----------------|:----------|:--------------------------------------------------------------------------------------------------------|
+| attribute        | Object    | A rule should contain at least one attributes (`index_pattern`, `principal.username`, `principal.role`) |
+| `description`    | String    | A description of the rule.                                                                              |
+| `workload_group` | String    | The workload group ID to apply to the requests matching this rule.                                      |
 
 ## Updating a rule
 
@@ -96,10 +111,10 @@ GET /_rules/workload_group/{rule_id}
 ```
 {% include copy-curl.html %}
 
-The following request retrieves all `workload_group` rules matching the specified `index_pattern`:
+The following request retrieves all `workload_group` rules matching the specified `index_pattern` and `principal.username`:
 
 ```json
-GET /_rules/workload_group?index_pattern=log*,event*
+GET /_rules/workload_group?index_pattern=log*,event*&principal.username=admin
 ```
 {% include copy-curl.html %}
 

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-groups.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-groups.md
@@ -96,7 +96,7 @@ GET /_wlm/workload_group/{name}
 To delete a workload group, specify its name as a path parameter:
 
 ```json
-DELETE /_wlm/query_group/{name}
+DELETE /_wlm/workload_group/{name}
 ```
 {% include copy-curl.html %}
 


### PR DESCRIPTION
### Description
Currently Rule-based Auto-tagging documentation page only contains documentation for index_pattern attribute. We're adding new principal attributes in OS 3.3, so this PR update the documentation to reflect this.

### Issues Resolved
Closes #11134 

### Version
3.3+

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
