### PR TITLE
Add directive to not index pages other than latest in Google

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -7,7 +7,7 @@
     function getStoredTheme() {
       try {
         return localStorage.getItem(THEME_KEY);
-      } 
+      }
       catch (e) {
         return null;
       }
@@ -31,12 +31,16 @@
     const theme = getPreferredTheme();
     if (theme === DARK_THEME) {
       document.documentElement.setAttribute('data-skin', 'dark');
-    } 
+    }
     else {
       document.documentElement.removeAttribute('data-skin');
     }
   })();
 </script>
+
+{% if site.doc_version != "latest" %}
+<meta name="robots" content="noindex, follow">
+{% endif %}
 
 {% if site.anchor_links != nil %}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"></script>


### PR DESCRIPTION
Add directive to not index pages other than latest in Google so that versioned pages do not compete with the latest page in Google search results. This affects only the versioned branches that are not "latest".

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
