### PR TITLE
Add encryption parameters to Kafka source documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/kafka.md
+++ b/_data-prepper/pipelines/configuration/sources/kafka.md
@@ -121,8 +121,8 @@ Option | Required | Type | Description
 :--- | :--- | :--- | :---
 `type` | No | String | The encryption type. Use `none` to disable encryption. Default is `ssl`.
 `certificate` | No | String | The SSL certificate content. Use either this option or `trust_store_file_path`, not both.
-`trust_store_file_path` | No | String | The path to the trust store file containing the SSL certificate. Use either this option or `certificate`, not both.
-`trust_store_password` | No | String | The password for the trust store file.
+`trust_store_file_path` | No | String | The path to the truststore file containing the SSL certificate. Use either this option or `certificate`, not both.
+`trust_store_password` | No | String | The password for the truststore file.
 `insecure` | No | Boolean | A Boolean flag used to turn off SSL certificate verification. If set to `true`, certificate authority (CA) certificate verification is turned off and insecure HTTP requests are sent. Default is `false`.
 
 


### PR DESCRIPTION
Add encryption parameters to Kafka source documentation

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
