### PR TITLE
delete incorrect output value in delete_entries processor example

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/delete-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/delete-entries.md
@@ -61,7 +61,7 @@ For example, before you run the `delete_entries` processor, if the `logs_json.lo
 When you run the `delete_entries` processor, it parses the message into the following output:
 
 ```json
-{"message2": "goodbye", "message3": "test"}
+{"message2": "goodbye"}
 ```
 
 


### PR DESCRIPTION
### Description
Deletes an incorrect output value to avoid misleading information.

### Version
all

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
