### PR TITLE
Update recovery_activity_timeout default to 30 minutes

### DIFF
--- a/_install-and-configure/configuring-opensearch/availability-recovery.md
+++ b/_install-and-configure/configuring-opensearch/availability-recovery.md
@@ -26,7 +26,7 @@ OpenSearch supports the following general recovery settings:
 
 - `indices.recovery.chunk_size` (Dynamic, byte unit): Controls the chunk size used when transferring data during index recovery operations. This setting affects the amount of data transferred in each network request during shard recovery. Larger chunk sizes can improve recovery speed but may increase memory usage. Default is `512kb`.
 
-- `indices.recovery.recovery_activity_timeout` (Dynamic, time unit): Sets the timeout for individual recovery activities during shard recovery operations. If a recovery activity (such as transferring a file chunk) takes longer than this timeout, the recovery operation is considered failed and will be retried. Default is `30s`.
+- `indices.recovery.recovery_activity_timeout` (Dynamic, time unit): Sets the timeout for individual recovery activities during shard recovery operations. If a recovery activity (such as transferring a file chunk) takes longer than this timeout, the recovery operation is considered failed and will be retried. Default is `30m`.
 
 ## Snapshot settings
 


### PR DESCRIPTION
According to the GitHub code, the default value is 30 minutes rather than 30 seconds.

https://github.com/opensearch-project/OpenSearch/blob/107aa5303fc94a2b8e89b44c6a9c884b3e903c69/server/src/main/java/org/opensearch/indices/recovery/RecoverySettings.java#L206

### Description
According to the GitHub code, the default value is 30 minutes rather than 30 seconds.

Originally reported in OpenSearch Forum 
https://forum.opensearch.org/t/opensearch-3-3-documentation-question/27687

### Version
1.x, 2.x and 3.x

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
