### PR TITLE
Actually note how to enable the security Update Configuration API

### DIFF
--- a/_api-reference/security/configuration/update-configuration.md
+++ b/_api-reference/security/configuration/update-configuration.md
@@ -235,4 +235,8 @@ The Update Configuration API allows you to directly modify the Security plugin's
 
 ## Enabling this API
 
-By default, this API is disabled for security reasons. To enable it, you need to:
+By default, this API is disabled for security reasons. To enable it, you need to add the following line to `opensearch.yml`:
+
+```yml
+plugins.security.unsupported.restapi.allow_securityconfig_modification: true
+```


### PR DESCRIPTION
### Description
The documentation for the `Update Configuration API` currently correctly notes that the API is disabled by default, but forgets to finish its sentence on how to actually enable it.

### Checklist
- [X] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
