### PR TITLE
Fix create sparse vector index error

### DIFF
--- a/_mappings/supported-field-types/sparse-vector.md
+++ b/_mappings/supported-field-types/sparse-vector.md
@@ -51,19 +51,19 @@ PUT sparse-vector-index
   "settings": {
     "index": {
       "sparse": true
-    },
-    "mappings": {
-      "properties": {
-        "sparse_embedding": {
-          "type": "sparse_vector",
-          "method": {
-            "name": "seismic",
-            "parameters": {
-              "n_postings": 300,
-              "cluster_ratio": 0.1,
-              "summary_prune_ratio": 0.4,
-              "approximate_threshold": 1000000
-            }
+    }
+  },
+  "mappings": {
+    "properties": {
+      "sparse_embedding": {
+        "type": "sparse_vector",
+        "method": {
+          "name": "seismic",
+          "parameters": {
+            "n_postings": 300,
+            "cluster_ratio": 0.1,
+            "summary_prune_ratio": 0.4,
+            "approximate_threshold": 1000000
           }
         }
       }


### PR DESCRIPTION
### Description
The command for creating a sparse index is incorrect: the mappings block was placed inside the settings block, whereas it should be placed outside.


### Issues Resolved
Closes https://github.com/opensearch-project/neural-search/issues/1758

### Version
3.3-3.5

### Frontend features
NA

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
