### PR TITLE
Adding fallback query documentation for agentic search

### DIFF
--- a/_ml-commons-plugin/agents-tools/tools/query-planning-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/query-planning-tool.md
@@ -22,7 +22,7 @@ The `QueryPlanningTool` supports two approaches for generating DSL queries from 
 
 - **Using search templates**: The LLM uses predefined search templates as additional context when generating queries. You provide a collection of search templates with descriptions, and the LLM uses these as examples and guidance to create more accurate queries. If the LLM determines that none of the provided templates are suitable for the user's question, the LLM attempts to generate the query independently.
 
-The `user_templates` approach is particularly useful when you have established query patterns for your specific use case or domain: it helps the LLM to generate queries that follow your preferred structure and to use appropriate field names from your index mappings.
+Using search templates is particularly useful when you have established query patterns for your specific use case or domain: it helps the LLM to generate queries that follow your preferred structure and to use appropriate field names from your index mappings.
 
 ## Step 1: Create an index and ingest sample data
 
@@ -84,7 +84,7 @@ The following example registers and deploys the Anthropic Claude 4 model:
 ```json
 POST /_plugins/_ml/models/_register?deploy=true
 {
-  "name": "Claude 4 sonnet Query Planner tool Model",
+  "name": "Claude 4 Sonnet Query Planner Tool Model",
   "function_name": "remote",
   "description": "Claude 4 sonnet for Query Planning",
   "connector": {
@@ -189,8 +189,7 @@ POST /_plugins/_ml/agents/_register
 ```
 {% include copy-curl.html %}
 
-When registering the agent, you can override parameters that you specified during model registration, such as `system_prompt` and `user_prompt`. 
-
+When registering the agent, you can override parameters that you specified during model registration, such as `system_prompt` and `user_prompt`.
 
 ### Using search templates
 
@@ -295,7 +294,6 @@ POST /_plugins/_ml/agents/RNjQi5gBOh0h20Y9-RX1/_execute
     "index_name": "iris-index"
   }
 }
