### PR TITLE
Add directive to not index pages other than latest in Google 1.1

### DIFF
--- a/_includes/head_custom.html
+++ b/_includes/head_custom.html
@@ -1,3 +1,5 @@
+<meta name="robots" content="noindex, follow">
+
 {% if site.anchor_links != nil %}
   <script src="https://cdnjs.cloudflare.com/ajax/libs/anchor-js/4.2.0/anchor.min.js"></script>
 {% endif %}


### PR DESCRIPTION
Add directive to not index pages other than latest in Google  - same as PR https://github.com/opensearch-project/documentation-website/pull/12326

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
