### PR TITLE
Fix workload reference missing from nav sidebar

### DIFF
--- a/_benchmark/reference/workloads/corpora.md
+++ b/_benchmark/reference/workloads/corpora.md
@@ -2,7 +2,7 @@
 layout: default
 title: corpora
 parent: Workload reference
-grand_parent: OpenSearch Benchmark Reference
+grand_parent: Reference
 nav_order: 70
 redirect_from:
   - /benchmark/workloads/corpora/

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Workload reference
 nav_order: 60
-parent: OpenSearch Benchmark Reference
+parent: Reference
 has_children: true
 redirect_from:
   - /benchmark/workloads/

--- a/_benchmark/reference/workloads/indices.md
+++ b/_benchmark/reference/workloads/indices.md
@@ -2,7 +2,7 @@
 layout: default
 title: indices
 parent: Workload reference
-grand_parent: OpenSearch Benchmark Reference
+grand_parent: Reference
 nav_order: 65
 redirect_from:
   - /benchmark/workloads/indices/

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -2,7 +2,7 @@
 layout: default
 title: operations
 parent: Workload reference
-grand_parent: OpenSearch Benchmark Reference
+grand_parent: Reference
 nav_order: 100
 ---
 

--- a/_benchmark/reference/workloads/test-procedures.md
+++ b/_benchmark/reference/workloads/test-procedures.md
@@ -2,7 +2,7 @@
 layout: default
 title: test_procedures
 parent: Workload reference
-grand_parent: OpenSearch Benchmark Reference
+grand_parent: Reference
 nav_order: 110
 ---
 


### PR DESCRIPTION
### Description
The Workload reference section was invisible in the nav because its parent was set to 'OpenSearch Benchmark Reference' which doesn't match the actual parent page title 'Reference'. Fix the parent/grand_parent references so the section appears under Reference in the sidebar.

### Issues Resolved
Closes https://github.com/opensearch-project/opensearch-benchmark/issues/1050
and brings back other documentation pages not referenced before

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
