### PR TITLE
Clarify upgrade path for OpenSearch versions

### DIFF
--- a/_migrate-or-upgrade/rolling-upgrade/index.md
+++ b/_migrate-or-upgrade/rolling-upgrade/index.md
@@ -22,6 +22,7 @@ This document serves as a high-level, platform-agnostic overview of the rolling 
 Before making any changes to your OpenSearch cluster, is it highly recommended to back up your configuration files and create a [snapshot]({{site.url}}{{site.baseurl}}/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/) of the cluster state and indexes.
 
 **Important**: OpenSearch nodes **cannot be downgraded**. If you need to revert the upgrade, then you will need to perform a new installation of OpenSearch and restore the cluster from a snapshot. Take a snapshot and store it in a remote repository before beginning the upgrade procedure. Rolling upgrades are **only supported between major adjacent versions**, for example, from OpenSearch 1.x to 2.x but not 1.x to 3.x.
+If you're running OpenSearch 1.3 or 2.x, you must first upgrade to OpenSearch 2.19 before upgrading to OpenSearch 3.x.
 {: .important}
 
 ## Performing the upgrade


### PR DESCRIPTION
Added note about upgrading to OpenSearch 2.19 before 3.x.

### Description
Current OpenSearch documentation doesn't specify a minimum 2.x version for a successful upgrade to 3.x. 

Upgrade from pre-2.19 to 3.x will fail with the following error. 

```
{“extra_data”:{“class”:“c.e.b.a.s.o.p.s.t.TlsTransport”},“message”:“Peer not connected [channel: Netty4TcpChannel{localAddress=/192.168.161.67:9300, remoteAddress=/192.168.52.103:50358}] Cause: Received message from unsupported version: [2.11.1] minimal compatible version is: [2.19.0]”,“metadata”:{“container_name”:“master”,“namespace”:“ashok”,“pod_name”:“opensearch-master-2”},“service_id”:“opensearch”,“severity”:“warning”,“timestamp”:“2025-11-20T12:15:45.180+00:00”,“version”:“1.2.0”}
```

### Version
OpenSearch 3.x

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
