### PR TITLE
Update opensearch-keystore.md

### DIFF
--- a/_security/configuration/opensearch-keystore.md
+++ b/_security/configuration/opensearch-keystore.md
@@ -141,6 +141,15 @@ No response exists for this command. To confirm that the setting was deleted, us
 For a complete list of secure settings that can be configured using `opensearch-keystore`, refer to [(Advanced) Using encrypted password settings for SSL]({{site.url}}{{site.baseurl}}/security/configuration/tls/#advanced-using-encrypted-password-settings-for-ssl).
 {: .note}
 
+### Upgrading the keystore
+
+The following command upgrades the keystore format to the latest version:
+
+```bash
+./bin/opensearch-keystore upgrade
+```
+{% include copy.html %}
+
 ## Keystore entries as OpenSearch settings
 
-After a setting has been added to a keystore, it is implicitly added to the OpenSearch configuration as if it were another entry in `opensearch.yml`. To modify a keystore entry use `./bin/opensearch-keystore upgrade <setting>`. To remove an entry, use `./bin/opensearch-keystore remove <setting>`.
+After a setting has been added to a keystore, it is implicitly added to the OpenSearch configuration as if it were another entry in `opensearch.yml`.


### PR DESCRIPTION
### Description

This PR corrects inaccurate documentation about `opensearch-keystore upgrade` command. The existing documentation implies that the `opensearch-keystore upgrade` command can be used to update an existing setting, which is not true. The command is used only for upgrading the format of the keystore: https://github.com/opensearch-project/OpenSearch/blob/main/distribution/tools/keystore-cli/src/main/java/org/opensearch/tools/cli/keystore/UpgradeKeyStoreCommand.java

### Issues Resolved

### Version

All


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
