### PR TITLE
Add skip_list details to date, scaled float

### DIFF
--- a/_field-types/supported-field-types/date.md
+++ b/_field-types/supported-field-types/date.md
@@ -56,6 +56,7 @@ Parameter | Description
 `locale` | A region- and language-specific way of representing the date. Default is [`ROOT`](https://docs.oracle.com/javase/8/docs/api/java/util/Locale.html#ROOT) (a region- and language-neutral locale).
 `meta` | Accepts metadata for this field.
 [`null_value`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/index#null-value) | A value to be used in place of `null`. Must be of the same type as the field. If this parameter is not specified, the field is treated as missing when its value is `null`. Default is `null`.
+`skip_list` | A Boolean value that specifies whether to enable skip list indexing for doc values. When enabled, this creates indexed doc values that can improve performance for `range` queries by allowing the query engine to skip over irrelevant document ranges. Default is `false`, but skip list indexing is automatically enabled for the `@timestamp` field and fields used for index sorting.
 `store` | A Boolean value that specifies whether the field value should be stored and can be retrieved separately from the _source field. Default is `false`. 
 
 ## Formats

--- a/_field-types/supported-field-types/numeric.md
+++ b/_field-types/supported-field-types/numeric.md
@@ -61,7 +61,7 @@ PUT testindex/_doc/1
 
 ## Example: Skip list
 
-Use the `skip_list` parameter for better query performance. The `skip_list` parameter is particularly beneficial for fields that are frequently used in `range` queries or aggregations because it allows the query engine to skip over document ranges that don't match the query criteria.
+Use the `skip_list` parameter for better query performance. The `skip_list` parameter is particularly beneficial for fields that are frequently used in `range` queries because it allows the query engine to skip over document ranges that don't match the query criteria.
 
 Create a mapping with skip list indexing enabled:
 
@@ -114,6 +114,7 @@ PUT testindex
     }
   }
 }
+
 ```
 {% include copy-curl.html %}
 
@@ -142,11 +143,12 @@ Parameter | Description
 `index` | A Boolean value that specifies whether the field should be searchable. Default is `true`. 
 `meta` | Accepts metadata for this field.
 [`null_value`]({{site.url}}{{site.baseurl}}/opensearch/supported-field-types/index#null-value) | A  value to be used in place of `null`. Must be of the same type as the field. If this parameter is not specified, the field is treated as missing when its value is `null`. Default is `null`.
-`skip_list` | A Boolean value that specifies whether to enable skip list indexing for doc values. When enabled, this creates indexed doc values that can improve performance for `range` queries and aggregations by allowing the query engine to skip over irrelevant document ranges. Default is `false`.
+`skip_list` | A Boolean value that specifies whether to enable skip list indexing for doc values. When enabled, this creates indexed doc values that can improve performance for `range` queries by allowing the query engine to skip over irrelevant document ranges. Default is `false`.
 `store` | A Boolean value that specifies whether the field value should be stored and can be retrieved separately from the _source field. Default is `false`. 
 
 Scaled float has an additional required parameter: `scaling_factor`.
 
 Parameter | Description 
 :--- | :--- 
-`scaling_factor` | A double value that is multiplied by the field value and rounded to the nearest long. Required. 
+`scaling_factor` | A double value that is multiplied by the field value and rounded to the nearest long. Required.
+`skip_list` | A Boolean value that specifies whether to enable skip list indexing for doc values. When enabled, this creates indexed doc values that can improve performance for `range` queries by allowing the query engine to skip over irrelevant document ranges. Default is `false`. 


### PR DESCRIPTION
* resolves https://github.com/opensearch-project/documentation-website/issues/11166

### Description
* added new skip_list param to date, scaled float
* also added details about default enabled for @timestamp and index sort field

### Issues Resolved
Closes #11166

### Version
3.3.0

### Frontend features
n/a

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
