### PR TITLE
Fix breadcrumbs and Migration Assistant left navigation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -262,13 +262,13 @@ defaults:
       path: "_clients"
     values:
       section: "clients"
-      section-name: "Clients"
+      section-name: "OpenSearch clients"
   -
     scope:
       path: "_benchmark"
     values:
       section: "benchmark"
-      section-name: "Benchmark"
+      section-name: "OpenSearch Benchmark"
   -
     scope:
       path: "_migration-assistant"

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -150,10 +150,38 @@ layout: table_wrappers
     <div class="main">
       <div id="main-content-wrap" class="main-content-wrap">
         {% unless page.url == "/" %}
-          {% if page.parent %}
+          {%- comment -%}Check if this is a collection index page{%- endcomment -%}
+          {% assign is_collection_index = false %}
+          {% if page.collection and page.parent == nil %}
+            {% assign expected_collection_url = page.collection | prepend: '/' | append: '/' %}
+            {% if page.url == expected_collection_url %}
+              {% assign is_collection_index = true %}
+            {% endif %}
+          {% endif %}
+
+          {% unless is_collection_index %}
+            {% if page.collection or page.parent %}
             <nav aria-label="Breadcrumb" class="breadcrumb-nav">
               <ol class="breadcrumb-nav-list">
-                {% if page.grand_parent %}
+                {%- comment -%}Add collection name as first breadcrumb{%- endcomment -%}
+                {% if page.collection %}
+                  {% if page.section == "opensearch" %}
+                    {%- comment -%}For OpenSearch collections, use collection name{%- endcomment -%}
+                    {% assign collection_config = site.opensearch_collection.collections[page.collection] %}
+                    {% if collection_config and collection_config.name %}
+                      <li class="breadcrumb-nav-list-item">
+                        <a href="{{ page.collection | prepend: '/' | append: '/' | relative_url }}">{{ collection_config.name }}</a>
+                      </li>
+                    {% endif %}
+                  {% else %}
+                    {%- comment -%}For non-OpenSearch collections, use section name{%- endcomment -%}
+                    <li class="breadcrumb-nav-list-item">
+                      <a href="{{ page.section | prepend: '/' | append: '/' | relative_url }}">{{ page.section-name }}</a>
+                    </li>
+                  {% endif %}
+                {% endif %}
+                {% if page.parent %}
+                  {% if page.grand_parent %}
                   {%- comment -%}Find URLs for 4-level breadcrumb{%- endcomment -%}
                   {%- assign all_pages = site.pages -%}
                   
@@ -198,9 +226,9 @@ layout: table_wrappers
                   {%- if great_grandparent_title != "" and great_grandparent_url != "" -%}
                     <li class="breadcrumb-nav-list-item"><a href="{{ great_grandparent_url }}">{{ great_grandparent_title }}</a></li>
                   {%- endif -%}
-                  <li class="breadcrumb-nav-list-item"><a href="{{ grandparent_url }}">{{ page.grand_parent }}</a></li>
-                  <li class="breadcrumb-nav-list-item"><a href="{{ parent_url }}">{{ page.parent }}</a></li>
-                {% else %}
+                    <li class="breadcrumb-nav-list-item"><a href="{{ grandparent_url }}">{{ page.grand_parent }}</a></li>
+                    <li class="breadcrumb-nav-list-item"><a href="{{ parent_url }}">{{ page.parent }}</a></li>
+                  {% else %}
                   {%- comment -%}Find parent URL for 2-level breadcrumb{%- endcomment -%}
                   {%- assign all_pages = site.pages -%}
                   
@@ -219,13 +247,15 @@ layout: table_wrappers
                       {%- break -%}
                     {%- endif -%}
                   {%- endfor -%}
-                  
-                  <li class="breadcrumb-nav-list-item"><a href="{{ parent_url }}">{{ page.parent }}</a></li>
+
+                    <li class="breadcrumb-nav-list-item"><a href="{{ parent_url }}">{{ page.parent }}</a></li>
+                  {% endif %}
                 {% endif %}
                 <li class="breadcrumb-nav-list-item"><span>{{ page.title }}</span></li>
               </ol>
             </nav>
-          {% endif %}
+            {% endif %}
+          {% endunless %}
         {% endunless %}
         <div id="main-content" class="main-content" role="main">
           {% if page.section == "opensearch" %}

--- a/_migration-assistant/architecture.md
+++ b/_migration-assistant/architecture.md
@@ -2,7 +2,6 @@
 layout: default
 title: Architecture
 nav_order: 15
-parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/architecture/
 redirect_from:
   - /migration-assistant/overview/architecture/

--- a/_migration-assistant/index.md
+++ b/_migration-assistant/index.md
@@ -3,6 +3,7 @@ layout: default
 title: Migration Assistant for OpenSearch
 nav_order: 30
 has_children: true
+nav_exclude: true
 permalink: /migration-assistant/
 redirect_from:
   - /migration-assistant/index/

--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -2,7 +2,6 @@
 layout: default
 title: Is Migration Assistant right for you?
 nav_order: 10
-parent: Migration Assistant for OpenSearch
 redirect_from:
   - /migration-assistant/overview/is-migration-assistant-right-for-you/
 ---

--- a/_migration-assistant/key-components.md
+++ b/_migration-assistant/key-components.md
@@ -1,6 +1,5 @@
 ---
 layout: default
-parent: Migration Assistant for OpenSearch
 title: Key components
 nav_order: 20
 permalink: /migration-assistant/key-components/

