### PR TITLE
Fix: Wrong links in Sparse ANN Doc

### DIFF
--- a/_vector-search/api/neural.md
+++ b/_vector-search/api/neural.md
@@ -455,7 +455,7 @@ POST /_plugins/_neural/warmup/index1,index2,index3
 ```
 {% include copy-curl.html %}
 
-You can use the warm up API operation with index patterns to clear one or more indexes that match a specified pattern from the cache:
+You can use the warm up API operation with index patterns to load one or more indexes that match a specified pattern into the cache:
 
 ```json
 POST /_plugins/_neural/warmup/index*

--- a/_vector-search/performance-tuning-sparse.md
+++ b/_vector-search/performance-tuning-sparse.md
@@ -54,7 +54,7 @@ Index building can benefit from using multiple threads. You can adjust the numbe
 
 ### Querying after a cold start
 
-After rebooting OpenSearch, the cache is empty, so the first several hundred queries may experience high latency. To address this "cold start" issue, you can use the [Warmup API]({{site.url}}{{site.baseurl}}/vector-search/api/knn/#warmup-operation). This API loads data from disk into cache, ensuring optimal performance for subsequent queries. You can also use the [Clear Cache API]({{site.url}}{{site.baseurl}}/vector-search/api/knn/#k-nn-clear-cache) to free up memory when needed.
+After rebooting OpenSearch, the cache is empty, so the first several hundred queries may experience high latency. To address this "cold start" issue, you can use the [Warmup API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#warm-up). This API loads data from disk into cache, ensuring optimal performance for subsequent queries. You can also use the [Clear Cache API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#clear-cache) to free up memory when needed.
 
 ### Force merging segments
 


### PR DESCRIPTION
### Description
Hi, I found there are two wrong links in commit `e0a98e6` and one mistake in commit `7731786` from PR #11127 

### Issues Resolved
Closes #10786 

### Version
3.3

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
