### PR TITLE
Document modulo operator for data prepper expressions

### DIFF
--- a/_data-prepper/pipelines/expression-syntax.md
+++ b/_data-prepper/pipelines/expression-syntax.md
@@ -30,7 +30,7 @@ The following table lists the supported operators. Operators are listed in order
 |------------------------|-------------------------------------------------------|---------------|
 | `()`                   | Priority expression                                   | Left to right |
 | `not`<br> `+`<br>  `-` | Unary logical NOT<br>Unary positive<br>Unary negative | Right to left |
-| `*`, `/`, `%`           | Multiplication, division, and modulo operators        | Left to right |
+| `*`, `/`, `%`           | Multiplication (`*`), division (`/`), and modulo (`%`) operators        | Left to right |
 | `+`, `-`               | Addition and subtraction operators                    | Left to right |
 | `+`                    | String concatenation operator                         | Left to right |
 | `<`, `<=`, `>`, `>=`   | Relational operators                                  | Left to right |


### PR DESCRIPTION
### Description
Documents the modulo operator for Data Prepper expressions as `%` syntax. 

PR reference: https://github.com/opensearch-project/data-prepper/pull/5729/changes

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
