### PR TITLE
Make sure 2.19.6 is also mentioned in the security plugin params comments

### DIFF
--- a/_install-and-configure/install-dashboards/debian.md
+++ b/_install-and-configure/install-dashboards/debian.md
@@ -26,6 +26,10 @@ This guide assumes that you are comfortable working from the Linux command line 
    # arm64
    sudo dpkg -i opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.deb
    ```
+   For new installations of OpenSearch Dashboards 2.19.6 and later, you can use the following environment variable to control the Security Dashboards plugin behavior:
+   ```bash
+   DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
+   ```
 1. After the installation completes, reload the systemd manager configuration.
     ```bash
     sudo systemctl daemon-reload

--- a/_install-and-configure/install-dashboards/rpm.md
+++ b/_install-and-configure/install-dashboards/rpm.md
@@ -40,6 +40,10 @@ OpenSearch Dashboards is the default visualization tool for data in OpenSearch. 
     # Install the arm64 package using rpm.
     sudo rpm -ivh opensearch-dashboards-{{site.opensearch_version}}-linux-arm64.rpm
     ```
+    For new installations of OpenSearch Dashboards 2.19.6 and later, you can use the following environment variable to control Security Dashboards plugin behavior:
+    ```bash
+    DISABLE_SECURITY_DASHBOARDS_PLUGIN=true
+    ```
 1. After the installation succeeds, enable OpenSearch Dashboards as a service.
     ```bash
     sudo systemctl enable opensearch-dashboards

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -40,15 +40,6 @@ This guide assumes that you are comfortable working from the Linux command line 
 1. Download the Debian package for the desired version directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The Debian package can be downloaded for both **x64** and **arm64** architectures.
 1. From the CLI, install the package using `dpkg`:
 
