### PR TITLE
[Workspace] Document workspace permission modes and fix Update API example

### DIFF
--- a/_dashboards/workspace/apis.md
+++ b/_dashboards/workspace/apis.md
@@ -194,6 +194,8 @@ The following example response shows a successful API call:
 
 #### Example request with permissions object
 
+When a request includes a `permissions` object, each user or group must be granted a complete access-level combination of permission modes (for example, `library_read` + `read` for read-only access). For the full list of permission modes and the access levels they map to, see [Defining workspace collaborators]({{site.url}}{{site.baseurl}}/dashboards/workspace/workspace-acl/#defining-workspace-collaborators).
+
 ```json
 curl -k -u admin:admin \
   -H 'osd-xsrf: true' \
@@ -203,8 +205,10 @@ curl -k -u admin:admin \
     "attributes": {},
     "settings": {
       "permissions": {
-        "library_write": { "groups": ["obs-admins"] },
-        "read": { "groups": ["obs-users"] }
+        "library_write": { "users": ["obs-admin-user"] },
+        "write": { "users": ["obs-admin-user"] },
+        "library_read": { "groups": ["obs-read-users"] },
+        "read": { "groups": ["obs-read-users"] }
       }
     }
   }'

--- a/_dashboards/workspace/apis.md
+++ b/_dashboards/workspace/apis.md
@@ -194,7 +194,7 @@ The following example response shows a successful API call:
 
 #### Example request with permissions object
 
-When a request includes a `permissions` object, each user or group must be granted a complete access-level combination of permission modes (for example, `library_read` + `read` for read-only access). For the full list of permission modes and the access levels they map to, see [Defining workspace collaborators]({{site.url}}{{site.baseurl}}/dashboards/workspace/workspace-acl/#defining-workspace-collaborators).
+When a request includes a `permissions` object, each user or group must be assigned the set of permission modes required for the desired access level. For example, read-only access requires both the `library_read` and `read` permission modes:
 
 ```json
 curl -k -u admin:admin \
@@ -215,14 +215,7 @@ curl -k -u admin:admin \
 ```
 {% include copy.html %}
 
-The following example response shows a successful API call:
-
-```json
-{
-    "success": true,
-    "result": true
-}
-```
+For a complete list of permission modes and the access levels they provide, see [Defining workspace collaborators]({{site.url}}{{site.baseurl}}/dashboards/workspace/workspace-acl/#defining-workspace-collaborators).
 
 ## Delete Workspaces API
 

--- a/_dashboards/workspace/workspace-acl.md
+++ b/_dashboards/workspace/workspace-acl.md
@@ -84,6 +84,27 @@ Access to collaborator management is limited to admins. The **Collaborators** fe
 - **Read and write:** Allows viewing and editing of assets within the workspace.
 - **Admin:** Provides full access, including viewing and editing of assets within the workspace and updating workspace metadata, such as name, description, data sources, and collaborators.
 
+#### Permission modes
+
+When you assign collaborators through the UI, access levels are applied automatically. When you set collaborators directly through the [Workspaces APIs]({{site.url}}{{site.baseurl}}/dashboards/workspace/apis/), each access level corresponds to a specific combination of *permission modes*. Permission modes fall into two independent dimensions:
+
+| Permission mode | Applies to | Description |
+| :--- | :--- | :--- |
+| `read` | The workspace itself | The principal can open and view the workspace. |
+| `write` | The workspace itself | The principal can manage the workspace itself: edit its name, description, and settings, manage collaborators, and associate data sources. |
+| `library_read` | The saved objects (assets) inside the workspace | The principal can view assets such as dashboards, visualizations, and index patterns. |
+| `library_write` | The saved objects (assets) inside the workspace | The principal can create, edit, and delete assets inside the workspace. |
+
+Each access level requires one mode from each dimension:
+
+| Access level | Required permission modes |
+| :--- | :--- |
+| Read only | `library_read` + `read` |
+| Read and write | `library_write` + `read` |
+| Admin | `library_write` + `write` |
+
+A partial combination (for example, only `read` without `library_read`) does not grant coherent access, and the principal will not appear as a collaborator.
+
 From the **Collaborators** page, you can by collaborator ID and filter results by collaborator type and access level.
 
 ### Adding collaborators

--- a/_dashboards/workspace/workspace-acl.md
+++ b/_dashboards/workspace/workspace-acl.md
@@ -9,7 +9,7 @@ nav_order: 3
 **Introduced 2.18**
 {: .label .label-purple }
 
-Workspace access control lists (ACLs) manage authorization for saved objects `AuthZ(Authorization)` while enabling [Security in OpenSearch]({{site.url}}{{site.baseurl}}/security/) for `AuthN(Authentication)`.
+Workspace access control lists (ACLs) manage authorization for saved objects while relying on the [Security plugin]({{site.url}}{{site.baseurl}}/security/) for authentication.
 
 ## Personas
 
@@ -78,7 +78,7 @@ Admin-restricted operations include the following:
 
 ## Defining workspace collaborators
 
-Access to collaborator management is limited to admins. The **Collaborators** feature is only available when permission control is enabled. For instructions on activating permission control, see [Enabling permission control](#enabling-permission-control). The access levels include the following:
+Access to collaborator management is limited to admins. The **Collaborators** feature is only available when permission control is enabled. For instructions on activating permission control, see [Enabling permission control](#enabling-permission-control). Access levels include the following:
 
 - **Read only:** Grants permission to view the workspace and its assets.
 - **Read and write:** Allows viewing and editing of assets within the workspace.
@@ -86,16 +86,16 @@ Access to collaborator management is limited to admins. The **Collaborators** fe
 
 #### Permission modes
 
-When you assign collaborators through the UI, access levels are applied automatically. When you set collaborators directly through the [Workspaces APIs]({{site.url}}{{site.baseurl}}/dashboards/workspace/apis/), each access level corresponds to a specific combination of *permission modes*. Permission modes fall into two independent dimensions:
+When you assign collaborators through the UI, access levels are applied automatically. When you assign collaborators through the [Workspaces APIs]({{site.url}}{{site.baseurl}}/dashboards/workspace/apis/), each access level corresponds to a specific combination of permission modes. The following table describes the available permission modes.
 
-| Permission mode | Applies to | Description |
+| Permission mode | Target | Description |
 | :--- | :--- | :--- |
 | `read` | The workspace itself | The principal can open and view the workspace. |
 | `write` | The workspace itself | The principal can manage the workspace itself: edit its name, description, and settings, manage collaborators, and associate data sources. |
-| `library_read` | The saved objects (assets) inside the workspace | The principal can view assets such as dashboards, visualizations, and index patterns. |
-| `library_write` | The saved objects (assets) inside the workspace | The principal can create, edit, and delete assets inside the workspace. |
+| `library_read` | The saved objects (assets) in the workspace | The principal can view assets such as dashboards, visualizations, and index patterns. |
+| `library_write` | The saved objects (assets) in the workspace | The principal can create, edit, and delete assets in the workspace. |
 
-Each access level requires one mode from each dimension:
+Each access level requires one permission mode for the workspace and one permission mode for the workspace's assets, as listed in the following table. If a user or group is assigned only a partial combination of permission modes (for example, `read` without `library_read`), that user or group does not appear as a collaborator.
 
 | Access level | Required permission modes |
 | :--- | :--- |
@@ -103,9 +103,7 @@ Each access level requires one mode from each dimension:
 | Read and write | `library_write` + `read` |
 | Admin | `library_write` + `write` |
 
-A partial combination (for example, only `read` without `library_read`) does not grant coherent access, and the principal will not appear as a collaborator.
-
-From the **Collaborators** page, you can by collaborator ID and filter results by collaborator type and access level.
+From the **Collaborators** page, you can search by collaborator ID and filter results by collaborator type and access level.
 
 ### Adding collaborators
 
@@ -127,11 +125,11 @@ To add groups, follow these steps:
 1. Select the **Add Groups** button to open the modal. The modal displays one empty `Group ID` field by default.
 2. Choose an access level: **Read only**, **Read and write**, or **Admin**.
 3. Use **Add another group** to add multiple groups. Do not use duplicate or existing `Group ID` fields to avoid errors.
-4. Resolve any errors before finalizing. Successfully added users appear in the collaborators table.
+4. Resolve any errors before finalizing. Successfully added groups appear in the collaborators table.
 
 ### Modifying access levels
 
-You can modify collaborators access levels after adding them to the collaborators table if you have the required permissions. Collaborators can be assigned any access level. However, if all **Admin** collaborators are changed to lower access levels, then only admins can manage workspace collaboration.
+You can modify collaborators' access levels after adding them to the collaborators table if you have the required permissions. Collaborators can be assigned any access level. However, if all **Admin** collaborators are changed to lower access levels, then only admins can manage workspace collaboration.
 
 #### Modifying individual access levels
 
@@ -181,8 +179,7 @@ When permission control is enabled, workspace administrators can set one of the 
 * **Anyone can view:** Grants **Read only** permissions to all workspace users, allowing them to view workspace assets. 
 * **Anyone can edit:** Grants **Read and write** permissions to all users, allowing them to view, create, and update workspace assets.
 
-Collaborators are granted higher permissions when their individual access level differs from that set in the workspace settings. For example, if workspace privacy is set to "Anyone can edit", any collaborator with read-only access will also be able to edit workspace assets.
-Users at the collaborator level are granted additional permissions even when their access level differs from that of the workspace.
+Collaborators receive whichever permission is higher: their individual access level or the workspace-wide privacy setting. For example, if workspace privacy is set to "Anyone can edit", a collaborator with read-only access can also edit workspace assets.
 You can set up workspace privacy on the **Create workspace** page as a **Dashboard admin**. You can also modify it on the **Collaborators** or **Workspace details** pages as a **Workspace admin** or **Dashboard admin**.
 
 ### Setting up workspace privacy during workspace creation
@@ -190,7 +187,7 @@ You can set up workspace privacy on the **Create workspace** page as a **Dashboa
 Use the following steps to change workspace privacy settings when creating a new workspace:
 
 1. Choose the desired access level from the **Set up privacy** panel. 
-2. _Optional_ Decide whether to add collaborators after workspace creation by selecting the **Add collaborators after workspace creation.** checkbox.
+2. (Optional) Select the **Add collaborators after workspace creation** checkbox to add collaborators later.
 3. Select **Create workspace** to create the workspace.
 
 ### Modifying workspace privacy on the **Collaborators** page


### PR DESCRIPTION
### Description
The Workspaces APIs page does not explain how workspace collaborator permissions work, and the "Update Workspaces API → Example request with permissions object" uses an incomplete combination (`library_write` for one group, `read` for another) that does not actually create a usable collaborator.

### Issues Resolved
https://github.com/opensearch-project/OpenSearch-Dashboards/issues/11996

### Version
2.18-latest

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
