### PR TITLE
Add RomanianAnalyzer to 3.x breaking changes

### DIFF
--- a/_about/breaking-changes.md
+++ b/_about/breaking-changes.md
@@ -211,5 +211,5 @@ For more information, see pull request [#9813](https://github.com/opensearch-pro
 
 ### Romanian analysis
 
-RomanianAnalyzer now works with Romanian in its modern unicode form, and normalizes cedilla forms to forms with commas. Both forms are still in use in "the wild": you should reindex Romanian documents.
+The `romanian` analyzer now supports Romanian in its modern Unicode form and normalizes cedilla characters to their comma-based equivalents. Because both forms are still in use, we recommend reindexing existing Romanian documents to ensure consistent analysis and search behavior.
 


### PR DESCRIPTION
### Description

This change documents the need to re-index Romanian documents when upgrading to OpenSearch 3.x. It's copied from the [Lucene migration guide](https://github.com/apache/lucene/blob/main/lucene/MIGRATE.md#romanian-analysis).

Do I need to target the `3.0` branch?

### Issues Resolved

Closes #12009.

### Version

This change applies to all OpenSearch 3.x versions.

### Frontend features

The documentation is not for an OpenSearch Dashboards feature.

### Checklist

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
