### PR TITLE
Add docs for CLUSTER_SETTINGS_CHANGED and INDEX_SETTINGS_CHANGED audit categories

### DIFF
--- a/_security/audit-logs/field-reference.md
+++ b/_security/audit-logs/field-reference.md
@@ -20,7 +20,7 @@ The following attributes are logged for all event categories, independent of the
 Name | Description
 :--- | :---
 `audit_format_version` | The audit log message format version.
-`audit_category` | The audit log category. FAILED_LOGIN, MISSING_PRIVILEGES, BAD_HEADERS, SSL_EXCEPTION, OPENSEARCH_SECURITY_INDEX_ATTEMPT, AUTHENTICATED, or GRANTED_PRIVILEGES.
+`audit_category` | The audit log category. FAILED_LOGIN, MISSING_PRIVILEGES, BAD_HEADERS, SSL_EXCEPTION, OPENSEARCH_SECURITY_INDEX_ATTEMPT, AUTHENTICATED, GRANTED_PRIVILEGES, CLUSTER_SETTINGS_CHANGED, or INDEX_SETTINGS_CHANGED.
 `audit_node_id ` | The ID of the node where the event was generated.
 `audit_node_name` | The name of the node where the event was generated.
 `audit_node_host_address` | The host address of the node where the event was generated.
@@ -173,3 +173,45 @@ Name | Description
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards, date patterns, and aliases. Only logged if `resolve_indices` is true.
 `audit_trace_resolved_indices` | The resolved index name(s) affected by the request. Only logged if `resolve_indices` is true.
 `audit_trace_doc_types` | The document types affected by the request. Only logged if `resolve_indices` is true.
+
+
+## Transport CLUSTER_SETTINGS_CHANGED attributes
+
+Name | Description
+:--- | :---
+`audit_request_effective_user` | The user who made the settings change.
+`audit_transport_request_type` | The type of request (for example, `ClusterUpdateSettingsRequest`).
+`audit_transport_action` | The transport action (for example, `cluster:admin/settings/update`).
+`audit_settings_changes` | An array of setting change objects, each containing `setting`, `old_value`, `new_value`, `operation`, and `scope`. Sensitive settings are automatically redacted.
+
+Each object in `audit_settings_changes` contains the following fields:
+
+Name | Description
+:--- | :---
+`setting` | The full setting name (for example, `cluster.max_shards_per_node`).
+`old_value` | The previous value of the setting, or `null` if not previously set.
+`new_value` | The new value of the setting, or `null` if the setting was removed.
+`operation` | Either `set` (value was assigned) or `removed` (value was reset to default).
+`scope` | Either `persistent` (survives restarts) or `transient` (lost on restart).
+
+
+## Transport INDEX_SETTINGS_CHANGED attributes
+
+Name | Description
+:--- | :---
+`audit_request_effective_user` | The user who made the settings change.
+`audit_transport_request_type` | The type of request (for example, `UpdateSettingsRequest`).
+`audit_transport_action` | The transport action (for example, `indices:admin/settings/update`).
+`audit_trace_indices` | The index name(s) included in the request. Can contain wildcards and aliases.
+`audit_trace_resolved_indices` | The resolved concrete index name(s) affected by the request.
+`audit_settings_changes` | An array of setting change objects, each containing `setting`, `old_value`, `new_value`, `operation`, and `scope`. Sensitive settings are automatically redacted.
+
+Each object in `audit_settings_changes` contains the following fields:
+
+Name | Description
+:--- | :---
+`setting` | The full setting name (for example, `index.number_of_replicas`).
+`old_value` | The previous value of the setting, or `null` if not previously set.
+`new_value` | The new value of the setting, or `null` if the setting was removed.
+`operation` | Either `set` (value was assigned) or `removed` (value was reset to default).
+`scope` | Always `index` for index settings changes.

--- a/_security/audit-logs/field-reference.md
+++ b/_security/audit-logs/field-reference.md
@@ -20,7 +20,7 @@ The following attributes are logged for all event categories, independent of the
 Name | Description
 :--- | :---
 `audit_format_version` | The audit log message format version.
