### PR TITLE
[Pull-based Ingestion] Update pull-based semantics and offset based lag metric

### DIFF
--- a/_api-reference/document-apis/pull-based-ingestion.md
+++ b/_api-reference/document-apis/pull-based-ingestion.md
@@ -200,7 +200,7 @@ The following table lists the available `polling_ingest_stats` metrics.
 | `consumer_stats.total_poller_message_failure_count` | The total number of failed messages on the poller. |
 | `consumer_stats.total_poller_message_dropped_count` | The total number of failed messages on the poller that were dropped. |
 | `consumer_stats.lag_in_millis` | Lag in milliseconds, computed as the time elapsed since the last processed message timestamp. |
-| `consumer_stats.pointer_based_lag` | Kafka offset based lag, computed as the difference between latest available offset and current message offset. This is only applicable when Kafka is used as the streaming source. |
+| `consumer_stats.pointer_based_lag` | The Apache Kafka offset-based lag, calculated as the difference between the latest available offset and the current message offset. This metric applies only when Apache Kafka is used as the streaming source. |
 
 To retrieve shard-level pull-based ingestion metrics, use the [Nodes Stats API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/update-settings/):
 


### PR DESCRIPTION
### Description
This PR updates the following.
1. Updates pull-based ingestion to at-least once semantics. Versioning will be used to ensure data consistency during recovery.
2. Add offset based lag metric which is only applicable to Kafka.

### Issues Resolved
Follow up for pull-based ingestion

### Version
3.4 onwards

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
