### PR TITLE
Add SLO and SLI documentation (experimental)

### DIFF
--- a/_observing-your-data/index.md
+++ b/_observing-your-data/index.md
@@ -101,6 +101,7 @@ OpenSearch provides tools for detecting issues and sending notifications:
 - [Alerting]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/) -- Create monitors that query your data on a schedule, define triggers for alert conditions, and execute actions when alerts fire.
 - [Anomaly detection]({{site.url}}{{site.baseurl}}/observing-your-data/ad/) -- Automatically detect anomalies in your time-series data using machine learning with the Random Cut Forest (RCF) algorithm.
 - [Forecasting]({{site.url}}{{site.baseurl}}/observing-your-data/forecast/) -- Predict future values in your time-series data using the RCF model to anticipate threshold breaches before they occur.
+- [Service level objectives]({{site.url}}{{site.baseurl}}/observing-your-data/slo/) -- Define availability and latency targets for your services and track error budgets and burn rates against a Prometheus-compatible ruler (experimental).
 - [Notifications]({{site.url}}{{site.baseurl}}/observing-your-data/notifications/) -- Configure channels for sending alerts through Slack, email, Amazon SNS, webhooks, and other communication services.
 
 ---

--- a/_observing-your-data/index.md
+++ b/_observing-your-data/index.md
@@ -101,7 +101,7 @@ OpenSearch provides tools for detecting issues and sending notifications:
 - [Alerting]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/) -- Create monitors that query your data on a schedule, define triggers for alert conditions, and execute actions when alerts fire.
 - [Anomaly detection]({{site.url}}{{site.baseurl}}/observing-your-data/ad/) -- Automatically detect anomalies in your time-series data using machine learning with the Random Cut Forest (RCF) algorithm.
 - [Forecasting]({{site.url}}{{site.baseurl}}/observing-your-data/forecast/) -- Predict future values in your time-series data using the RCF model to anticipate threshold breaches before they occur.
-- [Service level objectives]({{site.url}}{{site.baseurl}}/observing-your-data/slo/) -- Define availability and latency targets for your services and track error budgets and burn rates against a Prometheus-compatible ruler (experimental).
+- [Service-level objectives]({{site.url}}{{site.baseurl}}/observing-your-data/slo/) (Experimental) -- Define availability and latency targets for your services and track error budgets and consumption rates against a Prometheus-compatible ruler.
 - [Notifications]({{site.url}}{{site.baseurl}}/observing-your-data/notifications/) -- Configure channels for sending alerts through Slack, email, Amazon SNS, webhooks, and other communication services.
 
 ---

