### PR TITLE
Update PPL dev doc link from rst to md

### DIFF
--- a/_sql-and-ppl/ppl/index.md
+++ b/_sql-and-ppl/ppl/index.md
@@ -53,7 +53,7 @@ To run a PPL query using the API, see [SQL and PPL API]({{site.url}}{{site.baseu
 Developers can find information in the following resources:
 
 - [Piped Processing Language](https://github.com/opensearch-project/piped-processing-language) specification
-- [OpenSearch PPL Reference Manual](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.rst)
+- [OpenSearch PPL Reference Manual](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/index.md)
 - [Observability](https://github.com/opensearch-project/dashboards-observability/) using [PPL-based visualizations](https://github.com/opensearch-project/dashboards-observability#event-analytics)
-- PPL [Data types](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/general/datatypes.rst)
-- [Cross-cluster search](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/admin/cross_cluster_search.rst#using-cross-cluster-search-in-ppl) in PPL
+- PPL [Data types](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/general/datatypes.md)
+- [Cross-cluster search](https://github.com/opensearch-project/sql/blob/main/docs/user/ppl/admin/cross_cluster_search.md#using-cross-cluster-search-in-ppl) in PPL


### PR DESCRIPTION

### Description

PPL Plugin docs migrate from rst to md by [https://github.com/opensearch-project/sql/pull/4912](https://github.com/opensearch-project/sql/pull/4912)

### Issues Resolved

No related issue

### Version
Unfortunately, links to PPL plugin are not specified the version.


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