-`audit_category` | The audit log category. FAILED_LOGIN, MISSING_PRIVILEGES, BAD_HEADERS, SSL_EXCEPTION, OPENSEARCH_SECURITY_INDEX_ATTEMPT, AUTHENTICATED, GRANTED_PRIVILEGES, CLUSTER_SETTINGS_CHANGED, or INDEX_SETTINGS_CHANGED.
+`audit_category` | The audit log category. Values include `FAILED_LOGIN`, `MISSING_PRIVILEGES`, `BAD_HEADERS`, `SSL_EXCEPTION`, `OPENSEARCH_SECURITY_INDEX_ATTEMPT`, `AUTHENTICATED`, `GRANTED_PRIVILEGES`, `CLUSTER_SETTINGS_CHANGED`, and `INDEX_SETTINGS_CHANGED`.
 `audit_node_id ` | The ID of the node where the event was generated.
 `audit_node_name` | The name of the node where the event was generated.
 `audit_node_host_address` | The host address of the node where the event was generated.
@@ -31,6 +31,8 @@ Name | Description
 
 
 ## REST FAILED_LOGIN attributes
+
+The following attributes are logged for the REST layer failed login events.
 
 Name | Description
 :--- | :---
@@ -45,6 +47,8 @@ Name | Description
 
 ## REST AUTHENTICATED attributes
 
+The following attributes are logged for the REST layer successful authentication events.
+
 Name | Description
 :--- | :---
 `audit_request_effective_user` | The username that failed to authenticate.
@@ -58,12 +62,16 @@ Name | Description
 
 ## REST SSL_EXCEPTION attributes
 
+The following attributes are logged for the REST layer SSL exception events.
+
 Name | Description
 :--- | :---
 `audit_request_exception_stacktrace` | The stack trace of the SSL exception.
 
 
 ## REST BAD_HEADERS attributes
+
+The following attributes are logged for the REST layer bad headers events.
 
 Name | Description
 :--- | :---
@@ -75,13 +83,15 @@ Name | Description
 
 ## Transport FAILED_LOGIN attributes
 
+The following attributes are logged for the transport layer failed login events.
+
 Name | Description
 :--- | :---
 `audit_trace_task_id` | The ID of the request.
 `audit_transport_headers` | The headers of the request, if any.
 `audit_request_effective_user` | The username that failed to authenticate.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
-`audit_transport_request_type` | The type of request (e.g. `IndexRequest`).
+`audit_transport_request_type` | The request type (for example, `IndexRequest`).
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards, date patterns, and aliases. Only logged if `resolve_indices` is true.
 `audit_trace_resolved_indices` | The resolved index name(s) affected by the request. Only logged if `resolve_indices` is true.
@@ -90,13 +100,15 @@ Name | Description
 
 ## Transport AUTHENTICATED attributes
 
+The following attributes are logged for the transport layer successful authentication events.
+
 Name | Description
 :--- | :---
 `audit_trace_task_id` | The ID of the request.
 `audit_transport_headers` | The headers of the request, if any.
 `audit_request_effective_user` | The username that failed to authenticate.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
-`audit_transport_request_type` | The type of request (e.g. `IndexRequest`).
+`audit_transport_request_type` | The request type (for example, `IndexRequest`).
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards, date patterns, and aliases. Only logged if `resolve_indices` is true.
 `audit_trace_resolved_indices` | The resolved index name(s) affected by the request. Only logged if `resolve_indices` is true.
@@ -105,6 +117,8 @@ Name | Description
 
 ## Transport MISSING_PRIVILEGES attributes
 
+The following attributes are logged for the transport layer missing privileges events.
+
 Name | Description
 :--- | :---
 `audit_trace_task_id` | The ID of the request.
@@ -112,7 +126,7 @@ Name | Description
 `audit_transport_headers` | The headers of the request, if any.
 `audit_request_effective_user` | The username that failed to authenticate.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
-`audit_transport_request_type` | The type of request (e.g. `IndexRequest`).
+`audit_transport_request_type` | The request type (for example, `IndexRequest`).
 `audit_request_privilege` | The required privilege of the request (for example, `indices:data/read/search`).
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards, date patterns, and aliases. Only logged if `resolve_indices` is true.
@@ -122,6 +136,8 @@ Name | Description
 
 ## Transport GRANTED_PRIVILEGES attributes
 
+The following attributes are logged for the transport layer granted privileges events.
+
 Name | Description
 :--- | :---
 `audit_trace_task_id` | The ID of the request.
@@ -129,8 +145,8 @@ Name | Description
 `audit_transport_headers` | The headers of the request, if any.
 `audit_request_effective_user` | The username that failed to authenticate.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
