### PR TITLE
Fix geospatial settings max_coordinates_per_geo name

### DIFF
--- a/_dashboards/visualize/geojson-regionmaps.md
+++ b/_dashboards/visualize/geojson-regionmaps.md
@@ -81,7 +81,7 @@ The following example GeoJSON file provides coordinates for two US counties.
 
 The complexity of uploaded GeoJSON files can be configured using the following cluster settings:
 
-- `plugins.geospatial.geojson.max_coordinates_per_geometry` (Dynamic, integer): Sets the maximum number of coordinates allowed per geometry. Default is `10000`.
+- `plugins.geospatial.geojson.max_coordinates_per_geo` (Dynamic, integer): Sets the maximum number of coordinates allowed per geometry. Default is `10000`.
 
 - `plugins.geospatial.geojson.max_holes_per_polygon` (Dynamic, integer): Sets the maximum number of holes allowed per polygon. Default is `1000`.
 


### PR DESCRIPTION
### Description
We recently added new cluster settings for geospatial in #11817. However, the documentation for the setting name was incorrect. This fixes the documentation to match the actual setting name.

`max_coordinates_per_geo` vs `max_coordinates_per_geometry`

https://github.com/opensearch-project/geospatial/blob/1b9d5b987779cecea204815beeca37d4654d8465/src/main/java/org/opensearch/geospatial/settings/GeospatialSettings.java#L13



### Issues Resolved
See also #11817

### Version
3.5

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
