### PR TITLE
Revert "[Backport 3.5] Make index.neural_search.hybrid_collapse_docs_per_group_per_subquery setting deprecated"

### DIFF
--- a/_vector-search/ai-search/hybrid-search/collapse.md
+++ b/_vector-search/ai-search/hybrid-search/collapse.md
@@ -17,7 +17,7 @@ The `collapse` parameter is compatible with other hybrid query search options, s
 
 When using `collapse` in a hybrid query, note the following considerations:
 
-- The [`index.neural_search.hybrid_collapse_docs_per_group_per_subquery`]({{site.url}}{{site.baseurl}}/vector-search/settings/#hybrid-collapse-docs-per-group) setting is deprecated and has no effect. If this setting exists in your index configuration, you can safely remove it. Search results are entirely controlled by the `size` parameter in the search request.
+- Performance may be impacted when working with large result sets.  Starting with OpenSearch 3.2, the index-level [`index.neural_search.hybrid_collapse_docs_per_group_per_subquery`]({{site.url}}{{site.baseurl}}/vector-search/settings/#hybrid-collapse-docs-per-group) setting controls how many documents are stored per group per subquery. 
 - Aggregations run on pre-collapsed results, not the final output.
 - Pagination behavior changes: Because `collapse` reduces the total number of results, it can affect how results are distributed across pages. To retrieve more results, consider increasing the pagination depth.
 - Results may differ from those returned by the [`collapse` response processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/collapse-processor/), which applies collapse logic after the query is executed.

--- a/_vector-search/settings.md
+++ b/_vector-search/settings.md
@@ -120,4 +120,4 @@ The following Neural Search plugin settings apply at the index level:
 
 <p id="hybrid-collapse-docs-per-group"></p>
 
-- `index.neural_search.hybrid_collapse_docs_per_group_per_subquery` (_Deprecated_):  This setting is deprecated and no longer has any impact. The number of documents returned is controlled entirely by the `size` parameter.
+- `index.neural_search.hybrid_collapse_docs_per_group_per_subquery` (Dynamic, integer): Controls how many documents are stored per group per subquery. By default, the value is set to the `size` parameter specified in the query. Lower values prioritize latency, while higher values increase recall. Valid values are `0`--`1000`, inclusive. A value of `0` uses the `size` parameter from the query, not zero documents.


### PR DESCRIPTION
Reverts opensearch-project/documentation-website#12123