### PR TITLE
remove experimental tag and add some more links in Search Relevance Workbench

### DIFF
--- a/_search-plugins/search-relevance/compare-search-results.md
+++ b/_search-plugins/search-relevance/compare-search-results.md
@@ -93,7 +93,7 @@ By default, OpenSearch returns the top 10 results. To change the number of retur
 Setting `size` to a high value (for example, larger than 250 documents) may degrade performance.
 {: .note}
 
-You cannot save a given comparison for future use, so Compare Search Results is not suitable for systematic testing.  Instead, look at [Search result comparison]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/comparing-search-results/) experiment.
+You cannot save a given comparison for future use, so Compare Search Results is not suitable for systematic testing.  Instead, review the [Search result comparison]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/comparing-search-results/) experiment.
 {: .note}
 
 ## Comparing OpenSearch search results using Search Relevance Workbench

--- a/_search-plugins/search-relevance/using-search-relevance-workbench.md
+++ b/_search-plugins/search-relevance/using-search-relevance-workbench.md
@@ -15,7 +15,7 @@ In search applications, tuning relevance is a constant, iterative exercise inten
 Search Relevance Workbench consists of a [frontend component](https://github.com/opensearch-project/dashboards-search-relevance) that simplifies the process of evaluating search quality.
 The frontend uses the [OpenSearch Search Relevance plugin](https://github.com/opensearch-project/search-relevance) as a backend to manage the resources for each tool provided. For example, most use cases involve creating and using search configurations, query sets, and judgment lists. All of these resources are created, updated, deleted, and maintained by the Search Relevance plugin. When you are satisfied with the relevance improvements, you can take the output of the experimentation and manually deploy the changes into your search application.
 
-You can quickly analyze a single query via the [Single query comparison]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/compare-search-results/) UI before moving to more structured experiments.
+You can quickly analyze a single query using the [Single query comparison UI]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/compare-search-results/) before moving to more structured experiments.
 
 ## Key relevance concepts
 


### PR DESCRIPTION
### Description
Removes a setup task that no longer is needed.   

I thought we had some warnings about this being experimental, but I can't find it...  SRW is no longer experimental ;-)

### Issues Resolved
n/a

### Version
3.5.  

### Frontend features
n/a

### Checklist
- [x ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
