### PR TITLE
Correct the title: it is results from different configurations that are being compared against the same query set

### DIFF
--- a/_search-plugins/search-relevance/compare-query-sets.md
+++ b/_search-plugins/search-relevance/compare-query-sets.md
@@ -7,7 +7,7 @@ grand_parent: Search relevance
 has_children: false
 ---
 
-# Comparing query sets
+# Comparing search configurations
 
 To compare the results of two different search configurations, you can run a pairwise experiment. To achieve this, you need two search configurations and a query set to use for the search configuration.
 


### PR DESCRIPTION
…rations'

This is not about comparing query sets, but about comparing the results of running the *same* query set in two different search configurations.

### Description
_Describe what this change achieves._

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