--- a/_observing-your-data/slo/index.md
+++ b/_observing-your-data/slo/index.md
@@ -79,7 +79,7 @@ Each SLO is bound to a single data source, which must be a registered `DirectQue
 
 The SLI definition determines what data the ruler must be able to query:
 
-- **Availability and latency-threshold SLIs** require the named Prometheus counter or histogram metric to be present in the configured backend. APM service templates assume span-derived RED metrics produced by [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/); OpenTelemetry (OTel) semantic-convention templates assume the corresponding HTTP, RPC, database client, messaging, or generative AI metrics.
+- **Availability and latency-threshold SLIs** require the named Prometheus counter or histogram metric to be present in the configured backend. Application Performance Monitoring (APM) service templates expect span-derived Rate, Error, Duration (RED) metrics produced by [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). OpenTelemetry (OTel) semantic convention templates expect the corresponding HTTP, RPC, database client, messaging, or generative AI metrics.
 - **Custom SLIs** require your PromQL expression to evaluate successfully against the backend.
 
 ## Accessing SLOs

--- a/_observing-your-data/slo/index.md
+++ b/_observing-your-data/slo/index.md
@@ -7,197 +7,173 @@ redirect_from:
   - /observing-your-data/slo/
 ---
 
-# SLOs
+# Service-level objectives
+**Introduced 3.7**
+{: .label .label-purple }
 
-This feature is experimental and should not be used in production. The interface, APIs, and behavior may change in future releases.
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).
 {: .warning}
 
-OpenSearch Dashboards provides an experimental service level objective (SLO) and service level indicator (SLI) surface in the `dashboards-observability` plugin. It lets you define availability and latency targets for your services, deploy the supporting recording and alerting rules to a Prometheus-compatible ruler, and track health, error budgets, and burn rates from a dedicated view in the Application Monitoring nav.
+Service-level objectives (SLOs) let you define availability and latency targets for your services, deploy supporting recording and alerting rules to a Prometheus-compatible ruler, and track application health, error budgets, and budget consumption rates (burn rates) from a dedicated view in OpenSearch Dashboards.
 
-## Overview
+SLOs consolidate alerts from OpenSearch monitors and Prometheus alerting rules, so you can monitor service health across data sources without switching between tools.
 
-SLOs are workspace-scoped saved objects. Creating an SLO does the following:
+When you create an SLO, OpenSearch Dashboards generates Prometheus recording and alerting rules based on your configuration and deploys them to your Prometheus-compatible ruler. The rules track health, attainment, and remaining error budget for each objective.
 
-- Validates the SLI definition (availability, latency threshold, or custom PromQL) and the configured objectives.
-- Generates a group of Prometheus recording rules covering a fixed set of error-ratio windows (`5m`, `30m`, `1h`, `2h`, `6h`, `1d`, `3d`).
-- Generates multiwindow, multi-burn-rate (MWMBR) alerting rules using the Google SRE Workbook tier defaults.
-- Deploys both rule groups to a Prometheus-compatible ruler (Cortex or Mimir) through the OpenSearch SQL plugin's DirectQuery resource proxy.
-- Tracks live health, attainment, and remaining error budget per objective by querying the same backend at read time.
-
-The view is shown in OpenSearch Dashboards with a **Beta** badge while the SLO/SLI app is mounted.
-
-## Key terms
-
-The following table defines the SLO and SLI terms used in the plugin.
+The following table defines the SLO and SLI terms.
 
 | Term | Definition |
 | :--- | :--- |
-| Service level indicator (SLI) | The measurement that defines what "good" service looks like. The plugin supports `availability`, `latency_threshold`, and `custom` SLIs against a Prometheus-compatible backend. SLIs can be calculated from event counts, time slices (`periods`), or pre-aggregated ratios (`ratio_periods`). |
-| Service level objective (SLO) | A target attainment level for one or more SLIs, evaluated over a time window. Each SLO carries one or more objectives and a single window. |
-| Objective | A single target on the SLI, expressed as a decimal between `0.5` and `0.99999` (for example, `0.999`). Each objective generates its own set of recording and alerting rules. |
-| Time window | The period the SLO is evaluated over. The plugin supports rolling windows (for example, `7d`, `28d`, `30d`); the `calendar` window shape is reserved for a future release. |
-| Error budget | The fraction of failed events allowed in the window before the objective is breached. Tracked as `errorBudgetRemaining` in the live status response and can go negative once the budget is exhausted. |
-| Burn rate | The ratio at which the error budget is being consumed. The plugin uses MWMBR alerting with default tiers (`PageQuick`, `PageSlow`, `TicketQuick`, `TicketSlow`) per the Google SRE Workbook. |
-| SLO mode | `active` deploys recording and alerting rules and computes status. `shadow` deploys recording rules only — useful for validating an SLO before turning on alerts. |
-| Datasource | A registered DirectQuery Prometheus connection. The SLO is bound to a single datasource and all generated rules are written against it. |
-| Workspace | The OpenSearch Dashboards workspace the SLO belongs to. Workspace identity partitions SLO saved objects, the ruler namespace (`slo-generated-<workspace>`), and the recording-rule fingerprint registry. |
+| Service-level indicator (SLI) | A quantitative measurement of service performance, such as availability or latency. Supported SLI types are `availability`, `latency_threshold`, and `custom`. |
+| Service-level objective (SLO) | A target attainment level for one or more SLIs, evaluated over a single time window. Each SLO contains one or more objectives. |
+| Objective | A target value for an SLI, expressed as a decimal between `0.5` and `0.99999` (for example, `0.999`). Each objective generates its own set of recording and alerting rules. |
+| Time window | The rolling period over which the SLO is evaluated (for example, `7d`, `28d`, `30d`). Calendar windows are not yet supported. |
+| Error budget | The allowable fraction of failed events within the time window. When the error budget drops below zero, the objective is breached. |
+| Burn rate | The rate at which the error budget is being consumed relative to the time window. Used to trigger alerts at different severity tiers. |
+| SLO mode | Controls whether alerting is active. In `active` mode, both recording and alerting rules are deployed. In `shadow` mode, only recording rules are deployed, which is useful for validating an SLO before enabling alerts. |
+| Data source | The `DirectQuery` Prometheus connection that the SLO uses. Each SLO is bound to a single data source. |
+| Workspace | The OpenSearch Dashboards workspace that the SLO belongs to. Each workspace has its own set of SLOs and ruler namespace. |
 
-## Requirements
+## Prerequisites
 
-To use the SLO/SLI surface, your environment must meet the following requirements.
+Before using SLOs, complete the following setup steps.
 
-### Versions
+### Enabling the feature
 
-- OpenSearch 3.7 or later.
-- OpenSearch Dashboards 3.7 or later.
-
-### OpenSearch Dashboards plugins
-
-- `dashboards-observability` 3.7 or later, with both the SLO feature flag and the APM setting enabled. See [Enabling the feature](#enabling-the-feature).
-
-### OpenSearch plugins
-
-The following OpenSearch plugin must be installed on the cluster:
-
-- [SQL plugin](https://github.com/opensearch-project/sql) (`opensearch-sql`) — provides the DirectQuery resource proxy used by the plugin to read from and write to the Prometheus ruler.
-
-### Prometheus-compatible ruler
-
-SLOs in the current release deploy rules to a Prometheus-compatible ruler reached through the SQL plugin's DirectQuery resource proxy. The ruler must implement the Cortex/Mimir ruler API:
-
-- `POST /api/v1/rules/{namespace}` — upsert a rule group (Content-Type `application/yaml`).
-- `DELETE /api/v1/rules/{namespace}/{groupName}` — delete a rule group.
-
-Rule groups for a workspace are written to the namespace `slo-generated-<workspace-id>`. Tenant identity (for example, `X-Scope-OrgID`) is configured in the SQL plugin's Prometheus connector — the SLO plugin does not inject per-request tenant headers.
-
-### Datasource
-
-Each SLO is bound to a single datasource, which must be a registered DirectQuery Prometheus connection. The SLO API rejects creates and updates whose `spec.datasourceId` does not resolve to a datasource with a `directQueryName` field.
-
-### Permissions
-
-Users need the OpenSearch Dashboards `observability` capability to access the plugin. SLOs and their rule references are persisted as the saved-object types `slo-definition` and `slo-rule-ref`; standard saved-object permissions apply.
-
-### Data prerequisites
-
-The SLI definition determines what data the ruler must be able to reach:
-
-- **Availability and latency-threshold SLIs** require the named Prometheus counter or histogram metric to be present in the configured backend. APM service templates assume span-derived RED metrics produced by [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/); OpenTelemetry semantic-convention templates assume the corresponding HTTP, RPC, database client, messaging, or generative AI metrics.
-- **Custom SLIs** require the user-supplied PromQL to evaluate against the backend.
-
-## Enabling the feature
-
-The SLO/SLI surface ships disabled by default. To turn it on, add the following lines to `opensearch_dashboards.yml` and restart OpenSearch Dashboards:
+SLOs are disabled by default. To enable them, add the following settings to `opensearch_dashboards.yml`:
 
 ```yaml
