### PR TITLE
Update AWS Lambda plugin documentation for optional timeout configurations

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/processors/aws-lambda.md
@@ -91,7 +91,7 @@ The AWS Lambda processor supports multiple timeout layers following AWS SDK best
 - `api_call_attempt_timeout`: The time limit for each individual attempt.
 - `read_timeout`: The amount of time to wait for data from an established connection.
 
-For Lambda functions that run longer than 60 seconds, configure both `api_call_timeout` and `read_timeout` to appropriate values. The `api_call_attempt_timeout` enforces a per-attempt timeout, enabling fast failure of slow requests while preserving overall retry behavior.
+For Lambda functions that run for longer than 60 seconds, configure both `api_call_timeout` and `read_timeout` to appropriate values. The `api_call_attempt_timeout` enforces a per-attempt timeout, enabling fast failure of slow requests while preserving overall retry behavior.
 
 ## Usage
 

--- a/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
@@ -75,7 +75,7 @@ The AWS Lambda sink supports multiple timeout layers following AWS SDK best prac
 - `api_call_attempt_timeout`: The time limit for each individual attempt.
 - `read_timeout`: The amount of time to wait for data from an established connection.
 
-For Lambda functions that run longer than 60 seconds, configure both `api_call_timeout` and `read_timeout` to appropriate values. 
+For Lambda functions that run for longer than 60 seconds, configure both `api_call_timeout` and `read_timeout` to appropriate values. 
 
 ## Usage
 


### PR DESCRIPTION
### Description

Documentation updates support the new optional timeout features in Data Prepper AWS Lambda plugin.
1. Add api_call_attempt_timeout as optional configuration parameter
2. Update read_timeout to be optional (uses AWS SDK defaults when not specified)
    Signed-off-by: Aiswarya Sadananda Rao <aiswarao@amazon.com>

### Issues Resolved

https://github.com/opensearch-project/data-prepper/issues/6257

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [yes ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
