### PR TITLE
Add Peter and Craig as maintainers and move Nathan and Miki to emeriti

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-*  @kolchfa-aws @AMoo-Miki @natebower @dlvenable @epugh @sumobrian
+*  @kolchfa-aws @peterzhuamazon @cwperks @dlvenable @epugh @sumobrian

--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -7,16 +7,18 @@ This document lists the maintainers in this repo. See [opensearch-project/.githu
 | Maintainer       | GitHub ID                                       | Affiliation |
 | ---------------- | ----------------------------------------------- | ----------- |
 | Fanit Kolchina   | [kolchfa-aws](https://github.com/kolchfa-aws)   | Amazon      |
-| Nathan Bower     | [natebower](https://github.com/natebower)       | Amazon      |
-| Miki Barahmand   | [AMoo-Miki](https://github.com/AMoo-Miki)       | Amazon      |
+| Peter Zhu   | [peterzhuamazon](https://github.com/peterzhuamazon)   | Amazon      |
+| Craig Perkins  | [cwperks](https://github.com/cwperks)   | Amazon      |
 | David Venable    | [dlvenable](https://github.com/dlvenable)       | Amazon      | 
 | Brian Presley    | [sumobrian](https://github.com/sumobrian/)      | Amazon      |
 | Eric Pugh        | [epugh](https://github.com/epugh)               | OpenSource Connections  | 
 
-## Emeritus
+## Emeriti
 
 | Maintainer       | GitHub ID                                               | Affiliation |
 | ---------------- | ------------------------------------------------------- | ----------- |
+| Nathan Bower     | [natebower](https://github.com/natebower)       | Amazon      |
+| Miki Barahmand   | [AMoo-Miki](https://github.com/AMoo-Miki)       | Amazon      |
 | Heather Halter   | [hdhalter](https://github.com/hdhalter)                 | Amazon      |
 | Melissa Vagi     | [vagimeli](https://github.com/vagimeli)                 | Amazon      |
 | Stephen Crawford | [stephen-crawford](https://github.com/stephen-crawford) | Amazon      |


### PR DESCRIPTION
Add Peter and Craig as maintainers and move Nathan and Miki to emeriti

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
