### PR TITLE
Expand inclusive language rules to cover speciesist idioms

### DIFF
--- a/.github/vale/styles/OpenSearch/SpeciesismIdioms.yml
+++ b/.github/vale/styles/OpenSearch/SpeciesismIdioms.yml
@@ -1,0 +1,32 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This phrase normalizes violence toward animals."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'kill two birds with one stone': accomplish two things at once
+  'killing two birds with one stone': accomplishing two things at once
+  'killed two birds with one stone': accomplished two things at once
+  'beat a dead horse': belabor the point
+  'beating a dead horse': belaboring the point
+  'flog a dead horse': belabor the point
+  'flogging a dead horse': belaboring the point
+  'bring home the bacon': bring home the results
+  'bringing home the bacon': bringing home the results
+  'brought home the bacon': brought home the results
+  'more than one way to skin a cat': more than one way to solve this
+  'many ways to skin a cat': many ways to approach this
+  'let the cat out of the bag': reveal the secret
+  'letting the cat out of the bag': revealing the secret
+  'open a can of worms': create a complicated situation
+  'opening a can of worms': creating a complicated situation
+  'opened a can of worms': created a complicated situation
+  'wild goose chase': pointless pursuit
+  'take the bull by the horns': face the challenge head-on
+  'taking the bull by the horns': facing the challenge head-on
+  'took the bull by the horns': faced the challenge head-on
+  'like shooting fish in a barrel': extremely easy
+  'straight from the horse''s mouth': directly from the source
+  'from the horse''s mouth': from a reliable source
+  'whack-a-mole': recurring problem
+  'whack a mole': recurring problem

--- a/.github/vale/styles/OpenSearch/SpeciesismMetaphors.yml
+++ b/.github/vale/styles/OpenSearch/SpeciesismMetaphors.yml
@@ -1,0 +1,14 @@
+extends: substitution
+message: "Consider using '%s' instead of '%s'. This term references animals as objects or tools."
+link: https://doi.org/10.1007/s43681-023-00380-w
+level: warning
+ignorecase: true
+swap:
+  'guinea pig': test subject
+  'sacred cow': unquestioned belief
+  'sacred cows': unquestioned beliefs
+  'scapegoat(?:ed|ing)?': wrongly blamed
+  'dog-eat-dog': ruthlessly competitive
+  'dog eat dog': ruthlessly competitive
+  'rat race': competitive grind
+  'red herring': false lead


### PR DESCRIPTION
## Summary

Adds two new Vale style rules that flag common animal-derived idioms and metaphors, suggesting neutral alternatives that are often clearer for a global audience.

**SpeciesismIdioms.yml** — 26 substitution patterns for phrases like:
- "kill two birds with one stone" → "accomplish two things at once"
- "wild goose chase" → "pointless pursuit"
- "let the cat out of the bag" → "reveal the secret"

**SpeciesismMetaphors.yml** — 8 substitution patterns for terms like:
- "guinea pig" → "test subject"
- "scapegoat" → "wrongly blamed"
- "red herring" → "false lead"

Both are `warning`-level rules, matching the existing OpenSearch style conventions.

## Why

The OpenSearch style already includes `Inclusive.yml` and `LatinismsElimination.yml`, showing a commitment to clear, inclusive documentation language. Speciesist idioms are a natural next category — phrases that normalize violence toward animals while also being less clear than their neutral alternatives, particularly for non-native English speakers.

A growing number of open source documentation projects have adopted similar rules in their Vale configurations, including webpack.js.org, recognizing this as part of the broader inclusive language movement.

All substitution suggestions reference [this peer-reviewed paper](https://doi.org/10.1007/s43681-023-00380-w).

## Changes

- Added `.github/vale/styles/OpenSearch/SpeciesismIdioms.yml`
- Added `.github/vale/styles/OpenSearch/SpeciesismMetaphors.yml`