### PR TITLE
Update breaking changes documentation for v3

### DIFF
--- a/_about/breaking-changes.md
+++ b/_about/breaking-changes.md
@@ -62,14 +62,16 @@ The minimum supported JDK version is JDK 21.
 
 ### Version compatibility setting
 
-The `compatibility.override_main_response_version` setting has been removed.
-This functionality has been deprecated since OpenSearch 1.x.
+The `compatibility.override_main_response_version` setting has been removed. This functionality was deprecated in OpenSearch 1.x and is no longer supported.
+
 For more information, see issue [#18228](https://github.com/opensearch-project/OpenSearch/issues/18228).
-You can consult [agents and ingestion tools]({{site.url}}{{site.baseurl}}/tools/#agents-and-ingestion-tools) for potential solutions.
+
+For alternative approaches, see [Agents and ingestion tools]({{site.url}}{{site.baseurl}}/tools/#agents-and-ingestion-tools).
 
 ### Index version
 
-Indexes (including system ones) that are created in versions older than `2.x.x` are not supported and should be reindexed **before** the upgrade as per [documentation]({{site.url}}{{site.baseurl}}/im-plugin/reindex-data/).
+Indexes created in versions earlier than `2.x.x` (including system indexes) are not supported. These indexes must be reindexed **before upgrading**. For information about reindexing, see [Reindex data]({{site.url}}{{site.baseurl}}/im-plugin/reindex-data/).
+
 For more information, see issue [#18717](https://github.com/opensearch-project/OpenSearch/issues/18717).
 
 ### System index access


### PR DESCRIPTION
Added details about deprecated compatibility setting and index version compatibility.

### Description
Currently the two proposed breaking changes are not listed in the page.
They are both potential blockers for the v3 upgrade, and especially the index version one leads to an unresponsive/unfixable cluster.
So, I believe it is important to be mentioned.

### Version
3.0.0

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
