### PR TITLE
delete the unexist null_value property of version type

### DIFF
--- a/_mappings/supported-field-types/version.md
+++ b/_mappings/supported-field-types/version.md
@@ -276,31 +276,6 @@ The version field follows semantic versioning comparison rules:
 3. Pre-release comparison: When both versions are pre-releases, they are compared lexically by each dot-separated identifier (`1.0.0-alpha` < `1.0.0-alpha.1` < `1.0.0-beta`).
 4. Build metadata ignored: Build metadata does not affect version precedence (`1.0.0+build.1` equals `1.0.0+build.2` for sorting purposes).
 
-## Parameters
-
-The version field type accepts the following optional parameters.
-
-Parameter | Description
-:--- | :---
-`null_value` | A value to be substituted for any explicit `null` values. Must be a valid version string. Defaults to `null`, which means `null` fields are treated as missing.
-
-### Example with null_value
-
-```json
-PUT software_with_nulls
-{
-  "mappings": {
-    "properties": {
-      "version": {
-        "type": "version",
-        "null_value": "0.0.0"
-      }
-    }
-  }
-}
-```
-{% include copy-curl.html %}
-
 ## Limitations
 
 - Version strings must follow the semantic versioning format. Invalid version strings will cause indexing to fail.


### PR DESCRIPTION
### Description
It seems the person who wrote the documentation and the person who developed the feature are not the same person, which caused this discrepancy, In fact, the version type has never supported null_value..[#11461](https://github.com/opensearch-project/documentation-website/pull/11461) [#18454](https://github.com/opensearch-project/OpenSearch/pull/18454)

Additionally, the draft that added the null_value attribute has not been merged. I suspect the maintainer considers this attribute unnecessary. If this draft is merged, I will disable the draft that adds the null_value attribute.[#20636
](https://github.com/opensearch-project/OpenSearch/pull/20636)

### Issues Resolved
[#20629](https://github.com/opensearch-project/OpenSearch/issues/20629)

### Version
3.3-3.5

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
