### PR TITLE
Correcting documentation for simulation testing

### DIFF
--- a/_security/access-control/permissions.md
+++ b/_security/access-control/permissions.md
@@ -69,7 +69,7 @@ PUT /my_index/_doc/1?perform_permission_check=true
 ```
 {% include copy-curl.html %}
 
-The response indicates whether the user has sufficient permissions to perform the operation and lists any missing privileges. This option is useful for safely testing operations such as `POST`, `PUT`, and `DELETE` but does not apply to the `GET` operation.
+The response indicates whether the user has sufficient permissions to perform the operation and lists any missing privileges. This option is particularly useful for safely testing operations such as `POST`, `PUT`, and `DELETE`.
 
 When the user has sufficient permissions, the response appears similar to the following:
 


### PR DESCRIPTION
### Description
In this PR https://github.com/opensearch-project/documentation-website/pull/11155, we added documentation for permissions verification feature. However one part of sentence was incorrectly published during review, correcting it

### Version
3.2 and above

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