-
 ```
 {% include copy-curl.html %}
 
@@ -328,7 +326,7 @@ Parameter	| Type | Required/Optional | Description
 `query_planner_system_prompt` | String | Optional | A system prompt that provides high-level instructions to the LLM.
 `query_planner_user_prompt` | String | Optional | A user prompt template that defines how the natural language question and context are presented to the LLM for query generation.
 `search_templates` | Array | Optional | Applicable only when `generation_type` is `user_templates`. A list of search templates that provide the LLM with predefined query patterns for generating query DSL. Each template must include a `template_id` (unique identifier) and `template_description` (explains the template's purpose and use case to help the LLM choose appropriately).
-`fallback_query` | String | Optional | An OpenSearch fallback DSL query used in case the LLM fails to generate a valid DSL query for the given query text.
+`fallback_query` | String | Optional | An OpenSearch query DSL query used if the LLM fails to generate a valid DSL query for the given query text. See [Fallback behavior](#fallback-behavior).
 
 All parameters that were configured either in the connector or in the agent registration can be overridden during agent execution.
 {: .note}
@@ -546,65 +544,78 @@ Output:
 
 ## Fallback behavior
 
-The `QueryPlanningTool` includes a default fallback query: `{"size":10,"query":{"match_all":{}}}` which can optionally be configured via the `fallback_query` field of the Query Planning Tool configuration. 
+The `QueryPlanningTool` uses a fallback query when the LLM fails to generate valid query DSL. By default, the fallback query is `{"size":10,"query":{"match_all":{}}}`. You can override this default by specifying a custom `fallback_query` parameter when registering the agent.
 
-The code automatically extracts the first valid JSON object from the LLM's response, even if the JSON is surrounded by additional text, Markdown code fences, explanations, or other content. However, if no valid JSON can be extracted from the response (for example, when the response is completely empty, contains only non-JSON text, or contains only malformed JSON), the tool returns the default or configured fallback query.
+The tool automatically extracts the first valid JSON object from the LLM's response, even if the JSON is surrounded by additional text, Markdown code fences, explanations, or other content. However, if no valid JSON can be extracted from the response (for example, when the response is completely empty, contains only non-JSON text, or contains only malformed JSON), the tool returns the fallback query (either the default or your custom query).
 
 When the fallback is triggered, no error is thrown. Instead, a debug log is shown in the system logs. This ensures that query planning operations continue to work even when the LLM provides unexpected output.
 
-The following example demonstrates how the fallback query operates. First create an index, ingest data and register a model as per this [example]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/index/#step-1-create-an-index-for-ingestion).
+### Overriding the default fallback query
 
-Next configure your agent with your model ID and the fallback query you want to test. 
+The following example demonstrates how the fallback query operates. 
+
+To follow this example, first complete Steps 1--3 from the [Agentic search tutorial]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/index/): create an index, ingest data, and register a model.
+
+Next, register an agent using the model ID from Step 3. Include a custom `fallback_query` parameter to demonstrate the fallback behavior: 
 
 ```json
 POST _plugins/_ml/agents/_register
 {
-    "name": "Iris Search Agent with Fallback",
-    "type": "flow", 
-    "tools": [                                                                       
-      {                                           
-        "type": "QueryPlanningTool",
-        "parameters": {
-          "model_id": "<your-model-id>",
-          "fallback_query": "{\"size\":10,\"query\":{\"bool\":{\"should\":[{\"match\":{\"species\":{\"query\":\"${parameters.question}\",\"fuzziness\":\"AUTO\"}}},{\"match_all\":{\"boost\":0.1}}],\"minimum_should_match\":1}}}"
-        }                       
-      }                          
-    ]        
-  }
+  "name": "Iris Search Agent with Fallback",
+  "type": "flow",
+  "tools": [
+    {
+      "type": "QueryPlanningTool",
+      "parameters": {
+        "model_id": "<your-model-id>",
+        "fallback_query": "{\"size\":10,\"query\":{\"bool\":{\"should\":[{\"match\":{\"species\":{\"query\":\"${parameters.question}\",\"fuzziness\":\"AUTO\"}}},{\"match_all\":{\"boost\":0.1}}],\"minimum_should_match\":1}}}"
+      }
+    }
+  ]
+}
 ```
+{% include copy-curl.html %}
 
-Then create a search pipeline with the configured agent. 
+Next, create a search pipeline using the agent ID from the previous step:
 
 ```json
 PUT _search/pipeline/agentic_search_pipeline
 {
-    "request_processors": [                   
-        {                     
-            "agentic_query_translator": {
-                "agent_id": "<your-agent-id>"
-            }                                
-        }                                                   
-    ],                                       
-    "response_processors": [        {                                                                
-            "agentic_context": {
-                "dsl_query": true                            
-            }
-        }              
-    ]                                                                                                                      
+  "request_processors": [
+    {
+      "agentic_query_translator": {
+        "agent_id": "<your-agent-id>"
+      }
+    }
+  ],
+  "response_processors": [
+    {
+      "agentic_context": {
+        "dsl_query": true
+      }
+    }
+  ]
 }
 ```
+{% include copy-curl.html %}
 
-Now we can test the fallback behavior by asking a question completely unrelated to the target index. We can confirm the generated fallback query is used via the `agentic_context` response processor `dsl_query` output of the search response.
+To test the fallback behavior, send a search request with a question unrelated to the `iris-index`:
 
 ```json
-POST iris-index/_search?search_pipeline=agentic_search_pipeline&pretty
+POST /iris-index/_search?search_pipeline=agentic_search_pipeline&pretty
 {
-    "query": {
-        "agentic": {
-            "query_text": "Find all employees hired in 2023 with salary above 100000"
-        }
+  "query": {
+    "agentic": {
+      "query_text": "Find all employees hired in 2023 with salary above 100000"
     }
-}'
+  }
+}
+```
+{% include copy-curl.html %}
+
+The response includes the `dsl_query` field in the `ext` section containing the fallback query:
+
+```json
 {
   "took" : 5396,
   "timed_out" : false,
@@ -653,17 +664,23 @@ POST iris-index/_search?search_pipeline=agentic_search_pipeline&pretty
 }
 ```
 
-Asking a related question, however, does not use the fallback query. 
+Next, ask a question related to the `iris-index`:
 
 ```json
