### PR TITLE
Added username, user_roles, and wlm_group_id to query insights

### DIFF
--- a/_observing-your-data/query-insights/grouping-top-n-queries.md
+++ b/_observing-your-data/query-insights/grouping-top-n-queries.md
@@ -222,6 +222,7 @@ The response contains the top N query groups:
   "top_queries": [
     {
       "timestamp": 1725495127359,
+      "wlm_group_id": "DEFAULT_WORKLOAD_GROUP",
       "source": {
         "query": {
           "match_all": {
@@ -259,10 +260,14 @@ The response contains the top N query groups:
           }
         }
       ],
+      "username": "admin",
       "indices": [
         "my_index"
       ],
       "labels": {},
+      "user_roles": [
+        "all_access"
+      ],
       "search_type": "query_then_fetch",
       "measurements": {
         "latency": {
@@ -274,6 +279,7 @@ The response contains the top N query groups:
     },
     {
       "timestamp": 1725495135160,
+      "wlm_group_id": "DEFAULT_WORKLOAD_GROUP",
       "source": {
         "query": {
           "term": {
@@ -314,10 +320,14 @@ The response contains the top N query groups:
           }
         }
       ],
+      "username": "admin",
       "indices": [
         "my_index"
       ],
       "labels": {},
+      "user_roles": [
+        "all_access"
+      ],
       "search_type": "query_then_fetch",
       "measurements": {
         "latency": {
@@ -329,6 +339,7 @@ The response contains the top N query groups:
     },
     {
       "timestamp": 1725495139766,
+      "wlm_group_id": "DEFAULT_WORKLOAD_GROUP",
       "source": {
         "query": {
           "match": {
@@ -376,10 +387,14 @@ The response contains the top N query groups:
           }
         }
       ],
+      "username": "admin",
       "indices": [
         "my_index"
       ],
       "labels": {},
+      "user_roles": [
+        "all_access"
+      ],
       "search_type": "query_then_fetch",
       "measurements": {
         "latency": {

--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -105,6 +105,7 @@ Parameter | Data type     | Description
     {
       "timestamp" : 1745021834451,
       "id" : "36506bd2-7bca-4a0a-a6b8-f3e7db2b0745",
+      "wlm_group_id" : "DEFAULT_WORKLOAD_GROUP",
       "group_by" : "NONE",
       "indices" : [
         "my-index-0"
@@ -167,6 +168,7 @@ Parameter | Data type     | Description
           }
         }
       ],
+      "username" : "admin",
       "node_id" : "BBgWzu8QR0qDkR0G45aw8w",
       "phase_latency_map" : {
         "expand" : 0,
@@ -178,6 +180,9 @@ Parameter | Data type     | Description
       },
       "search_type" : "query_then_fetch",
       "total_shards" : 1,
+      "user_roles" : [
+        "all_access"
+      ],
       "measurements" : {
         "memory" : {
           "number" : 6608456,
@@ -199,6 +204,7 @@ Parameter | Data type     | Description
     {
       "timestamp" : 1745021826937,
       "id" : "86e161d0-e982-48c2-b8da-e3a3763f2e36",
+      "wlm_group_id" : "DEFAULT_WORKLOAD_GROUP",
       "group_by" : "NONE",
       "indices" : [
         "my-index-*"
@@ -236,6 +242,7 @@ Parameter | Data type     | Description
           }
         }
       ],
+      "username" : "admin",
       "node_id" : "BBgWzu8QR0qDkR0G45aw8w",
       "phase_latency_map" : {
         "expand" : 0,
@@ -245,6 +252,9 @@ Parameter | Data type     | Description
       "labels" : { },
       "search_type" : "query_then_fetch",
       "total_shards" : 1,
+      "user_roles" : [
+        "all_access"
+      ],
       "measurements" : {
         "memory" : {
           "number" : 4408088,


### PR DESCRIPTION
### Description
Added username, user_roles, and wlm_group_id to json examples in top n queries and grouping top n queries. 

### Issues Resolved
References PR: [opensearch-project/query-insights#508](https://github.com/opensearch-project/query-insights/pull/508)

### Version
3.5

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
