### PR TITLE
[Fix] Migration Assistant docs on uploading basic AUTH with AWS Secrets

### DIFF
--- a/_migration-assistant/migration-phases/deploy/index.md
+++ b/_migration-assistant/migration-phases/deploy/index.md
@@ -135,7 +135,7 @@ Before configuring the deployment, understand the RFS parameters. If you're crea
 ```
 {% include copy.html %}
 
-Additionally, you must assign the `migrationconsole` and `reindexFromSnapshot` task roles permissions to the S3 bucket.
+Additionally, you must assign the `migrationconsole` and `reindexFromSnapshot` task role permissions to the S3 bucket.
 
 ### Configuration and deployment steps
 


### PR DESCRIPTION
### Description
Corrects the basic authentication configuration format in Migration Assistant deployment documentation and removes unnecessary default options to simplify configuration examples.

### Issues Resolved
N/A

### Version
Migration Assistant (latest)

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
