### PR TITLE
Update LTR stats endpoint to /_plugins/_ltr/stats

### DIFF
--- a/_search-plugins/ltr/advanced-functionality.md
+++ b/_search-plugins/ltr/advanced-functionality.md
@@ -323,11 +323,11 @@ flag to the `sltr` query that is the target of feature score logging, as shown i
 You can use the Stats API to retrieve the plugin's overall status and statistics. To do this, send the following request:
 
 ```json
-GET /_ltr/_stats
+GET /_plugins/_ltr/stats
 ```
 {% include copy-curl.html %}
 
-The response includes information about the cluster, configured stores, and cache statistics for various plugin components:
+The response includes information about the cluster, configured stores, cache statistics for various plugin components, and request counts:
 
 ```json
 {
@@ -370,7 +370,9 @@ The response includes information about the cluster, configured stores, and cach
                "entry_count":0,
                "memory_usage_in_bytes":0
             }
-         }
+         },
+         "request_total_count": 0,
+         "request_error_count": 0
       }
    }
 }
@@ -380,15 +382,25 @@ The response includes information about the cluster, configured stores, and cach
 You can use filters to retrieve a single statistic by sending the following request:
 
 ```json
-GET /_ltr/_stats/{stat}
+GET /_plugins/_ltr/stats/{stat}
 ```
 {% include copy-curl.html %}
+
+The following table lists the available `{stat}` values.
+
+Stat | Description
+:--- | :---
+`stores` | Information about configured feature stores.
+`status` | The overall plugin status.
+`cache` | Per-node cache statistics for various plugin components (features, feature sets, and models).
+`request_total_count` | Per-node counter of the number of LTR queries executed.
+`request_error_count` | Per-node counter of the number of LTR queries that failed.
 
 You can limit the information to a single node in the cluster by sending the following requests:
 
 ```json
-GET /_ltr/_stats/nodes/{nodeId}
-GET /_ltr/_stats/{stat}/nodes/{nodeId}
+GET /_plugins/_ltr/{nodeId}/stats
+GET /_plugins/_ltr/{nodeId}/stats/{stat}
 ```
 {% include copy-curl.html %}
 

--- a/_search-plugins/ltr/advanced-functionality.md
+++ b/_search-plugins/ltr/advanced-functionality.md
@@ -386,7 +386,7 @@ GET /_plugins/_ltr/stats/{stat}
 ```
 {% include copy-curl.html %}
 
-The following table lists the available `{stat}` values.
+The following table lists the available `stat` values.
 
 Stat | Description
 :--- | :---


### PR DESCRIPTION
### Description
Updates LTR stats endpoint from `/_ltr/_stats` to `/_plugins/_ltr/stats` as `/_ltr/_stats` was deprecated and is no longer exposed.  Also updates descriptions and examples relating to this endpoint.

### Related Issues/PRs
- https://github.com/opensearch-project/opensearch-learning-to-rank-base/issues/99
- https://github.com/opensearch-project/opensearch-learning-to-rank-base/pull/117

### Version
2.19+

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
