### PR TITLE
Enable labeling of PRs created from forks

### DIFF
--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -1,8 +1,8 @@
 name: Label PRs
 
 on:
-  pull_request:
-    types: [opened, reopened, ready_for_review, converted_to_draft]
+  pull_request_target:
+    types: [opened, reopened, ready_for_review, converted_to_draft, labeled]
 
 jobs:
   label-pr:

--- a/.github/workflows/label-prs.yml
+++ b/.github/workflows/label-prs.yml
@@ -2,7 +2,7 @@ name: Label PRs
 
 on:
   pull_request_target:
-    types: [opened, reopened, ready_for_review, converted_to_draft, labeled]
+    types: [opened, reopened, ready_for_review, converted_to_draft]
 
 jobs:
   label-pr:


### PR DESCRIPTION
Updates `pull_request` to `pull_request_target` so the labeling workflow works on PRs created from forks.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
