### PR TITLE
Fix flashing of light mode in dark mode

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,3 +1,43 @@
+<!-- Inline theme detection to prevent dark mode flash -->
+<script>
+  (function() {
+    const THEME_KEY = 'opensearch-docs-theme';
+    const DARK_THEME = 'dark';
+
+    function getStoredTheme() {
+      try {
+        return localStorage.getItem(THEME_KEY);
+      } 
+      catch (e) {
+        return null;
+      }
+    }
+
+    function getSystemTheme() {
+      if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+        return DARK_THEME;
+      }
+      return 'light';
+    }
+
+    function getPreferredTheme() {
+      const stored = getStoredTheme();
+      if (stored) {
+        return stored;
+      }
+      return getSystemTheme();
+    }
+
+    const theme = getPreferredTheme();
+    if (theme === DARK_THEME) {
+      document.documentElement.setAttribute('data-skin', 'dark');
+    } 
+    else {
+      document.documentElement.removeAttribute('data-skin');
+    }
+  })();
+</script>
+
 {% if site.anchor_links != nil %}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"></script>
 {% endif %}

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -2,28 +2,8 @@ const THEME_KEY = 'opensearch-docs-theme';
 const DARK_THEME = 'dark';
 const LIGHT_THEME = 'light';
 
-function getSystemTheme() {
-  if (window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-    return DARK_THEME;
-  }
-  return LIGHT_THEME;
-}
-
-function getStoredTheme() {
-  try {
-    return localStorage.getItem(THEME_KEY);
-  } catch (e) {
-    return null;
-  }
-}
-
-function getPreferredTheme() {
-  // Precedence: stored theme > system theme > light theme
-  const stored = getStoredTheme();
-  if (stored) {
-    return stored;
-  }
-  return getSystemTheme();
+function getCurrentTheme() {
+  return document.documentElement.hasAttribute('data-skin') ? DARK_THEME : LIGHT_THEME;
 }
 
 function storeTheme(theme) {
@@ -40,17 +20,11 @@ function applyTheme(theme) {
   } else {
     document.documentElement.removeAttribute('data-skin');
   }
-
   storeTheme(theme);
-}
-
-function getNextTheme(currentTheme) {
-  return currentTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
 }
 
 function updateToggleButton(theme) {
   const toggleButtons = document.querySelectorAll('#theme-toggle');
-
   toggleButtons.forEach(button => {
     const title = theme === LIGHT_THEME ? 'Switch to dark mode' : 'Switch to light mode';
     button.setAttribute('title', title);
@@ -59,19 +33,15 @@ function updateToggleButton(theme) {
 }
 
 function handleThemeToggle() {
-  const currentTheme = getPreferredTheme();
-  const nextTheme = getNextTheme(currentTheme);
+  const currentTheme = getCurrentTheme();
+  const nextTheme = currentTheme === LIGHT_THEME ? DARK_THEME : LIGHT_THEME;
   applyTheme(nextTheme);
   updateToggleButton(nextTheme);
 }
 
-// prevent flashing
-const initialTheme = getPreferredTheme();
-applyTheme(initialTheme);
-
 // initialize UI elements when DOM is ready
 document.addEventListener('DOMContentLoaded', () => {
-  const currentTheme = getPreferredTheme();
+  const currentTheme = getCurrentTheme();
   updateToggleButton(currentTheme);
 
   const toggleButtons = document.querySelectorAll('#theme-toggle');


### PR DESCRIPTION
In production, there's a momentary flashing of the light mode if you're in dark mode and are changing pages. This PR puts the theme logic into an inline script so it is applied before the content is rendered.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
