### PR TITLE
Update text analyzer documentation clarifying the example

### DIFF
--- a/_analyzers/tokenizers/index.md
+++ b/_analyzers/tokenizers/index.md
@@ -44,8 +44,8 @@ Partial word tokenizers parse text into words and generate fragments of those wo
 
 Tokenizer | Description | Example
 :--- | :--- | :---
-[`ngram`]({{site.url}}{{site.baseurl}}/analyzers/tokenizers/ngram/)| - Parses strings into words on specified characters (for example, punctuation or white space characters) and generates n-grams of each word | `My repo` <br>becomes<br> [`M`, `My`, `y`, `y `, <code>&nbsp;</code>, <code>&nbsp;r</code>, `r`, `re`, `e`, `ep`, `p`, `po`, `o`] <br> because the default n-gram length is 1--2 characters 
-[`edge_ngram`]({{site.url}}{{site.baseurl}}/analyzers/tokenizers/edge-n-gram/) | - Parses strings into words on specified characters (for example, punctuation or white space characters) and generates edge n-grams of each word (n-grams that start at the beginning of the word) | `My repo` <br>becomes<br> [`M`, `My`] <br> because the default n-gram length is 1--2 characters 
+[`ngram`]({{site.url}}{{site.baseurl}}/analyzers/tokenizers/ngram/)| - Generates n-grams (overlapping character sequences) from the input <br> - By default, treats the entire input as a single token and generates n-grams from all characters (including spaces and punctuation) <br> - When configured with `token_chars`, first splits on specified characters, then generates n-grams from each resulting word | `My repo` <br>becomes<br> [`M`, `My`, `y`, `y `, <code>&nbsp;</code>, <code>&nbsp;r</code>, `r`, `re`, `e`, `ep`, `p`, `po`, `o`] <br> with default behavior (no `token_chars` configuration) and n-gram length of 1--2 characters. 
+[`edge_ngram`]({{site.url}}{{site.baseurl}}/analyzers/tokenizers/edge-n-gram/) | - Generates edge n-grams (n-grams that start at the beginning of each token) <br> - By default, treats the entire input as a single token <br> - When configured with `token_chars`, first splits on specified characters (for example, punctuation or white space), then generates edge n-grams from each resulting word | `My repo` <br>becomes<br> [`M`, `My`, `r`, `re`] <br> when configured with `token_chars: ["letter"]` and default n-gram length of 1--2 characters. 
 
 ### Structured text tokenizers
 


### PR DESCRIPTION
Corrects documentation for the edge_ngram and ngram tokenizers, which previously suggested that both tokenizers parse strings into words by default. In fact, tokenizers treat the entire input as a single token unless configured with token_chars. Updated descriptions to explain this default behavior and show that configuration is required for word-based parsing. Updated the edge_ngram example to demonstrate configured behavior.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
