### PR TITLE
[DOC] Add ISM Simulate Policy API documentation

### DIFF
--- a/_im-plugin/ism/api.md
+++ b/_im-plugin/ism/api.md
@@ -20,7 +20,7 @@ Use the index state management operations to programmatically work with policies
 
 
 ## Create policy
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Creates a policy.
@@ -74,7 +74,7 @@ PUT _plugins/_ism/policies/policy_1
   }
 }
 ```
-
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -139,7 +139,7 @@ PUT _plugins/_ism/policies/policy_1
 ---
 
 ## Add policy
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Adds a policy to an index. This operation does not change the policy if the index already has one.
@@ -152,6 +152,7 @@ POST _plugins/_ism/add/index_1
   "policy_id": "policy_1"
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -171,7 +172,7 @@ Don't use the broad `*` wildcard, and instead add a prefix, such as `my-logs*`, 
 
 
 ## Update policy
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Updates a policy. Use the `seq_no` and `primary_term` parameters to update an existing policy. If these numbers don't match the existing policy or the policy doesn't exist, ISM throws an error.
@@ -227,6 +228,7 @@ PUT _plugins/_ism/policies/policy_1?if_seq_no=7&if_primary_term=1
   }
 }
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -292,7 +294,7 @@ PUT _plugins/_ism/policies/policy_1?if_seq_no=7&if_primary_term=1
 ---
 
 ## Get policy
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Gets the policy by `policy_id`.
@@ -302,6 +304,7 @@ Gets the policy by `policy_id`.
 ```json
 GET _plugins/_ism/policies/policy_1
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -364,7 +367,7 @@ GET _plugins/_ism/policies/policy_1
 ---
 
 ## Get policies
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Gets a list of policies. This API accepts search parameters to filter and paginate the results.
@@ -504,7 +507,7 @@ GET _plugins/_ism/policies
 ---
 
 ## Remove policy from index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Removes any ISM policy from the index.
@@ -514,6 +517,7 @@ Removes any ISM policy from the index.
 ```json
 POST _plugins/_ism/remove/index_1
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -529,7 +533,7 @@ POST _plugins/_ism/remove/index_1
 ---
 
 ## Update managed index policy
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Updates the managed index policy to a new policy (or to a new version of the policy). You can use an index pattern to update multiple indexes at once. When updating multiple indexes, you might want to include a state filter to only affect certain managed indexes. The change policy filters out all the existing managed indexes and only applies the change to the ones in the state that you specify. You can also explicitly specify the state that the managed index transitions to after the change policy takes effect.
@@ -552,6 +556,7 @@ POST _plugins/_ism/change_policy/index_1
   ]
 }
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -567,7 +572,7 @@ POST _plugins/_ism/change_policy/index_1
 ---
 
 ## Retry failed index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Retries the failed action for an index. For the retry call to succeed, ISM must manage the index, and the index must be in a failed state. You can use index patterns (`*`) to retry multiple failed indexes.
@@ -580,6 +585,7 @@ POST _plugins/_ism/retry/index_1
   "state": "delete"
 }
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -595,7 +601,7 @@ POST _plugins/_ism/retry/index_1
 ---
 
 ## Explain index
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Gets the current state of the index. You can use index patterns to get the status of multiple indexes.
@@ -605,6 +611,7 @@ Gets the current state of the index. You can use index patterns to get the statu
 ```json
 GET _plugins/_ism/explain/index_1
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -624,6 +631,7 @@ Optionally, you can add the `show_policy` parameter to your request's path to ge
 ```json
 GET _plugins/_ism/explain/index_1?show_policy=true
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -664,10 +672,11 @@ You can use the `POST` method with the Explain API to filter the results based o
 ```
 POST _plugins/_ism/explain/{index}
 ```
+{% include copy-curl.html %}
 
 #### Request body
 
-The request body supports the following optional filters.
+The request body supports the following optional filters. If a filter is not specified, indexes with any value for that parameter are included in the results. The API returns only indexes that match all specified filters.
 
 | Parameter | Type | Description |
 |:----------|:-----|:------------|
@@ -675,7 +684,6 @@ The request body supports the following optional filters.
 | `state` | String | Filter results to show only indexes currently in the specified state. |
 | `action_type` | String | Filter results to show only indexes currently executing the specified action type. |
 | `failed` | Boolean | Filter results to show only failed managed indexes. |
-All filters are optional. If a filter is not specified, indexes with any value for that parameter will be included in the results. The API returns only indexes that match all specified filters.
 
 #### Example request: Filter by policy ID
 
@@ -842,21 +850,23 @@ POST _plugins/_ism/explain/data-*
 ---
 
 ## Simulate policy
-Introduced 3.7
-
+**Introduced 3.7**
 {: .label .label-purple }
 
-Previews how a policy would apply to one or more indexes without making any changes. For each index, the response shows the current state, the next action to execute, the evaluation of every transition condition, and which state the index would move to next. This is useful for validating a policy before attaching it or for debugging why an index is not transitioning as expected.
+Previews how a policy would apply to one or more indexes without making any changes. For each index, the response contains the current state, the next action to execute, the evaluation of every transition condition, and which state the index would move to next. Use this endpoint to validate a policy before attaching it or to debug why an index is not transitioning as expected.
 
 Exactly one of `policy_id` or `policy` must be provided.
 
 #### Endpoints
 
-```
+```json
 POST _plugins/_ism/simulate
 ```
