### PR TITLE
Document hybrid query nesting limitations

### DIFF
--- a/_query-dsl/compound/hybrid.md
+++ b/_query-dsl/compound/hybrid.md
@@ -148,14 +148,13 @@ Starting with OpenSearch 3.5, you can use hybrid queries on indexes with more th
 
 ## Limitations
 
-The hybrid query is designed to be the top-level query in a search request. It cannot be nested inside other compound or wrapper queries such as `function_score`, `constant_score`, `script_score`, or `boosting`. This restriction also applies to multi-level nesting, for example, `bool` containing `function_score` containing `hybrid`. Nesting a hybrid query inside these wrapper queries may produce a runtime error or silently bypass the normalization pipeline.
-{: .important}
+Hybrid query is designed to be a top-level query in a search request. It cannot be nested inside other compound or wrapper queries such as `function_score`, `constant_score`, `script_score`, or `boosting`. This restriction also applies to multilevel nesting, for example, a `bool` query containing a `function_score` query that itself contains a `hybrid` query. Nesting a hybrid query inside these wrapper queries may produce a runtime error or silently bypass the normalization pipeline.
 
-The hybrid query uses a specialized scoring mechanism that is incompatible with wrapper queries. These wrapper queries use a different internal scorer that bypasses the hybrid query's per-subquery score collection, which is required for the normalization and combination pipeline to function correctly.
+Hybrid query uses a specialized scoring mechanism that is incompatible with wrapper queries. Wrapper queries use a different internal scorer that bypasses the hybrid query's per-subquery score collection, which is required for the normalization and combination pipeline to function correctly.
 
-If you need to apply score boosting functions to hybrid search results, replace the `hybrid` clause with a `bool` query using `should` clauses containing the same subqueries. This workaround works on all OpenSearch versions that support hybrid query:
+To apply score-boosting functions to hybrid search results, replace the `hybrid` query with a `bool` query and move your subqueries into `should` clauses. This alternative works in all OpenSearch versions that support hybrid queries.
 
-Instead of the following **unsupported** query:
+For example, the following query is unsupported:
 
 ```json
 GET /my-index/_search?search_pipeline=my-pipeline
@@ -176,7 +175,7 @@ GET /my-index/_search?search_pipeline=my-pipeline
 }
 ```
 
-Use the following equivalent query:
+Instead, use the following equivalent query:
 
 ```json
 GET /my-index/_search
@@ -198,7 +197,7 @@ GET /my-index/_search
 ```
 {% include copy-curl.html %}
 
-Note that when using `bool` with `should` instead of `hybrid`, the search pipeline's normalization and combination processors are not applied. Scores from the subqueries are combined using standard Boolean scoring (sum of matching clauses), and then the `function_score` functions are applied on top.
+When using a `bool` query containing `should` clauses instead of a `hybrid` query, the search pipeline's normalization and combination processors are not applied. Instead, scores from the subqueries are combined using standard Boolean scoring (sum of matching clauses). The `function_score` functions are then applied to the combined score.
 {: .note}
 
 ## Disabling hybrid queries


### PR DESCRIPTION
### Description
Updated hybrid query page with details of unsupported nesting patterns and available workaround.

### Issues Resolved
https://github.com/opensearch-project/documentation-website/issues/12079

### Version
3.6+

### Frontend features
N/A

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
