### PR TITLE
[DOC] Update VectorDBTool: document runtime override for index and embedding_field

### DIFF
--- a/_ml-commons-plugin/agents-tools/tools/vector-db-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/vector-db-tool.md
@@ -219,8 +219,8 @@ The following table lists all tool parameters that are available when registerin
 Parameter	| Type | Required/Optional | Description	
 :--- | :--- | :--- | :---
 `model_id` | String | Required | The model ID of the model to use at search time.
-`index` | String | Required | The index to search.
-`embedding_field` | String | Required | When the model encodes raw text documents, the encoding result is saved in a field. Specify this field as the `embedding_field`. Neural search matches documents to the query by calculating the similarity score between the query text and the text in the document's `embedding_field`.
+`index` | String | Optional | The index to search. Can be provided at runtime by the LLM. Runtime values take priority over registered defaults.
+`embedding_field` | String | Optional | When the model encodes raw text documents, the encoding result is saved in a field. Specify this field as the `embedding_field`. Neural search matches documents to the query by calculating the similarity score between the query text and the text in the document's `embedding_field`. Can be provided at runtime by the LLM. Runtime values take priority over registered defaults.
 `source_field` | String | Required | The document field or fields to return. You can provide a list of multiple fields as an array of strings, for example, `["field1", "field2"]`.
 `input` | String | Required for flow agent | Runtime input sourced from flow agent parameters. If using a large language model (LLM), this field is populated with the LLM response.
 `doc_size` | Integer | Optional | The number of documents to fetch. Default is `2`.

--- a/_ml-commons-plugin/agents-tools/tools/vector-db-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/vector-db-tool.md
@@ -219,8 +219,8 @@ The following table lists all tool parameters that are available when registerin
 Parameter	| Type | Required/Optional | Description	
 :--- | :--- | :--- | :---
 `model_id` | String | Required | The model ID of the model to use at search time.
-`index` | String | Required | The index to search. Can also be provided at runtime by the LLM. Runtime values take priority over registered defaults.
-`embedding_field` | String | Required | When the model encodes raw text documents, the encoding result is saved in a field. Specify this field as the `embedding_field`. Neural search matches documents to the query by calculating the similarity score between the query text and the text in the document's `embedding_field`. Can also be provided at runtime by the LLM. Runtime values take priority over registered defaults.
+`index` | String | Required | The index to search. This value can also be provided at runtime by the LLM; runtime values take precedence over registered defaults.
+`embedding_field` | String | Required | When the model encodes raw text documents, the encoding result is saved in a field. Specify this field as the `embedding_field`. Neural search matches documents to the query by calculating the similarity score between the query text and the text in the document's `embedding_field`. This value can also be provided at runtime by the LLM; runtime values take precedence over registered defaults.
 `source_field` | String | Required | The document field or fields to return. You can provide a list of multiple fields as an array of strings, for example, `["field1", "field2"]`.
 `input` | String | Required for flow agent | Runtime input sourced from flow agent parameters. If using a large language model (LLM), this field is populated with the LLM response.
 `doc_size` | Integer | Optional | The number of documents to fetch. Default is `2`.

--- a/_ml-commons-plugin/agents-tools/tools/vector-db-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/vector-db-tool.md
@@ -219,8 +219,8 @@ The following table lists all tool parameters that are available when registerin
 Parameter	| Type | Required/Optional | Description	
 :--- | :--- | :--- | :---
 `model_id` | String | Required | The model ID of the model to use at search time.
-`index` | String | Optional | The index to search. Can be provided at runtime by the LLM. Runtime values take priority over registered defaults.
-`embedding_field` | String | Optional | When the model encodes raw text documents, the encoding result is saved in a field. Specify this field as the `embedding_field`. Neural search matches documents to the query by calculating the similarity score between the query text and the text in the document's `embedding_field`. Can be provided at runtime by the LLM. Runtime values take priority over registered defaults.
+`index` | String | Required | The index to search. Can also be provided at runtime by the LLM. Runtime values take priority over registered defaults.
+`embedding_field` | String | Required | When the model encodes raw text documents, the encoding result is saved in a field. Specify this field as the `embedding_field`. Neural search matches documents to the query by calculating the similarity score between the query text and the text in the document's `embedding_field`. Can also be provided at runtime by the LLM. Runtime values take priority over registered defaults.
 `source_field` | String | Required | The document field or fields to return. You can provide a list of multiple fields as an array of strings, for example, `["field1", "field2"]`.
 `input` | String | Required for flow agent | Runtime input sourced from flow agent parameters. If using a large language model (LLM), this field is populated with the LLM response.
 `doc_size` | Integer | Optional | The number of documents to fetch. Default is `2`.


### PR DESCRIPTION
### Description

Updates the VectorDBTool register parameters table to document that `index` and `embedding_field` can be provided at runtime by the LLM (e.g., via function calling in conversational agents), with runtime values taking priority over registered defaults. Both parameters remain marked as Required since the tool needs them to function — the change clarifies that they can be supplied at runtime rather than only at registration time.

### Related

- opensearch-project/skills#722 — adds `input_schema` and runtime param overrides to VectorDBTool
- Resolves #12202