### PR TITLE
Update Migration Assistant supported platforms and add Serverless as target

### DIFF
--- a/_migration-assistant/architecture.md
+++ b/_migration-assistant/architecture.md
@@ -19,7 +19,7 @@ Each node in the diagram correlates to the following steps in the migration proc
 
 1. Client traffic is directed to the existing cluster.
 2. An Application Load Balancer with capture proxies relays traffic to a source while replicating data to Amazon Managed Streaming for Apache Kafka (Amazon MSK).
-3. Using the migration console, a point-in-time snapshot is taken. Once the snapshot completes, the Metadata Migration Tool is used to establish indexes, templates, component templates, and aliases on the target cluster. With continuous traffic capture in place, `Reindex-from-Snapshot` migrates data from the source. For EKS-based deployments, RFS workers coordinate through a dedicated single-node OpenSearch cluster that manages shard assignments and tracks migration progress.
+3. Using the migration console, a point-in-time snapshot is taken. Once the snapshot completes, the Metadata Migration Tool is used to establish indexes, templates, component templates, and aliases on the target cluster. With continuous traffic capture in place, `Reindex-from-Snapshot` migrates data from the source.
 4. Once `Reindex-from-Snapshot` is complete, captured traffic is replayed from Amazon Managed Streaming for Apache Kafka (Amazon MSK) to the target cluster by Traffic Replayer.
 5. Performance and behavior of traffic sent to the source and target clusters are compared by reviewing logs and metrics.
 6. After confirming that the target cluster's functionality meets expectations, clients are redirected to the new target.

--- a/_migration-assistant/key-components.md
+++ b/_migration-assistant/key-components.md
@@ -33,11 +33,7 @@ The metadata migration tool integrated into the Migration CLI can be used indepe
 
 ## Reindex-from-Snapshot
 
-`Reindex-from-Snapshot` (RFS) reindexes data from an existing snapshot. Workers coordinate the migration of documents from an existing snapshot, reindexing the documents in parallel to a target cluster.
-
-## RFS Work Coordinator
-
-For EKS-based deployments, Migration Assistant deploys a dedicated single-node OpenSearch cluster to coordinate document backfill work across RFS workers. This coordinator manages shard assignments, lease tracking, and completion status, isolating coordination traffic from the target cluster. The coordinator is automatically deployed before backfill and torn down after completion.
+`Reindex-from-Snapshot` (RFS) reindexes data from an existing snapshot. Amazon Elastic Container Service (Amazon ECS) workers coordinate the migration of documents from an existing snapshot, reindexing the documents in parallel to a target cluster.
 
 ## Target cluster
 

--- a/_migration-assistant/migration-phases/backfill.md
+++ b/_migration-assistant/migration-phases/backfill.md
@@ -14,9 +14,6 @@ After the [metadata]({{site.url}}{{site.baseurl}}/migration-assistant/migration-
 
 ## Migrate documents with RFS
 
-For EKS-based deployments, RFS workers use a dedicated coordinator cluster for work coordination. This isolates coordination traffic from the target cluster.
-{: .note }
-
 You can now use RFS to migrate documents from your original cluster:
 
 ### Starting the backfill


### PR DESCRIPTION
### Description
Updates Migration Assistant documentation to reflect current platform support and authentication configuration for Amazon OpenSearch Serverless.

### Changes                                                                                                                                                              
                                                                                                                                                                        
- Add Amazon OpenSearch Serverless as a supported target-only platform
- Add Elastic Cloud and AWS EC2 as explicitly supported source/target platforms
- Update `serviceSigningName` documentation to include `aoss` for Serverless collections
- Update feature support table to reflect current status for ISM policies and Kibana dashboards

### Issues Resolved
N/A

### Version
Migration Assistant v 2.8.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
