### PR TITLE
Update documentation for arrays that semantic field cannot support it

### DIFF
--- a/_mappings/supported-field-types/index.md
+++ b/_mappings/supported-field-types/index.md
@@ -125,7 +125,7 @@ PUT testindex1/_doc/2
 }
 ```
 
-semantic field cannot support an array of values since we will map it to an embedding field as rank_features/knn_vector, and they cannot support multiple vectors.
+The `semantic` field cannot contain an array of values because it's mapped to an embedding field (`rank_features` or `knn_vector`), which supports only a single vector.
 {: .note}
 
 ## Multifields


### PR DESCRIPTION
### Description
Update documentation for arrays that semantic field cannot support it

### Issues Resolved
Closes #11481

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._
3.1, 3.2, 3.3

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
