### PR TITLE
Add multi-tenancy disable instructions for OpenSearch

### DIFF
--- a/_dashboards/workspace/workspace.md
+++ b/_dashboards/workspace/workspace.md
@@ -112,7 +112,25 @@ uiSettings:
 
 If your cluster has the Security plugin installed, then multi-tenancy must be disabled to avoid conflicts with similar workspaces:
 
+### OpenSearch Dashboards
+
+Disable multi-tenancy in `opensearch_dashboards.yml`
 ```yaml
 opensearch_security.multitenancy.enabled: false
+```
+### OpenSearch
+   
+Multi-tenancy in the OpenSearch Security plugin is enabled by default. To disable it, update the Security plugin `config.yml` file and apply the configuration using the `securityadmin.sh` script.
+
+```yaml
+_meta:
+  type: "config"
+  config_version: 2
+
+config:
+  dynamic:
+    kibana:
+      multitenancy_enabled: false
+...
 ```
 {% include copy.html %}

--- a/_dashboards/workspace/workspace.md
+++ b/_dashboards/workspace/workspace.md
@@ -110,7 +110,7 @@ uiSettings:
 ```
 {% include copy.html %}
 
-If your cluster has the Security plugin installed, then multi-tenancy must be disabled to avoid conflicts with similar workspaces:
+If your cluster has the Security plugin installed, then multi-tenancy must be disabled to avoid conflicts with similar workspaces.
 
 ### OpenSearch Dashboards
 

--- a/_dashboards/workspace/workspace.md
+++ b/_dashboards/workspace/workspace.md
@@ -118,6 +118,8 @@ Disable multi-tenancy in `opensearch_dashboards.yml`:
 
 ```yaml
 opensearch_security.multitenancy.enabled: false
+```
+
 ### OpenSearch
    
 Multi-tenancy in the OpenSearch Security plugin is enabled by default. To disable it, update the Security plugin `config.yml` file and apply the configuration using the `securityadmin.sh` script:

--- a/_dashboards/workspace/workspace.md
+++ b/_dashboards/workspace/workspace.md
@@ -114,13 +114,13 @@ If your cluster has the Security plugin installed, then multi-tenancy must be di
 
 ### OpenSearch Dashboards
 
-Disable multi-tenancy in `opensearch_dashboards.yml`
+Disable multi-tenancy in `opensearch_dashboards.yml`:
+
 ```yaml
 opensearch_security.multitenancy.enabled: false
-```
 ### OpenSearch
    
-Multi-tenancy in the OpenSearch Security plugin is enabled by default. To disable it, update the Security plugin `config.yml` file and apply the configuration using the `securityadmin.sh` script.
+Multi-tenancy in the OpenSearch Security plugin is enabled by default. To disable it, update the Security plugin `config.yml` file and apply the configuration using the `securityadmin.sh` script:
 
 ```yaml
 _meta:

--- a/_dashboards/workspace/workspace.md
+++ b/_dashboards/workspace/workspace.md
@@ -119,6 +119,8 @@ Disable multi-tenancy in `opensearch_dashboards.yml`:
 ```yaml
 opensearch_security.multitenancy.enabled: false
 ```
+{% include copy.html %}
+
 
 ### OpenSearch
    


### PR DESCRIPTION
Added instructions to disable multi-tenancy for OpenSearch and OpenSearch Dashboards.

### Description
Current documentation only instructs how to disable multi-tenancy in Opensearch Dashboards. Multi-tenancy in OpenSearch is enabled by default and must also be disabled when the workspaces feature is enabled. 

### Version
3.x

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
