### PR TITLE
Add double backslashes to grok processor documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -198,7 +198,7 @@ application-logs-pipeline:
   processor:
     - grok:
         match:
-          message: ['%{TIMESTAMP_ISO8601:timestamp} \[%{LOGLEVEL:level}\] %{DATA:component} - %{GREEDYDATA:details}']
+          message: ['%{TIMESTAMP_ISO8601:timestamp} \\[%{LOGLEVEL:level}\\] %{DATA:component} - %{GREEDYDATA:details}']
         pattern_definitions:
           LOGLEVEL: (?:INFO|WARN|ERROR|DEBUG|TRACE)
         break_on_match: true
@@ -332,7 +332,7 @@ network-device-logs-pipeline:
         match:
           message: [
             # syslog-like
-            '%{SYSLOGTIMESTAMP:timestamp} %{SYSLOGHOST:host} %{DATA:program}(?:\[%{POSINT:pid}\])?: %{GREEDYDATA:message}',
+            '%{SYSLOGTIMESTAMP:timestamp} %{SYSLOGHOST:host} %{DATA:program}(?:\\[%{POSINT:pid}\\])?: %{GREEDYDATA:message}',
             # ISO8601 + IP
             '%{TIMESTAMP_ISO8601:timestamp} %{IP:host} %{DATA:program}: %{GREEDYDATA:message}',
             # Cisco style


### PR DESCRIPTION
Single backslashes in YAML don't produce literal backslashes in the final pattern. Grok needs literal backslashes to properly escape square brackets in regex patterns. Added double backslashes to produce the single backslash in the final grok pattern.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
