### PR TITLE
Remote capable nodes maximum shards per node settings documentation missing

### DIFF
--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -193,6 +193,8 @@ OpenSearch supports the following cluster-level shard, block, and task settings:
 
 - `cluster.max_shards_per_node` (Integer): Limits the total number of primary and replica shards for the cluster. The limit is calculated as follows: `cluster.max_shards_per_node` multiplied by the number of non-frozen data nodes. Shards for closed indexes do not count toward this limit. Default is `1000`. 
 
+- `cluster.max_remote_capable_shards_per_node` (Integer): Limits the total number of primary and replica shards for the cluster used by warm role nodes. The limit is calculated as `cluster.max_remote_capable_shards_per_node` multiplied by the number of warm data nodes. This setting is useful for controlling the total number of shards for searchable snapshots. Default is `1000`. 
+
 - `cluster.persistent_tasks.allocation.enable` (String): Enables or disables allocation for persistent tasks.   
 
     Valid values are: 


### PR DESCRIPTION
### Description
The documentation is missing remote capable shard limits that is applicable for searchable snapshots.

### Issues Resolved
Closes #[20839]

### Version
_List the OpenSearch version to which this PR applies, e.g.  3.*

### Frontend features
N/A
### Checklist
- [ x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
