### PR TITLE
Update Data Prepper's Prometheus sink documentation

### DIFF
--- a/_data-prepper/pipelines/configuration/sinks/prometheus.md
+++ b/_data-prepper/pipelines/configuration/sinks/prometheus.md
@@ -16,11 +16,11 @@ To ensure compatibility, the Prometheus sink sorts metrics by timestamp within e
 
 ## Usage
 
-The following sections describe how to configure the Prometheus sink for different deployment scenarios.
+The following examples configure the Prometheus sink for different deployment scenarios.
 
 ### Open-source Prometheus with no authentication
 
-To use with an open-source Prometheus instance, provide an `https://` URL. To use `http://`, set `insecure` to `true`. No `aws` block is needed. Prometheus must be started with the `--web.enable-remote-write-receiver` flag.
+To use an open-source Prometheus instance, provide an `https://` URL. To use `http://`, set `insecure` to `true`. No `aws` block is needed. Prometheus must be started with the `--web.enable-remote-write-receiver` flag:
 
 ```yaml
 pipeline:
@@ -35,9 +35,9 @@ pipeline:
 ```
 {% include copy.html %}
 
-### Open-source Prometheus with HTTP basic authentication
+### Open-source Prometheus with HTTP Basic authentication
 
-To authenticate with HTTP Basic credentials, for example, when Prometheus is behind a reverse proxy with basic authentication enabled, use the `authentication` block:
+To authenticate with HTTP Basic credentials (for example, when Prometheus is behind a reverse proxy with basic authentication enabled), use the `authentication` block:
 
 ```yaml
 pipeline:
@@ -52,9 +52,9 @@ pipeline:
 ```
 {% include copy.html %}
 
-### Amazon Managed Service for Prometheus (AMP)
+### AMP
 
-To use with AMP, provide the `aws` configuration block. An `https://` URL is required when using AWS authentication.
+To use AMP, provide the `aws` configuration block. An `https://` URL is required when using AWS authentication:
 
 ```yaml
 pipeline:
@@ -109,7 +109,7 @@ Option | Required | Type | Description
 `idle_timeout` | No | Duration | The maximum amount of time an idle HTTP connection remains open before being closed. Default is `60s`.
 `request_timeout` | No | Duration | The maximum amount of time allowed for a full end-to-end HTTP request to complete. Default is `60s`.
 `threshold` | No | [Threshold configuration](#threshold-configuration) | Configuration for batching and flushing time-series data.
-`max_retries` | No | Integer | The maximum number of attempts for failed ingestion requests. Uses exponential backoff with jitter on `retryable` status codes (`429`, `502`, `503`, `504`). Default is `5`.
+`max_retries` | No | Integer | The maximum number of attempts for failed ingestion requests. Uses exponential backoff with jitter on `retryable` status codes (`429`, `502`, `503`, or `504`). Default is `5`.
 `aws` | No | [AWS configuration](#aws-configuration) | AWS configuration for AWS Signature Version 4 signing. When present, requests are signed with AWS credentials. Cannot be used with `authentication`.
 `authentication` | No | [Authentication configuration](#authentication-configuration) | HTTP Basic authentication credentials. Cannot be used with `aws`.
 
@@ -125,7 +125,7 @@ Option | Required | Type | Description
 
 ## AWS configuration
 
-When the `aws` block is present, requests are automatically signed with Signature Version 4. An `https://` URL is required.
+When an `aws` block is present, requests are automatically signed with Signature Version 4. An `https://` URL is required. The AWS configuration supports the following options.
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---
@@ -136,7 +136,7 @@ Option | Required | Type | Description
 
 ## Authentication configuration
 
-The `authentication` block supports HTTP Basic authentication. It cannot be used together with `aws` (Signature Version 4 signing).
+The `authentication` block supports HTTP Basic authentication. It cannot be used together with `aws` (Signature Version 4 signing). The authentication configuration supports the following options.
 
 Option | Required | Type | Description
 :--- | :--- | :--- | :---


### PR DESCRIPTION
### Description
Add support for opensource prometheus in Data prepper documentation

### Issues Resolved
Closes https://github.com/opensearch-project/documentation-website/issues/12172

### Version
Data Prepper 2.15

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
