### PR TITLE
Update _im-plugin/ism/api.md to include GET Policies Request for ISM

### DIFF
--- a/_im-plugin/ism/api.md
+++ b/_im-plugin/ism/api.md
@@ -379,7 +379,7 @@ The following table lists the available query parameters. All query parameters a
 | `from` | Integer | The starting position for pagination. |
 | `sortField` | String | The field by which to sort the results. |
 | `sortOrder` | String | The sort order for the results. Valid values are `asc` (ascending) and `desc` (descending). |
-| `queryString` | String | A query string to filter policies by name or other attributes. See [Query string query]({{site.url}}{{site.baseurl}}/query-dsl/full-text/query-string/).|
+| `queryString` | String | A query string used to filter policies by name or other attributes. See [Query string query]({{site.url}}{{site.baseurl}}/query-dsl/full-text/query-string/).|
 
 #### Example request
 


### PR DESCRIPTION
### Description
We noticed that there is an undocumented request in the ISM plugin for listing all existing ISM policies. So far the only documented GET request for policy is:

```
GET _plugins/_ism/policies/policy_1
```
We would like to add the `GET policies` request to the documentation. Here are the relevant REST methods:
* https://github.com/opensearch-project/index-management/blob/main/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/resthandler/RestGetPolicyAction.kt
* https://github.com/opensearch-project/index-management/blob/main/src/main/kotlin/org/opensearch/indexmanagement/indexstatemanagement/transport/action/getpolicy/GetPoliciesRequest.kt
* https://github.com/opensearch-project/index-management/blob/main/src/main/kotlin/org/opensearch/indexmanagement/common/model/rest/SearchParams.kt
### Issues Resolved
No issue was opened

### Version
all


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
