### PR TITLE
Remove request body automatic generation for cluster allocation explain

### DIFF
--- a/_api-reference/cluster-api/cluster-allocation.md
+++ b/_api-reference/cluster-api/cluster-allocation.md
@@ -50,10 +50,6 @@ The following table lists the available query parameters. All query parameters a
 
 <!-- spec_insert_end -->
 
-<!-- spec_insert_start
-api: cluster.allocation_explain
-component: request_body_parameters
--->
 ## Request body fields
 
 The index, shard, and primary flag for which to generate an explanation. Leave this empty to generate an explanation for the first unassigned shard.
@@ -66,8 +62,6 @@ The request body is optional. It is a JSON object with the following fields.
 | `index` | String | The name of the index that contains the shard for which to generate an explanation. |
 | `primary` | Boolean | When `true`, returns a routing explanation for the primary shard based on the node ID. |
 | `shard` | Integer | Specifies the ID of the shard that you would like an explanation for. |
-
-<!-- spec_insert_end -->
 
 ## Example request
 


### PR DESCRIPTION
Remove request body automatic generation for cluster allocation explain because parameter generation logic doesn't function correctly at the moment.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
