### PR TITLE
Fix JSON syntax highlighting in _security-analytics/threat-intelligence/getting-started.md

### DIFF
--- a/_security-analytics/threat-intelligence/getting-started.md
+++ b/_security-analytics/threat-intelligence/getting-started.md
@@ -67,25 +67,25 @@ When creating the role, customize the following settings:
 
 - Add the following custom trust policy:
 
-      ```bash
-      { 
-         "Version": "2012-10-17",
-          "Statement": [
-              {
-                  "Effect": "Allow",
-                  "Principal": {
-                      "Service": [
-                          "opensearchservice.amazonaws.com"
-                      ]
-                  },
-                  "Action": "sts:AssumeRole"
-              }
-          ]
-      }
-      ```
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": [
+          "opensearchservice.amazonaws.com"
+        ]
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}
+```
       
 - On the Permissions policies page, add the `AmazonS3ReadOnlyAccess` permission. 
-   
+
 
 #### Cross-account S3 bucket connection
 
@@ -93,19 +93,19 @@ Because the role ARN needs to be in the same account as the OpenSearch domain, a
 
 To download from an S3 bucket in another account, the trust policy for that bucket needs to give the role ARN permission to read from the object, as shown in the following example:
 
-```
+```json
 {
-    "Version": "2012-10-17",
-    "Statement": [
-     {
-            "Effect": "Allow",
-            "Principal": {
-                "AWS": "arn:aws:iam::123456789012:role/account-1-threat-intel-role"
-            },
-          "Action": "s3:*",
-            "Resource": "arn:aws:s3:::account-2-threat-intel-bucket/*"
-     }
- ]
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "AWS": "arn:aws:iam::123456789012:role/account-1-threat-intel-role"
+      },
+      "Action": "s3:*",
+      "Resource": "arn:aws:s3:::account-2-threat-intel-bucket/*"
+    }
+  ]
 }
 ```
 


### PR DESCRIPTION
### Description
In the `_security-analytics/threat-intelligence/getting-started.md` file, there was an error that made the JSON block render this way:

<img width="921" height="645" alt="before_addAWSOpenSearchServiceARN" src="https://github.com/user-attachments/assets/1745629f-2398-460b-863a-569beb5a7de6" />

Removed ```bash``` from the code block and replaced it with ```JSON``` to match what is below in the `Cross-account S3 bucket connection` section. Now the webpage renders like this: 

<img width="918" height="584" alt="after_addAWSOpenSearchServiceARN" src="https://github.com/user-attachments/assets/6ed8f5c4-f7e6-4fae-aa13-07be91b8b315" />

I've also updated the spacing within the code blocks in both sections (`Add AWS OpenSearch Service ARN` and `Cross-account S3 bucket connection`) so they're consistent on the webpage. 

### Issues Resolved
Did not find an issue referencing the typo.

### Version
all

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