-`audit_transport_request_type` | The type of request (for example, `IndexRequest`).
-`audit_request_privilege` | The required privilege of the request (e.g. `indices:data/read/search`).
+`audit_transport_request_type` | The request type (for example, `IndexRequest`).
+`audit_request_privilege` | The required privilege of the request (for example, `indices:data/read/search`).
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards, date patterns, and aliases. Only logged if `resolve_indices` is true.
 `audit_trace_resolved_indices` | The resolved index name(s) affected by the request. Only logged if `resolve_indices` is true.
@@ -139,12 +155,16 @@ Name | Description
 
 ## Transport SSL_EXCEPTION attributes
 
+The following attributes are logged for the transport layer SSL exception events.
+
 Name | Description
 :--- | :---
 `audit_request_exception_stacktrace` | The stack trace of the SSL exception.
 
 
 ## Transport BAD_HEADERS attributes
+
+The following attributes are logged for the transport layer bad headers events.
 
 Name | Description
 :--- | :---
@@ -153,7 +173,7 @@ Name | Description
 `audit_transport_headers` | The headers of the request, if any.
 `audit_request_effective_user` | The username that failed to authenticate.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
-`audit_transport_request_type` | The type of request (e.g. `IndexRequest`).
+`audit_transport_request_type` | The request type (for example, `IndexRequest`).
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards, date patterns, and aliases. Only logged if `resolve_indices` is true.
 `audit_trace_resolved_indices` | The resolved index name(s) affected by the request. Only logged if `resolve_indices` is true.
@@ -162,13 +182,15 @@ Name | Description
 
 ## Transport opensearch_SECURITY_INDEX_ATTEMPT attributes
 
+The following attributes are logged when a request attempts to access the OpenSearch security index.
+
 Name | Description
 :--- | :---
 `audit_trace_task_id` | The ID of the request.
 `audit_transport_headers` | The headers of the request, if any.
 `audit_request_effective_user` | The username that failed to authenticate.
 `audit_request_initiating_user` | The user that initiated the request. Only logged if it differs from the effective user.
-`audit_transport_request_type` | The type of request (e.g. `IndexRequest`).
+`audit_transport_request_type` | The request type (for example, `IndexRequest`).
 `audit_request_body` | The HTTP request body, if any (and if request body logging is enabled).
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards, date patterns, and aliases. Only logged if `resolve_indices` is true.
 `audit_trace_resolved_indices` | The resolved index name(s) affected by the request. Only logged if `resolve_indices` is true.
@@ -177,41 +199,45 @@ Name | Description
 
 ## Transport CLUSTER_SETTINGS_CHANGED attributes
 
+The following attributes are logged when cluster settings are changed.
+
 Name | Description
 :--- | :---
-`audit_request_effective_user` | The user who made the settings change.
-`audit_transport_request_type` | The type of request (for example, `ClusterUpdateSettingsRequest`).
+`audit_request_effective_user` | The user who made the setting change.
+`audit_transport_request_type` | The request type (for example, `ClusterUpdateSettingsRequest`).
 `audit_transport_action` | The transport action (for example, `cluster:admin/settings/update`).
 `audit_settings_changes` | An array of setting change objects, each containing `setting`, `old_value`, `new_value`, `operation`, and `scope`. Sensitive settings are automatically redacted.
 
-Each object in `audit_settings_changes` contains the following fields:
+Each object in `audit_settings_changes` contains the following fields.
 
 Name | Description
 :--- | :---
 `setting` | The full setting name (for example, `cluster.max_shards_per_node`).
 `old_value` | The previous value of the setting, or `null` if not previously set.
 `new_value` | The new value of the setting, or `null` if the setting was removed.
-`operation` | Either `set` (value was assigned) or `removed` (value was reset to default).
+`operation` | Either `set` (value was assigned) or `removed` (value was reset to the default).
 `scope` | Either `persistent` (survives restarts) or `transient` (lost on restart).
 
 
 ## Transport INDEX_SETTINGS_CHANGED attributes
 
+The following attributes are logged when index settings are changed.
+
 Name | Description
 :--- | :---