-   For new installations of OpenSearch 2.19.6 and later, you can use the following installation-time environment variables to control the Security plugin behavior:
-   * `DISABLE_INSTALL_DEMO_CONFIG=true` -- Prevents the installer from setting up demo security configuration (certificates, users, and roles). Use this for installations where you will configure security manually.
-   * `DISABLE_SECURITY_PLUGIN=true` -- Disables the Security plugin entirely. Only use this for testing or development environments where security is not required.
-
-   To use these environment variables, add them before the installation command with the `env` keyword:
-   ```bash
-   sudo env DISABLE_INSTALL_DEMO_CONFIG=true dpkg -i opensearch-{{site.opensearch_version}}-linux-x64.deb
-   ```
-
    For new installations of OpenSearch 2.12 and later, you must define a custom admin password in order to set up a demo security configuration. Use one of the following commands to define a custom admin password:
    ```bash
    # x64
@@ -64,6 +55,14 @@ This guide assumes that you are comfortable working from the Linux command line 
    
    # arm64
    sudo dpkg -i opensearch-{{site.opensearch_version}}-linux-arm64.deb
+   ```
+   For new installations of OpenSearch 2.19.6 and later, you can use the following installation-time environment variables to control the Security plugin behavior:
+   * `DISABLE_INSTALL_DEMO_CONFIG=true` -- Prevents the installer from setting up demo security configuration (certificates, users, and roles). Use this for installations where you will configure security manually.
+   * `DISABLE_SECURITY_PLUGIN=true` -- Disables the Security plugin entirely. Only use this for testing or development environments where security is not required.
+
+   To use these environment variables, add them before the installation command with the `env` keyword:
+   ```bash
+   sudo env DISABLE_INSTALL_DEMO_CONFIG=true dpkg -i opensearch-{{site.opensearch_version}}-linux-x64.deb
    ```
 
 1. After the installation succeeds, enable OpenSearch as a service.

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -40,6 +40,15 @@ This guide assumes that you are comfortable working from the Linux command line 
 1. Download the Debian package for the desired version directly from the [OpenSearch downloads page](https://opensearch.org/downloads.html){:target='\_blank'}. The Debian package can be downloaded for both **x64** and **arm64** architectures.
 1. From the CLI, install the package using `dpkg`:
 
+   For new installations of OpenSearch 2.19.6 and later, you can use the following installation-time environment variables to control the Security plugin behavior:
+   * `DISABLE_INSTALL_DEMO_CONFIG=true` -- Prevents the installer from setting up demo security configuration (certificates, users, and roles). Use this for installations where you will configure security manually.
+   * `DISABLE_SECURITY_PLUGIN=true` -- Disables the Security plugin entirely. Only use this for testing or development environments where security is not required.
+
+   To use these environment variables, add them before the installation command with the `env` keyword:
+   ```bash
+   sudo env DISABLE_INSTALL_DEMO_CONFIG=true dpkg -i opensearch-{{site.opensearch_version}}-linux-x64.deb
+   ```
+
    For new installations of OpenSearch 2.12 and later, you must define a custom admin password in order to set up a demo security configuration. Use one of the following commands to define a custom admin password:
    ```bash
    # x64

--- a/_install-and-configure/install-opensearch/rpm.md
+++ b/_install-and-configure/install-opensearch/rpm.md
@@ -47,6 +47,15 @@ This guide assumes that you are comfortable working from the Linux command line 
    
 1. From the CLI, you can install the package with `rpm` or `yum`:
 
+   For new installations of OpenSearch 2.19.6 and later, you can use the following installation-time environment variables to control the Security plugin behavior:
+   * `DISABLE_INSTALL_DEMO_CONFIG=true` -- Prevents the installer from setting up demo security configuration (certificates, users, and roles). Use this for installations where you will configure security manually.
+   * `DISABLE_SECURITY_PLUGIN=true` -- Disables the Security plugin entirely. Only use this for testing or development environments where security is not required.
+
+   To use these environment variables, add them before the installation command with the `env` keyword:
+   ```bash
+   sudo env DISABLE_INSTALL_DEMO_CONFIG=true yum install opensearch-{{site.opensearch_version}}-linux-x64.rpm
+   ```
+
    ```bash
    # For new installations of OpenSearch 2.12 and later, you must define a custom admin password in order to set up a demo security configuration.
    # Use one of the following commands to define a custom admin password:

--- a/_install-and-configure/install-opensearch/rpm.md
+++ b/_install-and-configure/install-opensearch/rpm.md
@@ -47,15 +47,6 @@ This guide assumes that you are comfortable working from the Linux command line 
    
 1. From the CLI, you can install the package with `rpm` or `yum`:
 
-   For new installations of OpenSearch 2.19.6 and later, you can use the following installation-time environment variables to control the Security plugin behavior:
-   * `DISABLE_INSTALL_DEMO_CONFIG=true` -- Prevents the installer from setting up demo security configuration (certificates, users, and roles). Use this for installations where you will configure security manually.
-   * `DISABLE_SECURITY_PLUGIN=true` -- Disables the Security plugin entirely. Only use this for testing or development environments where security is not required.
-
-   To use these environment variables, add them before the installation command with the `env` keyword:
-   ```bash
-   sudo env DISABLE_INSTALL_DEMO_CONFIG=true yum install opensearch-{{site.opensearch_version}}-linux-x64.rpm
-   ```
-
    ```bash
    # For new installations of OpenSearch 2.12 and later, you must define a custom admin password in order to set up a demo security configuration.
    # Use one of the following commands to define a custom admin password:
@@ -85,6 +76,14 @@ This guide assumes that you are comfortable working from the Linux command line 
 
    ## Install the arm64 package using rpm.
    sudo rpm -ivh opensearch-{{site.opensearch_version}}-linux-arm64.rpm
+   ```
+   For new installations of OpenSearch 2.19.6 and later, you can use the following installation-time environment variables to control the Security plugin behavior:
+   * `DISABLE_INSTALL_DEMO_CONFIG=true` -- Prevents the installer from setting up demo security configuration (certificates, users, and roles). Use this for installations where you will configure security manually.
+   * `DISABLE_SECURITY_PLUGIN=true` -- Disables the Security plugin entirely. Only use this for testing or development environments where security is not required.
+
+   To use these environment variables, add them before the installation command with the `env` keyword:
+   ```bash
+   sudo env DISABLE_INSTALL_DEMO_CONFIG=true yum install opensearch-{{site.opensearch_version}}-linux-x64.rpm
    ```
 
 1. After the installation succeeds, enable OpenSearch as a service.


### PR DESCRIPTION
### Description
Make sure 2.19.6 is also mentioned in the security plugin params comments

### Issues Resolved
Follow up https://github.com/opensearch-project/documentation-website/pull/12294.

### Version
Only merge to main and backport to 2.19 after 2.19.6 is live (June 30th, 2026).
Let me know if this is the right way @kolchfa-aws .

Thanks.


### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
