### PR TITLE
Add documentation for data prepper dynamodb source for new metrics and limitation on shard processing

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -177,7 +177,9 @@ When performing an export, the `"Sid": "allowReadFromStream"` section is not req
 
 ## Limitations
 
-* Each Data Prepper instance is limited to process a maximum of 150 DynamoDB stream shards in parallel at one time. You should configure the number of Data Prepper instances as ceil(totalOpenShards.max / 150) to prevent high latency or data loss.
+Note the following limitations:
+
+* Each Data Prepper instance can process up to 150 DynamoDB stream shards in parallel. To prevent high latency and data loss, set the number of Data Prepper instances to the maximum number of open shards divided by 150 (rounded up to the nearest integer).
 
 ## Metrics
 


### PR DESCRIPTION


### Description
Adds some documentation for new metrics for the DynamoDB source, as well as the limitation of each Data Prepper instance only being able to process 150 DynamoDB stream shards in parallel.

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