+{% include copy-curl.html %}
 
 #### Request body fields
+
+The following table lists the available request body fields.
 
 | Field | Type | Required | Description |
 |:------|:-----|:---------|:------------|
@@ -904,29 +914,29 @@ POST _plugins/_ism/simulate
 
 #### Response body fields
 
-The response contains a `simulate_results` array with one entry per index.
+The following table lists all response body fields. The response contains a `simulate_results` array with one entry per index.
 
 | Field | Type | Description |
 |:------|:-----|:------------|
 | `index_name` | String | The name of the index. |
 | `index_uuid` | String | The UUID of the index. `null` when the index was not found. |
 | `policy_id` | String | The ID of the policy used for simulation. Empty string for inline policies. |
-| `is_managed` | Boolean | Whether the index is currently managed by ISM. |
-| `current_state` | String | The state the index is currently in, or would start in for unmanaged indexes. Omitted when `error` is present. |
+| `is_managed` | Boolean | Whether the index is managed by ISM. |
+| `current_state` | String | The state the index is in, or would start in for unmanaged indexes. Omitted when `error` is present. |
 | `current_action` | String | The action that would execute next in the current state. Omitted when `error` is present. |
 | `transition_evaluation` | Array | Per-transition condition evaluations. Present only when the index is in the transition phase (no pending actions). Omitted when `error` is present. |
 | `next_state` | String | The state the index would transition to (first met condition). `null` if no condition is met. Omitted when `error` is present. |
-| `error` | String | An index-level error message, such as when the index does not exist. When present, all other fields except `index_name`, `index_uuid`, `policy_id`, and `is_managed` are omitted. |
+| `error` | String | An index-level error message. Present when the index does not exist or another index-level error occurs. When this field is present, all other fields except `index_name`, `index_uuid`, `policy_id`, and `is_managed` are omitted. |
 
 Each object in `transition_evaluation` contains the following fields.
 
 | Field | Type | Description |
 |:------|:-----|:------------|
 | `state_name` | String | The target state this transition would move the index to. |
-| `condition_met` | Boolean | Whether the transition condition is currently satisfied. |
-| `condition_type` | String | The kind of condition being evaluated (for example, `min_index_age`, `min_doc_count`, `min_size`). `unconditional` for transitions with no conditions. |
-| `current_value` | String | Human-readable current value of the metric being checked (for example, `"3d 4h"`). Absent for unconditional transitions. |
-| `required_value` | String | Human-readable threshold required by the condition (for example, `"7d"`). Absent for unconditional transitions. |
+| `condition_met` | Boolean | Whether the transition condition is satisfied. |
+| `condition_type` | String | The condition type (for example, `min_index_age`, `min_doc_count`, `min_size`). Set to `unconditional` for transitions with no conditions. |
+| `current_value` | String | The current value of the metric being checked, formatted as a readable string (for example, `"3d 4h"`). Omitted for unconditional transitions. |
+| `required_value` | String | The threshold required by the condition, formatted as a readable string (for example, `"7d"`). Omitted for unconditional transitions. |
 
 #### Example response
 
