### PR TITLE
Document --max-shard-size-bytes support for shards larger than 80 GiB

### DIFF
--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -161,7 +161,7 @@ To use `Reindex-from-Snapshot` (RFS), ensure the following:
 - If you choose to bring your own snapshot (that is, one not created by Migration Assistant), the following settings must be applied when creating the snapshot:
   - `include_global_state: true` – Ensures that global cluster state is included.
   - `compress: false` – Disables metadata compression, which is required for compatibility with RFS.
-- Shards of up to **80 GiB** are supported by default. Larger shard sizes can be configured, **except in AWS GovCloud (US)**, where 80 GiB is the maximum.
+- Shards of up to **80 GiB** are supported by default. Larger shard sizes can be configured. For details, see [Configuring large shard support]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/deploy/configuration-options/#configuring-large-shard-support). **In AWS GovCloud (US) with the ECS deployment**, 80 GiB is the maximum supported shard size.
 - In OpenSearch 2.9 and later, snapshots of indexes that use the zstd or zstd_no_dict codecs are not supported. If you need to migrate these indexes using `Reindex-from-Snapshot`, you must first reindex them on the source cluster using either `default` or `best_compression` before creating a new snapshot for use with RFS.
 
 ### Capture and Replay

--- a/_migration-assistant/migration-phases/backfill.md
+++ b/_migration-assistant/migration-phases/backfill.md
@@ -124,6 +124,14 @@ Migration Assistant creates an Amazon CloudWatch dashboard, named `MigrationAssi
 
 You can find the backfill dashboard in the CloudWatch console based on the AWS Region in which you have deployed Migration Assistant. The metric graphs for your target cluster will be blank until you select the OpenSearch domain you're migrating to from the dropdown menu at the top of the dashboard.
 
+## Troubleshooting
+
+Use the following guidance to troubleshoot common backfill issues.
+
+### Shards appear stuck with no errors
+
+If `console backfill status --deep-check` shows shards that remain in progress indefinitely with no errors in the logs, the shard may exceed the default **80 GiB** size limit. Shards larger than this limit are skipped by RFS workers without surfacing an error in the backfill status output. To resolve this, increase the `--max-shard-size-bytes` value in your deployment configuration. For details, see [Configuring large shard support]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/deploy/configuration-options/#configuring-large-shard-support).
+
 ## Validating the backfill
 
 After the backfill is complete and the workers have stopped, examine the contents of your cluster using the [Refresh API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/refresh/) and the [Flush API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/flush/). The following example uses the console CLI with the Refresh API to check the backfill status:

--- a/_migration-assistant/migration-phases/deploy/configuration-options.md
+++ b/_migration-assistant/migration-phases/deploy/configuration-options.md
@@ -80,6 +80,17 @@ The RFS configuration uses the following options. All options are optional.
 
 To view all available arguments for `reindexFromSnapshotExtraArgs`, see [Snapshot migrations README](https://github.com/opensearch-project/opensearch-migrations/blob/main/DocumentsFromSnapshotMigration/README.md#arguments). At a minimum, no extra arguments may be needed.
 
+### Configuring large shard support
+
+By default, RFS supports shards of up to **80 GiB**. To migrate larger shards, pass the `--max-shard-size-bytes` flag through `reindexFromSnapshotExtraArgs`. For example, to support shards up to 200 GiB:
+
+```json
+"reindexFromSnapshotExtraArgs": "--max-shard-size-bytes 214748364800"
+```
+{% include copy.html %}
+
+Ensure that your worker nodes have sufficient local disk space, because RFS requires approximately **2x the shard size** in local storage to unpack and process the Lucene index. For more information about available RFS arguments, see the [DocumentsFromSnapshotMigration README](https://github.com/opensearch-project/opensearch-migrations/blob/main/DocumentsFromSnapshotMigration/README.md#arguments).
+
 ## Live capture migration with C&R 
 
 The following sample CDK performs a live capture migration with C&R:


### PR DESCRIPTION
## Description

Documents how to configure RFS to migrate shards larger than the default 80 GiB limit using the `--max-shard-size-bytes` flag.

### Changes

- **is-migration-assistant-right-for-you.md**: Simplified the 80 GiB bullet to note that larger shards can be configured, with a link to the configuration options page for details.
- **configuration-options.md**: Added a "Configuring large shard support" subsection under the RFS backfill config section, with a `reindexFromSnapshotExtraArgs` example and disk space guidance.
- **backfill.md**: Added a Troubleshooting section with a "Shards appear stuck with no errors" entry describing the symptom and linking to the configuration fix.

### Context

Users migrating clusters with shards exceeding 80 GiB encounter a situation where the shard appears stuck indefinitely with no errors in the backfill status output. The RFS worker silently rejects the shard due to the default `--max-shard-size-bytes` limit (80 GB), and the work item is repeatedly acquired and failed without progress. This documentation update makes the configuration path discoverable.

### Issues Resolved

N/A

### Check List
- [x] New functionality includes testing
- [x] New functionality has been documented
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/documentation-website/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).