### PR TITLE
Rename convert_entry_type to convert_type in documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
+++ b/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
@@ -8,7 +8,7 @@ nav_order: 50
 
 # Convert type processor
 
-The `convert_type` processor converts a value type associated with the specified key in a event to the specified type. It is a casting processor that changes the types of some fields in events. Some data must be converted to a different type, such as an integer to a double, or a string to an integer, so that it will pass the events through condition-based processors or perform conditional routing.
+The `convert_type` processor converts a value type associated with the specified key in an event to the specified type. It is a casting processor that changes the types of some fields in events. Some data must be converted to a different type, such as an integer to a double or a string to an integer, so that it will pass the events through condition-based processors or perform conditional routing.
 
 Starting with OpenSearch Data Prepper version 2.10.0, the `convert_entry_type` processor has been renamed to `convert_type`. Configurations using `convert_entry_type` generate a deprecation warning and should be updated.
 {: .important }


### PR DESCRIPTION
### Description
Rename convert_entry_type to convert_type in documentation

### Issues Resolved
Closes #11841

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._: From Data Prepper 2.10.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
