### PR TITLE
[Documentation] configuring-benchmark.md: Add auth details

### DIFF
--- a/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
+++ b/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
@@ -34,8 +34,8 @@ You can customize `--client-options` with the following settings.
 | :---- | :---- | :---- |
 | `timeout` | Integer | Sets the request timeout value in seconds. |
 | `verify_certs` | Boolean | Determines whether to verify SSL certificates when connecting to the OpenSearch cluster. |
-| `basic_auth_user` | String | User for authentication to the OpenSearch cluster (if authentication is required). |
-| `basic_auth_password` | String | Password for authentication to the OpenSearch cluster (if authentication is required). |
+| `basic_auth_user` | String | The username used to authenticate with the OpenSearch cluster (if authentication is enabled). |
+| `basic_auth_password` | String | The password used to authenticate with the OpenSearch cluster (if authentication is enabled). |
 
 This example runs a benchmark with a 2-minute timeout and disabled certificate verification:
 


### PR DESCRIPTION
[Documentation] Add details on how to authenticate to clusters on which security is enabled.

### Description
Improve documentation on how to have opensearch-benchmark connect to a security-enabled opensearch cluster

### Issues Resolved
None

### Version
all

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
