### PR TITLE
Backport: Point the link in the supported/unsupported version header to home page for 404s (backport #11652)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -166,10 +166,10 @@ layout: table_wrappers
         {% endunless %}
         <div id="main-content" class="main-content" role="main">
           {% if page.section == "opensearch" %}
-            {% if site.doc_version == "supported" %}            
-              <p class="supported-version-warning">You're viewing version {{site.opensearch_major_minor_version}} of the OpenSearch documentation. For the latest version, see the <a href="{{ site.url }}/latest{{ page.url }}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
+            {% if site.doc_version == "supported" %}
+              <p class="supported-version-warning">You're viewing version {{site.opensearch_major_minor_version}} of the OpenSearch documentation. For the latest version, see the <a href="{% if page.url contains '404' %}{{ site.url }}/latest/about/{% else %}{{ site.url }}/latest{{ page.url }}{% endif %}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
             {% elsif site.doc_version == "unsupported" %}
-              <p class="unsupported-version-warning">You're viewing version {{site.opensearch_major_minor_version}} of the OpenSearch documentation. This version is no longer maintained. For the latest version, see the <a href="{{ site.url }}/latest{{ page.url }}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
+              <p class="unsupported-version-warning">You're viewing version {{site.opensearch_major_minor_version}} of the OpenSearch documentation. This version is no longer maintained. For the latest version, see the <a href="{% if page.url contains '404' %}{{ site.url }}/latest/about/{% else %}{{ site.url }}/latest{{ page.url }}{% endif %}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
             {% endif %}
           {% endif %}
           {% if site.heading_anchors != false %}


### PR DESCRIPTION
This is a backport of #11652 to version 2.18.

## Original PR
- **Original PR:** https://github.com/opensearch-project/documentation-website/pull/11652
- **Changes:** Point the link in the supported/unsupported version header to home page for 404s
- **Files modified:** _layouts/default.html

## Changes
This backport modifies the version warning messages in `_layouts/default.html` to:
- Point to the about page when the current page URL contains '404' 
- Otherwise point to the equivalent page in the latest version

This prevents 404 errors when users click links in version warnings on error pages.

## Merge Conflict Resolution
- Resolved conflict by adapting the new 404 handling logic to use `/latest` path format used in this version instead of `{{ site.latesturl }}`

---
**Cherry-picked from:** c5d8bca431732bc776b4afb79c7674a9e63c88a4