### PR TITLE
Add truncate as a normalizing token filter

### DIFF
--- a/_analyzers/normalizers.md
+++ b/_analyzers/normalizers.md
@@ -91,7 +91,7 @@ This module does not require installation; it is available by default.
 
 Character filters: `pattern_replace`, `mapping`
 
-Token filters: `arabic_normalization`, `asciifolding`, `bengali_normalization`, `cjk_width`, `decimal_digit`, `elision`, `german_normalization`, `hindi_normalization`, `indic_normalization`, `lowercase`, `persian_normalization`, `scandinavian_folding`, `scandinavian_normalization`, `serbian_normalization`, `sorani_normalization`, `trim`, `uppercase`
+Token filters: `arabic_normalization`, `asciifolding`, `bengali_normalization`, `cjk_width`, `decimal_digit`, `elision`, `german_normalization`, `hindi_normalization`, `indic_normalization`, `lowercase`, `persian_normalization`, `scandinavian_folding`, `scandinavian_normalization`, `serbian_normalization`, `sorani_normalization`, `trim`, `truncate`, `uppercase`
 
 ### The `analysis-icu` plugin
 


### PR DESCRIPTION
Relates to https://github.com/opensearch-project/OpenSearch/pull/19779

### Description
Add `tuncate` to the list of token filters that can be used in a normalizer.

### Version
* 3.4 ?

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
