### PR TITLE
Note that grok ingest processor patterns are not anchored

### DIFF
--- a/_ingest-pipelines/processors/grok.md
+++ b/_ingest-pipelines/processors/grok.md
@@ -21,6 +21,8 @@ For a list of available predefined patterns, see [Grok patterns](https://github.
 
 The `grok` processor is built on the [Oniguruma regular expression library](https://github.com/kkos/oniguruma/blob/master/doc/RE) and supports all the patterns from that library. You can use the [Grok Debugger](https://grokdebugger.com/) tool to test and debug your grok expressions.
 
+Note that patterns are *not anchored* - for performance and reliability it is advisable to include at least a start-of-line anchor (`^`)
+
 ## Syntax
 
 The following is the basic syntax for the `grok` processor: 


### PR DESCRIPTION
### Description
Make docs explicit that patterns are not anchored, with advice to do so for performance.

### Issues Resolved
None

### Version
All

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
