### PR TITLE
Add cluster.remote.<cluster_alias>.cluster_name documentation

### DIFF
--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -227,7 +227,7 @@ OpenSearch supports the following remote cluster settings:
 
 - `cluster.remote.<cluster_alias>.node_connections` (Dynamic, integer): Applicable to `sniff` mode only. Sets the number of gateway nodes to which to maintain active connections in the remote cluster. More connections provide better availability but consume more resources. Default is `3`.
 
-- `cluster.remote.<cluster_alias>.cluster_name` (Dynamic, string): Applicable to `sniff` mode only. This is optional. Sets the expected cluster name of the remote cluster. When set, the remote cluster's name will be validated against this setting when establishing the connection. This prevents accidentally connecting to the wrong cluster when seeds are misconfigured or stale. 
+- `cluster.remote.<cluster_alias>.cluster_name` (Dynamic, string): Applicable only to `sniff` mode. Specifies the expected name of the remote cluster. When configured, the remote cluster name is validated when establishing the connection. This helps prevent accidental connections to an unintended cluster if seed nodes are misconfigured or outdated.
 
 - `cluster.remote.node.attr` (Static, string): Applicable to `sniff` mode only. Specifies a node attribute to filter nodes that are eligible as gateway nodes in remote clusters. When set, only remote cluster nodes with the specified attribute will be used for connections. For example, if remote cluster nodes have `node.attr.gateway: true` and this setting is set to `gateway`, only those nodes will be connected to for cross-cluster operations.
 


### PR DESCRIPTION
### Description
Add cluster.remote.<cluster_alias>.cluster_name documentation. The added setting can be found here for reference: [link](https://github.com/opensearch-project/OpenSearch/blob/main/server/src/main/java/org/opensearch/transport/SniffConnectionStrategy.java#L148)


### Version
3.5 onwards

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
