### PR TITLE
Adds doc for OpenSearch Data Prepper opensearch sink using data strea…

### DIFF
--- a/_data-prepper/pipelines/configuration/sinks/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sinks/opensearch.md
@@ -190,7 +190,7 @@ Alternately, rather than admin credentials, you can specify the credentials of a
 - `indices:admin/template/get`
 - `indices:admin/template/put`
 
-In case the target is an OpenSearch data stream, this permission is needed from the data stream detector:
+If the target is an OpenSearch data stream, the following permission is required by the data stream detector:
 
 - `indices:admin/data_stream/get`
 


### PR DESCRIPTION
…ms / permissions

### Description
This change documents the permission needed to use data streams in Opensearch Data Prepper opensearch sink.

### Issues Resolved
Closes #11599 

### Version
Opensearch Data Prepper 2.13.0

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
