### PR TITLE
Add rename_pattern parameter to convert_index_to_remote documentation

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -427,6 +427,7 @@ Parameter | Description | Type | Required | Default
 `include_aliases` | Whether to include index aliases during the restore operation. If `true`, all aliases associated with the original index are restored with the remote index. If your application accesses the index using aliases, set this parameter to `true`. | Boolean | No | `false`
 `ignore_index_settings` | A comma-separated list of index settings to ignore during the restore operation. For example, `index.refresh_interval,index.number_of_replicas`. This is useful when you want to apply different settings to the restored remote index than the ones configured in the original index. | String | No | Empty string
 `number_of_replicas` | The number of replicas to configure for the restored remote index. This allows you to control replica allocation during the conversion process without requiring a separate update operation. Setting `number_of_replicas` during conversion helps prevent the cluster from entering a yellow state or creating unnecessary load during replica assignment. | Integer | No | `0`
+`rename_pattern` | The naming pattern for the restored searchable snapshot index. Use `$1` as a placeholder for the original index name. For example, `remote_$1` renames `my-index` to `remote_my-index`. | String | No | `$1_remote`
 
 #### Prerequisites
 
@@ -474,7 +475,8 @@ The following example demonstrates using all available configuration options. Th
       "snapshot": "daily-snapshot",
       "include_aliases": true,
       "ignore_index_settings": "index.refresh_interval,index.number_of_replicas",
-      "number_of_replicas": 0
+      "number_of_replicas": 0,
+      "rename_pattern": "remote_$1"
    }
 }
 ```


### PR DESCRIPTION
### Description
Add documentation for the optional `rename_pattern` parameter added to the `convert_index_to_remote` ISM action in index-management#1568.

The `rename_pattern` parameter allows users to customize the naming pattern for the restored searchable snapshot index. By default, the restored index is suffixed with `_remote` (e.g., `my-index` becomes `my-index_remote`).

### Issues Resolved
Related to index-management#1568

### Version
3.5 and later

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
