### PR TITLE
Remove duplicate query enhancement section

### DIFF
--- a/_search-plugins/searching-data/index.md
+++ b/_search-plugins/searching-data/index.md
@@ -48,10 +48,3 @@ Enhance user queries in real-time to improve search accuracy and user experience
 
 - [Autocomplete functionality]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/autocomplete/): Suggest phrases as the user types.
 - [Did-you-mean functionality]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/did-you-mean/): Check spelling of phrases as the user types.
-
-## Query enhancement
-
-Enhance user queries in real-time to improve search accuracy and user experience:
-
-- [Autocomplete functionality]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/autocomplete/): Suggest phrases as the user types.
-- [Did-you-mean functionality]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/did-you-mean/): Check spelling of phrases as the user types.


### PR DESCRIPTION
## Description

The **Query Enhancement** section was duplicated on the **Customizing Search Results** page. This PR removes the redundant duplicate section to improve clarity and readability.

## Issues Resolved

This resolves the issue where the **Query Enhancement** section appeared twice with identical content on the **Customizing Search Results** page.

Closes #<issue-number>

## Version

all

## Frontend features

N/A (documentation-only change)

## Checklist

* [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
