### PR TITLE
Update on-behalf-of token documentation with optional encryption_key

### DIFF
--- a/_security/access-control/authentication-tokens.md
+++ b/_security/access-control/authentication-tokens.md
@@ -38,7 +38,7 @@ config:
 
 The default encoding algorithm for signing the JWT is HMAC SHA512. Keys are Base64-encoded strings in the [`config/opensearch-security/config.yml` file]({{site.url}}{{site.baseurl}}/security/configuration/configuration/). After the configuration is applied using the `securityadmin.sh -cd <configuration directory>` command, the values are stored in the security system index and used cluster-wide.
 
-When `encryption_key` is omitted, roles and backend roles are stored as plain text in the token claims. When it is provided, the roles claim is encrypted. Cluster administrators can choose whether to encrypt role information based on their security requirements.
+When `encryption_key` is omitted, roles and backend roles are stored as plain text in the token claims. When it is provided, the `roles` claim is encrypted. Cluster administrators can choose whether to encrypt role information based on their security requirements.
 
 ### Token structure
 


### PR DESCRIPTION
### Description

In 3.6, `encryption_key` will be optional for configuring on-behalf-of tokens. This PR updates the documentation accordingly.

### Issues Resolved

Related to https://github.com/opensearch-project/security/pull/6017

### Version

3.6 and above

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
