### PR TITLE
Fix formatting of commit changes instruction

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -64,7 +64,7 @@ If you want to make minor changes to an existing file, you can use this approach
 
 1. In the upper-right corner, select the pencil icon and edit the file.
 
-1. In the upper-right corner, select **Commit changes...***. Enter the commit message and optional description and select **Create a new branch for this commit and start a pull request**.
+1. In the upper-right corner, select **Commit changes...**. Enter the commit message and optional description and select **Create a new branch for this commit and start a pull request**.
 
 ### Making major changes
 


### PR DESCRIPTION
## Summary

This pull request makes a minor correction to the `CONTRIBUTING.md` documentation by fixing a formatting issue in the instructions for committing changes.

### Changes

* Corrected the commit button label from **Commit changes...*** to **Commit changes...**
* Removed the extraneous asterisk to better match the GitHub UI text

### Issues Resolved

N/A

### Version

All

### Frontend features

N/A

### Checklist

* [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
