### PR TITLE
Enhanced the documentation for the convert_index_to_remote ISM action with comprehensive details and examples: #11491

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -421,7 +421,7 @@ The `convert_index_to_remote` operation has the following parameters.
 
 Parameter | Description | Type | Required | Default
 :--- | :--- |:--- |:--- |
-`repository` | The repository name registered through the native snapshot API operations. Must be a remote repository type (for example, S3, Azure, or GCS).  | String | Yes | N/A
+`repository` | The repository name registered through the native snapshot API operations. Must be a remote repository (for example, S3, Azure, or GCS).  | String | Yes | N/A
 `snapshot` | The name of the snapshot created by the snapshot action.  | String | Yes | N/A
 `include_aliases` | Whether to include index aliases during the restore operation. If `true`, all aliases associated with the original index are restored with the remote index. If your application accesses the index using aliases, set this parameter to `true`. | Boolean | No | `false`
 `ignore_index_settings` | A comma-separated list of index settings to ignore during the restore operation. For example, `index.refresh_interval,index.number_of_replicas`. This is useful when you want to apply different settings to the restored remote index than the ones configured in the original index. | String | No | Empty string


### PR DESCRIPTION
## Description

Enhanced the documentation for the `convert_index_to_remote` ISM action with comprehensive details and examples:

- **Expanded description**: Clarifies that this action converts indexes to searchable snapshots by restoring from a remote repository, with automatic deletion of the original index to complete the conversion process
- **Additional parameters**: Documents three optional parameters:
  - `include_aliases`: Control whether to restore index aliases along with the index
  - `ignore_index_settings`: Specify settings to ignore during restore for customized configuration
  - `number_of_replicas`: Set replica count during conversion to prevent cluster yellow state
- **Prerequisites section**: Lists requirements before using the action (remote repository setup, snapshot existence, repository name matching)
- **Usage notes**: Provides essential operational guidance on automatic deletion, repository matching, variable references, and replica considerations
- **Three comprehensive examples**: 
  - Basic example with minimum required parameters
  - Advanced configuration example demonstrating all optional parameters
  - Complete policy example showing a full workflow for archiving indexes older than 30 days to searchable snapshots

The resolved documentation provides more explicit guidance for users implementing searchable snapshots with ISM policies.

### Issues Resolved

Closes https://github.com/opensearch-project/index-management/issues/1487, https://github.com/opensearch-project/index-management/issues/808#issuecomment-3272436776

### Version

All versions with ISM searchable snapshot support.

### Frontend features

N/A - Documentation only change.

### Checklist

- [v] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).