### PR TITLE
Add Migration Companion documentation: AI-guided migration experience

### DIFF
--- a/_migration-assistant/index.md
+++ b/_migration-assistant/index.md
@@ -27,6 +27,9 @@ items:
 
 # ![Migration Assistant icon]({{site.url}}{{site.baseurl}}/images/icons/MigrationUpgrade_Color_Icon.svg){: .heading-icon} Migration Assistant for OpenSearch
 
+**New: [Migration Companion]({{site.url}}{{site.baseurl}}/migration-assistant/migration-companion/)** — an AI-guided experience that handles assessment, deployment, and execution for you. Start a conversation in your IDE, AWS CloudShell, or Docker and the companion walks you through your entire migration. Or follow the manual guides below if you prefer to operate directly.
+{: .tip }
+
 Migration Assistant for OpenSearch helps you successfully perform an end-to-end, zero-downtime upgrade and migration to OpenSearch. There are three aspects of a migration that must be understood:
 
 - **Metadata migration**: Migrate cluster metadata, such as index settings, aliases, and templates.

--- a/_migration-assistant/migration-companion/cloudshell.md
+++ b/_migration-assistant/migration-companion/cloudshell.md
@@ -1,0 +1,56 @@
+---
+layout: default
+title: "Install: AWS CloudShell"
+nav_order: 2
+parent: Migration Companion
+permalink: /migration-assistant/migration-companion/cloudshell/
+---
+
+# Install Migration Companion in AWS CloudShell
+
+This install modality is not yet available. The following describes the intended experience.
+{: .warning }
+
+AWS CloudShell provides a browser-based terminal with AWS credentials pre-configured. The Migration Companion bootstrap script installs the companion tooling and connects to Amazon Bedrock for AI capabilities — no separate API key needed.
+
+## Intended experience
+
+### Step 1: Open CloudShell
+
+Open [AWS CloudShell](https://console.aws.amazon.com/cloudshell/) from the AWS Console in the region where you want to deploy.
+
+### Step 2: Bootstrap the companion
+
+```bash
+curl -sSL https://releases.opensearch.org/migration-companion/bootstrap.sh | bash
+```
+
+This script will:
+- Clone the opensearch-migrations repository
+- Install required tools (kubectl, Helm)
+- Configure the AI CLI to use Amazon Bedrock
+- Start the companion session
+
+### Step 3: Start the conversation
+
+The companion opens an interactive session. Describe your migration:
+
+```
+I need to migrate my Amazon Elasticsearch Service 7.10 domain to 
+Amazon OpenSearch Service 2.19. The domain is in us-east-1.
+```
+
+The companion uses your CloudShell AWS credentials automatically — no additional credential setup needed for AWS resources.
+
+## How it differs from the IDE modality
+
+| Aspect | CloudShell | IDE agent |
+|:-------|:-----------|:----------|
+| AI provider | Amazon Bedrock (automatic) | Your IDE's AI (Cursor, Cline, Kiro, etc.) |
+| AWS credentials | Pre-configured in CloudShell | You configure via `aws configure` or env vars |
+| Session persistence | CloudShell home directory (1 GB, persists across sessions) | Local filesystem |
+| Best for | Quick start from the AWS Console, no local setup | Developers who want full IDE integration |
+
+## Current status
+
+The CloudShell bootstrap script is not yet published. Today, you can use CloudShell as a terminal to run the [EKS deployment]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/deploy/deploying-to-eks/) manually, or use the [IDE agent]({{site.url}}{{site.baseurl}}/migration-assistant/migration-companion/ide-agent/) modality instead.

