### PR TITLE
Fix tool registration endpoint in mcp-server.md

### DIFF
--- a/_ml-commons-plugin/api/mcp-server-apis/mcp-server.md
+++ b/_ml-commons-plugin/api/mcp-server-apis/mcp-server.md
@@ -68,7 +68,7 @@ While not required for normal usage, you can manually invoke the MCP server usin
 Before connecting to the MCP server, you can register custom tools using the [Register MCP Tools API]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/mcp-server-apis/register-mcp-tools/). For example, to register a [List Index tool]({{site.url}}{{site.baseurl}}/ml-commons-plugin/agents-tools/tools/list-index-tool/), send the following request :
 
 ```json
-POST /_plugins/_ml/mcp/register
+POST /_plugins/_ml/mcp/tools/_register
 {
     "tools": [
         {


### PR DESCRIPTION
### Description
A small fix of invalid URL in example for registering tools. Other documentation pages point to correct one. I double checked that currently provided endpoint returns an error when called.

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

3.3--3.6

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
