### PR TITLE
Fixed formatting for score_ranker page

### DIFF
--- a/_search-plugins/search-pipelines/score-ranker-processor.md
+++ b/_search-plugins/search-pipelines/score-ranker-processor.md
@@ -22,6 +22,7 @@ Field | Data type | Description
 `combination.technique` | String | The technique used for combining scores. Required. Valid value is `rrf`.
 `combination.rank_constant` | Integer | A constant added to each document's rank before calculating the reciprocal score. Must be `1` or greater. A larger rank constant makes the scores more uniform, reducing the influence of top-ranked results. A smaller rank constant creates a greater score difference between ranks, giving more weight to top-ranked items. Optional. Default is `60`.
 `combination.parameters.weights` | Array of floating-point values | Specifies the weights to use for each query. Valid values are in the [0.0, 1.0] range and signify decimal percentages. The closer the weight is to 1.0, the more weight is given to a query. The number of values in the `weights` array must equal the number of queries. The sum of the values in the array must equal 1.0. Optional. If not provided, all queries are given equal weight.
+
 ## Example
 
 The following example demonstrates using a search pipeline with a `score-ranker-processor`.


### PR DESCRIPTION
### Description
Fixed issue with formatting in "Score ranker processor" page.

Issue exists in the 3.2 (latest) page https://docs.opensearch.org/latest/search-plugins/search-pipelines/score-ranker-processor/.

After the change I tested locally, page format looks correct

<img width="1368" height="904" alt="image" src="https://github.com/user-attachments/assets/1e2e6c79-87c8-4829-9d20-f69ee57741f6" />


### Version
latest (3.2)

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