-POST iris-index/_search?search_pipeline=agentic_search_pipeline&pretty
+POST /iris-index/_search?search_pipeline=agentic_search_pipeline
 {
-    "query": {
-        "agentic": {
-            "query_text": "Find all setosa species"                                  
-        }
+  "query": {
+    "agentic": {
+      "query_text": "Find all setosa species"
     }
-}'
+  }
+}
+```
+{% include copy-curl.html %}
+
+The response contains the proper LLM-generated query instead of using the fallback query:
+
+```json
 {
   "took" : 4037,
   "timed_out" : false,

--- a/_vector-search/ai-search/agentic-search/agent-converse.md
+++ b/_vector-search/ai-search/agentic-search/agent-converse.md
@@ -65,7 +65,7 @@ POST _bulk
 
 Review the [model configuration]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agent-customization/#model-configuration) and choose a model to use.
 
-Here we register a GPT model that will be used by both the conversational agent and the `QueryPlanningTool`:
+The following example registers a GPT model that will be used by both the conversational agent and the `QueryPlanningTool`:
 
 ```json
 POST /_plugins/_ml/models/_register
@@ -98,6 +98,7 @@ POST /_plugins/_ml/models/_register
     }
 }
 ```
+{% include copy-curl.html %}
 
 ## Step 4: Register an agent
 

--- a/_vector-search/ai-search/agentic-search/agentic-memory.md
+++ b/_vector-search/ai-search/agentic-search/agentic-memory.md
@@ -9,13 +9,13 @@ has_children: false
 
 # Using agentic memory for agentic search
 
-[Agentic memory]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agentic-memory/) provides a structured approach to managing conversation context in agentic search through dedicated memory containers. Unlike the default `conversation_index` memory type used by conversational agents, agentic memory uses separately created and configured memory containers that give you greater control over how conversation history is stored and managed. This is useful for scenarios where you want to manage memory lifecycle independently from the agent, configure memory behavior or share memory containers across different workflows.
+[Agentic memory]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agentic-memory/) provides a structured approach to managing conversation context in agentic search through dedicated memory containers. Unlike the default `conversation_index` memory type used by conversational agents, agentic memory uses separately created and configured memory containers that give you greater control over how conversation history is stored and managed. This is useful for scenarios where you want to manage memory lifecycle independently from the agent, configure memory behavior, or share memory containers across different workflows.
 
-This guide demonstrates how to create a memory container, configure an agent with agentic memory, and use memory continuity across multiple search queries.
+The following example demonstrates how to create a memory container, configure an agent with agentic memory, and use memory continuity across multiple search queries.
 
 ## Step 1: Create a product index
 
