### PR TITLE
Update index compatibility reference through OpenSearch 3.5.0

### DIFF
--- a/_migrate-or-upgrade/index.md
+++ b/_migrate-or-upgrade/index.md
@@ -179,7 +179,17 @@ td {
 </style>
 <table>
   <tr><th>Lucene version</th><th>OpenSearch version</th><th>Elasticsearch version</th></tr>
-  <tr><td>9.10.0</td><td>2.14.0<br>2.13.0</td><td>8.13</td></tr>
+  <tr><td>10.3.2</td><td>3.5.0<br>3.4.0</td><td>&#8212;</td></tr>
+  <tr><td>10.3.1</td><td>3.3.2<br>3.3.1<br>3.3.0</td><td>&#8212;</td></tr>
+  <tr><td>10.2.2</td><td>3.2.0</td><td>&#8212;</td></tr>
+  <tr><td>10.2.1</td><td>3.1.0</td><td>&#8212;</td></tr>
+  <tr><td>10.1.0</td><td>3.0.0</td><td>&#8212;</td></tr>
+  <tr><td>9.12.3</td><td>2.19.5<br>2.19.4</td><td>&#8212;</td></tr>
+  <tr><td>9.12.2</td><td>2.19.3</td><td>&#8212;</td></tr>
+  <tr><td>9.12.1</td><td>2.19.2<br>2.19.1<br>2.19.0</td><td>&#8212;</td></tr>
+  <tr><td>9.12.0</td><td>2.18.0</td><td>&#8212;</td></tr>
+  <tr><td>9.11.1</td><td>2.17.1<br>2.17.0<br>2.16.0</td><td>&#8212;</td></tr>
+  <tr><td>9.10.0</td><td>2.15.0<br>2.14.0<br>2.13.0</td><td>8.13</td></tr>
   <tr><td>9.9.2</td><td>2.12.0</td><td>&#8212;</td></tr>
   <tr><td>9.7.0</td><td>2.11.1<br>2.9.0</td><td>8.9.0</td></tr>
   <tr><td>9.6.0</td><td>2.8.0</td><td>8.8.0</td></tr>


### PR DESCRIPTION
### Description

Extends the index compatibility reference table on the [Migrate or upgrade](https://docs.opensearch.org/latest/upgrade-or-migrate/#index-compatibility-reference) page to include all OpenSearch releases from 2.15.0 through 3.5.0, with their corresponding Lucene versions.

The table previously stopped at OpenSearch 2.14.0 (Lucene 9.10.0). This PR adds:

| Lucene version | OpenSearch versions |
|---|---|
| 10.3.2 | 3.5.0, 3.4.0 |
| 10.3.1 | 3.3.2, 3.3.1, 3.3.0 |
| 10.2.2 | 3.2.0 |
| 10.2.1 | 3.1.0 |
| 10.1.0 | 3.0.0 |
| 9.12.3 | 2.19.5, 2.19.4 |
| 9.12.2 | 2.19.3 |
| 9.12.1 | 2.19.2, 2.19.1, 2.19.0 |
| 9.12.0 | 2.18.0 |
| 9.11.1 | 2.17.1, 2.17.0, 2.16.0 |
| 9.10.0 | 2.15.0 (added to existing row) |

### Verification

All Lucene versions were verified directly from the [OpenSearch source repository](https://github.com/opensearch-project/OpenSearch) by checking `gradle/libs.versions.toml` at each release tag. The Elasticsearch column uses em-dash (—) for the new rows since OpenSearch 2.15+ and 3.x have no corresponding Elasticsearch releases sharing the same Lucene version.

Cross-referenced against public Elasticsearch documentation to confirm no Elasticsearch versions share these Lucene versions.

### Issues Resolved

Resolves #12176

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`