### PR TITLE
Add dedicated documentation page for Hadoop connector (Spark, Hive, MapReduce)

### DIFF
--- a/_clients/hadoop.md
+++ b/_clients/hadoop.md
@@ -1,10 +1,10 @@
 ---
 layout: default
-title: Hadoop connector (Spark, Hive, MapReduce)
-nav_order: 90
+title: Hadoop connector
+nav_order: 110
 ---
 
-# Hadoop connector (Spark, Hive, MapReduce)
+# Hadoop connector
 
 The OpenSearch Hadoop connector lets you read and write data between [Apache Spark](http://spark.apache.org), [Apache Hive](http://hive.apache.org), Hadoop MapReduce, and OpenSearch. It enables Spark jobs to directly index data into OpenSearch and run queries against it, with parallel reads and writes across Spark partitions and OpenSearch shards for efficient distributed processing.
 
@@ -14,19 +14,28 @@ For the source code, see the [OpenSearch Hadoop](https://github.com/opensearch-p
 
 Add the connector to your Spark application using `--packages`:
 
+- For Spark 3.4.x, run the following command:
+
 ```bash
-# Spark 3.4.x
 pyspark --packages org.opensearch.client:opensearch-spark-30_2.12:2.0.0
+```
+{% include copy.html %}
 
-# Spark 3.5.x
+- For Spark 3.5.x, run the following command:
+
+```bash
 pyspark --packages org.opensearch.client:opensearch-spark-35_2.12:2.0.0
+```
+{% include copy.html %}
 
-# Spark 4.x
+- For Spark 4.x, run the following command:
+
+```bash
 pyspark --packages org.opensearch.client:opensearch-spark-40_2.13:2.0.0
 ```
 {% include copy.html %}
 
-Or add it as a dependency in your build file:
+Alternatively, add Spark as a dependency in your build file:
 
 ```xml
 <dependency>
@@ -37,7 +46,7 @@ Or add it as a dependency in your build file:
 ```
 {% include copy.html %}
 
-Choose the artifact that matches your Spark and Scala version:
+Choose the artifact that matches your Spark and Scala version listed in the following table.
 
 Spark version | Scala version | Artifact
 :--- | :--- | :---
@@ -47,9 +56,13 @@ Spark version | Scala version | Artifact
 3.5.x | 2.13 | `org.opensearch.client:opensearch-spark-35_2.13:2.0.0`
 4.x | 2.13 | `org.opensearch.client:opensearch-spark-40_2.13:2.0.0`
 
-## PySpark
+## Basic usage
 
-No additional Python package is needed. The Java connector is loaded via `--packages` or `spark.jars`.
+The following examples demonstrate basic read and write operations using the connector with different Spark APIs.
+
+### PySpark
+
+No additional Python package is needed. The Java connector is loaded using `--packages` or `spark.jars`:
 
 ```python
 # Write (index documents into OpenSearch)
@@ -68,7 +81,9 @@ filtered = spark.read \
 ```
 {% include copy.html %}
 
-## Scala
+### Scala
+
+Use the Scala API to access helper methods like `saveToOpenSearch` for cleaner syntax:
 
 ```scala
 import org.opensearch.spark.sql._
@@ -89,7 +104,9 @@ val filtered = spark.read
 ```
 {% include copy.html %}
 
-## Java
+### Java
+
+Use the `JavaOpenSearchSparkSQL` wrapper for Java applications:
 
 ```java
 import org.opensearch.spark.sql.api.java.JavaOpenSearchSparkSQL;
@@ -104,9 +121,9 @@ result.show();
 ```
 {% include copy.html %}
 
-## Spark SQL
+### Spark SQL
 
-You can register an OpenSearch index as a temporary view and query it with SQL:
+You can register an OpenSearch index as a temporary view and query it using SQL:
 
 ```python
 spark.sql("""
@@ -119,11 +136,11 @@ spark.sql("SELECT * FROM people WHERE age > 25").show()
 ```
 {% include copy.html %}
 
-## Common patterns
+## Write operations
 
-The following sections describe common configuration patterns for reading and writing data.
+Configure how documents are written to OpenSearch indexes, including document IDs, write modes, and routing strategies.
 
-### Specifying document ID
+### Specifying a document ID
 
 Use `opensearch.mapping.id` to control the `_id` of each document:
 
@@ -136,6 +153,8 @@ df.write.format("opensearch") \
 
 ### Write modes
 
+Control how data is written to OpenSearch using Spark's write modes:
+
 ```python
 # Append (default): add documents to the index
 df.write.format("opensearch").mode("append").save("my-index")
@@ -147,7 +166,7 @@ df.write.format("opensearch").mode("overwrite").save("my-index")
 
 ### Upsert
 
-Update existing documents or insert new ones:
+Update documents if they exist or insert them as new documents if they don't. This operation requires specifying a document ID field:
 
 ```python
 df.write.format("opensearch") \
@@ -156,6 +175,28 @@ df.write.format("opensearch") \
     .save("my-index")
 ```
 {% include copy.html %}
+
+### Dynamic index routing
+
+Use placeholders in the index name to route documents to different indexes based on field values. This feature requires the Scala `saveToOpenSearch` method:
+
+```scala
+import org.opensearch.spark.sql._
+
+// Route by field value: {"category": "electronics", "name": "TV"} -> index "electronics"
+df.saveToOpenSearch("{category}")
+
+// Prefix + field value: {"env": "prod", "msg": "ok"} -> index "logs-prod"
+df.saveToOpenSearch("logs-{env}")
+
+// Date formatting: {"timestamp": "2026-02-16T10:30:00.000Z", "msg": "ok"} -> index "logs-2026.02.16"
+df.saveToOpenSearch("logs-{timestamp|yyyy.MM.dd}")
+```
+{% include copy.html %}
+
+## Read operations
+
+Optimize data retrieval from OpenSearch by filtering queries and selecting specific fields to reduce data transfer.
 
 ### Reading with a query
 
@@ -185,7 +226,13 @@ df = spark.read.format("opensearch") \
 ```
 {% include copy.html %}
 
+## Security
+
+Secure connections to OpenSearch clusters using authentication and encryption.
+
 ### Basic authentication
+
+Provide credentials for OpenSearch clusters with authentication enabled:
 
 ```python
 df.write.format("opensearch") \
@@ -197,6 +244,8 @@ df.write.format("opensearch") \
 
 ### HTTPS
 
+Enable SSL/TLS encryption for secure connections:
+
 ```python
 df.write.format("opensearch") \
     .option("opensearch.net.ssl", "true") \
@@ -204,27 +253,13 @@ df.write.format("opensearch") \
 ```
 {% include copy.html %}
 
-### Dynamic index routing
+## Advanced Spark features
 
-Use placeholders in the index name to route documents to different indexes based on field values. This feature requires the Scala `saveToOpenSearch` method:
+Access low-level Spark APIs and streaming capabilities for specialized use cases.
 
-```scala
-import org.opensearch.spark.sql._
+### Spark resilient distributed dataset
 
-// Route by field value: {"category": "electronics", "name": "TV"} -> index "electronics"
-df.saveToOpenSearch("{category}")
-
-// Prefix + field value: {"env": "prod", "msg": "ok"} -> index "logs-prod"
-df.saveToOpenSearch("logs-{env}")
-
-// Date formatting: {"timestamp": "2026-02-16T10:30:00.000Z", "msg": "ok"} -> index "logs-2026.02.16"
-df.saveToOpenSearch("logs-{timestamp|yyyy.MM.dd}")
-```
-{% include copy.html %}
-
-## Spark Resilient Distributed Dataset (RDD)
-
-For low-level access, the connector provides RDD-based read and write methods:
+For low-level access, the connector provides resilient distributed dataset (RDD)-based read and write methods:
 
 ```scala
 import org.opensearch.spark._
@@ -245,7 +280,7 @@ val filtered = sc.opensearchRDD("people", "?q=name:John")
 ```
 {% include copy.html %}
 
-## Structured Streaming
+### Structured Streaming
 
 The connector supports Spark Structured Streaming as a sink:
 
@@ -257,24 +292,49 @@ val query = streamingDF.writeStream
 ```
 {% include copy.html %}
 
-## Configuration properties
+## Alternative interfaces
 
-All configuration properties start with the `opensearch` prefix. Properties can be set using Spark configuration (`--conf`), as options on the DataFrame reader/writer, or in the Hadoop configuration.
+Use the connector with Hadoop MapReduce and Apache Hive for alternative workflows.
 
-Property | Default | Description
-:--- | :--- | :---
-`opensearch.resource` | (none) | OpenSearch index name. Can also be specified as the argument to `saveToOpenSearch()` or `load()`.
-`opensearch.nodes` | `localhost` | OpenSearch host address.
-`opensearch.port` | `9200` | OpenSearch REST port.
-`opensearch.nodes.wan.only` | `false` | Set to `true` when connecting through a load balancer or proxy.
-`opensearch.query` | match all | Query DSL or URI query for reading.
-`opensearch.net.ssl` | `false` | Enable HTTPS.
-`opensearch.mapping.id` | (none) | Document field to use as the `_id`.
-`opensearch.write.operation` | `index` | Write operation: `index`, `create`, `update`, `upsert`.
-`opensearch.scroll.size` | `1000` | Number of documents fetched per batch when reading.
-`opensearch.read.field.include` | (none) | Comma-separated list of fields to read.
+### Hadoop MapReduce
 
-## Amazon OpenSearch Service
+For Hadoop MapReduce jobs, the connector provides `OpenSearchInputFormat` and `OpenSearchOutputFormat`. Add `opensearch-hadoop-mr-2.0.0.jar` to your job `classpath`.
+
+```java
+// Writing
+Configuration conf = new Configuration();
+conf.set("opensearch.resource", "my-index");
+Job job = new Job(conf);
+job.setOutputFormatClass(OpenSearchOutputFormat.class);
+job.waitForCompletion(true);
+
+// Reading
+Configuration conf = new Configuration();
+conf.set("opensearch.resource", "my-index");
+Job job = new Job(conf);
+job.setInputFormatClass(OpenSearchInputFormat.class);
+job.waitForCompletion(true);
+```
+{% include copy.html %}
+
+### Apache Hive
+
+The connector provides an Apache Hive storage handler. Add `opensearch-hadoop-hive-2.0.0.jar` to your Hive classpath:
+
+```sql
+ADD JAR /path/opensearch-hadoop-hive-2.0.0.jar;
+
+CREATE EXTERNAL TABLE people (
+    name STRING,
+    age  INT)
+STORED BY 'org.opensearch.hadoop.hive.OpenSearchStorageHandler'
+TBLPROPERTIES('opensearch.resource' = 'people');
+
+SELECT * FROM people;
+```
+{% include copy.html %}
+
+## Connecting to Amazon OpenSearch Service
 
 To connect to Amazon OpenSearch Service with IAM authentication, enable AWS Signature Version 4 signing and HTTPS:
 
@@ -298,7 +358,7 @@ The following AWS SDK v2 dependencies are required on the `classpath`:
 - `software.amazon.awssdk:sdk-core:2.31.59` (or later)
 - `software.amazon.awssdk:utils:2.31.59` (or later)
 
-## Amazon OpenSearch Serverless
+## Connecting to Amazon OpenSearch Serverless
 
 To connect to Amazon OpenSearch Serverless, add `opensearch.serverless` and set the Signature Version 4 service name to `aoss`:
 
@@ -316,47 +376,29 @@ df.write.format("opensearch") \
 ```
 {% include copy.html %}
 
+## Configuration properties
+
+All configuration properties start with the `opensearch` prefix. Properties can be set using Spark configuration (`--conf`), as options of the `DataFrame` reader/writer, or in the Hadoop configuration.
+
+Property | Default | Description
+:--- | :--- | :---
+`opensearch.resource` | (none) | The OpenSearch index name. Can also be specified as the argument to `saveToOpenSearch()` or `load()`.
+`opensearch.nodes` | `localhost` | The OpenSearch host address.
+`opensearch.port` | `9200` | The OpenSearch REST port.
+`opensearch.nodes.wan.only` | `false` | Set to `true` when connecting through a load balancer or proxy.
+`opensearch.query` | match all | A query DSL or Uniform Resource Identifier (URI) query for reading.
+`opensearch.net.ssl` | `false` | Enables HTTPS.
+`opensearch.mapping.id` | (none) | The document field to use as the `_id`.
+`opensearch.write.operation` | `index` | The write operation: `index`, `create`, `update`, or `upsert`.
+`opensearch.scroll.size` | `1000` | The number of documents fetched per batch when reading.
+`opensearch.read.field.include` | (none) | A comma-separated list of fields to read.
+
 ## Compatibility
 
-Client version | Minimum Java runtime | OpenSearch version | Spark version
+The following table lists the connector versions and their compatible runtime versions.
+
+Client version | Minimum Java runtime version | OpenSearch version | Spark version
 :--- | :--- | :--- | :---
 1.0.0--1.3.0 | Java 8 | 1.x, 2.x | 3.4.x
 2.0.0 | Java 11 | 1.x, 2.x, 3.x | 3.4.x, 3.5.x, 4.x
 
-## Map/Reduce
-
-For Hadoop Map/Reduce jobs, the connector provides `OpenSearchInputFormat` and `OpenSearchOutputFormat`. Add `opensearch-hadoop-mr-2.0.0.jar` to your job `classpath`.
-
-```java
-// Writing
-Configuration conf = new Configuration();
-conf.set("opensearch.resource", "my-index");
-Job job = new Job(conf);
-job.setOutputFormatClass(OpenSearchOutputFormat.class);
-job.waitForCompletion(true);
-
-// Reading
-Configuration conf = new Configuration();
-conf.set("opensearch.resource", "my-index");
-Job job = new Job(conf);
-job.setInputFormatClass(OpenSearchInputFormat.class);
-job.waitForCompletion(true);
-```
-{% include copy.html %}
-
-## Apache Hive
-
-The connector provides a Hive storage handler. Add `opensearch-hadoop-hive-2.0.0.jar` to your Hive classpath:
-
-```sql
-ADD JAR /path/opensearch-hadoop-hive-2.0.0.jar;
-
-CREATE EXTERNAL TABLE people (
-    name STRING,
-    age  INT)
-STORED BY 'org.opensearch.hadoop.hive.OpenSearchStorageHandler'
-TBLPROPERTIES('opensearch.resource' = 'people');
-
-SELECT * FROM people;
-```
-{% include copy.html %}

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -39,7 +39,7 @@ OpenSearch provides clients for the following programming languages and platform
 * **Rust**
   * [OpenSearch Rust client]({{site.url}}{{site.baseurl}}/clients/rust/)
 * **Hadoop**
-  * [Hadoop connector (Spark, Hive, MapReduce)]({{site.url}}{{site.baseurl}}/clients/hadoop/)
+  * [Hadoop connector (Apache Spark, Apache Hive, and Hadoop MapReduce)]({{site.url}}{{site.baseurl}}/clients/hadoop/)
 
 
 ## Legacy clients


### PR DESCRIPTION
### Description

Add a dedicated documentation page for the OpenSearch Hadoop connector under the Clients section. Previously, the Hadoop connector only had a link to the GitHub repository, while all other clients had full documentation pages.
https://github.com/opensearch-project/opensearch-hadoop
https://github.com/opensearch-project/opensearch-hadoop/releases/tag/v2.0.0

The new page covers:
- Setup with `--packages` and Maven/Gradle
- PySpark, Scala, and Java usage examples
- Spark SQL, Spark RDD, and Structured Streaming
- Common patterns: document ID, write modes, upsert, query pushdown, field selection, dynamic index routing
- Configuration properties reference
- Amazon OpenSearch Service (SigV4 IAM authentication)
- Amazon OpenSearch Serverless
- Compatibility matrix
- Map/Reduce and Hive (brief)

Also updates `_clients/index.md` to link to the new page instead of the GitHub repository.

### Issues Resolved

Closes #12125

### Version

All (the Hadoop connector page covers versions 1.0.0 through 2.0.0)

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).