### PR TITLE
Document z_score normalization and rrf combination in Hybrid Optimizer

### DIFF
--- a/_search-plugins/search-relevance/optimize-hybrid-search.md
+++ b/_search-plugins/search-relevance/optimize-hybrid-search.md
@@ -81,9 +81,15 @@ PUT _plugins/_search_relevance/experiments
 
 The hybrid search optimization experiment runs different evaluations based on the search configuration. The following parameters and parameter values are taken into account:
 
-* Two normalization techniques: `l2` and `min_max`.
+**Score-based variants**:
+
+* Three normalization techniques: `l2`, `min_max`, and `z_score`. (`z_score` is only paired with `arithmetic_mean`.)
 * Three combination techniques: `arithmetic_mean`, `harmonic_mean`, `geometric_mean`.
 * The lexical and neural search weights, which are values ranging from `0.0` to `1.0` in 0.1 increments.
+
+**Rank-based variants**:
+
+* The `rrf` (Reciprocal Rank Fusion) combination technique, evaluated with `rank_constant` values of `1`, `5`, `10`, `20`, and `60`.
 
 Every query in the query set is executed for all different parameter combinations, and the results are evaluated by using the judgment list.
 

--- a/_search-plugins/search-relevance/optimize-hybrid-search.md
+++ b/_search-plugins/search-relevance/optimize-hybrid-search.md
@@ -83,13 +83,15 @@ The hybrid search optimization experiment runs different evaluations based on th
 
 **Score-based variants**:
 
-* Three normalization techniques: `l2`, `min_max`, and `z_score`. (`z_score` is only paired with `arithmetic_mean`.)
+* Three normalization techniques: `l2`, `min_max`, and `z_score`.
 * Three combination techniques: `arithmetic_mean`, `harmonic_mean`, `geometric_mean`.
 * The lexical and neural search weights, which are values ranging from `0.0` to `1.0` in 0.1 increments.
 
+Note that `z_score` is paired only with `arithmetic_mean` due to a [normalization-processor](https://docs.opensearch.org/latest/search-plugins/search-pipelines/normalization-processor/#request-body-fields) restriction.
+
 **Rank-based variants**:
 
-* The `rrf` (Reciprocal Rank Fusion) combination technique, evaluated with `rank_constant` values of `1`, `5`, `10`, `20`, and `60`.
+* The `rrf` ([Reciprocal Rank Fusion](https://docs.opensearch.org/latest/search-plugins/search-pipelines/score-ranker-processor/)) combination technique, evaluated with `rank_constant` values of `1`, `5`, `10`, `20`, and `60`. RRF variants use the default equal weights across sub-queries.
 
 Every query in the query set is executed for all different parameter combinations, and the results are evaluated by using the judgment list.
 

--- a/_search-plugins/search-relevance/optimize-hybrid-search.md
+++ b/_search-plugins/search-relevance/optimize-hybrid-search.md
@@ -79,21 +79,15 @@ PUT _plugins/_search_relevance/experiments
 
 ## Experimentation process
 
-The hybrid search optimization experiment runs different evaluations based on the search configuration. The following parameters and parameter values are taken into account:
+The hybrid search optimization experiment evaluates all combinations of the following parameter variants for each query in the query set and scores the results against the judgment list:
 
-**Score-based variants**:
+- Score-based variants:
+  - Normalization techniques: `l2`, `min_max`, and `z_score`. The `z_score` technique can be combined only with `arithmetic_mean` because of a [normalization processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/normalization-processor/#request-body-fields) restriction.
+  - Combination techniques: `arithmetic_mean`, `harmonic_mean`, and `geometric_mean`.
+  - Lexical and neural search weights ranging from `0.0` to `1.0`, in `0.1` increments.
 
-* Three normalization techniques: `l2`, `min_max`, and `z_score`.
-* Three combination techniques: `arithmetic_mean`, `harmonic_mean`, `geometric_mean`.
-* The lexical and neural search weights, which are values ranging from `0.0` to `1.0` in 0.1 increments.
-
-Note that `z_score` is paired only with `arithmetic_mean` due to a [normalization-processor](https://docs.opensearch.org/latest/search-plugins/search-pipelines/normalization-processor/#request-body-fields) restriction.
-
-**Rank-based variants**:
-
-* The `rrf` ([Reciprocal Rank Fusion](https://docs.opensearch.org/latest/search-plugins/search-pipelines/score-ranker-processor/)) combination technique, evaluated with `rank_constant` values of `1`, `5`, `10`, `20`, and `60`. RRF variants use the default equal weights across sub-queries.
-
-Every query in the query set is executed for all different parameter combinations, and the results are evaluated by using the judgment list.
+- Rank-based variants:
+  - The `rrf` ([Reciprocal Rank Fusion (RRF)]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/score-ranker-processor/)) combination technique, evaluated using `rank_constant` values of `1`, `5`, `10`, `20`, and `60`. RRF variants use equal weights in all subqueries.
 
 ## Evaluating the results
 


### PR DESCRIPTION
### Description
Updates the Hybrid Optimizer documentation to reflect two newly added techniques:
- `z_score` normalization
- `rrf` (Reciprocal Rank Fusion) combination, parameterized by `rank_constant`

Existing language and structure are preserved; the bullet list is split into a **Score-based variants** group and a **Rank-based variants** group to accommodate RRF, which has different parameters.


### Issues Resolved
Closes #12482

### Version
3.7.0

### Related PR
- Backend (search-relevance): https://github.com/opensearch-project/search-relevance/pull/465
- Dashboards (dashboards-search-relevance): https://github.com/opensearch-project/dashboards-search-relevance/pull/836

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