-Create a sample index with product data that includes various attributes like name, price, color, and category:
+Create a sample index with product data that includes various product attributes such as a `product_name`, `price`, `color`, and `category`:
 
 ```json
 PUT /products-index
@@ -65,67 +65,69 @@ POST _bulk
 
 Review the [model configuration]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agent-customization/#model-configuration) and choose a model to use.
 
-Here we register a GPT model that will be used by both the conversational agent and the `QueryPlanningTool`:
+The following example registers a GPT model that will be used by both the `conversational` agent and the `QueryPlanningTool`:
 
 ```json
 POST /_plugins/_ml/models/_register
 {
-    "name": "My OpenAI model: gpt-5",
-    "function_name": "remote",
-    "description": "test model",
-    "connector": {
-        "name": "My openai connector: gpt-5",
-        "description": "The connector to openai chat model",
-        "version": 1,
-        "protocol": "http",
-        "parameters": {
-            "model": "gpt-5"
+  "name": "My OpenAI model: gpt-5",
+  "function_name": "remote",
+  "description": "test model",
+  "connector": {
+    "name": "My openai connector: gpt-5",
+    "description": "The connector to openai chat model",
+    "version": 1,
+    "protocol": "http",
+    "parameters": {
+      "model": "gpt-5"
+    },
+    "credential": {
+      "openAI_key": "your-openai-api-key"
+    },
+    "actions": [
+      {
+        "action_type": "predict",
+        "method": "POST",
+        "url": "https://api.openai.com/v1/chat/completions",
+        "headers": {
+          "Authorization": "Bearer ${credential.openAI_key}"
         },
-        "credential": {
-            "openAI_key": "your-openai-api-key"
-        },
-        "actions": [
-            {
-                "action_type": "predict",
-                "method": "POST",
-                "url": "https://api.openai.com/v1/chat/completions",
-                "headers": {
-                    "Authorization": "Bearer ${credential.openAI_key}"
-                },
-                "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": [{\"role\":\"developer\",\"content\":\"${parameters.system_prompt}\"},${parameters._chat_history:-}{\"role\":\"user\",\"content\":\"${parameters.user_prompt}\"}${parameters._interactions:-}], \"reasoning_effort\":\"low\"${parameters.tool_configs:-}}"
-            }
-        ]
-    }
-}
-```
-
-## Step 4: Create a memory container
-
-Create a memory container to store conversation context for the agent. The memory container is created independently and can be configured with various options. For more details, see [configuration]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/agentic-memory-apis/create-memory-container/#the-configuration-object)
-
-```json
-POST /_plugins/_ml/memory_containers/_create
-{
-    "name": "agent-memory-container",
-    "configuration": {
-        "disable_history": true
-    }
+        "request_body": "{ \"model\": \"${parameters.model}\", \"messages\": [{\"role\":\"developer\",\"content\":\"${parameters.system_prompt}\"},${parameters._chat_history:-}{\"role\":\"user\",\"content\":\"${parameters.user_prompt}\"}${parameters._interactions:-}], \"reasoning_effort\":\"low\"${parameters.tool_configs:-}}"
+      }
+    ]
+  }
 }
 ```
 {% include copy-curl.html %}
 
-The response returns a memory container ID:
+## Step 4: Create a memory container
+
+Create a memory container to store conversation context for the agent:
+
+```json
+POST /_plugins/_ml/memory_containers/_create
+{
+  "name": "agent-memory-container",
+  "configuration": {
+    "disable_history": true
+  }
+}
+```
+{% include copy-curl.html %}
+
+The memory container is created independently and can be configured using various options. For more information, see [The configuration object]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/agentic-memory-apis/create-memory-container/#the-configuration-object).
+
+The response contains the memory container ID:
+
 ```json
 {
-    "memory_container_id": "your-memory-container-id"
+  "memory_container_id": "your-memory-container-id"
 }
 ```
 
-## Step 5: Register an agent with agentic memory
+## Step 5: Register an agent with an agentic memory
 
-Register a conversational agent that uses `agentic_memory` as the memory type. Reference the memory container created in the previous step using its `memory_container_id`. The agent includes the required `QueryPlanningTool` for generating OpenSearch DSL:
-
-See [Configuring agentic search agents]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agent-customization/) for basic configurations :
+Register a conversational agent that uses `agentic_memory` as the memory type. Specify the memory container created in the previous step in the `memory_container_id` field. The agent includes the required `QueryPlanningTool` for generating query domain-specific language (DSL):
 
 ```json
 POST /_plugins/_ml/agents/_register
@@ -156,9 +158,11 @@ POST /_plugins/_ml/agents/_register
 ```
 {% include copy-curl.html %}
 
+For more configuration options, see [Configuring agentic search agents]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agent-customization/).
+
 ## Step 6: Configure a search pipeline
 
-Create a search pipeline with both request and response processors. The [`agentic_query_translator` request processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) translates natural language queries into OpenSearch DSL, while the [`agentic_context` response processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-context-processor/) adds agent execution context information for monitoring and conversation continuity:
+Create a search pipeline containing both request and response processors. The [`agentic_query_translator` request processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) translates natural language queries into query DSL. The [`agentic_context` response processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-context-processor/) adds agent execution context information for monitoring and conversation continuity:
 
 ```json
 PUT _search/pipeline/agentic_search_pipeline
@@ -183,7 +187,7 @@ PUT _search/pipeline/agentic_search_pipeline
 
 ## Step 7: Run an agentic search
 
-To run a search, send a natural language search query. The agent analyzes the request, discovers appropriate indexes, and generates an optimized DSL query:
+To run an agentic search, send a natural language search query:
 
 ```json
 GET /_search?search_pipeline=agentic_search_pipeline
@@ -197,7 +201,7 @@ GET /_search?search_pipeline=agentic_search_pipeline
 ```
 {% include copy-curl.html %}
 
-The response includes matching products and the `ext` object containing the `memory_id` for conversation continuity and the generated `dsl_query`:
+The agent analyzes the request, discovers appropriate indexes, and generates an optimized DSL query. The response includes matching products in the `hits` array. The `ext` object contains the `memory_id` (for continuing the conversation) and the generated `dsl_query`:
 
 ```json
 {
@@ -271,9 +275,9 @@ The response includes matching products and the `ext` object containing the `mem
 }
 ```
 
-## Step 8: Run a follow up agentic search with a memory ID
+## Step 8: Run a follow-up agentic search
 
-Send a follow-up query using the memory_id from the previous response. The agent uses the agentic memory container to recall the previous conversation context:
+Send a follow-up query using the `memory_id` from the previous response:
 
 ```json
 GET /_search?search_pipeline=agentic_search_pipeline
@@ -288,7 +292,7 @@ GET /_search?search_pipeline=agentic_search_pipeline
 ```
 {% include copy-curl.html %}
 
-The agent remembers the context and applies it to the new request. It successfully interprets "black ones instead" and maintains the $150 budget from the previous context:
+Using the agentic memory container, the agent recalls the previous conversation and applies it to the new request. The agent successfully interprets "black ones instead" while maintaining the price constraint of 150 dollars or less. In the response, the `memory_id` remains the same, and the generated DSL query changes only the color filter from white to black while preserving all other constraints:
 
 ```json
 {
@@ -362,11 +366,9 @@ The agent remembers the context and applies it to the new request. It successful
 }
 ```
 
-Notice that the memory_id remains the same across both requests, indicating the agent is using the same memory container to maintain conversational context. The generated DSL query changed only the color filter from white to black while preserving all other constraints from the original query.
-
 ## Next steps
 
 - [Using conversational agents]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agent-converse/) -- Learn about conversational agents with reasoning traces and conversation index memory.
-- [Agentic query translator processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) -- Learn more about the request processor that translates natural language queries into OpenSearch DSL.
+- [Agentic query translator processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-query-translator-processor/) -- Learn more about the request processor that translates natural language queries into query DSL.
 - [Agentic context processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/agentic-context-processor/) -- Learn more about the response processor that adds agent execution context information for monitoring and conversation continuity.
 - [Configuring agentic search agents]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agent-customization/) -- Configure agent behaviors with different models, tools, and prompts.

--- a/_vector-search/ai-search/agentic-search/index.md
+++ b/_vector-search/ai-search/agentic-search/index.md
@@ -133,7 +133,11 @@ POST /_plugins/_ml/models/_register
 
 ## Step 4: Create an agent
 
-Create a conversational agent with the `QueryPlannerTool` (required), you can add other tools as needed. The following example creates a conversational agent with `conversation_index` memory. :
+Create a `conversational` agent with the `QueryPlannerTool` (required). You can add other tools as needed. 
+
+### Create an agent with a conversation index memory
+
+The following example creates a `conversational` agent that uses a `conversation_index` memory:
 
 ```json
 POST /_plugins/_ml/agents/_register
@@ -162,10 +166,14 @@ POST /_plugins/_ml/agents/_register
   "app_type": "os_chat"
 }
 ```
+{% include copy-curl.html %}
 
-You can also configure your agent with [agentic memory]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agentic-memory/) and attach the `memory_container_id` to your agent to save memories and interactions. The following example creates a conversational agent with `agentic_memory`. See [Using agentic memory]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agentic-memory/) for more details :
+### Create an agent with an agentic memory
+
+To save memories and interactions, you can configure your agent to use [agentic memory]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agentic-memory/). For more information, see [Using agentic memory]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agentic-memory/). The following example creates a `conversational` agent that uses an `agentic_memory` memory: 
 
 ```json
+POST /_plugins/_ml/agents/_register
 {
   "name": "GPT 5 Agent for Agentic Search",
   "type": "conversational",
@@ -192,7 +200,6 @@ You can also configure your agent with [agentic memory]({{site.url}}{{site.baseu
   "app_type": "os_chat"
 }
 ```
-
 {% include copy-curl.html %}
 
 ## Step 5: Create a search pipeline
@@ -286,7 +293,7 @@ After setting up basic agentic search, you can enhance your implementation with 
 
 - [Rerank agentic search results]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/rerank-agentic-search-results/) -- Add a rerank search response processor to your agentic search pipeline to futher rerank search results.
 
-- [Use agentic memory]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agentic-memory/) -- Configure agentic search with memory contains
+- [Use agentic memory]({{site.url}}{{site.baseurl}}/vector-search/ai-search/agentic-search/agentic-memory/) -- Configure agentic search to save memories and interactions using memory containers, enabling persistent context across conversations.
 
 ## Next steps
 


### PR DESCRIPTION
### Description
Updates QueryPlanningTool documentation for `fallback_query` optional field. Also adds a new page for agentic search with agentic memory

### Issues Resolved
Closes #12124 

### Version
3.6+

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
