### PR TITLE
Document Explain API search_pipeline limitation

### DIFF
--- a/_api-reference/search-apis/explain.md
+++ b/_api-reference/search-apis/explain.md
@@ -23,7 +23,7 @@ Using the Explain API is expensive in terms of both resources and time. For prod
 
 The Explain API does not support the `search_pipeline` parameter. Sending a request with an inline or named search pipeline results in a `parsing_exception` error. This applies to all query types.
 
-To use search pipeline processors with explain, use the [Search API]({{site.url}}{{site.baseurl}}/api-reference/search/) with `explain=true`. For more information about using explain with hybrid queries, see [Hybrid search explain]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/explain/).
+To use search pipeline processors with `explain`, provide the `explain=true` query parameter to the [Search API]({{site.url}}{{site.baseurl}}/api-reference/search/). For more information about using `explain` with hybrid queries, see [Hybrid search explain]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/explain/).
 
 
 ## Endpoints

--- a/_vector-search/ai-search/hybrid-search/explain.md
+++ b/_vector-search/ai-search/hybrid-search/explain.md
@@ -38,10 +38,10 @@ In this case, the result contains only raw Lucene-level scoring information, for
 
 The Explain API has the following limitations when used with hybrid queries:
 
-- **No search pipeline support**: The `_explain` endpoint does not support the `search_pipeline` parameter, either inline or as a URL parameter. Sending a request with `search_pipeline` results in a `parsing_exception` error. This limitation applies to all query types, not only hybrid queries.
-- **No normalization or combination details**: Score normalization techniques (such as `min_max`, `l2`, or `z_score`) and combination techniques (such as `arithmetic_mean`) require scores from all matching documents to compute statistics. Because the Explain API operates on a single document, it cannot provide normalization context. The `hybrid_score_explanation` response processor is not invoked.
+- The `_explain` endpoint does not support the `search_pipeline` query parameter, either inline or as a query parameter. Providing a `search_pipeline` parameter results in a `parsing_exception` error. This limitation applies to all query types, not only hybrid queries.
+- Score normalization techniques (such as `min_max`, `l2`, or `z_score`) and combination techniques (such as `arithmetic_mean`) require scores from all matching documents to compute statistics. Because the Explain API operates on a single document, it cannot provide normalization context. The `hybrid_score_explanation` response processor is not invoked and no normalized scoring details are returned.
 
-To get a full hybrid query explanation with normalization and combination details for a specific document, use the Search API with `explain=true` and filter to the target document:
+To get a full hybrid query explanation with normalization and combination details for a specific document, use the Search API with `explain=true` and filter the query for the desired document ID:
 
 ```json
 GET <index>/_search?search_pipeline=<search_pipeline>&explain=true


### PR DESCRIPTION
### Description

Clarifies that the `_explain` endpoint does not support the `search_pipeline` parameter and that hybrid query normalization details are not available through the Explain API.

### Changes

- **Core Explain API page**: Added a Limitations section noting `search_pipeline` is not supported, with a pointer to the Search API alternative.
- **Hybrid search explain page**: Replaced the vague `_explain/<id>` description with explicit limitations and a workaround using `_search` with `explain=true` and `_id` filter.

### Issues Resolved

Closes #12087

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/documentation-website/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).