### PR TITLE
Reorder PPL command pages so syntax is displayed first

### DIFF
--- a/_sql-and-ppl/ppl/commands/ad.md
+++ b/_sql-and-ppl/ppl/commands/ad.md
@@ -3,7 +3,7 @@ layout: default
 title: ad
 parent: Commands
 grand_parent: PPL
-nav_order: 1
+nav_order: 2
 ---
 
 # ad (Deprecated)

--- a/_sql-and-ppl/ppl/commands/addcoltotals.md
+++ b/_sql-and-ppl/ppl/commands/addcoltotals.md
@@ -3,7 +3,7 @@ layout: default
 title: addcoltotals
 parent: Commands
 grand_parent: PPL
-nav_order: 2
+nav_order: 3
 ---
 
 # addcoltotals

--- a/_sql-and-ppl/ppl/commands/addtotals.md
+++ b/_sql-and-ppl/ppl/commands/addtotals.md
@@ -3,7 +3,7 @@ layout: default
 title: addtotals
 parent: Commands
 grand_parent: PPL
-nav_order: 3
+nav_order: 4
 ---
 
 # addtotals

--- a/_sql-and-ppl/ppl/commands/append.md
+++ b/_sql-and-ppl/ppl/commands/append.md
@@ -3,7 +3,7 @@ layout: default
 title: append
 parent: Commands
 grand_parent: PPL
-nav_order: 4
+nav_order: 5
 ---
 
 # append

--- a/_sql-and-ppl/ppl/commands/appendcol.md
+++ b/_sql-and-ppl/ppl/commands/appendcol.md
@@ -3,7 +3,7 @@ layout: default
 title: appendcol
 parent: Commands
 grand_parent: PPL
-nav_order: 5
+nav_order: 6
 ---
 
 # appendcol

--- a/_sql-and-ppl/ppl/commands/appendpipe.md
+++ b/_sql-and-ppl/ppl/commands/appendpipe.md
@@ -3,7 +3,7 @@ layout: default
 title: appendpipe
 parent: Commands
 grand_parent: PPL
-nav_order: 6
+nav_order: 7
 ---
 
 # appendpipe

--- a/_sql-and-ppl/ppl/commands/bin.md
+++ b/_sql-and-ppl/ppl/commands/bin.md
@@ -3,7 +3,7 @@ layout: default
 title: bin
 parent: Commands
 grand_parent: PPL
-nav_order: 7
+nav_order: 8
 ---
 
 # bin

--- a/_sql-and-ppl/ppl/commands/chart.md
+++ b/_sql-and-ppl/ppl/commands/chart.md
@@ -3,7 +3,7 @@ layout: default
 title: chart
 parent: Commands
 grand_parent: PPL
-nav_order: 8
+nav_order: 9
 ---
 
 # chart

--- a/_sql-and-ppl/ppl/commands/dedup.md
+++ b/_sql-and-ppl/ppl/commands/dedup.md
@@ -3,7 +3,7 @@ layout: default
 title: dedup
 parent: Commands
 grand_parent: PPL
-nav_order: 9
+nav_order: 10
 ---
 
 # dedup

--- a/_sql-and-ppl/ppl/commands/describe.md
+++ b/_sql-and-ppl/ppl/commands/describe.md
@@ -3,7 +3,7 @@ layout: default
 title: describe
 parent: Commands
 grand_parent: PPL
-nav_order: 10
+nav_order: 11
 ---
 
 # describe

--- a/_sql-and-ppl/ppl/commands/eval.md
+++ b/_sql-and-ppl/ppl/commands/eval.md
@@ -3,7 +3,7 @@ layout: default
 title: eval
 parent: Commands
 grand_parent: PPL
-nav_order: 11
+nav_order: 12
 ---
 
 # eval

--- a/_sql-and-ppl/ppl/commands/eventstats.md
+++ b/_sql-and-ppl/ppl/commands/eventstats.md
@@ -3,7 +3,7 @@ layout: default
 title: eventstats
 parent: Commands
 grand_parent: PPL
-nav_order: 12
+nav_order: 13
 ---
 
 # eventstats

--- a/_sql-and-ppl/ppl/commands/expand.md
+++ b/_sql-and-ppl/ppl/commands/expand.md
@@ -3,7 +3,7 @@ layout: default
 title: expand
 parent: Commands
 grand_parent: PPL
-nav_order: 13
+nav_order: 14
 ---
 
 # expand

--- a/_sql-and-ppl/ppl/commands/explain.md
+++ b/_sql-and-ppl/ppl/commands/explain.md
@@ -3,7 +3,7 @@ layout: default
 title: explain
 parent: Commands
 grand_parent: PPL
-nav_order: 14
+nav_order: 15
 ---
 
 # explain

--- a/_sql-and-ppl/ppl/commands/fields.md
+++ b/_sql-and-ppl/ppl/commands/fields.md
@@ -3,7 +3,7 @@ layout: default
 title: fields
 parent: Commands
 grand_parent: PPL
