### PR TITLE
Remove last modified at Jekyll plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,7 +24,6 @@ gem 'just-the-docs', '~> 0.3.3'
 
 # If you have any plugins, put them here!
 group :jekyll_plugins do
-  gem 'jekyll-last-modified-at'
   gem 'jekyll-sitemap'
   gem 'jekyll-spec-insert', :path => './spec-insert'
 end

--- a/_config.yml
+++ b/_config.yml
@@ -330,15 +330,10 @@ doc_version: latest
 footer_content:
 
 plugins:
-  - jekyll-last-modified-at
   - jekyll-remote-theme
   - jekyll-redirect-from
   - jekyll-sitemap
   - jekyll-spec-insert
-
-# This format has to conform to RFC822
-last-modified-at:
-  date-format: '%a, %d %b %Y %H:%M:%S %z'
 
 # Exclude from processing.
 # The following items will not be processed, by default. Create a custom list

--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -11,5 +11,3 @@
 {% else %}
   <script src="{{ '/latest/assets/js/version-selector.js' }}"></script>
 {% endif %}
-
-<!-- Last-Modified: {% last_modified_at %} -->


### PR DESCRIPTION
The Jekyll last modified at plugin was implemented as a potential SEO fix that would require upstream changes in the build. Since these upstream changes have not been implemented and are not necessary because the SEO was fixed via a different method, this PR removes the plugin and reduces build times by eliminating the time spent on file modification timestamps.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
