### PR TITLE
Fix mget docs to correctly ref routing param

### DIFF
--- a/_api-reference/document-apis/multi-get.md
+++ b/_api-reference/document-apis/multi-get.md
@@ -52,7 +52,7 @@ Field | Type | Description | Required
 docs | Array | The documents you want to retrieve data from. Can contain the attributes: `_id`, `_index`, `routing`, `_source`, and `_stored_fields`. If you specify an index in the URL, you can omit this field and add IDs of the documents to retrieve. | Yes if an index is not specified in the URL
 _id | String | The ID of the document. | Yes if `docs` is specified in the request body
 _index | String | Name of the index. | Yes if an index is not specified in the URL
-routing | String | The value of the shard that has the document. | Yes if a routing value was used when indexing the document
+routing | String | The value of the shard that contains the document. | Yes if a routing value was used when indexing the document
 _source | Object | Specifies whether to return the `_source` field from an index (boolean), whether to return specific fields (array), or whether to include or exclude certain fields. | No
 _source.includes | Array | Specifies which fields to include in the query response. For example, `"_source": { "include": ["Title"] }` retrieves `Title` from the index. | No
 _source.excludes | Array | Specifies which fields to exclude in the query response. For example, `"_source": { "exclude": ["Director"] }` excludes `Director` from the query response. | No


### PR DESCRIPTION
### Description
The `routing` param in the body is not prefixed with `_`. This fixes the documentation to correctly reference the param.

### Version
3.1

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
