### PR TITLE
Backport: Point the link in the supported/unsupported version header to home page for 404s (backport #11652)

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -142,10 +142,7 @@ layout: table_wrappers
           {% endif %}
         {% endunless %}
         <div id="main-content" class="main-content" role="main">
-            {% if site.doc_version == "supported" %}
-              <p class="supported-version-warning">You're viewing version {{site.opensearch_major_minor_version}} of the OpenSearch documentation. For the latest version, see the <a href="{% if page.url contains '404' %}{{ site.url }}/latest/about/{% else %}{{ site.url }}/latest{{ page.url }}{% endif %}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
-            {% elsif site.doc_version == "unsupported" %}
-              <p class="unsupported-version-warning">You're viewing version {{site.opensearch_major_minor_version}} of the OpenSearch documentation. This version is no longer maintained. For the latest version, see the <a href="{% if page.url contains '404' %}{{ site.url }}/latest/about/{% else %}{{ site.url }}/latest{{ page.url }}{% endif %}">current documentation</a>. For information about OpenSearch version maintenance, see <a href="https://opensearch.org/releases.html">Release Schedule and Maintenance Policy</a>.</p>
+          {% include warning.html %}
           {% if site.heading_anchors != false %}
             {% include vendor/anchor_headings.html html=content beforeHeading="true" anchorBody="<svg viewBox=\"0 0 16 16\" aria-hidden=\"true\"><use xlink:href=\"#svg-link\"></use></svg>" anchorClass="anchor-heading" anchorAttrs="aria-labelledby=\"%html_id%\"" %}
           {% else %}


### PR DESCRIPTION
This is a backport of #11652 to version 1.0.