### PR TITLE
Fix Query Insights historical top n links

### DIFF
--- a/_observing-your-data/query-insights/top-n-queries.md
+++ b/_observing-your-data/query-insights/top-n-queries.md
@@ -107,8 +107,8 @@ The following table lists the available query parameters. All query parameters a
 Parameter | Data type     | Description
 :--- |:---------| :---
 `type`    | String   | The metric type for which to retrieve top N query data. Results will be sorted in descending order based on this metric. Valid values are `latency`, `cpu`, and `memory`. Default is `latency`.
-`from`    | String | The start of the time range for fetching historical top N queries. For more information, see [Monitoring historical top N queries](#monitoring-historical-top-N-queries).
-`to`      | String | The end of the time range for fetching historical top N queries. For more information, see [Monitoring historical top N queries](#monitoring-historical-top-N-queries).
+`from`    | String | The start of the time range for fetching historical top N queries. For more information, see [Monitoring historical top N queries](#monitoring-historical-top-n-queries).
+`to`      | String | The end of the time range for fetching historical top N queries. For more information, see [Monitoring historical top N queries](#monitoring-historical-top-n-queries).
 `id`      | String   | The ID of a specific top query record to retrieve.
 `verbose` | Boolean  | Indicates whether to return verbose output. Default is `true`.
 


### PR DESCRIPTION
### Description
"Monitoring historical top N queries" link does not work on https://docs.opensearch.org/latest/observing-your-data/query-insights/top-n-queries/#query-parameters

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
all

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