-nav_order: 15
+nav_order: 16
 ---
 
 # fields

--- a/_sql-and-ppl/ppl/commands/fillnull.md
+++ b/_sql-and-ppl/ppl/commands/fillnull.md
@@ -3,7 +3,7 @@ layout: default
 title: fillnull
 parent: Commands
 grand_parent: PPL
-nav_order: 16
+nav_order: 17
 ---
 
 # fillnull

--- a/_sql-and-ppl/ppl/commands/flatten.md
+++ b/_sql-and-ppl/ppl/commands/flatten.md
@@ -3,7 +3,7 @@ layout: default
 title: flatten
 parent: Commands
 grand_parent: PPL
-nav_order: 17
+nav_order: 18
 ---
 
 # flatten

--- a/_sql-and-ppl/ppl/commands/grok.md
+++ b/_sql-and-ppl/ppl/commands/grok.md
@@ -3,7 +3,7 @@ layout: default
 title: grok
 parent: Commands
 grand_parent: PPL
-nav_order: 18
+nav_order: 19
 ---
 
 # grok

--- a/_sql-and-ppl/ppl/commands/head.md
+++ b/_sql-and-ppl/ppl/commands/head.md
@@ -3,7 +3,7 @@ layout: default
 title: head
 parent: Commands
 grand_parent: PPL
-nav_order: 19
+nav_order: 20
 ---
 
 # head

--- a/_sql-and-ppl/ppl/commands/join.md
+++ b/_sql-and-ppl/ppl/commands/join.md
@@ -3,7 +3,7 @@ layout: default
 title: join
 parent: Commands
 grand_parent: PPL
-nav_order: 21
+nav_order: 22
 ---
 
 # join

--- a/_sql-and-ppl/ppl/commands/kmeans.md
+++ b/_sql-and-ppl/ppl/commands/kmeans.md
@@ -3,7 +3,7 @@ layout: default
 title: kmeans
 parent: Commands
 grand_parent: PPL
-nav_order: 22
+nav_order: 23
 ---
 
 # kmeans (Deprecated)

--- a/_sql-and-ppl/ppl/commands/lookup.md
+++ b/_sql-and-ppl/ppl/commands/lookup.md
@@ -3,7 +3,7 @@ layout: default
 title: lookup
 parent: Commands
 grand_parent: PPL
-nav_order: 23
+nav_order: 24
 ---
 
 # lookup

--- a/_sql-and-ppl/ppl/commands/ml.md
+++ b/_sql-and-ppl/ppl/commands/ml.md
@@ -3,7 +3,7 @@ layout: default
 title: ml
 parent: Commands
 grand_parent: PPL
-nav_order: 24
+nav_order: 25
 ---
 
 # ml

--- a/_sql-and-ppl/ppl/commands/multisearch.md
+++ b/_sql-and-ppl/ppl/commands/multisearch.md
@@ -3,7 +3,7 @@ layout: default
 title: multisearch
 parent: Commands
 grand_parent: PPL
-nav_order: 25
+nav_order: 26
 ---
 
 # multisearch

--- a/_sql-and-ppl/ppl/commands/parse.md
+++ b/_sql-and-ppl/ppl/commands/parse.md
@@ -3,7 +3,7 @@ layout: default
 title: parse
 parent: Commands
 grand_parent: PPL
-nav_order: 26
+nav_order: 27
 ---
 
 # parse

--- a/_sql-and-ppl/ppl/commands/patterns.md
+++ b/_sql-and-ppl/ppl/commands/patterns.md
@@ -3,7 +3,7 @@ layout: default
 title: patterns
 parent: Commands
 grand_parent: PPL
-nav_order: 27
+nav_order: 28
 ---
 
 # patterns

--- a/_sql-and-ppl/ppl/commands/rare.md
+++ b/_sql-and-ppl/ppl/commands/rare.md
@@ -3,7 +3,7 @@ layout: default
 title: rare
 parent: Commands
 grand_parent: PPL
-nav_order: 28
+nav_order: 29
 ---
 
 # rare

--- a/_sql-and-ppl/ppl/commands/regex.md
+++ b/_sql-and-ppl/ppl/commands/regex.md
@@ -3,7 +3,7 @@ layout: default
 title: regex
 parent: Commands
 grand_parent: PPL
-nav_order: 29
+nav_order: 30
 ---
 
 # regex

--- a/_sql-and-ppl/ppl/commands/rename.md
+++ b/_sql-and-ppl/ppl/commands/rename.md
@@ -3,7 +3,7 @@ layout: default
 title: rename
 parent: Commands
 grand_parent: PPL
-nav_order: 30
+nav_order: 31
 ---
 
 # rename

