### PR TITLE
Fix broken relative links in benchmark common-operations.md

### DIFF
--- a/_benchmark/user-guide/understanding-workloads/common-operations.md
+++ b/_benchmark/user-guide/understanding-workloads/common-operations.md
@@ -89,7 +89,7 @@ The following example creates a new index with all index settings specified in t
 ## delete-index
 <!-- vale on -->
 
-The `delete-index` operation runs the [Delete Index API](api-reference/index-apis/delete-index/). Like with the [`create-index`](#create-index) operation, you can delete all indexes found in the `indices` section of the workload or delete one or more indexes based on the string passed in the `index` setting.
+The `delete-index` operation runs the [Delete Index API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/delete-index/). Like with the [`create-index`](#create-index) operation, you can delete all indexes found in the `indices` section of the workload or delete one or more indexes based on the string passed in the `index` setting.
 
 The following example deletes all indexes found in the `indices` section of the workload:
 
@@ -120,7 +120,8 @@ The following example deletes all `logs_*` indexes:
 ## cluster-health
 <!-- vale on -->
 
-The `cluster-health` operation runs the [Cluster Health API](api-reference/cluster-api/cluster-health/), which checks the cluster health status and returns the expected status according to the parameters set for `request-params`. If an unexpected cluster health status is returned, the operation reports a failure. You can use the `--on-error` option in the OpenSearch Benchmark `run` command to control how OpenSearch Benchmark behaves when the health check fails.
+The `cluster-health` operation runs the [Cluster Health API]({{site.url}}{{site.baseurl}}/api-reference/cluster-api/cluster-health/), which checks the cluster health status and returns the expected status according to the parameters set for `request-params`. If an unexpected cluster health status is returned, the operation reports a failure. You can use the `--on-error` option in the OpenSearch Benchmark `run` command to control how OpenSearch Benchmark behaves when the health check fails.
+
 
 The following example creates a `cluster-health` operation that checks for a `green` health status on any `log-*` indexes:
 


### PR DESCRIPTION
### Description
Fixes two broken internal links in the benchmark `common-operations.md` page. The `delete-index` and `cluster-health` sections were linking to `api-reference/...` without a leading `/`, causing 404s. Added the missing `/` to both links.

### Issues Resolved
Relates to [opensearch-project/opensearch-benchmark#1056](https://github.com/opensearch-project/opensearch-benchmark/issues/1056)

### Version
all

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).