### PR TITLE
Add FunctionScoreQuery fields and k-NN link on gRPC Search page

### DIFF
--- a/_api-reference/grpc-apis/search.md
+++ b/_api-reference/grpc-apis/search.md
@@ -505,14 +505,14 @@ The [`FunctionScoreQuery`](https://github.com/opensearch-project/opensearch-prot
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `query` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L1341) | Query that matches documents before functions run. |
-| `functions` | `repeated` [`FunctionScoreContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2181) | Score functions; each entry may set `filter`, `weight`, and one of `exp`, `gauss`, `linear`, `field_value_factor`, `random_score`, or `script_score`. |
-| `score_mode` | `optional` [`FunctionScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2957) | How multiple function scores combine. |
-| `boost_mode` | `optional` [`FunctionBoostMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2947) | How the function score merges with the query score. |
-| `max_boost` | `optional float` | Maximum score after functions. |
-| `min_score` | `optional float` | Drop documents below this score. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
+| `boost_mode` | `optional` [`FunctionBoostMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2947) | How the function score merges with the query score. |
+| `functions` | `repeated` [`FunctionScoreContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2181) | Score functions; each entry may set `filter`, `weight`, and one of `exp`, `gauss`, `linear`, `field_value_factor`, `random_score`, or `script_score`. |
+| `max_boost` | `optional float` | Maximum score after functions. |
+| `min_score` | `optional float` | Drop documents below this score. |
+| `query` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L1341) | Query that matches documents before functions run. |
+| `score_mode` | `optional` [`FunctionScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2957) | How multiple function scores combine. |
 
 See also [Function score query]({{site.url}}{{site.baseurl}}/query-dsl/compound/function-score/).
 

--- a/_api-reference/grpc-apis/search.md
+++ b/_api-reference/grpc-apis/search.md
@@ -499,6 +499,23 @@ The [`ConstantScoreQuery`](https://github.com/opensearch-project/opensearch-prot
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 
+#### FunctionScoreQuery fields
+
+The [`FunctionScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2154) message accepts the following fields.
+
+| Field | Protobuf type | Description |
+| :---- | :---- | :---- |
+| `query` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L1341) | Query that matches documents before functions run. |
+| `functions` | `repeated` [`FunctionScoreContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2181) | Score functions; each entry may set `filter`, `weight`, and one of `exp`, `gauss`, `linear`, `field_value_factor`, `random_score`, or `script_score`. |
+| `score_mode` | `optional` [`FunctionScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2957) | How multiple function scores combine. |
+| `boost_mode` | `optional` [`FunctionBoostMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2947) | How the function score merges with the query score. |
+| `max_boost` | `optional float` | Maximum score after functions. |
+| `min_score` | `optional float` | Drop documents below this score. |
+| `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
+| `x_name` | `optional string` | A query name for query tagging. |
+
+See also [Function score query]({{site.url}}{{site.baseurl}}/query-dsl/compound/function-score/).
+
 ### Joining query fields
 
 The following sections describe the fields for each joining query message.
@@ -556,6 +573,8 @@ A geodistance query returns documents with geopoints that are within a specified
 ### Specialized query fields
 
 The following sections describe the fields for each specialized query message.
+
+For `knn`, see [k-NN (gRPC)]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/knn/).
 
 #### ScriptQuery fields
 

--- a/_api-reference/grpc-apis/search.md
+++ b/_api-reference/grpc-apis/search.md
@@ -507,14 +507,14 @@ The [`FunctionScoreQuery`](https://github.com/opensearch-project/opensearch-prot
 | :---- | :---- | :---- |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `boost_mode` | `optional` [`FunctionBoostMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2947) | How the function score merges with the query score. |
-| `functions` | `repeated` [`FunctionScoreContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2181) | Score functions; each entry may set `filter`, `weight`, and one of `exp`, `gauss`, `linear`, `field_value_factor`, `random_score`, or `script_score`. |
-| `max_boost` | `optional float` | Maximum score after functions. |
-| `min_score` | `optional float` | Drop documents below this score. |
-| `query` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L1341) | Query that matches documents before functions run. |
-| `score_mode` | `optional` [`FunctionScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2957) | How multiple function scores combine. |
+| `boost_mode` | `optional` [`FunctionBoostMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2947) | Determines how the computed function score is combined with the query score. |
+| `functions` | `repeated` [`FunctionScoreContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2181) | The score functions. Each entry may set `filter`, `weight`, and one of `exp`, `gauss`, `linear`, `field_value_factor`, `random_score`, or `script_score`. |
+| `max_boost` | `optional float` | The maximum boost value that a function can apply to a document score. |
+| `min_score` | `optional float` | Excludes documents with a score below this threshold from the results. |
+| `query` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L1341) | The query used to select documents before applying score functions. |
+| `score_mode` | `optional` [`FunctionScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2957) | Determines how scores from multiple functions are combined into a single score. |
 
-See also [Function score query]({{site.url}}{{site.baseurl}}/query-dsl/compound/function-score/).
+For more information, see [Function score query]({{site.url}}{{site.baseurl}}/query-dsl/compound/function-score/).
 
 ### Joining query fields
 
@@ -574,7 +574,7 @@ A geodistance query returns documents with geopoints that are within a specified
 
 The following sections describe the fields for each specialized query message.
 
-For `knn`, see [k-NN (gRPC)]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/knn/).
+For `knn` query fields, see [k-NN (gRPC)]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/knn/).
 
 #### ScriptQuery fields
 


### PR DESCRIPTION
### Description

Documents **FunctionScoreQuery** on the gRPC Search page (`_api-reference/grpc-apis/search.md`): adds **`#### FunctionScoreQuery fields`** under compound queries, with a field table and protobuf links aligned to **opensearch-protobufs 1.2.0** (same pattern as `BoolQuery` / `ConstantScoreQuery`). Adds a short line under **Specialized query fields** linking to **[k-NN (gRPC)](https://docs.opensearch.org/latest/api-reference/grpc-apis/knn/)** so readers can open the dedicated `KnnQuery` documentation.

### Issues Resolved

Closes #12421

### Version

OpenSearch **3.x** (gRPC Search API; protobuf references **1.2.0** as used elsewhere on the page).

### Frontend features

N/A

### Checklist

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
  For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).