### PR TITLE
Updating kinesis and s3 source documentation to add support for otel_traces codec 

### DIFF
--- a/_data-prepper/pipelines/configuration/sources/kinesis.md
+++ b/_data-prepper/pipelines/configuration/sources/kinesis.md
@@ -88,14 +88,14 @@ Option | Required | Type    | Description
 
 ### `otel_traces` codec
 
-The `otel_traces` codec parses each Kinesis data stream record as an OpenTelemetry trace record and creates a Data Prepper Span event for each span record.
+The `otel_traces` codec parses each Kinesis data stream record as an OpenTelemetry trace record and creates a Data Prepper span event for each span record.
 
 You can use the following options to configure the `otel_traces` codec.
 
 Option | Required | Type    | Description
 :--- | :--- |:--------| :---
-`format` | No | String | Specifies the format of the OpenTelemetry traces. Valid options are `json` and `protobuf`. Default is `json`.
-`otel_format` | No | String | Specifies the output format of the decoded spans. Valid options are `opensearch` and `otel`. Default is `opensearch`.
+`format` | No | String | Specifies the format of the OpenTelemetry traces. Valid values are `json` and `protobuf`. Default is `json`.
+`otel_format` | No | String | Specifies the output format of the decoded spans. Valid values are `opensearch` and `otel`. Default is `opensearch`.
 `length_prefixed_encoding` | No | Boolean | Specifies whether the length precedes the data in protobuf format. Default is `false`.
 
 ### polling

--- a/_data-prepper/pipelines/configuration/sources/kinesis.md
+++ b/_data-prepper/pipelines/configuration/sources/kinesis.md
@@ -86,6 +86,18 @@ Option | Required | Type    | Description
 `skip_lines` | No | Integer | Sets the number of lines to skip before creating events. You can use this configuration to skip common header rows. Default is `0`.
 `header_destination` | No | String  | Defines a key value to assign to the header line of the stream event. If this option is specified, then each event will contain a `header_destination` field.
 
+### `otel_traces` codec
+
+The `otel_traces` codec parses each Kinesis data stream record as an OpenTelemetry trace record and creates a Data Prepper Span event for each span record.
+
+You can use the following options to configure the `otel_traces` codec.
+
+Option | Required | Type    | Description
+:--- | :--- |:--------| :---
+`format` | No | String | Specifies the format of the OpenTelemetry traces. Valid options are `json` and `protobuf`. Default is `json`.
+`otel_format` | No | String | Specifies the output format of the decoded spans. Valid options are `opensearch` and `otel`. Default is `opensearch`.
+`length_prefixed_encoding` | No | Boolean | Specifies whether the length precedes the data in protobuf format. Default is `false`.
+
 ### polling
 
 When the `consumer_strategy` is set to `polling`, the `kinesis` source uses a polling-based approach to read records from the Kinesis data streams, instead of the default `fan-out` approach.

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -173,14 +173,14 @@ Parameters | Required | Type   | Description
 
 ### `otel_traces` codec
 
-The `otel_traces` codec parses each S3 object as an OpenTelemetry trace record and creates a Data Prepper Span event for each span record.
+The `otel_traces` codec parses each S3 object as an OpenTelemetry trace record and creates a Data Prepper span event for each span record.
 
 Use the following parameters to configure the `otel_traces` codec.
 
 Parameter | Required | Type    | Description
 :--- | :--- |:--------| :---
-`format` | No | String | Specifies the format of the OpenTelemetry traces. Valid options are `json` and `protobuf`. Default is `json`.
-`otel_format` | No | String | Specifies the output format of the decoded spans. Valid options are `opensearch` and `otel`. Default is `opensearch`.
+`format` | No | String | Specifies the format of the OpenTelemetry traces. Valid values are `json` and `protobuf`. Default is `json`.
+`otel_format` | No | String | Specifies the output format of the decoded spans. Valid values are `opensearch` and `otel`. Default is `opensearch`.
 `length_prefixed_encoding` | No | Boolean | Specifies whether the length precedes the data in protobuf format. Default is `false`.
 
 ## Using `s3_select` with the `s3` source<a name="s3_select"></a>

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -171,6 +171,18 @@ Parameters | Required | Type   | Description
 `header` | No   | String list | The header containing the column names used to parse CSV data.
 `detect_header` | No   | Boolean   | Whether the first line of the Amazon S3 object should be interpreted as a header. Default is `true`.
 
+### `otel_traces` codec
+
+The `otel_traces` codec parses each S3 object as an OpenTelemetry trace record and creates a Data Prepper Span event for each span record.
+
+Use the following parameters to configure the `otel_traces` codec.
+
+Parameter | Required | Type    | Description
+:--- | :--- |:--------| :---
+`format` | No | String | Specifies the format of the OpenTelemetry traces. Valid options are `json` and `protobuf`. Default is `json`.
+`otel_format` | No | String | Specifies the output format of the decoded spans. Valid options are `opensearch` and `otel`. Default is `opensearch`.
+`length_prefixed_encoding` | No | Boolean | Specifies whether the length precedes the data in protobuf format. Default is `false`.
+
 ## Using `s3_select` with the `s3` source<a name="s3_select"></a>
 
 When configuring `s3_select` to parse S3 objects, use the following parameters.


### PR DESCRIPTION
### Description
Updating kinesis and s3 source documentation to add support for otel_traces codec 

### Issues Resolved
Resolves https://github.com/opensearch-project/data-prepper/issues/6650

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
