### PR TITLE
docs: fix mappings field type join example

### DIFF
--- a/_mappings/supported-field-types/join.md
+++ b/_mappings/supported-field-types/join.md
@@ -64,7 +64,7 @@ PUT testindex1/_doc/1
 
 When indexing child documents, you need to specify the `routing` query parameter because parent and child documents in the same parent/child hierarchy must be indexed on the same shard. For more information, see [Routing]({{site.url}}{{site.baseurl}}/mappings/metadata-fields/routing/). Each child document refers to its parent's ID in the `parent` field.
 
-Index two child documents, one for each parent:
+Index two child documents for the same parent:
 
 ```json
 PUT testindex1/_doc/3?routing=1
@@ -84,7 +84,7 @@ PUT testindex1/_doc/4?routing=1
   "name": "Product 2",
   "product_to_brand": {
     "name": "product", 
-    "parent": "2" 
+    "parent": "1" 
   }
 }
 ```


### PR DESCRIPTION
### Description
* Fix example wrongly indicated
  * Reason: 🧠example goal is to index documents on different parents, but ONLY 1 is specified🧠

### Version
* ALL

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
