### PR TITLE
adding examples to http source of data prepper

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/http.md
+++ b/_data-prepper/pipelines/configuration/sources/http.md
@@ -45,7 +45,7 @@ The `http` protocol only supports the JSON UTF-8 codec for incoming requests, fo
 
 ## Example
 
-The following examples demonstrate different configurations that can be used with `http` source.
+The following examples demonstrate different configurations that can be used with the `http` source.
 
 ### Minimal HTTP source
 
@@ -78,7 +78,7 @@ You should see the following output in the Data Prepper logs:
 
 ### Custom path using the pipeline name and health check
 
-The following example uses a custom path, configures a custom port, and enables health check:
+The following example uses a custom path, configures a custom port, and enables health checks:
 
 ```yaml
 audit-pipeline:
@@ -111,7 +111,7 @@ curl -s "http://localhost:2022/audit-pipeline/logs" \
 
 ### Basic authentication on the source
 
-The following example configures a custom port and path, enables health check, and configures basic authentication:
+The following example configures a custom port and path, enables health checks, and configures basic authentication:
 
 ```yaml
 secure-intake-pipeline:


### PR DESCRIPTION
### Description
adding examples to http source of data prepper

### Version
all

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
