### PR TITLE
Fix typo: occured -> occurred

### DIFF
--- a/_api-reference/snapshots/get-snapshot.md
+++ b/_api-reference/snapshots/get-snapshot.md
@@ -113,6 +113,6 @@ Upon success, the response returns snapshot information:
 | end_time | string | Date/time when the snapshot creation process ended. |
 | end_time_in_millis | long | Time (in milliseconds) when the snapshot creation process ended. |
 | duration_in_millis | long | Total time (in milliseconds) that the snapshot creation process lasted. |
-| failures | array | Failures, if any, that occured during snapshot creation. |
+| failures | array | Failures, if any, that occurred during snapshot creation. |
 | shards | object | Total number of shards created along with number of successful and failed shards. |
 | state | string | Snapshot status. Possible values: `IN_PROGRESS`, `SUCCESS`, `FAILED`, `PARTIAL`. |


### PR DESCRIPTION
Corrects a typo in the snapshots API reference.