### PR TITLE
Revert "Adding documentation for adaptive shard selection (#11808)"

### DIFF
--- a/_im-plugin/append-only-index.md
+++ b/_im-plugin/append-only-index.md
@@ -66,26 +66,3 @@ POST /_reindex
 
 ```
 {% include copy-curl.html %}
-
-## Adaptive shard selection for bulk indexing
-**Introduced 3.5**
-{: .label .label-purple }
-
-For append-only indexes, OpenSearch automatically generates a random `_id` for write routing when you don't explicitly specify one. In bulk writing, a single bulk entry may be split into dozens of sub-bulks and dispatched to different shards, which leads to significant long-tail latency and markedly degrades write performance.
-
-Adaptive shard selection guarantees that all sub-bulks of a single bulk entry are routed to the same shard, thereby achieving a substantial boost in bulk write performance.
-
-To use adaptive shard selection, update the index settings as follows:
-
-```json
-PUT /my-append-only-index
-{
-    "settings": {
-        "index.append_only.enabled": "true",
-        "index.bulk.adaptive_shard_selection.enabled": "true"
-    }
-}
-```
-{% include copy-curl.html %}
-
-For more information, see [Dynamic settings]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/index/#dynamic-settings).

--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -188,9 +188,7 @@ For `zstd`, `zstd_no_dict`, `qat_lz4`, and `qat_deflate`, you can specify the co
 
 - `index.append_only.enabled` (Boolean): Set to `true` to prevent any updates to documents in the index. Default is `false`.
 
-- `index.derived_source.enabled` (Boolean): Set to `true` to dynamically generate the source without explicitly storing the `_source` field, which can optimize storage. Default is `false`. For more information, see [Derived source]({{site.url}}{{site.baseurl}}/mappings/metadata-fields/source/#derived-source).
-
-- `index.bulk.adaptive_shard_selection.enabled` (Boolean): Set to `true` to enable adaptive shard selection for bulk operations so that a single shard is chosen for append-only indexes. Default is `false`. For more information, see [Adaptive shard selection for bulk indexing]({{site.url}}{{site.baseurl}}/im-plugin/append-only-index/#adaptive-shard-selection-for-bulk-indexing).
+- `index.derived_source.enabled` (Boolean): Set to `true` to dynamically generate the source without explicitly storing the `_source` field, which can optimize storage. Default is `false`. For more information, see [Derived source]({{site.url}}{{site.baseurl}}/mappings/metadata-fields/source/#derived-source). 
 
 ### Updating a static index setting
 


### PR DESCRIPTION
This reverts commit b8f221936799393129bb7ddfecfc08e23877352a.

Since this feature is merged into 3.6, reverting the PR and will merge it into 3.6.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