--- a/_migration-assistant/migration-companion/docker.md
+++ b/_migration-assistant/migration-companion/docker.md
@@ -1,0 +1,96 @@
+---
+layout: default
+title: "Install: Docker"
+nav_order: 3
+parent: Migration Companion
+permalink: /migration-assistant/migration-companion/docker/
+---
+
+# Install Migration Companion with Docker
+
+This install modality is not yet available. The following describes the intended experience.
+{: .warning }
+
+The Docker modality packages the Migration Companion as a container image with a built-in AI CLI. State persists across sessions via a mounted volume. This is ideal for local environments, air-gapped networks, and CI/CD pipelines.
+
+## Intended experience
+
+### Step 1: Pull and run
+
+```bash
+docker run -it \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -v ~/.migration-companion:/workspace/state \
+  public.ecr.aws/opensearchproject/opensearch-migrations-migration-companion:latest
+```
+
+The container includes:
+- The opensearch-migrations repository with all steering docs and SOPs
+- A built-in AI CLI (Claude by default)
+- kubectl, Helm, AWS CLI, and all required tools
+- The sizing calculator and workflow schema
+
+### Step 2: Start the conversation
+
+The companion opens an interactive terminal session:
+
+```
+Welcome to OpenSearch Migration Companion.
+
+I can help you migrate from Elasticsearch, OpenSearch, or Apache Solr 
+to OpenSearch. Tell me about your source cluster and I'll guide you 
+through the entire process.
+
+> I have an Elasticsearch 6.8 cluster with 500GB of data running on 
+  EC2. I need to migrate to OpenSearch 3.x on EKS.
+```
+
+### Step 3: Provide credentials
+
+Mount your AWS credentials or pass them as environment variables:
+
+```bash
+docker run -it \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -e AWS_ACCESS_KEY_ID=... \
+  -e AWS_SECRET_ACCESS_KEY=... \
+  -e AWS_SESSION_TOKEN=... \
+  -v ~/.migration-companion:/workspace/state \
+  public.ecr.aws/opensearchproject/opensearch-migrations-migration-companion:latest
+```
+
+Or mount your AWS config:
+
+```bash
+docker run -it \
+  -e ANTHROPIC_API_KEY=sk-ant-... \
+  -v ~/.aws:/root/.aws:ro \
+  -v ~/.migration-companion:/workspace/state \
+  public.ecr.aws/opensearchproject/opensearch-migrations-migration-companion:latest
+```
+
+## AI provider configuration
+
+The Docker image ships with Claude as the default AI provider. To use a different provider:
+
+| Provider | Configuration |
+|:---------|:-------------|
+| Claude (default) | Set `ANTHROPIC_API_KEY` environment variable |
+| Amazon Bedrock | Set `AWS_REGION` and ensure IAM role has Bedrock access |
+| Bring your own | Mount a custom AI CLI configuration |
+
+The AI provider configuration is not yet finalized. Details will be updated when the Docker modality is released.
+{: .warning }
+
+## How it differs from other modalities
+
+| Aspect | Docker | CloudShell | IDE agent |
+|:-------|:-------|:-----------|:----------|
+| AI provider | Configurable (Claude default) | Amazon Bedrock | Your IDE's AI |
+| Requires internet | For AI API calls and AWS access | Yes (CloudShell) | For AI and AWS |
+| Session persistence | Mounted volume | CloudShell home dir | Local filesystem |
+| Best for | Local/air-gapped, CI/CD, no IDE | Quick AWS start | Full IDE integration |
+
+## Current status
+
+The companion Docker image (`opensearch-migrations-migration-companion`) exists in ECR but does not yet provide the full interactive companion experience described above. Today, use the [IDE agent]({{site.url}}{{site.baseurl}}/migration-assistant/migration-companion/ide-agent/) modality for the most complete experience.