--- a/_sql-and-ppl/ppl/commands/replace.md
+++ b/_sql-and-ppl/ppl/commands/replace.md
@@ -3,7 +3,7 @@ layout: default
 title: replace
 parent: Commands
 grand_parent: PPL
-nav_order: 31
+nav_order: 32
 ---
 
 # replace

--- a/_sql-and-ppl/ppl/commands/reverse.md
+++ b/_sql-and-ppl/ppl/commands/reverse.md
@@ -3,7 +3,7 @@ layout: default
 title: reverse
 parent: Commands
 grand_parent: PPL
-nav_order: 32
+nav_order: 33
 ---
 
 # reverse

--- a/_sql-and-ppl/ppl/commands/rex.md
+++ b/_sql-and-ppl/ppl/commands/rex.md
@@ -3,7 +3,7 @@ layout: default
 title: rex
 parent: Commands
 grand_parent: PPL
-nav_order: 33
+nav_order: 34
 ---
 
 # rex

--- a/_sql-and-ppl/ppl/commands/search.md
+++ b/_sql-and-ppl/ppl/commands/search.md
@@ -3,7 +3,7 @@ layout: default
 title: search
 parent: Commands
 grand_parent: PPL
-nav_order: 34
+nav_order: 35
 ---
 
 # search

--- a/_sql-and-ppl/ppl/commands/showdatasources.md
+++ b/_sql-and-ppl/ppl/commands/showdatasources.md
@@ -3,7 +3,7 @@ layout: default
 title: show datasources
 parent: Commands
 grand_parent: PPL
-nav_order: 35
+nav_order: 36
 ---
 
 # show datasources

--- a/_sql-and-ppl/ppl/commands/sort.md
+++ b/_sql-and-ppl/ppl/commands/sort.md
@@ -3,7 +3,7 @@ layout: default
 title: sort
 parent: Commands
 grand_parent: PPL
-nav_order: 36
+nav_order: 37
 ---
 
 # sort

--- a/_sql-and-ppl/ppl/commands/spath.md
+++ b/_sql-and-ppl/ppl/commands/spath.md
@@ -3,7 +3,7 @@ layout: default
 title: spath
 parent: Commands
 grand_parent: PPL
-nav_order: 37
+nav_order: 38
 ---
 
 # spath

--- a/_sql-and-ppl/ppl/commands/stats.md
+++ b/_sql-and-ppl/ppl/commands/stats.md
@@ -3,7 +3,7 @@ layout: default
 title: stats
 parent: Commands
 grand_parent: PPL
-nav_order: 38
+nav_order: 39
 ---
 
 # stats

--- a/_sql-and-ppl/ppl/commands/streamstats.md
+++ b/_sql-and-ppl/ppl/commands/streamstats.md
@@ -3,7 +3,7 @@ layout: default
 title: streamstats
 parent: Commands
 grand_parent: PPL
-nav_order: 39
+nav_order: 40
 ---
 
 # streamstats

--- a/_sql-and-ppl/ppl/commands/subquery.md
+++ b/_sql-and-ppl/ppl/commands/subquery.md
@@ -3,7 +3,7 @@ layout: default
 title: subquery
 parent: Commands
 grand_parent: PPL
-nav_order: 40
+nav_order: 41
 ---
 
 # subquery

--- a/_sql-and-ppl/ppl/commands/table.md
+++ b/_sql-and-ppl/ppl/commands/table.md
@@ -3,7 +3,7 @@ layout: default
 title: table
 parent: Commands
 grand_parent: PPL
-nav_order: 42
+nav_order: 43
 ---
 
 # table

--- a/_sql-and-ppl/ppl/commands/timechart.md
+++ b/_sql-and-ppl/ppl/commands/timechart.md
@@ -3,7 +3,7 @@ layout: default
 title: timechart
 parent: Commands
 grand_parent: PPL
-nav_order: 43
+nav_order: 44
 ---
 
 # timechart

--- a/_sql-and-ppl/ppl/commands/top.md
+++ b/_sql-and-ppl/ppl/commands/top.md
@@ -3,7 +3,7 @@ layout: default
 title: top
 parent: Commands
 grand_parent: PPL
-nav_order: 44
+nav_order: 45
 ---
 
 # top {#top-command}

--- a/_sql-and-ppl/ppl/commands/trendline.md
+++ b/_sql-and-ppl/ppl/commands/trendline.md
@@ -3,7 +3,7 @@ layout: default
 title: trendline
 parent: Commands
 grand_parent: PPL
-nav_order: 45
+nav_order: 46
 ---
 
 # trendline

--- a/_sql-and-ppl/ppl/commands/where.md
+++ b/_sql-and-ppl/ppl/commands/where.md
@@ -3,7 +3,7 @@ layout: default
 title: where
 parent: Commands
 grand_parent: PPL
-nav_order: 46
+nav_order: 47
 ---
 
 # where


### PR DESCRIPTION
Reorder PPL command pages so syntax is displayed first

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
