### PR TITLE
Update the default value for  `cluster.search.ignore_awareness_attributes` settings

### DIFF
--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -145,7 +145,7 @@ OpenSearch supports the following cluster-level shard, block, and task settings:
 
 OpenSearch supports the following cluster-level search settings:
 
-- `cluster.search.ignore_awareness_attributes` (Boolean): Controls whether awareness attributes are considered during shard query routing. If `true`, the cluster ignores awareness attributes and uses Adaptive Replica Selection (ARS) to choose the optimal shard copy, reducing query response latency. Set this to `false` for routing decisions to prioritize awareness attributes instead of performance-based selection. Default is `false` (`true` for Amazon OpenSearch Service).
+- `cluster.search.ignore_awareness_attributes` (Boolean): Controls whether awareness attributes are considered during shard query routing. If `true`, the cluster ignores awareness attributes and uses Adaptive Replica Selection (ARS) to choose the optimal shard copy, reducing query response latency. Set this to `false` for routing decisions to prioritize awareness attributes instead of performance-based selection. Default is `true` (`false` for Amazon OpenSearch Service).
 
 ## Cluster-level slow log settings
 


### PR DESCRIPTION
### Description
The default value mentioned for `cluster.search.ignore_awareness_attributes` setting was not correct, updated it.


### Issues Resolved
#9879 

### Version
3.3. and 3.4

~~### Frontend features~~

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
