### PR TITLE
Fix broken links from automated checker

### DIFF
--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -66,6 +66,7 @@ module Jekyll::LinkChecker
     'www.cloudflare.com', # 403s on bots
     'platform.openai.com', # 403s on bots
     'openai.com', # 403s on bots
+    'opensourceconnections.com', # 403s on bots
     'mvnrepository.com', # 403s on bots
     'www.intel.com', # 403s on bots
     'wordnet.princeton.edu', # 403s on bots


### PR DESCRIPTION
## Summary

Closes #12332.

## Changes

- Added 1 domain to the exclusion list (403 on bots)

### Domains Added to Exclusion List:
- `opensourceconnections.com` - Returns 403 when accessed by automated tools

### Link Details:
- **URL**: https://opensourceconnections.com/slack
- **File**: _search-plugins/ltr/faq.md
- **Error**: 403 Forbidden (blocks bots)

## Verification

The link was manually verified:
- Link is accessible in a browser but blocks automated tools with 403 status
- Added domain to `_plugins/link-checker.rb` ignored_domains list

Closes #12332

🤖 Generated with [Claude Code](https://claude.com/claude-code)