### PR TITLE
Add default labeling to PRs and correct delete branch workflow

### DIFF
--- a/.github/workflows/delete_merged_branch.yml
+++ b/.github/workflows/delete_merged_branch.yml
@@ -9,14 +9,23 @@ jobs:
     runs-on: ubuntu-latest
     if: |
       github.repository == 'opensearch-project/documentation-website' &&
-      ${{ !startsWith(github.event.pull_request.head.ref, 'main') }} &&
-      ${{ !startsWith(github.event.pull_request.head.ref, '1.') }} &&
-      ${{ !startsWith(github.event.pull_request.head.ref, '2.') }} &&
-      ${{ !startsWith(github.event.pull_request.head.ref, 'version/') }}
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !startsWith(github.event.pull_request.head.ref, 'main') &&
+      !startsWith(github.event.pull_request.head.ref, '1.') &&
+      !startsWith(github.event.pull_request.head.ref, '2.') &&
+      !startsWith(github.event.pull_request.head.ref, 'version/')
     steps:
-      - name: Echo remove branch
-        run: echo Removing ${{github.event.pull_request.head.ref}}
       - name: Delete merged branch
-        uses: SvanBoxel/delete-merged-branch@main
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const branchName = context.payload.pull_request.head.ref;
+            console.log(`Deleting branch: ${branchName}`);
+
+            await github.rest.git.deleteRef({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              ref: `heads/${branchName}`
+            });

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,0 +1,60 @@
+name: Label PRs
+
+on:
+  pull_request:
+    types: [opened, reopened, ready_for_review, converted_to_draft]
+
+jobs:
+  label-pr:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+
+    steps:
+      - name: Label draft PR as "In progress"
+        if: github.event.pull_request.draft == true
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['In progress']
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'Tech review'
+              });
+            } catch (error) {
+              console.log('Tech review label not found, skipping removal');
+            }
+
+      - name: Label non-draft PR as "Tech review"
+        if: github.event.pull_request.draft == false
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            await github.rest.issues.addLabels({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+              labels: ['Tech review']
+            });
+
+            try {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+                name: 'In progress'
+              });
+            } catch (error) {
+              console.log('In progress label not found, skipping removal');
+            }


### PR DESCRIPTION
This PR adds a workflow to label incoming PRs: draft PRs get an "In progress" label while non-draft PRs get a "Tech review" label. When a PR changes status, the labels change accordingly.

This PR also updates the delete-merge-branch workflow to an explicit working script.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