@@ -994,7 +1004,7 @@ When a concrete index name does not exist in the cluster, the result contains an
 ---
 
 ## Delete policy
-Introduced 1.0
+**Introduced 1.0**
 {: .label .label-purple }
 
 Deletes the policy by `policy_id`.
@@ -1004,6 +1014,7 @@ Deletes the policy by `policy_id`.
 ```json
 DELETE _plugins/_ism/policies/policy_1
 ```
+{% include copy-curl.html %}
 
 
 #### Example response
@@ -1026,23 +1037,26 @@ DELETE _plugins/_ism/policies/policy_1
 ```
 
 ## Error prevention validation
-Introduced 2.4
+**Introduced 2.4**
 {: .label .label-purple }
 
-ISM allows you to run an action automatically. However, running an action can fail for a variety of reasons. You can use error prevention validation to test an action in order to rule out failures.
+ISM runs actions automatically. However, actions can fail for various reasons. You can use error prevention validation to test an action and identify potential failures.
 
-To enable error prevention validation, set the `plugins.index_state_management.action_validation.enabled` setting to `true`:
+To enable error prevention validation, set `plugins.index_state_management.action_validation.enabled` to `true`:
 
-```bash
+```json
 PUT _cluster/settings
 {
-   "persistent":{
+   "persistent": {
       "plugins.index_state_management.action_validation.enabled": true
    }
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
+
+The following response confirms the setting was updated:
 
 ```json
 {
@@ -1060,11 +1074,12 @@ PUT _cluster/settings
 }
 ```
 
-To check an error prevention validation status and message, pass `validate_action=true` to the `_plugins/_ism/explain` endpoint:
+To retrieve the error prevention validation status and message, pass `validate_action=true` to the `_plugins/_ism/explain` endpoint:
 
 ```bash
 GET _plugins/_ism/explain/test-000001?validate_action=true
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -1116,17 +1131,17 @@ The response contains an additional validate object with a validation message an
 }
 ```
 
-If you pass `validate_action=false` or do not pass a `validate_action` value to the `_plugins/_ism/explain` endpoint, the response will not contain an error prevention validation status and message:
+If you pass `validate_action=false` or omit the `validate_action` parameter, the response does not contain the validation status and message:
 
 ```bash
 GET _plugins/_ism/explain/test-000001?validate_action=false
 ```
-
-Or:
+{% include copy-curl.html %}
 
 ```bash
 GET _plugins/_ism/explain/test-000001
 ```
+{% include copy-curl.html %}
 
 #### Example response
 

--- a/_im-plugin/ism/api.md
+++ b/_im-plugin/ism/api.md
@@ -841,6 +841,158 @@ POST _plugins/_ism/explain/data-*
 
 ---
 
+## Simulate policy
+Introduced 3.7
+
+{: .label .label-purple }
+
+Previews how a policy would apply to one or more indexes without making any changes. For each index, the response shows the current state, the next action to execute, the evaluation of every transition condition, and which state the index would move to next. This is useful for validating a policy before attaching it or for debugging why an index is not transitioning as expected.
+
+Exactly one of `policy_id` or `policy` must be provided.
+
+#### Endpoints
+
+```
+POST _plugins/_ism/simulate
+```
+
+#### Request body fields
+
+| Field | Type | Required | Description |
+|:------|:-----|:---------|:------------|
+| `policy_id` | String | Conditional | The ID of a stored ISM policy to simulate. Required when `policy` is not provided. |
+| `policy` | Object | Conditional | An inline policy definition to simulate without saving it. Required when `policy_id` is not provided. |
+| `indices` | Array of strings | Yes | The index names or wildcard patterns to simulate against. Wildcard patterns are expanded to matching concrete indexes. Patterns that match no indexes are silently ignored. Concrete index names that do not exist return an error in the per-index result. |
+
+#### Example request: Simulate a stored policy
+
+```json
+POST _plugins/_ism/simulate
+{
+  "policy_id": "my-lifecycle-policy",
+  "indices": ["logs-2024-01-*", "logs-2024-02-01"]
+}
+```
+{% include copy-curl.html %}
+
+#### Example request: Simulate an inline policy
+
+```json
+POST _plugins/_ism/simulate
+{
+  "policy": {
+    "description": "hot-warm lifecycle",
+    "default_state": "hot",
+    "states": [
+      {
+        "name": "hot",
+        "actions": [],
+        "transitions": [
+          {
+            "state_name": "warm",
+            "conditions": { "min_index_age": "7d" }
+          }
+        ]
+      },
+      { "name": "warm", "actions": [], "transitions": [] }
+    ]
+  },
+  "indices": ["my-index"]
+}
+```
+{% include copy-curl.html %}
+
+#### Response body fields
+
+The response contains a `simulate_results` array with one entry per index.
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `index_name` | String | The name of the index. |
+| `index_uuid` | String | The UUID of the index. `null` when the index was not found. |
+| `policy_id` | String | The ID of the policy used for simulation. Empty string for inline policies. |
+| `is_managed` | Boolean | Whether the index is currently managed by ISM. |
+| `current_state` | String | The state the index is currently in, or would start in for unmanaged indexes. Omitted when `error` is present. |
+| `current_action` | String | The action that would execute next in the current state. Omitted when `error` is present. |
+| `transition_evaluation` | Array | Per-transition condition evaluations. Present only when the index is in the transition phase (no pending actions). Omitted when `error` is present. |
+| `next_state` | String | The state the index would transition to (first met condition). `null` if no condition is met. Omitted when `error` is present. |
+| `error` | String | An index-level error message, such as when the index does not exist. When present, all other fields except `index_name`, `index_uuid`, `policy_id`, and `is_managed` are omitted. |
+
+Each object in `transition_evaluation` contains the following fields.
+
+| Field | Type | Description |
+|:------|:-----|:------------|
+| `state_name` | String | The target state this transition would move the index to. |
+| `condition_met` | Boolean | Whether the transition condition is currently satisfied. |
+| `condition_type` | String | The kind of condition being evaluated (for example, `min_index_age`, `min_doc_count`, `min_size`). `unconditional` for transitions with no conditions. |
+| `current_value` | String | Human-readable current value of the metric being checked (for example, `"3d 4h"`). Absent for unconditional transitions. |
+| `required_value` | String | Human-readable threshold required by the condition (for example, `"7d"`). Absent for unconditional transitions. |
+
+#### Example response
+
+```json
+{
+  "simulate_results": [
+    {
+      "index_name": "logs-2024-01-15",
+      "index_uuid": "gCFlS_zcTdih8xyxf3jQ-A",
+      "policy_id": "my-lifecycle-policy",
+      "is_managed": false,
+      "current_state": "hot",
+      "current_action": "transition",
+      "transition_evaluation": [
+        {
+          "state_name": "warm",
+          "condition_met": true,
+          "condition_type": "min_index_age",
+          "current_value": "10d",
+          "required_value": "7d"
+        }
+      ],
+      "next_state": "warm"
+    },
+    {
+      "index_name": "logs-2024-02-01",
+      "index_uuid": "LmJgKNatQZWHQu-qIHlcJw",
+      "policy_id": "my-lifecycle-policy",
+      "is_managed": false,
+      "current_state": "hot",
+      "current_action": "transition",
+      "transition_evaluation": [
+        {
+          "state_name": "warm",
+          "condition_met": false,
+          "condition_type": "min_index_age",
+          "current_value": "3d 2h",
+          "required_value": "7d"
+        }
+      ],
+      "next_state": null
+    }
+  ]
+}
+```
+
+#### Example response: Index not found
+
+When a concrete index name does not exist in the cluster, the result contains an `error` field instead of state information.
+
+```json
+{
+  "simulate_results": [
+    {
+      "index_name": "nonexistent-index",
+      "index_uuid": null,
+      "policy_id": "my-lifecycle-policy",
+      "is_managed": false,
+      "error": "Index 'nonexistent-index' not found in cluster"
+    }
+  ]
+}
+```
+
+---
+
 ## Delete policy
 Introduced 1.0
 {: .label .label-purple }


### PR DESCRIPTION

### Description
 - Documents the `POST /_plugins/_ism/simulate` endpoint
  - Covers both usage modes: simulating a stored policy by ID and simulating an inline policy definition
  - Describes all request body fields (`policy_id`, `policy`, `indices`) with conditionality rules
  - Documents all response fields including `transition_evaluation` sub-object
  - Includes two example requests and two example responses (happy path and index-not-found error case)


### Issues Resolved
Closes #12464 

### Version
3.7 and above


### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
