### PR TITLE
Added note for large shard count support for hybrid query

### DIFF
--- a/_query-dsl/compound/hybrid.md
+++ b/_query-dsl/compound/hybrid.md
@@ -29,7 +29,6 @@ Parameter | Description
 Starting with version 3.5, the [`min_score`]({{site.url}}{{site.baseurl}}/api-reference/search-apis/search/#request-body) parameter is applied after score normalization and combination. It can be used only when sorting by `_score` or when no explicit sort order is specified. If `min_score` is used with any other sorting criteria, the request results in an error.
 {: .note}
 
-
 Starting with OpenSearch 3.5, you can use hybrid queries on indexes with more than 512 shards. OpenSearch automatically disables batched reduction to ensure proper score normalization across all shards. No configuration is required. Note that memory usage on the coordinating node may be higher for indexes with a large number of shards. The `_msearch` endpoint does not support automatic handling of batched reduction. For multi-search requests with hybrid queries across many shards, use the `_search` endpoint with index patterns or aliases instead.
 {: .note}
 


### PR DESCRIPTION
### Description
Documents large shard count support for hybrid queries in OpenSearch 3.5. OpenSearch now automatically disables batched reduction to ensure proper score normalization across all shards when running hybrid queries on indexes with 513+ shards.

### Issues Resolved
Describes changes introduced in scope of https://github.com/opensearch-project/neural-search/issues/1733

### Version
3.5+

### Frontend features
none

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
