### PR TITLE
Add password requirements to docker install documentation

### DIFF
--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -199,7 +199,7 @@ OpenSearch uses the following default password requirements:
 
 - Minimum password length: 8 characters.
 - Maximum password length: 100 characters.
-- No requirements for special characters, numbers, or uppercase letters.
+- Must contain at least one uppercase letter, one lowercase letter, one digit, and one special character.
 - Passwords must be rated `strong` using the `zxcvbn` entropy-based calculation.
 
 You can customize the default password requirements by updating the [password cluster settings]({{site.url}}{{site.baseurl}}/security/configuration/yaml/#password-settings).


### PR DESCRIPTION
Add password requirements to docker install documentation

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