+workspace.enabled: true
+explore.enabled: true
+explore.discoverTraces.enabled: true
 observability.slo.enabled: true
 ```
 {% include copy.html %}
 
-The plugin also requires the APM advanced setting to be on, because the SLO app is registered under the **Application Monitoring** category alongside Services and the Topology Map. In **Stack Management** > **Advanced settings**, set `observability:apmEnabled` to `true`.
+Then restart OpenSearch Dashboards. 
 
-The following optional settings tune SLO behavior:
+### Observability workspace
 
-| Setting | Default | Description |
-| :--- | :--- | :--- |
-| `observability.slo.enabled` | `false` | Top-level feature gate. Toggling this value requires an OpenSearch Dashboards restart. |
-| `observability.slo.ruleDedup.enabled` | `true` | When enabled, recording rules are shared across SLOs with equivalent SLI shapes through a workspace-scoped fingerprint registry. Reduces evaluation cost on the ruler when many SLOs share the same backend query. Exposed as the **SLO recording-rule dedup** advanced setting. |
-| `observability.slo.reconciler.enabled` | `true` | Enables the background sweep that garbage-collects shared recording rules whose aggregate reference count has been zero past the grace window. |
-| `observability.slo.reconciler.intervalMs` | `300000` | Reconciler sweep cadence, in milliseconds. |
-| `observability.slo.reconciler.graceMs` | `86400000` | Grace window, in milliseconds, between a shared rule's refcount dropping to zero and the reconciler deleting it from the ruler. Defaults to 24 hours. |
+The SLO feature is available within an Observability [workspace]({{site.url}}{{site.baseurl}}/dashboards/workspace/). To create a workspace, follow these steps:
 
-## Accessing the SLO view
+1. Navigate to the OpenSearch Dashboards home page.
+2. Select **Create workspace**.
+3. Enter a workspace name.
+4. Select the **Observability** use case.
+5. Select **Create workspace**.
 
-After the feature flag is enabled and OpenSearch Dashboards is restarted, an **SLOs** application appears under **Application Monitoring** in the OpenSearch Dashboards main menu. The application is mounted on the hash route `/slos` and uses the following internal routes:
+### Prometheus-compatible ruler
 
-| Route | Page |
-| :--- | :--- |
-| `/slos` | SLO listing with filters and an overview panel. |
-| `/slos/create` | Template selector. Picking a template opens the wizard prefilled with that template's SLI shape. |
-| `/slos/create/:templateId` | Wizard prefilled from the named template. |
-| `/slos/:id` | SLO detail page. |
+SLOs deploy recording and alerting rules to a Prometheus-compatible ruler (Cortex or Grafana Mimir) through the `DirectQuery` resource proxy. The ruler must support the following API endpoints:
 
-While the application is open, OpenSearch Dashboards displays a **Beta** badge in the chrome.
+- `POST /api/v1/rules/{namespace}` -- Creates or updates a rule group.
+- `DELETE /api/v1/rules/{namespace}/{groupName}` -- Deletes a rule group.
+
+Rule groups for a given workspace are written to the namespace `slo-generated-<workspace-id>`. Tenant identity (for example, `X-Scope-OrgID`) is configured in the [Prometheus connector]({{site.url}}{{site.baseurl}}/dashboards/management/connect-prometheus/) settings.
+
+### Data source
+
+Each SLO is bound to a single data source, which must be a registered `DirectQuery` Prometheus connection. For information about configuring a Prometheus data source, see [Connecting Prometheus to OpenSearch]({{site.url}}{{site.baseurl}}/dashboards/management/connect-prometheus/).
+
+### Data prerequisites
+
+The SLI definition determines what data the ruler must be able to query:
+
+- **Availability and latency-threshold SLIs** require the named Prometheus counter or histogram metric to be present in the configured backend. APM service templates assume span-derived RED metrics produced by [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/); OpenTelemetry (OTel) semantic-convention templates assume the corresponding HTTP, RPC, database client, messaging, or generative AI metrics.
+- **Custom SLIs** require your PromQL expression to evaluate successfully against the backend.
+
+## Accessing SLOs
+
+To access SLOs, select your Observability workspace from the home page, or create one if you don't have one (see [Observability workspace](#observability-workspace)). Then navigate to **Application Performance** > **SLOs**.
+
 
 ## Creating an SLO
 
-From the listing page, choose **Create SLO** to open the template selector. The available templates are grouped by category:
+To create an SLO, follow these steps:
 
-- **APM service SLOs (span-derived).** SLIs built from the RED metrics that [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/) emits for every traced service. Templates: APM service availability, APM service latency, APM dependency availability, APM dependency latency.
-- **OpenTelemetry semantic-convention metrics.** SLIs built from OTel semantic-convention metrics emitted by instrumented services. Templates: HTTP availability, HTTP latency, RPC availability, RPC latency, database client latency, messaging latency, generative AI availability.
-- **Custom.** Starts from blank PromQL.
+1. In the **SLOs** view, choose **Create SLO**.
+2. Select a template. Templates are grouped into the following categories:
+   - **APM service SLOs**: SLIs based on RED metrics from [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/). Templates include **APM service availability**, **APM service latency**, **APM dependency availability**, and **APM dependency latency**.
+   - **OTel semantic convention metrics**: SLIs based on standard OTel metrics. Templates include **HTTP availability**, **HTTP latency**, **RPC/gRPC availability**, **RPC/gRPC latency**, **Database client latency**, **Messaging processing latency**, and **GenAI invocation availability**.
+   - **Custom**: A blank **Custom PromQL** template for custom PromQL expressions.
+3. Configure the SLO in the wizard. The wizard contains the following sections:
+   - **Identity**: A unique name, description, and data source (a registered DirectQuery Prometheus connection).
+   - **Window & mode**: A rolling window (for example, `28d`) and an optional shadow mode that deploys recording rules without alerting.
+   - **Service & owner**: The service name and owner team.
+   - **SLI**: For prebuilt templates, the SLI type and metric are preconfigured. You can optionally add dimensions (label filters) to narrow the query. For the **Custom PromQL** template, you provide your own PromQL expressions---either separate good-events and total-events queries, or a single pre-computed error-ratio query.
+   - **Probe SLI**: Tests the proposed query against the Prometheus backend over a configurable look-back period (`1h`, `24h`, or `7d`) so you can verify the query returns data before creating the SLO.
+   - **Objectives**: One or more target values between `0.5` and `0.99999` (for example, `99.9%`). For latency SLIs, each objective also sets a latency bound.
+   - **Advanced**: Burn rate alerting tiers, budget warnings, and supplemental alarms.
+   - **Exclusion windows**: Time periods during which the SLO ignores measurements (for example, maintenance windows or deploy freezes).
+   - **Labels & annotations**: Optional metadata that propagates to the generated rules.
+   - **Rule preview**: A read-only preview of the recording and alerting rules that will be deployed to the ruler.
+4. Choose **Create SLO**. The rules are validated and deployed to the ruler. If the ruler rejects the rules, the error is displayed and the SLO is not saved.
 
-Picking a template opens the wizard with the SLI definition prefilled. The wizard is divided into the following sections:
+## Monitoring SLOs
 
-- **Name and ownership.** A workspace-unique name (1–128 characters), service name, and owner team. The first team in the list is the primary owner.
-- **Datasource.** A registered DirectQuery Prometheus connection. The wizard help text reads "The registered Prometheus / AMP DirectQuery connection."
-- **SLI definition.** The SLI type (`availability`, `latency_threshold`, or `custom`), the calculation method (`events`, `periods`, or `ratio_periods`), the metric, and an optional good-events filter (a PromQL label matcher, for example `status_code!~"5.."`). For `latency_threshold` SLIs, the threshold unit (`seconds` or `milliseconds`) is also configurable. For custom SLIs, you supply either separate `goodQuery` and `totalQuery` PromQL expressions (`mode: events`) or a single `errorRatioQuery` (`mode: raw`).
-- **Probe SLI.** A wizard-side dry run that issues the proposed PromQL against the selected backend over a `1h`, `24h`, or `7d` lookback so you can confirm the queries match series before you create the SLO.
-- **Objectives.** One or more objectives. Each objective sets a target between `0.5` and `0.99999` (the wizard accepts the value as a percentage and stores the ratio). For latency-threshold SLIs, each objective also sets a latency bound. For period-based calculation methods, each objective sets a time-slice target.
-- **Time window.** A rolling window expressed as a Prometheus duration (for example, `7d`, `28d`, `30d`).
-- **Alerting strategy.** Multiwindow, multi-burn-rate (MWMBR) alerting. Defaults follow the Google SRE Workbook tiers: `5m`/`1h` × 14.4 (`PageQuick`), `30m`/`6h` × 6 (`PageSlow`), `2h`/`1d` × 3 (`TicketQuick`), and `6h`/`3d` × 1 (`TicketSlow`).
-- **Supplemental alarms.** Optional toggles for SLI health, attainment-breach, budget-warning, no-data, and resolved alerts. Budget-warning is on by default; the others are off.
-- **Budget warning thresholds.** Fractions of the remaining budget that fire warning alerts. Defaults to one threshold at `0.5` with severity `warning`.
-- **Exclusion windows.** Cron- or one-off windows during which the SLO ignores measurements. Currently accepted by the API but not evaluated.
-- **Generated rules preview.** A read-only preview of the recording and alerting rules that will be deployed. The same generator runs server-side at deploy time, so what you see is what is written to the ruler.
+The **SLOs** listing displays each SLO with its current state, attainment percentage, remaining error budget, and a spark line. 
 
-After you submit the wizard, the plugin validates the spec, generates rules, and writes them to the ruler synchronously. If the ruler rejects the group, the wizard surfaces the upstream error code and message and no SLO record is persisted.
 
-## Viewing SLO health and error budgets
+The following table describes the SLO states.
 
-The **SLOs** listing shows one row per SLO with current state, attainment, remaining error budget, and a sparkline. SLO state is the worst per-objective state, with `disabled` and `stale` taking precedence:
-
-| State | Meaning |
+| State | Description |
 | :--- | :--- |
 | `ok` | All objectives are above target. |
-| `warning` | At least one objective is consuming budget faster than expected (a warning-tier burn-rate alert is firing). |
+| `warning` | At least one objective is consuming budget faster than expected. |
 | `breached` | At least one objective has exhausted its error budget. |
-| `no_data` | The SLI query returned no series in the evaluation window. |
-| `stale` | The latest sample is older than the freshness threshold. |
-| `disabled` | The SLO has been disabled (rules are torn down). |
-| `rules_missing` | The recording rules expected by the aggregator are not present on the ruler. |
+| `no_data` | The SLI query returned no data in the evaluation window. |
+| `stale` | The latest data sample is older than expected, which may indicate a problem with the data source connection. |
+| `disabled` | The SLO has been disabled. |
+| `rules_missing` | The expected recording rules are not present on the ruler. |
 
-The detail page (`/slos/:id`) shows per-objective attainment, remaining error budget, the active burn-rate panel, the budget-remaining chart, the budget panel, and the metadata panel. The **Generated rules preview** shows the recording and alerting rules currently deployed for the SLO. The **Probe SLI** panel re-runs the dry-run query against the backend.
-
-The aggregator caches ruler responses for the rule evaluation interval (60 seconds by default), so the freshest sample available to the listing is at most about a minute old.
+To view details for a specific SLO, select it in the listing. The detail page shows per-objective attainment, remaining error budget, budget consumption rate, and the deployed recording and alerting rules.
 
 ## Editing an SLO
 
-To update an SLO, open the detail page and choose **Edit**. The wizard accepts a partial update — only the fields you change are sent. The update API uses optimistic concurrency: the request must include the current `status.version`, and the server returns `409 Conflict` if the SLO has changed since you loaded it. After a successful update, the plugin regenerates the rule group and re-deploys it to the ruler.
+To update an SLO, select the SLO in the list and choose **Edit**. Only the fields you change are updated. After a successful update, the rule group is regenerated and redeployed to the ruler.
 
-You can also temporarily pause an SLO without deleting it:
+You can also change the SLO mode without editing the full configuration:
 
-- **Disable.** Tears down the rule group on the ruler and marks the SLO as `disabled` in the listing. No alerts fire while disabled.
-- **Enable.** Redeploys the rule group and resumes status computation.
-- **Mode.** Switching from `active` to `shadow` keeps the recording rules in place but stops generating alerts — useful for validating a freshly authored SLO.
+- **Disable**: Removes the rule group from the ruler and stops alerting.
+- **Enable**: Redeploys the rule group and resumes status computation.
+- **Shadow mode**: Keeps recording rules in place but stops alerting. Use this to validate a new SLO before enabling alerts.
 
 ## Deleting an SLO
 
-To delete an SLO, choose **Delete** on the detail page or in the row actions on the listing. The plugin tears down the rule group on the ruler and removes the saved object. If the underlying datasource has been removed out-of-band, the API logs a warning and proceeds to delete the saved object; the reconciler sweep eventually cleans up any orphan rule groups left on the ruler.
+To delete an SLO, select it from the listing and choose **Delete** from the detail page or the row actions menu. The associated rule group is removed from the ruler and the SLO configuration is deleted.
 
-If a delete fails because the rule group is shared with other SLOs (recording-rule deduplication is on), the plugin only releases this SLO's reference. The shared rule group is removed by the reconciler after its aggregate reference count has been zero past the grace window (24 hours by default).
+If the SLO shares recording rules with other SLOs (when rule deduplication is enabled), only the reference is released. The shared rules are removed automatically after the grace window (24 hours by default).
 
-## Limitations
+## Configuration settings
 
-The SLO/SLI surface has the following limitations:
+The following table lists the SLO configuration settings.
 
-- The feature is experimental, ships disabled by default, and is shown in OpenSearch Dashboards with a **Beta** badge. The interface, APIs, and behavior may change in future releases.
-- Toggling `observability.slo.enabled` requires an OpenSearch Dashboards restart to take effect.
-- Only the Prometheus SLI backend is wired up. The OpenSearch SLI backend is reserved in the schema but not yet implemented.
-- Only single-leaf SLIs are supported. Composite SLOs (rolling up multiple SLOs by `all` or `any`) are reserved in the schema but not yet implemented.
-- Only rolling windows are supported. Calendar windows (`week`, `month`, `quarter`) are reserved in the schema but not evaluated.
-- Only the multiwindow, multi-burn-rate (`mwmbr`) alerting strategy is supported.
-- Exclusion windows are accepted by the API but their evaluation is deferred to a later release.
-- Workspace resolution for the ruler write path is hardcoded to `default` in the current release. The plugin still partitions saved objects per workspace, but rules generated by every workspace currently land in the `slo-generated-default` namespace until workspace-scope plumbing lands.
-- Acting-user attribution stamps a placeholder identity (`osd-user`) on `createdBy` and `updatedBy` until the security-plugin user resolver lands.
-- The ruler write is synchronous and fail-loud. If the ruler rejects a rule group, the create or update returns an error and no SLO record is persisted.
+| Setting | Default | Description |
+| :--- | :--- | :--- |
+| `observability.slo.enabled` | `false` | Enables SLOs. Requires an OpenSearch Dashboards restart. |
+| `observability.slo.ruleDedup.enabled` | `true` | Allows multiple SLOs that use the same query to share a single set of recording rules on the ruler, reducing duplicate evaluations. |
+| `observability.slo.reconciler.enabled` | `true` | Enables automatic cleanup of shared recording rules that are no longer referenced by any SLO. |
+| `observability.slo.reconciler.intervalMs` | `300000` (5 minutes) | How often the cleanup process runs, in milliseconds. |
+| `observability.slo.reconciler.graceMs` | `86400000` (24 hours) | The amount of time to wait after all references to a shared rule are removed before deleting the rule from the ruler, in milliseconds. |
 
 ## Troubleshooting
 
-- **The SLOs application is not visible in the menu.** Confirm that `observability.slo.enabled` is set to `true` in `opensearch_dashboards.yml`, that OpenSearch Dashboards has been restarted, and that the `observability:apmEnabled` advanced setting is `true`.
-- **Create or update fails with "Datasource ... is not registered" or "is not a DirectQuery Prometheus connection."** The SLO API only writes rules to DirectQuery Prometheus datasources. Check that the datasource you are targeting is registered with a `directQueryName` field.
-- **The ruler returns a non-2xx response.** The wizard surfaces the upstream HTTP status and body. The plugin does not retry; correct the underlying issue (for example, an authentication failure or a malformed PromQL expression) and resubmit.
-- **An SLO shows `rules_missing` or `no_data`.** Use the **Rule health** action on the detail page (introduced by [dashboards-observability#2689](https://github.com/opensearch-project/dashboards-observability/pull/2689)) to probe the ruler and the underlying SLI query. The **Repair** action redeploys missing rule groups.
+The following table describes common issues and their solutions.
+
+| Problem | Solution |
+| :--- | :--- |
+| The ruler returns an error when creating or updating an SLO. | The error details are displayed in the wizard. Correct the underlying issue (for example, an authentication failure or malformed PromQL) and resubmit. |
+| An SLO shows `rules_missing` or `no_data`. | Use the **Rule health** action on the detail page to check the ruler and the SLI query. Use **Repair** to redeploy missing rule groups. |
+
+## Limitations
+
+SLOs have the following limitations:
+
+- Only Prometheus data sources are supported for SLI evaluation.
+- Only single SLIs are supported. Composite SLOs that combine multiple SLOs are not yet available.
+- Only rolling time windows are supported. Calendar windows (`week`, `month`, `quarter`) are not yet available.
+- Only the multi-window, multi-burn-rate (MWMBR) alerting strategy is supported.
+- Exclusion windows can be configured but are not yet evaluated.
 
 ## Related documentation
 

--- a/_observing-your-data/slo/index.md
+++ b/_observing-your-data/slo/index.md
@@ -1,0 +1,205 @@
+---
+layout: default
+title: SLOs
+nav_order: 125
+has_children: false
+redirect_from:
+  - /observing-your-data/slo/
+---
+
+# SLOs
+
+This feature is experimental and should not be used in production. The interface, APIs, and behavior may change in future releases.
+{: .warning}
+
+OpenSearch Dashboards provides an experimental service level objective (SLO) and service level indicator (SLI) surface in the `dashboards-observability` plugin. It lets you define availability and latency targets for your services, deploy the supporting recording and alerting rules to a Prometheus-compatible ruler, and track health, error budgets, and burn rates from a dedicated view in the Application Monitoring nav.
+
+## Overview
+
+SLOs are workspace-scoped saved objects. Creating an SLO does the following:
+
+- Validates the SLI definition (availability, latency threshold, or custom PromQL) and the configured objectives.
+- Generates a group of Prometheus recording rules covering a fixed set of error-ratio windows (`5m`, `30m`, `1h`, `2h`, `6h`, `1d`, `3d`).
+- Generates multiwindow, multi-burn-rate (MWMBR) alerting rules using the Google SRE Workbook tier defaults.
+- Deploys both rule groups to a Prometheus-compatible ruler (Cortex or Mimir) through the OpenSearch SQL plugin's DirectQuery resource proxy.
+- Tracks live health, attainment, and remaining error budget per objective by querying the same backend at read time.
+
+The view is shown in OpenSearch Dashboards with a **Beta** badge while the SLO/SLI app is mounted.
+
+## Key terms
+
+The following table defines the SLO and SLI terms used in the plugin.
+
+| Term | Definition |
+| :--- | :--- |
+| Service level indicator (SLI) | The measurement that defines what "good" service looks like. The plugin supports `availability`, `latency_threshold`, and `custom` SLIs against a Prometheus-compatible backend. SLIs can be calculated from event counts, time slices (`periods`), or pre-aggregated ratios (`ratio_periods`). |
+| Service level objective (SLO) | A target attainment level for one or more SLIs, evaluated over a time window. Each SLO carries one or more objectives and a single window. |
+| Objective | A single target on the SLI, expressed as a decimal between `0.5` and `0.99999` (for example, `0.999`). Each objective generates its own set of recording and alerting rules. |
+| Time window | The period the SLO is evaluated over. The plugin supports rolling windows (for example, `7d`, `28d`, `30d`); the `calendar` window shape is reserved for a future release. |
+| Error budget | The fraction of failed events allowed in the window before the objective is breached. Tracked as `errorBudgetRemaining` in the live status response and can go negative once the budget is exhausted. |
+| Burn rate | The ratio at which the error budget is being consumed. The plugin uses MWMBR alerting with default tiers (`PageQuick`, `PageSlow`, `TicketQuick`, `TicketSlow`) per the Google SRE Workbook. |
+| SLO mode | `active` deploys recording and alerting rules and computes status. `shadow` deploys recording rules only — useful for validating an SLO before turning on alerts. |
+| Datasource | A registered DirectQuery Prometheus connection. The SLO is bound to a single datasource and all generated rules are written against it. |
+| Workspace | The OpenSearch Dashboards workspace the SLO belongs to. Workspace identity partitions SLO saved objects, the ruler namespace (`slo-generated-<workspace>`), and the recording-rule fingerprint registry. |
+
+## Requirements
+
+To use the SLO/SLI surface, your environment must meet the following requirements.
+
+### Versions
+
+- OpenSearch 3.7 or later.
+- OpenSearch Dashboards 3.7 or later.
+
+### OpenSearch Dashboards plugins
+
+- `dashboards-observability` 3.7 or later, with both the SLO feature flag and the APM setting enabled. See [Enabling the feature](#enabling-the-feature).
+
+### OpenSearch plugins
+
+The following OpenSearch plugin must be installed on the cluster:
+
+- [SQL plugin](https://github.com/opensearch-project/sql) (`opensearch-sql`) — provides the DirectQuery resource proxy used by the plugin to read from and write to the Prometheus ruler.
+
+### Prometheus-compatible ruler
+
+SLOs in the current release deploy rules to a Prometheus-compatible ruler reached through the SQL plugin's DirectQuery resource proxy. The ruler must implement the Cortex/Mimir ruler API:
+
+- `POST /api/v1/rules/{namespace}` — upsert a rule group (Content-Type `application/yaml`).
+- `DELETE /api/v1/rules/{namespace}/{groupName}` — delete a rule group.
+
+Rule groups for a workspace are written to the namespace `slo-generated-<workspace-id>`. Tenant identity (for example, `X-Scope-OrgID`) is configured in the SQL plugin's Prometheus connector — the SLO plugin does not inject per-request tenant headers.
+
+### Datasource
+
+Each SLO is bound to a single datasource, which must be a registered DirectQuery Prometheus connection. The SLO API rejects creates and updates whose `spec.datasourceId` does not resolve to a datasource with a `directQueryName` field.
+
+### Permissions
+
+Users need the OpenSearch Dashboards `observability` capability to access the plugin. SLOs and their rule references are persisted as the saved-object types `slo-definition` and `slo-rule-ref`; standard saved-object permissions apply.
+
+### Data prerequisites
+
+The SLI definition determines what data the ruler must be able to reach:
+
+- **Availability and latency-threshold SLIs** require the named Prometheus counter or histogram metric to be present in the configured backend. APM service templates assume span-derived RED metrics produced by [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/); OpenTelemetry semantic-convention templates assume the corresponding HTTP, RPC, database client, messaging, or generative AI metrics.
+- **Custom SLIs** require the user-supplied PromQL to evaluate against the backend.
+
+## Enabling the feature
+
+The SLO/SLI surface ships disabled by default. To turn it on, add the following lines to `opensearch_dashboards.yml` and restart OpenSearch Dashboards:
+
+```yaml
+observability.slo.enabled: true
+```
+{% include copy.html %}
+
+The plugin also requires the APM advanced setting to be on, because the SLO app is registered under the **Application Monitoring** category alongside Services and the Topology Map. In **Stack Management** > **Advanced settings**, set `observability:apmEnabled` to `true`.
+
+The following optional settings tune SLO behavior:
+
+| Setting | Default | Description |
+| :--- | :--- | :--- |
+| `observability.slo.enabled` | `false` | Top-level feature gate. Toggling this value requires an OpenSearch Dashboards restart. |
+| `observability.slo.ruleDedup.enabled` | `true` | When enabled, recording rules are shared across SLOs with equivalent SLI shapes through a workspace-scoped fingerprint registry. Reduces evaluation cost on the ruler when many SLOs share the same backend query. Exposed as the **SLO recording-rule dedup** advanced setting. |
+| `observability.slo.reconciler.enabled` | `true` | Enables the background sweep that garbage-collects shared recording rules whose aggregate reference count has been zero past the grace window. |
+| `observability.slo.reconciler.intervalMs` | `300000` | Reconciler sweep cadence, in milliseconds. |
+| `observability.slo.reconciler.graceMs` | `86400000` | Grace window, in milliseconds, between a shared rule's refcount dropping to zero and the reconciler deleting it from the ruler. Defaults to 24 hours. |
+
+## Accessing the SLO view
+
+After the feature flag is enabled and OpenSearch Dashboards is restarted, an **SLOs** application appears under **Application Monitoring** in the OpenSearch Dashboards main menu. The application is mounted on the hash route `/slos` and uses the following internal routes:
+
+| Route | Page |
+| :--- | :--- |
+| `/slos` | SLO listing with filters and an overview panel. |
+| `/slos/create` | Template selector. Picking a template opens the wizard prefilled with that template's SLI shape. |
+| `/slos/create/:templateId` | Wizard prefilled from the named template. |
+| `/slos/:id` | SLO detail page. |
+
+While the application is open, OpenSearch Dashboards displays a **Beta** badge in the chrome.
+
+## Creating an SLO
+
+From the listing page, choose **Create SLO** to open the template selector. The available templates are grouped by category:
+
+- **APM service SLOs (span-derived).** SLIs built from the RED metrics that [OpenSearch Data Prepper]({{site.url}}{{site.baseurl}}/data-prepper/) emits for every traced service. Templates: APM service availability, APM service latency, APM dependency availability, APM dependency latency.
+- **OpenTelemetry semantic-convention metrics.** SLIs built from OTel semantic-convention metrics emitted by instrumented services. Templates: HTTP availability, HTTP latency, RPC availability, RPC latency, database client latency, messaging latency, generative AI availability.
+- **Custom.** Starts from blank PromQL.
+
+Picking a template opens the wizard with the SLI definition prefilled. The wizard is divided into the following sections:
+
+- **Name and ownership.** A workspace-unique name (1–128 characters), service name, and owner team. The first team in the list is the primary owner.
+- **Datasource.** A registered DirectQuery Prometheus connection. The wizard help text reads "The registered Prometheus / AMP DirectQuery connection."
+- **SLI definition.** The SLI type (`availability`, `latency_threshold`, or `custom`), the calculation method (`events`, `periods`, or `ratio_periods`), the metric, and an optional good-events filter (a PromQL label matcher, for example `status_code!~"5.."`). For `latency_threshold` SLIs, the threshold unit (`seconds` or `milliseconds`) is also configurable. For custom SLIs, you supply either separate `goodQuery` and `totalQuery` PromQL expressions (`mode: events`) or a single `errorRatioQuery` (`mode: raw`).
+- **Probe SLI.** A wizard-side dry run that issues the proposed PromQL against the selected backend over a `1h`, `24h`, or `7d` lookback so you can confirm the queries match series before you create the SLO.
+- **Objectives.** One or more objectives. Each objective sets a target between `0.5` and `0.99999` (the wizard accepts the value as a percentage and stores the ratio). For latency-threshold SLIs, each objective also sets a latency bound. For period-based calculation methods, each objective sets a time-slice target.
+- **Time window.** A rolling window expressed as a Prometheus duration (for example, `7d`, `28d`, `30d`).
+- **Alerting strategy.** Multiwindow, multi-burn-rate (MWMBR) alerting. Defaults follow the Google SRE Workbook tiers: `5m`/`1h` × 14.4 (`PageQuick`), `30m`/`6h` × 6 (`PageSlow`), `2h`/`1d` × 3 (`TicketQuick`), and `6h`/`3d` × 1 (`TicketSlow`).
+- **Supplemental alarms.** Optional toggles for SLI health, attainment-breach, budget-warning, no-data, and resolved alerts. Budget-warning is on by default; the others are off.
+- **Budget warning thresholds.** Fractions of the remaining budget that fire warning alerts. Defaults to one threshold at `0.5` with severity `warning`.
+- **Exclusion windows.** Cron- or one-off windows during which the SLO ignores measurements. Currently accepted by the API but not evaluated.
+- **Generated rules preview.** A read-only preview of the recording and alerting rules that will be deployed. The same generator runs server-side at deploy time, so what you see is what is written to the ruler.
+
+After you submit the wizard, the plugin validates the spec, generates rules, and writes them to the ruler synchronously. If the ruler rejects the group, the wizard surfaces the upstream error code and message and no SLO record is persisted.
+
+## Viewing SLO health and error budgets
+
+The **SLOs** listing shows one row per SLO with current state, attainment, remaining error budget, and a sparkline. SLO state is the worst per-objective state, with `disabled` and `stale` taking precedence:
+
+| State | Meaning |
+| :--- | :--- |
+| `ok` | All objectives are above target. |
+| `warning` | At least one objective is consuming budget faster than expected (a warning-tier burn-rate alert is firing). |
+| `breached` | At least one objective has exhausted its error budget. |
+| `no_data` | The SLI query returned no series in the evaluation window. |
+| `stale` | The latest sample is older than the freshness threshold. |
+| `disabled` | The SLO has been disabled (rules are torn down). |
+| `rules_missing` | The recording rules expected by the aggregator are not present on the ruler. |
+
+The detail page (`/slos/:id`) shows per-objective attainment, remaining error budget, the active burn-rate panel, the budget-remaining chart, the budget panel, and the metadata panel. The **Generated rules preview** shows the recording and alerting rules currently deployed for the SLO. The **Probe SLI** panel re-runs the dry-run query against the backend.
+
+The aggregator caches ruler responses for the rule evaluation interval (60 seconds by default), so the freshest sample available to the listing is at most about a minute old.
+
+## Editing an SLO
+
+To update an SLO, open the detail page and choose **Edit**. The wizard accepts a partial update — only the fields you change are sent. The update API uses optimistic concurrency: the request must include the current `status.version`, and the server returns `409 Conflict` if the SLO has changed since you loaded it. After a successful update, the plugin regenerates the rule group and re-deploys it to the ruler.
+
+You can also temporarily pause an SLO without deleting it:
+
+- **Disable.** Tears down the rule group on the ruler and marks the SLO as `disabled` in the listing. No alerts fire while disabled.
+- **Enable.** Redeploys the rule group and resumes status computation.
+- **Mode.** Switching from `active` to `shadow` keeps the recording rules in place but stops generating alerts — useful for validating a freshly authored SLO.
+
+## Deleting an SLO
+
+To delete an SLO, choose **Delete** on the detail page or in the row actions on the listing. The plugin tears down the rule group on the ruler and removes the saved object. If the underlying datasource has been removed out-of-band, the API logs a warning and proceeds to delete the saved object; the reconciler sweep eventually cleans up any orphan rule groups left on the ruler.
+
+If a delete fails because the rule group is shared with other SLOs (recording-rule deduplication is on), the plugin only releases this SLO's reference. The shared rule group is removed by the reconciler after its aggregate reference count has been zero past the grace window (24 hours by default).
+
+## Limitations
+
+The SLO/SLI surface has the following limitations:
+
+- The feature is experimental, ships disabled by default, and is shown in OpenSearch Dashboards with a **Beta** badge. The interface, APIs, and behavior may change in future releases.
+- Toggling `observability.slo.enabled` requires an OpenSearch Dashboards restart to take effect.
+- Only the Prometheus SLI backend is wired up. The OpenSearch SLI backend is reserved in the schema but not yet implemented.
+- Only single-leaf SLIs are supported. Composite SLOs (rolling up multiple SLOs by `all` or `any`) are reserved in the schema but not yet implemented.
+- Only rolling windows are supported. Calendar windows (`week`, `month`, `quarter`) are reserved in the schema but not evaluated.
+- Only the multiwindow, multi-burn-rate (`mwmbr`) alerting strategy is supported.
+- Exclusion windows are accepted by the API but their evaluation is deferred to a later release.
+- Workspace resolution for the ruler write path is hardcoded to `default` in the current release. The plugin still partitions saved objects per workspace, but rules generated by every workspace currently land in the `slo-generated-default` namespace until workspace-scope plumbing lands.
+- Acting-user attribution stamps a placeholder identity (`osd-user`) on `createdBy` and `updatedBy` until the security-plugin user resolver lands.
+- The ruler write is synchronous and fail-loud. If the ruler rejects a rule group, the create or update returns an error and no SLO record is persisted.
+
+## Troubleshooting
+
+- **The SLOs application is not visible in the menu.** Confirm that `observability.slo.enabled` is set to `true` in `opensearch_dashboards.yml`, that OpenSearch Dashboards has been restarted, and that the `observability:apmEnabled` advanced setting is `true`.
+- **Create or update fails with "Datasource ... is not registered" or "is not a DirectQuery Prometheus connection."** The SLO API only writes rules to DirectQuery Prometheus datasources. Check that the datasource you are targeting is registered with a `directQueryName` field.
+- **The ruler returns a non-2xx response.** The wizard surfaces the upstream HTTP status and body. The plugin does not retry; correct the underlying issue (for example, an authentication failure or a malformed PromQL expression) and resubmit.
+- **An SLO shows `rules_missing` or `no_data`.** Use the **Rule health** action on the detail page (introduced by [dashboards-observability#2689](https://github.com/opensearch-project/dashboards-observability/pull/2689)) to probe the ruler and the underlying SLI query. The **Repair** action redeploys missing rule groups.
+
+## Related documentation
+
+- [Application Performance Monitoring]({{site.url}}{{site.baseurl}}/observing-your-data/apm/)
+- [Alerting]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/)

--- a/_observing-your-data/slo/index.md
+++ b/_observing-your-data/slo/index.md
@@ -62,10 +62,6 @@ The SLO feature is available within an Observability [workspace]({{site.url}}{{s
 4. Select the **Observability** use case.
 5. Select **Create workspace**.
 
-### OpenSearch plugins
-
-The [SQL plugin](https://github.com/opensearch-project/sql) (`opensearch-sql`) must be installed on the cluster. SLOs read from and write to the Prometheus-compatible ruler through the DirectQuery resource proxy provided by the SQL plugin, so the Prometheus features will not work without it.
-
 ### Prometheus-compatible ruler
 
 SLOs deploy recording and alerting rules to a Prometheus-compatible ruler (Cortex or Grafana Mimir) through the `DirectQuery` resource proxy. The ruler must support the following API endpoints:

--- a/_observing-your-data/slo/index.md
+++ b/_observing-your-data/slo/index.md
@@ -62,6 +62,10 @@ The SLO feature is available within an Observability [workspace]({{site.url}}{{s
 4. Select the **Observability** use case.
 5. Select **Create workspace**.
 
+### OpenSearch plugins
+
+The [SQL plugin](https://github.com/opensearch-project/sql) (`opensearch-sql`) must be installed on the cluster. SLOs read from and write to the Prometheus-compatible ruler through the DirectQuery resource proxy provided by the SQL plugin, so the Prometheus features will not work without it.
+
 ### Prometheus-compatible ruler
 
 SLOs deploy recording and alerting rules to a Prometheus-compatible ruler (Cortex or Grafana Mimir) through the `DirectQuery` resource proxy. The ruler must support the following API endpoints:


### PR DESCRIPTION
### Description
Adds documentation for the experimental **Service Level Objectives (SLOs)** and **Service Level Indicators (SLIs)** surface in the OpenSearch Dashboards `dashboards-observability` plugin.

The page lives at `_observing-your-data/slo/index.md` and renders under https://docs.opensearch.org/latest/observing-your-data/slo/. It covers:

- An experimental warning callout at the top.
- An overview of how SLOs are persisted, how recording and alerting rules are generated, and how they are deployed to a Prometheus-compatible ruler (Cortex/Mimir) via the SQL plugin's DirectQuery resource proxy.
- Key terms (SLI, SLO, objective, time window, error budget, burn rate, mode, datasource, workspace).
- Requirements: OpenSearch 3.7+, OpenSearch Dashboards 3.7+, the `opensearch-sql` plugin, a Prometheus-compatible ruler, a registered DirectQuery Prometheus datasource, and the `observability` capability.
- The `observability.slo.enabled: true` feature flag (and the dependency on the `observability:apmEnabled` advanced setting) plus a table of related configuration keys.
- How to access the **SLOs** application under **Application Monitoring**, the hash routes the app uses, and the **Beta** chrome badge.
- How to create an SLO from a template (APM span-derived RED metrics, OTel semconv metrics, custom PromQL), the wizard sections, and the dry-run probe.
- How to view SLO health and error budgets, including the per-objective state model.
- How to edit, disable/enable, and delete an SLO.
- Known limitations of the experimental release (Prometheus-only backend, single-leaf SLIs only, rolling windows only, MWMBR alerting only, hardcoded `default` workspace on the ruler write path, placeholder `osd-user` attribution, synchronous fail-loud ruler writes, exclusion-window evaluation deferred).
- Troubleshooting guidance.
- A small one-line entry under **Alerting and detection** in `_observing-your-data/index.md` so the new page is discoverable from the Observability landing page.

The page reflects the feature as it will exist once [opensearch-project/dashboards-observability#2689](https://github.com/opensearch-project/dashboards-observability/pull/2689) lands. A few specifics — the template selector, the `/probe-sli` dry-run endpoint, the `/{id}/repair` and `/{id}/rule_health` endpoints, the **Beta** chrome badge, and the `observability.slo.reconciler.*` configuration keys — come from that PR.

### Issues Resolved
N/A — new experimental feature documentation, no tracking issue.

### Version
3.7

### Frontend features
The SLO/SLI surface is an OpenSearch Dashboards feature, but it is experimental and disabled by default. A walkthrough video has not been recorded yet; the page documents the behavior described in the upstream `dashboards-observability` source (both `origin/main` and PR #2689). Happy to add a recording in a follow-up once the feature stabilizes.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).