### PR TITLE
Remove editorial review from PR review workflow

### DIFF
--- a/.github/workflows/pr_checklist.yml
+++ b/.github/workflows/pr_checklist.yml
@@ -18,18 +18,18 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           issue-number: ${{ github.event.pull_request.number }}
           body: |
-            Thank you for submitting your PR. The PR states are In progress (or Draft) -> Tech review -> Doc review -> Editorial review -> Merged.
+            Thank you for submitting your PR. The PR states are In progress (or Draft) -> Tech review -> Doc review -> Merged.
             
             Before you submit your PR for doc review, make sure the content is technically accurate. If you need help finding a tech reviewer, tag a [maintainer](https://github.com/opensearch-project/documentation-website/blob/main/MAINTAINERS.md).
 
-            **When you're ready for doc review, tag the assignee of this PR**. The doc reviewer may push edits to the PR directly or leave comments and editorial suggestions for you to address (let us know in a comment if you have a preference). The doc reviewer will arrange for an editorial review.
+            **When you're ready for doc review, tag the assignee of this PR**. The doc reviewer may push edits to the PR directly or leave comments and editorial suggestions for you to address (let us know in a comment if you have a preference).
 
       - name: Auto assign PR to repo owner
         uses: actions/github-script@v6
         with:
           script: |
             let assignee = context.payload.pull_request.user.login;
-            const prOwners = ['kolchfa-aws', 'natebower'];
+            const prOwners = ['kolchfa-aws'];
             
             if (!prOwners.includes(assignee)) {
               assignee = 'kolchfa-aws'


### PR DESCRIPTION
Remove editorial review from PR review workflow

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
