### PR TITLE
Update v3 rolling upgrade instructions with minimum version requirement

### DIFF
--- a/_migrate-or-upgrade/rolling-upgrade/index.md
+++ b/_migrate-or-upgrade/rolling-upgrade/index.md
@@ -24,7 +24,7 @@ Before making any changes to your OpenSearch cluster, is it highly recommended t
 **Important**: OpenSearch nodes **cannot be downgraded**. If you need to revert the upgrade, then you will need to perform a new installation of OpenSearch and restore the cluster from a snapshot. Take a snapshot and store it in a remote repository before beginning the upgrade procedure. Rolling upgrades are **only supported between major adjacent versions**, for example, from OpenSearch 1.x to 2.x but not 1.x to 3.x.
 {: .important}
 
-**Important**: The minimum required cluster version for upgrades to `3.x.x` is `2.19.0`.
+**Important**: The minimum required cluster version for upgrades to 3.x.x is 2.19.0.
 {: .important}
 
 ## Performing the upgrade


### PR DESCRIPTION
Added note about minimum required cluster version for upgrades to 3.x.x.

### Description
For a v2->v3 rolling upgrade to work smoothly, the minimum required version is v2.19.0.
This is not currently not listed in the page, so people (like myself) can try rolling upgrade e.g., from 2.18.0 to 3.2.0 which fails.
More info: https://github.com/opensearch-project/OpenSearch/issues/19375

### Version
3.0.0

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
