### PR TITLE
Document automatic vector normalization with Faiss cosinesimil

### DIFF
--- a/_about/breaking-changes.md
+++ b/_about/breaking-changes.md
@@ -47,7 +47,7 @@ OpenSearch 2.5 contains a bug fix that corrects the behavior of the `case_insens
 
 ### Default k-NN engine change
 
-The default k-NN engine changed from NMSLIB to Faiss. If you use `space_type: "cosinesimil"` without explicitly specifying an engine, your vectors are now automatically normalized to unit length during indexing. This happens because Faiss does not natively support cosine similarity and instead uses inner product on normalized vectors. As a result, stored vector values will differ from input values, which may affect code that retrieves and compares vectors. If your vectors are already normalized, consider using `space_type: "innerproduct"` instead for mathematically equivalent results with explicit control over normalization. For more information, see pull request [#2221](https://github.com/opensearch-project/k-NN/pull/2221).
+The default k-NN engine changed from NMSLIB to Faiss. If you use `space_type: "cosinesimil"` without explicitly specifying an engine, your vectors are now automatically normalized to unit length during indexing. This happens because Faiss does not natively support cosine similarity and instead uses inner product on normalized vectors. As a result, stored vector values will differ from input values, which may affect code that retrieves and compares vectors. If your vectors are already normalized, consider setting `space_type` to `innerproduct` instead of `cosinesimil` to obtain mathematically equivalent results with explicit control over normalization. For more information, see pull request [#2221](https://github.com/opensearch-project/k-NN/pull/2221).
 
 ## 2.19.0
 

--- a/_mappings/supported-field-types/knn-methods-engines.md
+++ b/_mappings/supported-field-types/knn-methods-engines.md
@@ -132,7 +132,7 @@ Method name | Requires training | Supported spaces
 [`hnsw`](#hnsw-parameters-1) | No | `l2`, `innerproduct` (not available when [PQ](#pq-parameters) is used), `hamming`, and `cosinesimil` (supported in OpenSearch 2.19 and later).
 [`ivf`](#ivf-parameters) | Yes | `l2`, `innerproduct`, `hamming` (supported for binary vectors in OpenSearch version 2.16 and later. For more information, see [Binary k-NN vectors]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/knn-memory-optimized#binary-vectors), `cosinesimil` (supported in OpenSearch 2.19 and later).
 
-When using `cosinesimil` with the Faiss engine, vectors are automatically normalized to unit length during indexing because Faiss uses inner product on normalized vectors internally. Stored vector values will differ from input values.
+When using `cosinesimil` with the Faiss engine, vectors are automatically normalized to unit length during indexing because Faiss uses inner product on normalized vectors internally. As a result, stored vector values will differ from input values.
 {: .important}
 
 #### HNSW parameters

--- a/_mappings/supported-field-types/knn-spaces.md
+++ b/_mappings/supported-field-types/knn-spaces.md
@@ -40,7 +40,7 @@ With cosine similarity, it is not valid to pass a zero vector (`[0, 0, ...]`) as
 The `hamming` space type is supported for binary vectors in OpenSearch version 2.16 and later. For more information, see [Binary k-NN vectors]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/knn-memory-optimized#binary-vectors).
 {: .note}
 
-When using `cosinesimil` with the Faiss engine, vectors are automatically normalized to unit length during indexing because Faiss uses inner product on normalized vectors internally. If your vectors are already normalized, consider using `innerproduct` instead for equivalent results with explicit control over normalization.
+When using `cosinesimil` with the Faiss engine, vectors are automatically normalized to unit length during indexing because Faiss uses inner product on normalized vectors internally. If your vectors are already normalized, consider using `innerproduct` instead of `cosinesimil` to obtain equivalent results with explicit control over normalization.
 {: .important}
 
 ## Specifying the space type


### PR DESCRIPTION
## Description

When using `space_type: "cosinesimil"` with the Faiss engine (default since v2.18), vectors are automatically normalized to unit length during indexing. This behavior was undocumented and can affect users upgrading from earlier versions.

## Changes

- **breaking-changes.md**: Added 2.18.0 section documenting the default engine change from NMSLIB to Faiss and its implications for cosinesimil users
- **knn-spaces.md**: Added important note about automatic normalization with Faiss
- **knn-methods-engines.md**: Added important note in the Faiss engine section

## Related Issue

Relates to: https://github.com/opensearch-project/k-NN/issues/3045

## Check List

- [x] New documentation follows the [style guidelines](https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md)
- [x] Commits are signed with DCO