### PR TITLE
Add ttl_delete metadata attribute documentation for DynamoDB source

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -102,7 +102,7 @@ The following metadata will be added to each event that is processed by the `dyn
 * `opensearch_action`: A default value for mapping DynamoDB event actions to OpenSearch actions. This action will be `index` for export items, and `INSERT` or `MODIFY` for stream events, and `REMOVE` stream events when the OpenSearch action is `delete`.
 * `dynamodb_event_name`: The exact event type for the item. Will be `null` for export items and either `INSERT`, `MODIFY`, or `REMOVE` for stream events.
 * `table_name`: The name of the DynamoDB table that an event came from.
-* `ttl_delete`: A boolean value indicating whether a `REMOVE` event was triggered by DynamoDB Time-To-Live (TTL). The `ttl_delete` attribute is `true` for TTL-based deletions and `false` for all other events. This metadata can be used with conditional routing or filtering to handle TTL deletions differently from manual deletions.
+* `ttl_delete`: A Boolean value indicating whether a `REMOVE` event was triggered by DynamoDB Time-To-Live (TTL). The `ttl_delete` attribute is `true` for TTL-based deletions and `false` for all other events. This metadata can be used with conditional routing or filtering to handle TTL deletions differently from manual deletions.
 
 
 ## Permissions


### PR DESCRIPTION
### Description
This change documents the new `ttl_delete` metadata attribute for the DynamoDB source in Data Prepper. This attribute allows users to identify and handle TTL-based deletions differently from manual deletions in their pipelines.

### Issues Resolved
https://github.com/opensearch-project/data-prepper/issues/4560
Related to https://github.com/opensearch-project/data-prepper/pull/4982

### Version
2.10.0

### Frontend features
N/A - This is a documentation update for Data Prepper backend functionality.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