--- a/_migration-assistant/migration-companion/ide-agent.md
+++ b/_migration-assistant/migration-companion/ide-agent.md
@@ -1,0 +1,105 @@
+---
+layout: default
+title: "Install: IDE agent"
+nav_order: 1
+parent: Migration Companion
+permalink: /migration-assistant/migration-companion/ide-agent/
+---
+
+# Install Migration Companion in your IDE
+
+Use your IDE's built-in AI agent (Cursor, VS Code + Cline, Kiro, Windsurf, or any MCP-compatible agent) as the Migration Companion. The opensearch-migrations repository contains steering docs, knowledge bases, and tool definitions that turn any capable AI agent into a migration expert.
+
+## Prerequisites
+
+- An AI-enabled IDE with agent/chat capabilities
+- Git
+- AWS CLI (for EKS deployments)
+- kubectl and Helm (installed automatically by the bootstrap script on EKS)
+
+## Step 1: Clone the repository
+
+```bash
+git clone https://github.com/opensearch-project/opensearch-migrations.git
+cd opensearch-migrations
+```
+{% include copy.html %}
+
+The repository IS the companion. It contains:
+
+| Directory | Purpose |
+|:----------|:--------|
+| `agent-sops/` | Standard operating procedures that guide the AI through each migration phase |
+| `kiro-cli/kiro-cli-config/steering/` | Steering docs with migration best practices, safety guardrails, and domain knowledge |
+| `orchestrationSpecs/` | Workflow schema and config processor — the AI uses these to generate valid workflow configs |
+| `deployment/k8s/` | Helm charts and bootstrap scripts for deployment |
+
+## Step 2: Open in your IDE
+
+Open the `opensearch-migrations` directory in your IDE. The AI agent will automatically discover the steering docs and SOPs.
+
+### Agent configuration
+
+Most AI agents will work out of the box by reading the repository's steering files. For agents that support explicit configuration:
+
+- **MCP tools**: The companion exposes tools via the Model Context Protocol for cluster analysis, sizing estimation, and workflow management. Check your agent's MCP configuration docs.
+- **Context files**: Point your agent at `agent-sops/` and `kiro-cli/kiro-cli-config/steering/` for migration-specific knowledge.
+- **System prompts**: The steering docs in `kiro-cli/kiro-cli-config/steering/product.md` describe the migration domain and supported paths.
+
+## Step 3: Start the conversation
+
+Open your IDE's AI chat and describe your migration goal:
+
+```
+I need to migrate from Elasticsearch 7.10 to OpenSearch. My source cluster 
+is running on EC2 at https://my-es-cluster:9200. I want to deploy the 
+migration infrastructure on EKS in us-east-2.
+```
+
+The companion will:
+1. Ask clarifying questions (authentication, target preferences, downtime tolerance)
+2. Assess your source cluster
+3. Recommend a migration strategy
+4. Guide you through deployment and execution
+
+## Step 4: Provide credentials
+
+The companion needs access to your source cluster and AWS account. Provide credentials as you normally would for your environment:
+
+- **AWS**: Configure via `aws configure`, environment variables, or IAM role
+- **Source cluster**: Basic auth credentials, SigV4, or mTLS as appropriate
+
+The companion will create Kubernetes secrets for cluster authentication as part of the deployment flow.
+
+## What the companion can do
+
+| Capability | How it works |
+|:-----------|:-------------|
+| Assess source cluster | Connects via REST API, analyzes version, schemas, and compatibility |
+| Estimate target sizing | Uses the sizing calculator MCP tool (Elasticsearch/OpenSearch sources) |
+| Deploy on EKS | Runs `aws-bootstrap.sh` with appropriate flags |
+| Deploy on K8s | Runs `helm install` with appropriate values |
+| Generate workflow config | Produces valid YAML from the current `workflowMigration.schema.json` |
+| Submit and monitor | Runs `workflow submit`, `workflow status`, `workflow manage` |
+| Validate results | Compares document counts and runs test queries |
+
+## What the companion cannot do yet
+
+The following capabilities are planned but not yet available:
+
+Sizing estimation for Solr sources is not yet implemented. The companion will note this gap and ask you to provide target sizing manually.
+{: .warning }
+
+Workflow API endpoints for programmatic `configure`, `submit`, `status`, and `approve` are not yet available. The companion currently drives these operations by executing CLI commands on the migration console pod.
+{: .warning }
+
+A persistent migration session that carries assessment results, sizing recommendations, deployment state, and workflow IDs across conversations is not yet implemented. Each conversation starts fresh, though the companion can read existing cluster and workflow state.
+{: .warning }
+
+## Next steps
+
+Once the companion has deployed Migration Assistant and submitted a workflow, you can:
+
+- Monitor progress via `workflow manage` (interactive TUI)
+- Review the [architecture]({{site.url}}{{site.baseurl}}/migration-assistant/architecture/) to understand what's running
+- Check [troubleshooting]({{site.url}}{{site.baseurl}}/migration-assistant/troubleshooting/) if issues arise

