### PR TITLE
[3.5] [Index Rollups] Add documentation for cardinality metric and multi-tier rollup in Index Rollups

### DIFF
--- a/_im-plugin/index-rollups/index.md
+++ b/_im-plugin/index-rollups/index.md
@@ -255,7 +255,7 @@ For multi-tier rollups to work correctly, you must fulfill the following prerequ
 
 ### Example: Two-tier rollup strategy
 
-This example demonstrates a two-tier rollup for IoT sensor data. It consists of Tier 1 and Tier 2:
+This example demonstrates a two-tier rollup for Internet of Things (IoT) sensor data. It consists of Tier 1 and Tier 2:
 - Both tiers use identical dimension fields: `timestamp`, `sensor_id`, `location`.
 - Both tiers use identical metric fields: `temperature` (`avg`/`max`/`min`), `device_id` (`cardinality`).
 - The cardinality `precision_threshold` is the same in both tiers (`10000`).


### PR DESCRIPTION
### Description
This PR adds documentation for Multi-Tier Rollups and Cardinality Metric features in Index Rollups, which are going to be released in OS 3.5

### Issues Resolved
Closes #11827

### Version
v3.5.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
