### PR TITLE
document fallback value support in DLS

### DIFF
--- a/_security/access-control/document-level-security.md
+++ b/_security/access-control/document-level-security.md
@@ -132,6 +132,22 @@ Term | Replaced with
 `${user.securityRoles}` | A comma-separated, quoted list of user security roles. 
 `${attr.<TYPE>.<NAME>}` | An attribute with name `<NAME>` defined for a user. `<TYPE>` is `internal`, `jwt`, `proxy` or `ldap`
 
+If a variable does not exist then an error will be thrown.
+
+### Fallback values
+
+Introduced 3.7.0
+{: .label .label-purple }
+
+If it is unclear whether a variable is present then a fallback value can be specified, which can either be a constant
+value or another variable.
+
+Example where the `notexists` attribute doesn't exist and `attr1` is set to `foo`:
+
+ Term                                           | Replaced with
+:-----------------------------------------------|:--------------
+ `${attr.proxy.notexists:-bar}`                 | "bar"
+ `${attr.proxy.notexists:-${attr.proxy.attr1}}` | "foo"
 
 ## Attribute-based security
 

--- a/_security/access-control/document-level-security.md
+++ b/_security/access-control/document-level-security.md
@@ -144,8 +144,8 @@ In the following examples, the `notexists` attribute is not defined and `attr1` 
 
  Term                                           | Replacement
 :-----------------------------------------------|:--------------
- `${attr.proxy.notexists:-bar}`                 | "bar"
- `${attr.proxy.notexists:-${attr.proxy.attr1}}` | "foo"
+ `${attr.proxy.notexists:-bar}`                 | `bar`
+ `${attr.proxy.notexists:-${attr.proxy.attr1}}` | `foo`
 
 ## Attribute-based security
 

--- a/_security/access-control/document-level-security.md
+++ b/_security/access-control/document-level-security.md
@@ -132,19 +132,17 @@ Term | Replaced with
 `${user.securityRoles}` | A comma-separated, quoted list of user security roles. 
 `${attr.<TYPE>.<NAME>}` | An attribute with name `<NAME>` defined for a user. `<TYPE>` is `internal`, `jwt`, `proxy` or `ldap`
 
-If a variable does not exist then an error will be thrown.
+If a variable does not exist, an error is thrown.
 
 ### Fallback values
-
-Introduced 3.7.0
+**Introduced 3.7.0**
 {: .label .label-purple }
 
-If it is unclear whether a variable is present then a fallback value can be specified, which can either be a constant
-value or another variable.
+You can specify a fallback value for a variable that may not exist. The fallback can be either a literal value or another variable.
 
-Example where the `notexists` attribute doesn't exist and `attr1` is set to `foo`:
+In the following examples, the `notexists` attribute is not defined and `attr1` is set to `foo`.
 
- Term                                           | Replaced with
+ Term                                           | Replacement
 :-----------------------------------------------|:--------------
  `${attr.proxy.notexists:-bar}`                 | "bar"
  `${attr.proxy.notexists:-${attr.proxy.attr1}}` | "foo"


### PR DESCRIPTION
### Description
this feature was introduced with opensearch-project/security#6111 in 3.7.0.

the error being thrown is not new, but was not documented so far.

### Issues Resolved
n/a

### Version
3.7.0

### Frontend features
n/a

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
