### PR TITLE
[Fix] dark mode text visibility in breaking-changes selector

### DIFF
--- a/_migration-assistant/assets/css/breaking-changes-selector.css
+++ b/_migration-assistant/assets/css/breaking-changes-selector.css
@@ -1,5 +1,6 @@
 .breaking-changes-selector {
-  background: #f5f7f7;
+  background: var(--sidebar-bg, #f5f7f7);
+  color: var(--body-text, #333);
   padding: 15px;
   border-radius: 4px;
   margin-bottom: 20px;
@@ -16,6 +17,8 @@
 .breaking-changes-selector select {
   margin-right: 15px;
   padding: 4px;
+  background: var(--body-bg, #fff);
+  color: var(--body-text, #333);
 }
 
 .breaking-changes-selector input[type="checkbox"] {
@@ -33,8 +36,9 @@
 .transformation-info {
   margin-left: 20px;
   padding: 5px 10px;
-  background-color: #e6f7ff;
-  border-left: 3px solid #1890ff;
+  background-color: var(--code-bg, #e6f7ff);
+  border-left: 3px solid var(--link-color, #1890ff);
+  color: var(--body-text, #333);
   margin-top: 5px;
   margin-bottom: 5px;
   font-size: 0.9em;
@@ -48,7 +52,8 @@
 .transformation-request {
   margin-top: 15px;
   padding: 10px;
-  background-color: #f0f0f0;
+  background-color: var(--sidebar-bg, #f0f0f0);
+  color: var(--body-text, #333);
   border-radius: 4px;
   font-size: 0.9em;
   font-style: italic;


### PR DESCRIPTION
### Description
The breaking-changes selector on the Assessment page (/migration-assistant/migration-phases/assessment/#understanding-breaking-changes) has invisible text in dark mode. The
hardcoded light mode colors cause text to camouflage against the background when dark mode is enabled.

This PR replaces hardcoded color values with the site's existing CSS theme variables so the component automatically inherits correct colors from the theme toggle.

### Issues Resolved
NA

### Version
NA

### Frontend features
- Before this PR
<img width="963" height="392" alt="darkmode_before" src="https://github.com/user-attachments/assets/4d7829de-f27b-495c-a422-58e83ed2c37c" />

- After this PR
<img width="963" height="451" alt="darkmode_after" src="https://github.com/user-attachments/assets/6a328a3d-8676-4be5-b5a0-ae9901073e3b" />


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