--- a/_migration-assistant/migration-companion/index.md
+++ b/_migration-assistant/migration-companion/index.md
@@ -1,0 +1,111 @@
+---
+layout: default
+title: Migration Companion
+nav_order: 5
+has_children: true
+has_toc: true
+permalink: /migration-assistant/migration-companion/
+---
+
+# Migration Companion
+
+Migration Companion is an AI-guided experience that walks you through your entire migration — from initial assessment through final cutover — within a single continuous conversation. Instead of reading docs, running CLI commands, and stitching together tools manually, you describe your migration goal and the companion handles assessment, planning, deployment, and execution.
+
+You remain in control through approval gates and plan review, but the cognitive load shifts from you to the system.
+{: .note }
+
+## How it works
+
+Migration Companion wraps the same Migration Assistant engine (Workflow CLI, Reindex-from-Snapshot, Capture and Replay) with an AI advisor that can:
+
+- **Assess** your source cluster — detect version, analyze schemas, identify breaking changes, estimate target sizing
+- **Plan** your migration — recommend backfill-only vs. capture-and-replay, choose target type (provisioned vs. serverless), generate transforms
+- **Deploy** Migration Assistant infrastructure — bootstrap EKS, install Helm charts, configure networking
+- **Execute** the migration — generate workflow configs, submit workflows, monitor progress, handle approvals
+- **Validate** results — compare document counts, run test queries, verify metadata
+
+## Choose your install modality
+
+Migration Companion runs in three modalities. Each one gives you the same migration experience — only the bootstrap and credential setup differ.
+
+| Modality | Best for | AI provider | Status |
+|:---------|:---------|:------------|:-------|
+| [IDE agent]({{site.url}}{{site.baseurl}}/migration-assistant/migration-companion/ide-agent/) | Developers with Cursor, VS Code + Cline, Kiro, or any AI-enabled IDE | Your IDE's built-in AI | Available |
+| [AWS CloudShell]({{site.url}}{{site.baseurl}}/migration-assistant/migration-companion/cloudshell/) | AWS users who want to start from the console with no local setup | Amazon Bedrock | Coming soon |
+| [Docker]({{site.url}}{{site.baseurl}}/migration-assistant/migration-companion/docker/) | Local or air-gapped environments, CI/CD pipelines | Configurable (Claude API, Bedrock, or bring your own) | Coming soon |
+
+## The migration journey
+
+Regardless of which modality you choose, the companion guides you through the same phases:
+
+### 1. Assessment
+
+The companion connects to your source cluster, detects the platform (Elasticsearch, OpenSearch, or Solr), and produces a readiness report:
+
+- Source version and compatibility check against [supported migration paths]({{site.url}}{{site.baseurl}}/migration-assistant/is-migration-assistant-right-for-you/)
+- Breaking changes analysis (field type incompatibilities, deprecated features)
+- Target sizing recommendation using the [cluster sizing estimator](#sizing-estimator)
+- Snapshot prerequisites (S3 plugin, IAM roles, bucket access)
+
+### 2. Planning
+
+Based on the assessment, the companion recommends a migration strategy:
+
+- **Backfill only** — for clusters where writes can be paused briefly
+- **Backfill + Capture and Replay** — for zero-downtime migrations
+- **Solr backfill + shim validation** — for Solr sources
+
+The companion generates a draft migration plan including target type (provisioned OpenSearch Service, OpenSearch Serverless, or self-managed), authentication model, snapshot location, and workflow configuration.
+
+### 3. Deployment
+
+With your approval, the companion deploys or attaches to Migration Assistant:
+
+- On AWS: runs `aws-bootstrap.sh` to create the EKS cluster, install Helm charts, and configure CloudWatch dashboards
+- On existing Kubernetes: installs the Migration Assistant Helm chart
+- Configures source and target cluster access, creates Kubernetes secrets, validates network connectivity
+
+### 4. Execution
+
+The companion materializes a valid workflow configuration from the current schema, submits it, and monitors progress:
+
+- Generates `workflow-config.yaml` from assessment outputs (not blank templates)
+- Runs `console clusters connection-check` before submitting
+- Submits via `workflow submit` and monitors via `workflow status`
+- Handles approval gates automatically or prompts you for review
+- Reports progress: snapshot creation, metadata migration, backfill, replay
+
+### 5. Validation
+
+After the workflow completes, the companion verifies the migration:
+
+- Compares document counts between source and target
+- Runs representative queries
+- Reports any discrepancies
+- Provides a readiness summary before traffic switchover
+
+## Sizing estimator
+
+The target cluster sizing estimator is a CLI tool and MCP server that recommends optimal OpenSearch configurations based on your source cluster's characteristics.
+
+This feature is not yet available for all source types. Currently supports Elasticsearch and OpenSearch sources. Solr source analysis is planned.
+{: .warning }
+
+| Workload type | Key inputs | Optimization focus |
+|:-------------|:-----------|:-------------------|
+| Search | Data volume, query rate, latency SLA | Query performance, replica count |
+| Time-series / Logs | Ingestion rate, retention period | Storage efficiency, warm/cold tiers |
+| Vector search | Vector dimensions, index size, recall target | Memory capacity, k-NN engine selection |
+
+The estimator provides recommendations for both provisioned clusters and serverless collections.
+
+## Relationship to Migration Assistant
+
+Migration Companion is the **front door** to Migration Assistant. Under the hood, it uses the same components:
+
+- [Workflow CLI]({{site.url}}{{site.baseurl}}/migration-assistant/workflow-cli/) for migration orchestration
+- [Reindex-from-Snapshot]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/backfill/) for document backfill
+- [Capture and Replay]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/replay-captured-traffic/) for zero-downtime migration
+- [EKS deployment]({{site.url}}{{site.baseurl}}/migration-assistant/migration-phases/deploy/deploying-to-eks/) for infrastructure
+
+All Migration Assistant documentation remains valid. The companion automates the steps described in those pages — it doesn't replace them. If you prefer to operate manually, follow the [Workflow CLI getting started]({{site.url}}{{site.baseurl}}/migration-assistant/workflow-cli/getting-started/) guide directly.


### PR DESCRIPTION
New section: Migration Companion
- Landing page: explains the 5-phase journey (assess, plan, deploy, execute, validate) and relationship to Migration Assistant
- IDE agent install (available): agent-agnostic guide for Cursor, VS Code + Cline, Kiro, Windsurf, or any MCP-compatible agent. Documents what works today and what's missing (red warnings).
- CloudShell install (coming soon): describes intended Bedrock-powered experience with red warning that bootstrap script is not yet published.
- Docker install (coming soon): describes intended containerized experience with red warning that full companion UX is not yet available.

Key decisions:
- Companion is the front door, Migration Assistant is the engine
- IDE modality is agent-agnostic (not Kiro-specific)
- Missing features marked with red warning callouts
- Sizing estimator documented with Solr gap noted
- Persistent migration session gap noted
- Workflow API gap noted
- All existing Migration Assistant docs unchanged

Updated: Landing page adds tip callout pointing to Migration Companion as the recommended starting point.

### Description
_Describe what this change achieves._

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
