### PR TITLE
[Agentic Search] Add Query Planning tool Fallback Documentation

### DIFF
--- a/_ml-commons-plugin/agents-tools/tools/query-planning-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/query-planning-tool.md
@@ -336,15 +336,19 @@ All parameters that were configured either in the connector or in the agent regi
 
 The `response_filter` parameter uses JSONPath expressions to extract the generated query from the LLM's response. Different model providers return responses in different formats, so you need to specify the appropriate filter for your model type.
 
-**OpenAI models:**
+**OpenAI models**:
+
 ```json
 "response_filter": "$.choices[0].message.content"
 ```
+{% include copy.html %}
 
-**Anthropic Claude models (Amazon Bedrock Converse API):**
+**Anthropic Claude models (Amazon Bedrock Converse API)**:
+
 ```json
 "response_filter": "$.output.message.content[0].text"
 ```
+{% include copy.html %}
 
 ## Execute parameters
 
@@ -386,7 +390,8 @@ POST /_plugins/_ml/agents/_register
 ```
 {% include copy-curl.html %}
 
-**Note**: Use the appropriate `response_filter` based on your model type. See [Response filter configuration](#response-filter-configuration) for examples.
+Use the appropriate `response_filter` based on your model type. For more information and examples, see [Response filter configuration](#response-filter-configuration).
+{: .note}
 
 The following is the default system prompt:
 
@@ -540,9 +545,9 @@ Output:
 
 ## Fallback behavior
 
-The query planner tool includes a default fallback query: `{"size":10,"query":{"match_all":{}}}`. 
+The `QueryPlanningTool` includes a default fallback query: `{"size":10,"query":{"match_all":{}}}`. 
 
-The code automatically extracts the first valid JSON object from the LLM's response, even if the JSON is surrounded by additional text, markdown code fences, explanations, or other content. However, if no valid JSON can be extracted from the response (for example, when the response is completely empty, contains only non-JSON text, or contains only malformed JSON), the tool returns the default fallback query.
+The code automatically extracts the first valid JSON object from the LLM's response, even if the JSON is surrounded by additional text, Markdown code fences, explanations, or other content. However, if no valid JSON can be extracted from the response (for example, when the response is completely empty, contains only non-JSON text, or contains only malformed JSON), the tool returns the default fallback query.
 
 When the fallback is triggered, no error is thrown. Instead, a debug log is shown in the system logs. This ensures that query planning operations continue to work even when the LLM provides unexpected output.
 


### PR DESCRIPTION
### Description
Describes the fall back behavior to the readers and also the available response filters.
### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
