### PR TITLE
Fix credential field name in agent registration

### DIFF
--- a/_ml-commons-plugin/agents-tools/agents/index.md
+++ b/_ml-commons-plugin/agents-tools/agents/index.md
@@ -106,7 +106,7 @@ POST /_plugins/_ml/agents/_register
   "model": {
     "model_id": "gpt-4",
     "model_provider": "openai/v1/chat/completions",
-    "credentials": {
+    "credential": {
       "openai_key": "sk-your-api-key"
     },
     "parameters": {


### PR DESCRIPTION
### Description
The field name in the agent registration should be `credential` instead of `credentials`

### Version
all

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