-`audit_request_effective_user` | The user who made the settings change.
-`audit_transport_request_type` | The type of request (for example, `UpdateSettingsRequest`).
+`audit_request_effective_user` | The user who made the setting change.
+`audit_transport_request_type` | The request type (for example, `UpdateSettingsRequest`).
 `audit_transport_action` | The transport action (for example, `indices:admin/settings/update`).
 `audit_trace_indices` | The index name(s) included in the request. Can contain wildcards and aliases.
 `audit_trace_resolved_indices` | The resolved concrete index name(s) affected by the request.
 `audit_settings_changes` | An array of setting change objects, each containing `setting`, `old_value`, `new_value`, `operation`, and `scope`. Sensitive settings are automatically redacted.
 
-Each object in `audit_settings_changes` contains the following fields:
+Each object in `audit_settings_changes` contains the following fields.
 
 Name | Description
 :--- | :---
 `setting` | The full setting name (for example, `index.number_of_replicas`).
 `old_value` | The previous value of the setting, or `null` if not previously set.
 `new_value` | The new value of the setting, or `null` if the setting was removed.
-`operation` | Either `set` (value was assigned) or `removed` (value was reset to default).
-`scope` | Always `index` for index settings changes.
+`operation` | Either `set` (value was assigned) or `removed` (value was reset to the default).
+`scope` | Always `index` for index setting changes.

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -57,7 +57,7 @@ Event | Logged on REST | Logged on transport | Description
 `SSL_EXCEPTION` | Yes | Yes | An attempt was made to access OpenSearch without a valid SSL/TLS certificate.
 `opensearch_SECURITY_INDEX_ATTEMPT` | No | Yes | An attempt was made to modify the Security plugin internal user and privileges index without the required permissions or TLS admin certificate.
 `BAD_HEADERS` | Yes | Yes | An attempt was made to spoof a request to OpenSearch with the Security plugin internal headers.
-`CLUSTER_SETTINGS_CHANGED` | No | Yes | A cluster setting was changed (persistent or transient). Disabled by default.
+`CLUSTER_SETTINGS_CHANGED` | No | Yes | A persistent or transient cluster setting was changed. Disabled by default.
 `INDEX_SETTINGS_CHANGED` | No | Yes | An index setting was changed. Disabled by default.
 
 

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -57,6 +57,8 @@ Event | Logged on REST | Logged on transport | Description
 `SSL_EXCEPTION` | Yes | Yes | An attempt was made to access OpenSearch without a valid SSL/TLS certificate.
 `opensearch_SECURITY_INDEX_ATTEMPT` | No | Yes | An attempt was made to modify the Security plugin internal user and privileges index without the required permissions or TLS admin certificate.
 `BAD_HEADERS` | Yes | Yes | An attempt was made to spoof a request to OpenSearch with the Security plugin internal headers.
+`CLUSTER_SETTINGS_CHANGED` | No | Yes | A cluster setting was changed (persistent or transient). Disabled by default.
+`INDEX_SETTINGS_CHANGED` | No | Yes | An index setting was changed. Disabled by default.
 
 
 ## Audit log settings
@@ -90,6 +92,17 @@ config:
       - AUTHENTICATED
       - GRANTED_PRIVILEGES
     disabled_transport_categories: [ GRANTED_PRIVILEGES ]
+```
+{% include copy.html %}
+
+By default, the `CLUSTER_SETTINGS_CHANGED` and `INDEX_SETTINGS_CHANGED` categories are disabled on the transport layer. To enable them, remove them from `disabled_transport_categories`:
+
+```yml
+config:
+  audit:
+    disabled_transport_categories:
+      - AUTHENTICATED
+      - GRANTED_PRIVILEGES
 ```
 {% include copy.html %}
 


### PR DESCRIPTION
### Description

Adds public documentation for the new `CLUSTER_SETTINGS_CHANGED` and `INDEX_SETTINGS_CHANGED` audit log categories introduced in https://github.com/opensearch-project/security/pull/6113.

### Changes

- **`_security/audit-logs/index.md`**: Added the two new categories to the tracked events table and documented that they are disabled by default on the transport layer with instructions on how to enable them.
- **`_security/audit-logs/field-reference.md`**: Added field reference sections for both categories, including the `audit_settings_changes` array structure with sub-fields (`setting`, `old_value`, `new_value`, `operation`, `scope`). Updated the `audit_category` common attribute to list the new categories.

### Issues Resolved

Documents https://github.com/opensearch-project/security/pull/6113

### Check List
- [x] Commits are signed per the DCO using `--signoff`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).