### PR TITLE
Add Unified Alerts View documentation (experimental)

### DIFF
--- a/_observing-your-data/alerting/dashboards-alerting.md
+++ b/_observing-your-data/alerting/dashboards-alerting.md
@@ -1,8 +1,9 @@
 ---
 layout: default
-title: Alerting dashboards and visualizations 
+title: Alerting dashboards and visualizations
 parent: Alerting
 nav_order: 50
+has_children: true
 ---
 
 # Alerting dashboards and visualizations

--- a/_observing-your-data/alerting/unified-alerts-view.md
+++ b/_observing-your-data/alerting/unified-alerts-view.md
@@ -1,88 +1,56 @@
 ---
 layout: default
-title: Unified Alerts View
-parent: Alerting
-nav_order: 55
+title: Unified alerts view
+parent: Alerting dashboards and visualizations
+grand_parent: Alerting
+nav_order: 10
 ---
 
-# Unified Alerts View
-Introduced 3.7
+# Unified alerts view
+**Introduced 3.7**
 {: .label .label-purple }
 
-This feature is experimental and should not be used in production. The interface, APIs, and behavior may change in future releases.
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).
 {: .warning}
 
-The Unified Alerts View is a new surface in OpenSearch Dashboards that consolidates alerts from multiple data sources—OpenSearch Alerting monitors and Prometheus alerting rules—into a single, filterable view. It is delivered behind a feature flag and shown in the application chrome with a **Beta** badge.
+The unified alerts view consolidates alerts from OpenSearch monitors and Prometheus alerting rules into a single view, so you can triage alerts across data sources without switching between tools.
 
-## Overview
+## Enabling the unified alerts view
 
-The Unified Alerts View lets you:
-
-- See alert history and currently firing alerts from one or more data sources in a single timeline and table.
-- Filter alerts by data source, severity, state, and label.
-- Acknowledge OpenSearch alerts and drill into per-alert and per-monitor details.
-- Review alerting rules and notification routing across the same set of data sources.
-
-## Requirements
-
-To use the Unified Alerts View, your environment must meet the following requirements:
-
-- OpenSearch 3.7 or later.
-- OpenSearch Dashboards 3.7 or later.
-
-### Required OpenSearch plugins
-
-The following OpenSearch plugins must be installed on the cluster:
-
-- [SQL plugin](https://github.com/opensearch-project/sql) (`opensearch-sql`)
-- [Alerting plugin](https://github.com/opensearch-project/alerting) (`opensearch-alerting`)
-
-## Enabling the Unified Alerts View
-
-The Unified Alerts View ships disabled by default. To turn it on, add the following line to `opensearch_dashboards.yml` and restart OpenSearch Dashboards:
+The unified alerts view is disabled by default. To enable it, add the following line to `opensearch_dashboards.yml`:
 
 ```yaml
 observability.alertManager.enabled: true
 ```
 {% include copy.html %}
 
-Toggling this setting requires a restart to take effect.
+Then restart OpenSearch Dashboards. After the restart, an **Alerts** option appears in the OpenSearch Dashboards main menu under **Observability**.
 
-## Accessing the Unified Alerts View
+## Investigating an alert
 
-After the feature flag is enabled and OpenSearch Dashboards is restarted, an **Alerts** application appears in the OpenSearch Dashboards main menu under **Observability**. While the application is open, the chrome displays a **Beta** badge.
+The **Alerts** tab displays an alert timeline for the selected time range, a faceted filter panel, and a table of individual alerts. You can filter alerts by data source, severity, state, and label.
 
-## Using the view
+To investigate an alert, select it in the table to open the alert detail flyout. The flyout shows alert metadata and its source monitor.
 
-The Unified Alerts View is organized into three tabs: **Alerts**, **Rules**, and **Routing**. A data source selector and time-range picker are available above each tab.
+The view supports the following alert states: `active`, `pending`, `acknowledged`, `silenced`, `resolved`, and `error`. The supported severity levels are `critical`, `high`, `medium`, `low`, and `info`.
 
-### Alerts tab
+## Acknowledging alerts
 
-The **Alerts** tab is the default. It displays an alert timeline for the selected time range, a faceted filter panel, and a drill-down table of individual alerts. From the table, you can:
+From the **Alerts** tab, you can acknowledge one or more active OpenSearch alerts. Select the alerts in the table and select **Acknowledge**.
 
-- Open an alert detail flyout to inspect the alert and its source monitor.
-- Acknowledge an active OpenSearch alert.
+For Prometheus data sources, the view is read-only. You cannot acknowledge Prometheus alerts from the unified alerts view.
+{: .note}
 
-The view recognizes the alert states `active`, `pending`, `acknowledged`, `silenced`, `resolved`, and `error`, and the severities `critical`, `high`, `medium`, `low`, and `info`.
+## Alerting rules
 
-### Rules tab
+The **Rules** tab lists alerting rules and monitors across the selected data sources. You can filter rules by monitor type and status.
 
-The **Rules** tab lists alerting rules and monitors discovered across the selected data sources, with filters for monitor type and status.
-
-### Routing tab
+## Notification routing
 
 The **Routing** tab shows how alerts from the selected data sources map to notification channels.
-
-## Limitations
-
-The Unified Alerts View has the following limitations:
-
-- The feature is experimental and ships disabled by default. The interface, APIs, and behavior may change in future releases.
-- Toggling the feature flag requires an OpenSearch Dashboards restart.
-- For Prometheus data sources, the view is read-only and may show only currently active alerts when historical alert data is unavailable.
 
 ## Related documentation
 
 - [Alerting]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/index/)
-- [Monitors]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/monitors/)
 - [Alerting dashboards and visualizations]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/dashboards-alerting/)
