### PR TITLE
Automatically set canonical links for all pages

### DIFF
--- a/_plugins/set_canonical.rb
+++ b/_plugins/set_canonical.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+# Automatically sets canonical_url pointing to /latest/ for previous version branches
+
+Jekyll::Hooks.register :site, :post_read do |site|
+  next if site.config['doc_version'] == 'latest'
+
+  url = site.config['url'] || ''
+  latesturl = site.config['latesturl'] || '/latest'
+
+  # Process regular pages
+  site.pages.each do |page|
+    next unless page.respond_to?(:output_ext) && page.output_ext == '.html'
+    next if page.data['canonical_url']
+    next if page.url.include?('/search.html') || page.url.include?('/404.html')
+
+    page.data['canonical_url'] = "#{url}#{latesturl}#{page.url}"
+  end
+
+  # Process collection documents
+  site.documents.each do |doc|
+    next unless doc.respond_to?(:output_ext) && doc.output_ext == '.html'
+    next if doc.data['canonical_url']
+
+    doc.data['canonical_url'] = "#{url}#{latesturl}#{doc.url}"
+  end
+end


### PR DESCRIPTION
Automatically set canonical links for all generated HTML pages except for the 404 and search page.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
