### PR TITLE
Update the version for adaptive shard selection in bulk indexing

### DIFF
--- a/_im-plugin/append-only-index.md
+++ b/_im-plugin/append-only-index.md
@@ -68,7 +68,7 @@ POST /_reindex
 {% include copy-curl.html %}
 
 ## Adaptive shard selection for bulk indexing
-**Introduced 3.5**
+**Introduced 3.6**
 {: .label .label-purple }
 
 For append-only indexes, OpenSearch automatically generates a random `_id` for write routing when you don't explicitly specify one. In bulk writing, a single bulk entry may be split into dozens of sub-bulks and dispatched to different shards, which leads to significant long-tail latency and markedly degrades write performance.


### PR DESCRIPTION
### Description
This feature was not included in the 3.5 release, but was merged in version 3.6.

https://github.com/opensearch-project/OpenSearch/pull/20065/changes#diff-84cd59ac8d9f96d574bbef8611ef394f75ef0075b3741d844d2b97545bcb9ac4

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