+- [Monitors]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/monitors/)

--- a/_observing-your-data/alerting/unified-alerts-view.md
+++ b/_observing-your-data/alerting/unified-alerts-view.md
@@ -1,0 +1,88 @@
+---
+layout: default
+title: Unified Alerts View
+parent: Alerting
+nav_order: 55
+---
+
+# Unified Alerts View
+Introduced 3.7
+{: .label .label-purple }
+
+This feature is experimental and should not be used in production. The interface, APIs, and behavior may change in future releases.
+{: .warning}
+
+The Unified Alerts View is a new surface in OpenSearch Dashboards that consolidates alerts from multiple data sources—OpenSearch Alerting monitors and Prometheus alerting rules—into a single, filterable view. It is delivered behind a feature flag and shown in the application chrome with a **Beta** badge.
+
+## Overview
+
+The Unified Alerts View lets you:
+
+- See alert history and currently firing alerts from one or more data sources in a single timeline and table.
+- Filter alerts by data source, severity, state, and label.
+- Acknowledge OpenSearch alerts and drill into per-alert and per-monitor details.
+- Review alerting rules and notification routing across the same set of data sources.
+
+## Requirements
+
+To use the Unified Alerts View, your environment must meet the following requirements:
+
+- OpenSearch 3.7 or later.
+- OpenSearch Dashboards 3.7 or later.
+
+### Required OpenSearch plugins
+
+The following OpenSearch plugins must be installed on the cluster:
+
+- [SQL plugin](https://github.com/opensearch-project/sql) (`opensearch-sql`)
+- [Alerting plugin](https://github.com/opensearch-project/alerting) (`opensearch-alerting`)
+
+## Enabling the Unified Alerts View
+
+The Unified Alerts View ships disabled by default. To turn it on, add the following line to `opensearch_dashboards.yml` and restart OpenSearch Dashboards:
+
+```yaml
+observability.alertManager.enabled: true
+```
+{% include copy.html %}
+
+Toggling this setting requires a restart to take effect.
+
+## Accessing the Unified Alerts View
+
+After the feature flag is enabled and OpenSearch Dashboards is restarted, an **Alerts** application appears in the OpenSearch Dashboards main menu under **Observability**. While the application is open, the chrome displays a **Beta** badge.
+
+## Using the view
+
+The Unified Alerts View is organized into three tabs: **Alerts**, **Rules**, and **Routing**. A data source selector and time-range picker are available above each tab.
+
+### Alerts tab
+
+The **Alerts** tab is the default. It displays an alert timeline for the selected time range, a faceted filter panel, and a drill-down table of individual alerts. From the table, you can:
+
+- Open an alert detail flyout to inspect the alert and its source monitor.
+- Acknowledge an active OpenSearch alert.
+
+The view recognizes the alert states `active`, `pending`, `acknowledged`, `silenced`, `resolved`, and `error`, and the severities `critical`, `high`, `medium`, `low`, and `info`.
+
+### Rules tab
+
+The **Rules** tab lists alerting rules and monitors discovered across the selected data sources, with filters for monitor type and status.
+
+### Routing tab
+
+The **Routing** tab shows how alerts from the selected data sources map to notification channels.
+
+## Limitations
+
+The Unified Alerts View has the following limitations:
+
+- The feature is experimental and ships disabled by default. The interface, APIs, and behavior may change in future releases.
+- Toggling the feature flag requires an OpenSearch Dashboards restart.
+- For Prometheus data sources, the view is read-only and may show only currently active alerts when historical alert data is unavailable.
+
+## Related documentation
+
+- [Alerting]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/index/)
+- [Monitors]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/monitors/)
+- [Alerting dashboards and visualizations]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/dashboards-alerting/)


### PR DESCRIPTION
### Description
Adds a new documentation page for the **Unified Alerts View**, a new experimental surface in the OpenSearch Dashboards `dashboards-observability` plugin that consolidates alerts from OpenSearch Alerting and Prometheus into a single, filterable view.

The page lives at `_observing-your-data/alerting/unified-alerts-view.md` and renders under https://docs.opensearch.org/latest/observing-your-data/alerting/unified-alerts-view/. It covers:

- An experimental warning callout at the top.
- An overview of what the view does.
- Requirements: OpenSearch 3.7+, OpenSearch Dashboards 3.7+, the `opensearch-sql` plugin, and the `opensearch-alerting` plugin.
- The single-line `observability.alertManager.enabled: true` feature flag and how to enable the view.
- How to access and use the **Alerts**, **Rules**, and **Routing** tabs.
- Known limitations of the experimental release.
- Cross-links to existing alerting documentation.

### Issues Resolved
N/A — new experimental feature documentation, no tracking issue.

### Version
3.7

### Frontend features
The Unified Alerts View is an OpenSearch Dashboards feature, but it is experimental and disabled by default. A walkthrough video has not been recorded yet; the page documents the behavior described in the upstream `dashboards-observability` source. Happy to add a recording in a follow-up once the feature stabilizes.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).