--- a/_migration-assistant/migration-console/accessing-the-migration-console.md
+++ b/_migration-assistant/migration-console/accessing-the-migration-console.md
@@ -3,7 +3,6 @@ layout: default
 title: Accessing the migration console
 nav_order: 1
 parent: Migration console
-grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-console/accessing-the-migration-console/
 redirect_from:
   - /migration-console/accessing-the-migration-console/

--- a/_migration-assistant/migration-console/index.md
+++ b/_migration-assistant/migration-console/index.md
@@ -1,6 +1,5 @@
 ---
 layout: default
-parent: Migration Assistant for OpenSearch
 title: Migration console
 nav_order: 50
 nav_exclude: false

--- a/_migration-assistant/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant/migration-console/migration-console-commands-references.md
@@ -3,7 +3,6 @@ layout: default
 title: Command reference
 nav_order: 2
 parent: Migration console
-grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-console/migration-console-command-reference/
 redirect_from:
   - /migration-console/migration-console-commands-references/

--- a/_migration-assistant/migration-phases/assessment/index.md
+++ b/_migration-assistant/migration-phases/assessment/index.md
@@ -3,7 +3,6 @@ layout: default
 title: Assessment
 nav_order: 1
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 has_children: false
 has_toc: false
 permalink: /migration-assistant/migration-phases/assessment/

--- a/_migration-assistant/migration-phases/backfill.md
+++ b/_migration-assistant/migration-phases/backfill.md
@@ -3,7 +3,6 @@ layout: default
 title: Backfill
 nav_order: 6
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-phases/backfill/
 redirect_from:
   - /migration-phases/backfill/

--- a/_migration-assistant/migration-phases/create-snapshot.md
+++ b/_migration-assistant/migration-phases/create-snapshot.md
@@ -2,7 +2,6 @@
 layout: default
 title: Creating a snapshot
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 nav_order: 4
 permalink: /migration-assistant/migration-phases/create-snapshot/
 ---

--- a/_migration-assistant/migration-phases/deploy/index.md
+++ b/_migration-assistant/migration-phases/deploy/index.md
@@ -2,7 +2,6 @@
 layout: default
 title: Deploy
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 nav_order: 2
 has_children: true
 has_toc: true

--- a/_migration-assistant/migration-phases/index.md
+++ b/_migration-assistant/migration-phases/index.md
@@ -1,7 +1,6 @@
 ---
 layout: default
 title: Migration phases
-parent: Migration Assistant for OpenSearch
 nav_order: 40
 nav_exclude: false
 has_children: true

--- a/_migration-assistant/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/index.md
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: Live traffic migration
+parent: Migration phases
 nav_order: 99
 nav_exclude: true
 permalink: /migration-assistant/live-traffic-migration/

--- a/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
@@ -1,6 +1,8 @@
 ---
 layout: default
 title: Switching traffic from the source cluster
+parent: Live traffic migration
+grand_parent: Migration phases
 nav_order: 110
 nav_exclude: true
 permalink: /migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/

--- a/_migration-assistant/migration-phases/migrate-metadata/index.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/index.md
@@ -3,7 +3,6 @@ layout: default
 title: Migrate metadata
 nav_order: 5
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 has_children: true
 has_toc: true
 permalink: /migration-assistant/migration-phases/migrate-metadata/

--- a/_migration-assistant/migration-phases/remove-migration-infrastructure.md
+++ b/_migration-assistant/migration-phases/remove-migration-infrastructure.md
@@ -3,7 +3,6 @@ layout: default
 title: Removing Migration Assistant
 nav_order: 9
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-phases/remove-migration-infrastructure/
 redirect_from:
   - /migration-assistant/migration-phases/removing-migration-infrastructure/

--- a/_migration-assistant/migration-phases/replay-captured-traffic.md
+++ b/_migration-assistant/migration-phases/replay-captured-traffic.md
@@ -3,7 +3,6 @@ layout: default
 title: Using Traffic Replayer
 nav_order: 7
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-phases/replay-captured-traffic/
 redirect_from: 
   - /migration-assistant/migration-phases/using-traffic-replayer/

--- a/_migration-assistant/migration-phases/reroute-source-to-proxy.md
+++ b/_migration-assistant/migration-phases/reroute-source-to-proxy.md
@@ -3,7 +3,6 @@ layout: default
 title: Reroute client traffic
 nav_order: 3
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-phases/reroute-source-to-proxy/
 ---
 

--- a/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
+++ b/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
@@ -3,7 +3,6 @@ layout: default
 title: Reroute traffic to the target
 nav_order: 8
 parent: Migration phases
-grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 ---
 

--- a/_migration-assistant/security-patching-and-updating.md
+++ b/_migration-assistant/security-patching-and-updating.md
@@ -2,7 +2,6 @@
 layout: default
 title: Security patching & updating
 nav_order: 30
-parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/security-patching-and-updating/
 ---
 

--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -810,6 +810,11 @@ main {
   content: none !important;
 }
 
+.breadcrumb-nav-list {
+  display: flex;
+  flex-wrap: wrap;
+}
+
 .main-content {
   h1, h2, h3, h4, h5, h6 {
     a {


### PR DESCRIPTION
This PR:

- Makes the Migration Assistant section left navigation follow the same pattern as the other sections
- Fixes breadcrumb display for all sections 
- Fixes the Migration Assistant section left nav opening/closing and highlighting correctly
- Displays breadcrumbs linearly so the line wraps, as opposed to the table layout, which pushed the slashes down for long breadcrumb text
- Reduces build time from 440 sec to 346 sec by replacing all-page lookups with collection lookups 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
