### PR TITLE
Fix/benchmark recovery stats wrong params

### DIFF
--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -86,7 +86,7 @@ The `node-stats` device supports the following parameters:
 
 The `recovery-stats` telemetry device regularly calls the [CAT Recovery API]({{site.url}}{{site.baseurl}}/api-reference/cat/cat-recovery/) and records one metrics document per shard.
 
-This telemetry device supports the following parameters:
+The `recovery-stats` telemetry device supports the following parameters.
 
 | Parameter | Data type | Description |
 | :--- | :--- | :--- |

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -88,8 +88,8 @@ The `recovery-stats` telemetry device regularly calls the [CAT Recovery API]({{s
 
 This telemetry device supports the following parameters:
 
-- `searchable-snapshots-stats-indices` A string with the index pattern, or list of index patterns, that searchable snapshots stats should additionally be collected from. If unset, only cluster-level stats will be collected. Default is `None`.
-- `searchable-snapshots-stats-sample-interval`: A positive number greater than zero denoting the sampling interval in seconds. Default is `1`.
+- `recovery-stats-indices`: A string with the index pattern or a JSON object keyed by cluster name when using `--target-hosts`, specifying the indices to collect recovery stats from. If unset, stats are collected for all indices. Default is `None`.
+- `recovery-stats-sample-interval`: A positive number greater than zero denoting the sampling interval in seconds. Default is `1`.
 
 <!-- vale off -->
 ## shard-stats

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -88,8 +88,10 @@ The `recovery-stats` telemetry device regularly calls the [CAT Recovery API]({{s
 
 This telemetry device supports the following parameters:
 
-- `recovery-stats-indices`: A string with the index pattern or a JSON object keyed by cluster name when using `--target-hosts`, specifying the indices to collect recovery stats from. If unset, stats are collected for all indices. Default is `None`.
-- `recovery-stats-sample-interval`: A positive number greater than zero denoting the sampling interval in seconds. Default is `1`.
+| Parameter | Data type | Description |
+| :--- | :--- | :--- |
+| `recovery-stats-indices` | String or JSON object | Specifies the indexes from which to collect recovery statistics. Valid values are:<br>- A string that specifies an index pattern. <br>- A JSON object that maps cluster names to index patterns when `--target-hosts` is used to define multiple clusters. <br><br>If not set, recovery statistics are collected for all indexes. Default is `None`. |
+| `recovery-stats-sample-interval` | Number | A positive number denoting the sampling interval, in seconds. Default is `1`. |
 
 <!-- vale off -->
 ## shard-stats


### PR DESCRIPTION
### Description
Fixes incorrect parameters documented under the `recovery-stats` telemetry device. The page listed `searchable-snapshots-stats-indices` and `searchable-snapshots-stats-sample-interval` under `recovery-stats`, which belong to the `SearchableSnapshotsStats` device. Replaced them with the correct parameters `recovery-stats-indices` and `recovery-stats-sample-interval` as defined in `osbenchmark/telemetry.py`.

### Issues Resolved
Relates to [opensearch-project/opensearch-benchmark#1058](https://github.com/opensearch-project/opensearch-benchmark/issues/1058)

### Version
all

### Frontend features
N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).