### PR TITLE
Add a 5th level of navigation to the site

### DIFF
--- a/FORMATTING_GUIDE.md
+++ b/FORMATTING_GUIDE.md
@@ -46,11 +46,11 @@ nav_order: 25
 has_children: false
 parent: Date field types
 grand_parent: Supported field types
-grand_grand_parent: Mappings
+great_grand_parent: Mappings
 ---
 ```
 
-If you want to reorganize content or add a new page, make sure to set the appropriate `has_children`, `parent`, `grand_parent`, `grand_grand_parent`, and `nav_order` variables, which define the hierarchy of pages in the left navigation.
+If you want to reorganize content or add a new page, make sure to set the appropriate `has_children`, `parent`, `grand_parent`, `great_grand_parent`, and `nav_order` variables, which define the hierarchy of pages in the left navigation.
 
 When adding a page or a section, make the `nav_order` of the child pages multiples of 10. For example, if you have a parent page `Clients`, make child pages `Java`, `Python`, and `JavaScript` have a `nav_order` of 10, 20, and 30, respectively. Doing so makes inserting additional child pages easier because it does not require you to renumber existing pages.
 

--- a/FORMATTING_GUIDE.md
+++ b/FORMATTING_GUIDE.md
@@ -46,10 +46,11 @@ nav_order: 25
 has_children: false
 parent: Date field types
 grand_parent: Supported field types
+grand_grand_parent: Mappings
 ---
 ```
 
-If you want to reorganize content or add a new page, make sure to set the appropriate `has_children`, `parent`, `grand_parent`, and `nav_order` variables, which define the hierarchy of pages in the left navigation. 
+If you want to reorganize content or add a new page, make sure to set the appropriate `has_children`, `parent`, `grand_parent`, `grand_grand_parent`, and `nav_order` variables, which define the hierarchy of pages in the left navigation.
 
 When adding a page or a section, make the `nav_order` of the child pages multiples of 10. For example, if you have a parent page `Clients`, make child pages `Java`, `Python`, and `JavaScript` have a `nav_order` of 10, 20, and 30, respectively. Doing so makes inserting additional child pages easier because it does not require you to renumber existing pages.
 

--- a/_dashboards/visualize/index.md
+++ b/_dashboards/visualize/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Building data visualizations
 nav_order: 30
-has_children: false
+has_children: true
 has_toc: false
 redirect_from:
   - /dashboards/visualize/

--- a/_dashboards/visualize/visualization-editor/area-chart.md
+++ b/_dashboards/visualize/visualization-editor/area-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Area chart
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 10
 ---
 

--- a/_dashboards/visualize/visualization-editor/bar-chart.md
+++ b/_dashboards/visualize/visualization-editor/bar-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Bar chart
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 15
 ---
 

--- a/_dashboards/visualize/visualization-editor/bar-gauge-chart.md
+++ b/_dashboards/visualize/visualization-editor/bar-gauge-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Bar gauge chart
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 20
 ---
 

--- a/_dashboards/visualize/visualization-editor/configuring-visualizations/index.md
+++ b/_dashboards/visualize/visualization-editor/configuring-visualizations/index.md
@@ -2,6 +2,7 @@
 layout: default
 title: Configuring visualizations
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 90
 has_children: true
 has_toc: false

--- a/_dashboards/visualize/visualization-editor/configuring-visualizations/thresholds.md
+++ b/_dashboards/visualize/visualization-editor/configuring-visualizations/thresholds.md
@@ -3,7 +3,7 @@ layout: default
 title: Thresholds
 parent: Configuring visualizations
 grand_parent: Creating visualizations using queries
-grand_grand_parent: Building data visualizations
+great_grand_parent: Building data visualizations
 nav_order: 10
 ---
 

--- a/_dashboards/visualize/visualization-editor/configuring-visualizations/thresholds.md
+++ b/_dashboards/visualize/visualization-editor/configuring-visualizations/thresholds.md
@@ -3,6 +3,7 @@ layout: default
 title: Thresholds
 parent: Configuring visualizations
 grand_parent: Creating visualizations using queries
+grand_grand_parent: Building data visualizations
 nav_order: 10
 ---
 

--- a/_dashboards/visualize/visualization-editor/configuring-visualizations/value-calculations.md
+++ b/_dashboards/visualize/visualization-editor/configuring-visualizations/value-calculations.md
@@ -3,7 +3,7 @@ layout: default
 title: Value calculations
 parent: Configuring visualizations
 grand_parent: Creating visualizations using queries
-grand_grand_parent: Building data visualizations
+great_grand_parent: Building data visualizations
 nav_order: 20
 ---
 

--- a/_dashboards/visualize/visualization-editor/configuring-visualizations/value-calculations.md
+++ b/_dashboards/visualize/visualization-editor/configuring-visualizations/value-calculations.md
@@ -3,6 +3,7 @@ layout: default
 title: Value calculations
 parent: Configuring visualizations
 grand_parent: Creating visualizations using queries
+grand_grand_parent: Building data visualizations
 nav_order: 20
 ---
 

--- a/_dashboards/visualize/visualization-editor/dashboard-variables/index.md
+++ b/_dashboards/visualize/visualization-editor/dashboard-variables/index.md
@@ -5,6 +5,7 @@ has_children: true
 has_toc: false
 nav_order: 100
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 redirect_from:
   - /dashboards/visualize/visualization-editor/dashboard-variables/
 ---

--- a/_dashboards/visualize/visualization-editor/dashboard-variables/managing-variables.md
+++ b/_dashboards/visualize/visualization-editor/dashboard-variables/managing-variables.md
@@ -3,6 +3,7 @@ layout: default
 title: Managing dashboard variables
 parent: Dashboard variables
 grand_parent: Creating visualizations using queries
+grand_grand_parent: Building data visualizations
 nav_order: 10
 ---
 

--- a/_dashboards/visualize/visualization-editor/dashboard-variables/managing-variables.md
+++ b/_dashboards/visualize/visualization-editor/dashboard-variables/managing-variables.md
@@ -3,7 +3,7 @@ layout: default
 title: Managing dashboard variables
 parent: Dashboard variables
 grand_parent: Creating visualizations using queries
-grand_grand_parent: Building data visualizations
+great_grand_parent: Building data visualizations
 nav_order: 10
 ---
 

--- a/_dashboards/visualize/visualization-editor/dashboard-variables/using-variables.md
+++ b/_dashboards/visualize/visualization-editor/dashboard-variables/using-variables.md
@@ -3,6 +3,7 @@ layout: default
 title: Using dashboard variables
 parent: Dashboard variables
 grand_parent: Creating visualizations using queries
+grand_grand_parent: Building data visualizations
 nav_order: 20
 ---
 

--- a/_dashboards/visualize/visualization-editor/dashboard-variables/using-variables.md
+++ b/_dashboards/visualize/visualization-editor/dashboard-variables/using-variables.md
@@ -3,7 +3,7 @@ layout: default
 title: Using dashboard variables
 parent: Dashboard variables
 grand_parent: Creating visualizations using queries
-grand_grand_parent: Building data visualizations
+great_grand_parent: Building data visualizations
 nav_order: 20
 ---
 

--- a/_dashboards/visualize/visualization-editor/gauge-chart.md
+++ b/_dashboards/visualize/visualization-editor/gauge-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Gauge chart
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 25
 ---
 

--- a/_dashboards/visualize/visualization-editor/heatmap-chart.md
+++ b/_dashboards/visualize/visualization-editor/heatmap-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Heatmap
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 30
 ---
 

--- a/_dashboards/visualize/visualization-editor/histogram-chart.md
+++ b/_dashboards/visualize/visualization-editor/histogram-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Histogram
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 35
 ---
 

--- a/_dashboards/visualize/visualization-editor/index.md
+++ b/_dashboards/visualize/visualization-editor/index.md
@@ -2,6 +2,8 @@
 layout: default
 title: Creating visualizations using queries
 nav_order: 50
+parent: Building data visualizations
+grand_parent: OpenSearch Dashboards
 has_children: true
 has_toc: false
 redirect_from:

--- a/_dashboards/visualize/visualization-editor/line-chart.md
+++ b/_dashboards/visualize/visualization-editor/line-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Line chart
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 40
 ---
 

--- a/_dashboards/visualize/visualization-editor/metric-chart.md
+++ b/_dashboards/visualize/visualization-editor/metric-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Metric chart
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 45
 ---
 

--- a/_dashboards/visualize/visualization-editor/pie-chart.md
+++ b/_dashboards/visualize/visualization-editor/pie-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Pie chart
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 50
 ---
 

--- a/_dashboards/visualize/visualization-editor/scatter-chart.md
+++ b/_dashboards/visualize/visualization-editor/scatter-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Scatter plot
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 55
 ---
 

--- a/_dashboards/visualize/visualization-editor/state-timeline-chart.md
+++ b/_dashboards/visualize/visualization-editor/state-timeline-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: State timeline
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 60
 ---
 

--- a/_dashboards/visualize/visualization-editor/table-chart.md
+++ b/_dashboards/visualize/visualization-editor/table-chart.md
@@ -2,6 +2,7 @@
 layout: default
 title: Table
 parent: Creating visualizations using queries
+grand_parent: Building data visualizations
 nav_order: 65
 ---
 

--- a/_dashboards/visualize/visualize-app/area.md
+++ b/_dashboards/visualize/visualize-app/area.md
@@ -2,6 +2,7 @@
 layout: default
 title: Area charts
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 30
 redirect_from:
   - /dashboards/visualize/area/

--- a/_dashboards/visualize/visualize-app/bar-charts.md
+++ b/_dashboards/visualize/visualize-app/bar-charts.md
@@ -2,6 +2,7 @@
 layout: default
 title: Bar charts
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 40
 redirect_from:
   - /dashboards/visualize/bar-charts/

--- a/_dashboards/visualize/visualize-app/configuring-maps.md
+++ b/_dashboards/visualize/visualize-app/configuring-maps.md
@@ -2,6 +2,7 @@
 layout: default
 title: Configuring maps
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 has_children: true
 has_toc: false
 nav_order: 210

--- a/_dashboards/visualize/visualize-app/configuring-viz.md
+++ b/_dashboards/visualize/visualize-app/configuring-viz.md
@@ -2,6 +2,7 @@
 layout: default
 title: Configuring visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 200
 redirect_from:
   - /dashboards/visualize/viz-tool-ref/

--- a/_dashboards/visualize/visualize-app/controls.md
+++ b/_dashboards/visualize/visualize-app/controls.md
@@ -2,6 +2,7 @@
 layout: default
 title: Controls
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 50
 redirect_from:
   - /dashboards/visualize/controls/

--- a/_dashboards/visualize/visualize-app/coordinate-maps.md
+++ b/_dashboards/visualize/visualize-app/coordinate-maps.md
@@ -2,6 +2,7 @@
 layout: default
 title: Coordinate maps
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 55
 redirect_from:
   - /dashboards/visualize/coordinate-maps/

--- a/_dashboards/visualize/visualize-app/data-table.md
+++ b/_dashboards/visualize/visualize-app/data-table.md
@@ -2,6 +2,7 @@
 layout: default
 title: Data tables
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 60
 redirect_from:
   - /dashboards/visualize/data-table/

--- a/_dashboards/visualize/visualize-app/gauge.md
+++ b/_dashboards/visualize/visualize-app/gauge.md
@@ -2,6 +2,7 @@
 layout: default
 title: Gauge visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 70
 redirect_from:
   - /dashboards/visualize/gauge/

--- a/_dashboards/visualize/visualize-app/goal.md
+++ b/_dashboards/visualize/visualize-app/goal.md
@@ -2,6 +2,7 @@
 layout: default
 title: Goal visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 80
 redirect_from:
   - /dashboards/visualize/goal/

--- a/_dashboards/visualize/visualize-app/heat-map.md
+++ b/_dashboards/visualize/visualize-app/heat-map.md
@@ -2,6 +2,7 @@
 layout: default
 title: Heat maps
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 90
 redirect_from:
   - /dashboards/visualize/heat-map/

--- a/_dashboards/visualize/visualize-app/index.md
+++ b/_dashboards/visualize/visualize-app/index.md
@@ -2,6 +2,8 @@
 layout: default
 title: Creating visualizations in the Visualize application
 nav_order: 40
+parent: Building data visualizations
+grand_parent: OpenSearch Dashboards
 has_children: true
 has_toc: false
 redirect_from:

--- a/_dashboards/visualize/visualize-app/line-charts.md
+++ b/_dashboards/visualize/visualize-app/line-charts.md
@@ -2,6 +2,7 @@
 layout: default
 title: Line charts
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 100
 redirect_from:
   - /dashboards/visualize/line-charts/

--- a/_dashboards/visualize/visualize-app/maps-stats-api.md
+++ b/_dashboards/visualize/visualize-app/maps-stats-api.md
@@ -3,7 +3,7 @@ layout: default
 title: Maps Stats API
 nav_order: 20
 grand_parent: Creating visualizations in the Visualize application
-grand_grand_parent: Building data visualizations
+great_grand_parent: Building data visualizations
 parent: Maps application
 has_children: false
 redirect_from:

--- a/_dashboards/visualize/visualize-app/maps-stats-api.md
+++ b/_dashboards/visualize/visualize-app/maps-stats-api.md
@@ -3,6 +3,7 @@ layout: default
 title: Maps Stats API
 nav_order: 20
 grand_parent: Creating visualizations in the Visualize application
+grand_grand_parent: Building data visualizations
 parent: Maps application
 has_children: false
 redirect_from:

--- a/_dashboards/visualize/visualize-app/maps.md
+++ b/_dashboards/visualize/visualize-app/maps.md
@@ -2,6 +2,7 @@
 layout: default
 title: Maps application
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 has_children: true
 has_toc: false
 nav_order: 105

--- a/_dashboards/visualize/visualize-app/maptiles.md
+++ b/_dashboards/visualize/visualize-app/maptiles.md
@@ -3,6 +3,7 @@ layout: default
 title: Configuring a Web Map Service (WMS)
 parent: Configuring maps
 grand_parent: Creating visualizations in the Visualize application
+grand_grand_parent: Building data visualizations
 nav_order: 30
 redirect_from:
   - /dashboards/visualize/maptiles/

--- a/_dashboards/visualize/visualize-app/maptiles.md
+++ b/_dashboards/visualize/visualize-app/maptiles.md
@@ -3,7 +3,7 @@ layout: default
 title: Configuring a Web Map Service (WMS)
 parent: Configuring maps
 grand_parent: Creating visualizations in the Visualize application
-grand_grand_parent: Building data visualizations
+great_grand_parent: Building data visualizations
 nav_order: 30
 redirect_from:
   - /dashboards/visualize/maptiles/

--- a/_dashboards/visualize/visualize-app/markdown.md
+++ b/_dashboards/visualize/visualize-app/markdown.md
@@ -2,6 +2,7 @@
 layout: default
 title: Markdown visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 110
 redirect_from:
   - /dashboards/visualize/markdown/

--- a/_dashboards/visualize/visualize-app/metric.md
+++ b/_dashboards/visualize/visualize-app/metric.md
@@ -2,6 +2,7 @@
 layout: default
 title: Metric visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 120
 redirect_from:
   - /dashboards/visualize/metric/

--- a/_dashboards/visualize/visualize-app/pie-charts.md
+++ b/_dashboards/visualize/visualize-app/pie-charts.md
@@ -2,6 +2,7 @@
 layout: default
 title: Pie charts
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 130
 redirect_from:
   - /dashboards/visualize/pie-charts/

--- a/_dashboards/visualize/visualize-app/ppl.md
+++ b/_dashboards/visualize/visualize-app/ppl.md
@@ -2,6 +2,7 @@
 layout: default
 title: PPL visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 140
 redirect_from:
   - /dashboards/visualize/ppl/

--- a/_dashboards/visualize/visualize-app/region-maps.md
+++ b/_dashboards/visualize/visualize-app/region-maps.md
@@ -2,6 +2,7 @@
 layout: default
 title: Region maps
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 145
 redirect_from:
   - /dashboards/visualize/region-maps/

--- a/_dashboards/visualize/visualize-app/selfhost-maps-server.md
+++ b/_dashboards/visualize/visualize-app/selfhost-maps-server.md
@@ -3,6 +3,7 @@ layout: default
 title: Using self-hosted map servers
 parent: Configuring maps
 grand_parent: Creating visualizations in the Visualize application
+grand_grand_parent: Building data visualizations
 nav_order: 40
 redirect_from:
   - /dashboards/visualize/selfhost-maps-server/

--- a/_dashboards/visualize/visualize-app/selfhost-maps-server.md
+++ b/_dashboards/visualize/visualize-app/selfhost-maps-server.md
@@ -3,7 +3,7 @@ layout: default
 title: Using self-hosted map servers
 parent: Configuring maps
 grand_parent: Creating visualizations in the Visualize application
-grand_grand_parent: Building data visualizations
+great_grand_parent: Building data visualizations
 nav_order: 40
 redirect_from:
   - /dashboards/visualize/selfhost-maps-server/

--- a/_dashboards/visualize/visualize-app/tag-cloud.md
+++ b/_dashboards/visualize/visualize-app/tag-cloud.md
@@ -2,6 +2,7 @@
 layout: default
 title: Tag clouds
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 150
 redirect_from:
   - /dashboards/visualize/tag-cloud/

--- a/_dashboards/visualize/visualize-app/timeline.md
+++ b/_dashboards/visualize/visualize-app/timeline.md
@@ -2,6 +2,7 @@
 layout: default
 title: Timeline visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 160
 redirect_from:
   - /dashboards/visualize/timeline/

--- a/_dashboards/visualize/visualize-app/tsvb.md
+++ b/_dashboards/visualize/visualize-app/tsvb.md
@@ -2,6 +2,7 @@
 layout: default
 title: TSVB visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 170
 redirect_from:
   - /dashboards/visualize/tsvb/

--- a/_dashboards/visualize/visualize-app/vega.md
+++ b/_dashboards/visualize/visualize-app/vega.md
@@ -2,6 +2,7 @@
 layout: default
 title: Vega visualizations
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 180
 redirect_from:
   - /dashboards/visualize/vega/

--- a/_dashboards/visualize/visualize-app/visbuilder.md
+++ b/_dashboards/visualize/visualize-app/visbuilder.md
@@ -2,6 +2,7 @@
 layout: default
 title: VisBuilder
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 190
 redirect_from:
   - /dashboards/visualize/visbuilder/

--- a/_dashboards/visualize/visualize-app/viz-types.md
+++ b/_dashboards/visualize/visualize-app/viz-types.md
@@ -2,6 +2,7 @@
 layout: default
 title: Choosing a visualization type
 parent: Creating visualizations in the Visualize application
+grand_parent: Building data visualizations
 nav_order: 5
 has_toc: false
 redirect_from:

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -49,6 +49,7 @@
 {%- assign current_url = page.url -%}
 {%- assign current_parent = page.parent -%}
 {%- assign current_grand_parent = page.grand_parent -%}
+{%- assign current_grand_grand_parent = page.grand_grand_parent -%}
 
 <ul 
   role="tree" 
@@ -63,7 +64,7 @@
       {%- comment -%}Optimized ancestor checking{%- endcomment -%}
       {%- assign is_ancestor = false -%}
       {%- if current_collection == include.key -%}
-        {%- if current_url == node.url or current_parent == node.title or current_grand_parent == node.title -%}
+        {%- if current_url == node.url or current_parent == node.title or current_grand_parent == node.title or current_grand_grand_parent == node.title -%}
           {%- assign is_ancestor = true -%}
         {%- endif -%}
       {%- endif -%}
@@ -92,7 +93,7 @@
           {%- for child in children_list -%}
             {%- unless child.nav_exclude -%}
             {%- assign child_is_ancestor = false -%}
-            {%- if current_url == child.url or current_parent == child.title -%}
+            {%- if current_url == child.url or current_parent == child.title or current_grand_parent == child.title or current_grand_grand_parent == child.title -%}
               {%- assign child_is_ancestor = true -%}
             {%- endif -%}
             <li role="none" class="nav-list-item{% if child_is_ancestor %} active{% endif %}">
@@ -119,7 +120,7 @@
                 {%- for grand_child in grand_children_list -%}
                   {%- unless grand_child.nav_exclude -%}
                   {%- assign grand_child_is_ancestor = false -%}
-                  {%- if current_url == grand_child.url or current_parent == grand_child.title -%}
+                  {%- if current_url == grand_child.url or current_parent == grand_child.title or current_grand_parent == grand_child.title -%}
                     {%- assign grand_child_is_ancestor = true -%}
                   {%- endif -%}
                   <li role="none" class="nav-list-item{% if grand_child_is_ancestor %} active{% endif %}">
@@ -140,17 +141,49 @@
                       class="nav-list-link{% if current_url == grand_child.url %} active{% endif %}"
                     >{{ grand_child.title }}</a>
                     {%- if grand_child.has_children -%}
-                      {%- assign great_grand_children_list = pages_list | where: "parent", grand_child.title -%}
+                      {%- assign great_grand_children_list = pages_list | where: "parent", grand_child.title | where: "grand_parent", child.title -%}
                       <ul role="tree" class="nav-list" id="{{ nested_nested_nested_owned_tree_id }}">
                       {%- for great_grand_child in great_grand_children_list -%}
                         {%- unless great_grand_child.nav_exclude -%}
-                        <li role="none" class="nav-list-item {% if current_url == great_grand_child.url %} active{% endif %}">
+                        {%- assign nested_nested_nested_nested_owned_tree_id = nested_nested_nested_owned_tree_id | append: "_" | append: forloop.index | append: "_" | append: great_grand_child.title | append: "_navitems" | replace: " ", "_" -%}
+                        {%- assign great_grand_child_is_ancestor = false -%}
+                        {%- if current_url == great_grand_child.url or current_parent == great_grand_child.title -%}
+                          {%- assign great_grand_child_is_ancestor = true -%}
+                        {%- endif -%}
+                        <li role="none" class="nav-list-item{% if great_grand_child_is_ancestor %} active{% endif %}">
+                          {%- if great_grand_child.has_children -%}
+                            <a
+                              role="treeitem"
+                              aria-owns="{{ nested_nested_nested_nested_owned_tree_id }}"
+                              {%- if current_url == great_grand_child.url -%}aria-current="page"{%- endif -%}
+                              href="#"
+                              class="nav-list-expander"
+                            ><svg viewBox="0 0 24 24"><use xlink:href="#svg-arrow-right"></use></svg></a>
+                          {%- endif -%}
                           <a
                             role="treeitem"
+                            {%- if great_grand_child.has_children -%}aria-owns="{{ nested_nested_nested_nested_owned_tree_id }}"{%- endif -%}
                             {%- if current_url == great_grand_child.url -%}aria-current="page"{%- endif -%}
-                            href="{{ great_grand_child.url | absolute_url }}" 
+                            href="{{ great_grand_child.url | absolute_url }}"
                             class="nav-list-link{% if current_url == great_grand_child.url %} active{% endif %}"
                           >{{ great_grand_child.title }}</a>
+                          {%- if great_grand_child.has_children -%}
+                            {%- assign great_great_grand_children_list = pages_list | where: "parent", great_grand_child.title | where: "grand_parent", grand_child.title -%}
+                            <ul role="tree" class="nav-list" id="{{ nested_nested_nested_nested_owned_tree_id }}">
+                            {%- for great_great_grand_child in great_great_grand_children_list -%}
+                              {%- unless great_great_grand_child.nav_exclude -%}
+                              <li role="none" class="nav-list-item{% if current_url == great_great_grand_child.url %} active{% endif %}">
+                                <a
+                                  role="treeitem"
+                                  {%- if current_url == great_great_grand_child.url -%}aria-current="page"{%- endif -%}
+                                  href="{{ great_great_grand_child.url | absolute_url }}"
+                                  class="nav-list-link{% if current_url == great_great_grand_child.url %} active{% endif %}"
+                                >{{ great_great_grand_child.title }}</a>
+                              </li>
+                              {%- endunless -%}
+                            {%- endfor -%}
+                            </ul>
+                          {%- endif -%}
                         </li>
                         {%- endunless -%}
                       {%- endfor -%}

--- a/_includes/nav.html
+++ b/_includes/nav.html
@@ -49,7 +49,7 @@
 {%- assign current_url = page.url -%}
 {%- assign current_parent = page.parent -%}
 {%- assign current_grand_parent = page.grand_parent -%}
-{%- assign current_grand_grand_parent = page.grand_grand_parent -%}
+{%- assign current_great_grand_parent = page.great_grand_parent -%}
 
 <ul 
   role="tree" 
@@ -64,7 +64,7 @@
       {%- comment -%}Optimized ancestor checking{%- endcomment -%}
       {%- assign is_ancestor = false -%}
       {%- if current_collection == include.key -%}
-        {%- if current_url == node.url or current_parent == node.title or current_grand_parent == node.title or current_grand_grand_parent == node.title -%}
+        {%- if current_url == node.url or current_parent == node.title or current_grand_parent == node.title or current_great_grand_parent == node.title -%}
           {%- assign is_ancestor = true -%}
         {%- endif -%}
       {%- endif -%}
@@ -93,7 +93,7 @@
           {%- for child in children_list -%}
             {%- unless child.nav_exclude -%}
             {%- assign child_is_ancestor = false -%}
-            {%- if current_url == child.url or current_parent == child.title or current_grand_parent == child.title or current_grand_grand_parent == child.title -%}
+            {%- if current_url == child.url or current_parent == child.title or current_grand_parent == child.title or current_great_grand_parent == child.title -%}
               {%- assign child_is_ancestor = true -%}
             {%- endif -%}
             <li role="none" class="nav-list-item{% if child_is_ancestor %} active{% endif %}">

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -202,8 +202,8 @@ layout: table_wrappers
 
                   {%- comment -%}Collect ancestor titles (deepest ancestor first){%- endcomment -%}
                   {%- assign breadcrumb_titles = "" | split: "" -%}
-                  {%- if page.grand_grand_parent -%}
-                    {%- assign breadcrumb_titles = breadcrumb_titles | push: page.grand_grand_parent -%}
+                  {%- if page.great_grand_parent -%}
+                    {%- assign breadcrumb_titles = breadcrumb_titles | push: page.great_grand_parent -%}
                   {%- endif -%}
                   {%- if page.grand_parent -%}
                     {%- assign breadcrumb_titles = breadcrumb_titles | push: page.grand_parent -%}

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -191,75 +191,35 @@ layout: table_wrappers
                   {% endif %}
                 {% endif %}
                 {% if page.parent %}
-                  {% if page.grand_parent %}
-                  {%- comment -%}Find URLs for 4-level breadcrumb{%- endcomment -%}
+                  {%- comment -%}Build page list for URL lookups{%- endcomment -%}
                   {%- assign all_pages = site.pages -%}
-                  
-                  {%- comment -%}Add collection pages based on current page collection{%- endcomment -%}
                   {%- if page.collection -%}
                     {%- assign current_collection = site[page.collection] -%}
                     {%- if current_collection -%}
                       {%- assign all_pages = all_pages | concat: current_collection -%}
                     {%- endif -%}
                   {%- endif -%}
-                  
-                  {%- assign grandparent_url = "" -%}
-                  {%- assign parent_url = "" -%}
-                  
-                  {%- for p in all_pages -%}
-                    {%- if p.title == page.grand_parent -%}
-                      {%- assign grandparent_url = p.url | relative_url -%}
-                    {%- elsif p.title == page.parent -%}
-                      {%- assign parent_url = p.url | relative_url -%}
-                    {%- endif -%}
-                  {%- endfor -%}
-                  
-                  {%- comment -%}Find great-grandparent by looking at grandparent's parent{%- endcomment -%}
-                  {%- assign great_grandparent_url = "" -%}
-                  {%- assign great_grandparent_title = "" -%}
-                  {%- for p in all_pages -%}
-                    {%- if p.title == page.grand_parent and p.parent -%}
-                      {%- assign great_grandparent_title = p.parent -%}
-                      {%- break -%}
-                    {%- endif -%}
-                  {%- endfor -%}
-                  
-                  {%- if great_grandparent_title != "" -%}
+
+                  {%- comment -%}Collect ancestor titles (deepest ancestor first){%- endcomment -%}
+                  {%- assign breadcrumb_titles = "" | split: "" -%}
+                  {%- if page.grand_grand_parent -%}
+                    {%- assign breadcrumb_titles = breadcrumb_titles | push: page.grand_grand_parent -%}
+                  {%- endif -%}
+                  {%- if page.grand_parent -%}
+                    {%- assign breadcrumb_titles = breadcrumb_titles | push: page.grand_parent -%}
+                  {%- endif -%}
+                  {%- assign breadcrumb_titles = breadcrumb_titles | push: page.parent -%}
+
+                  {%- for crumb_title in breadcrumb_titles -%}
+                    {%- assign crumb_url = "" -%}
                     {%- for p in all_pages -%}
-                      {%- if p.title == great_grandparent_title -%}
-                        {%- assign great_grandparent_url = p.url | relative_url -%}
+                      {%- if p.title == crumb_title and p.collection == page.collection -%}
+                        {%- assign crumb_url = p.url | relative_url -%}
                         {%- break -%}
                       {%- endif -%}
                     {%- endfor -%}
-                  {%- endif -%}
-                  
-                  {%- if great_grandparent_title != "" and great_grandparent_url != "" -%}
-                    <li class="breadcrumb-nav-list-item"><a href="{{ great_grandparent_url }}">{{ great_grandparent_title }}</a></li>
-                  {%- endif -%}
-                    <li class="breadcrumb-nav-list-item"><a href="{{ grandparent_url }}">{{ page.grand_parent }}</a></li>
-                    <li class="breadcrumb-nav-list-item"><a href="{{ parent_url }}">{{ page.parent }}</a></li>
-                  {% else %}
-                  {%- comment -%}Find parent URL for 2-level breadcrumb{%- endcomment -%}
-                  {%- assign all_pages = site.pages -%}
-                  
-                  {%- comment -%}Add collection pages based on current page collection{%- endcomment -%}
-                  {%- if page.collection -%}
-                    {%- assign current_collection = site[page.collection] -%}
-                    {%- if current_collection -%}
-                      {%- assign all_pages = all_pages | concat: current_collection -%}
-                    {%- endif -%}
-                  {%- endif -%}
-                  
-                  {%- assign parent_url = "" -%}
-                  {%- for p in all_pages -%}
-                    {%- if p.title == page.parent -%}
-                      {%- assign parent_url = p.url | relative_url -%}
-                      {%- break -%}
-                    {%- endif -%}
+                    <li class="breadcrumb-nav-list-item"><a href="{{ crumb_url }}">{{ crumb_title }}</a></li>
                   {%- endfor -%}
-
-                    <li class="breadcrumb-nav-list-item"><a href="{{ parent_url }}">{{ page.parent }}</a></li>
-                  {% endif %}
                 {% endif %}
                 <li class="breadcrumb-nav-list-item"><span>{{ page.title }}</span></li>
               </ol>


### PR DESCRIPTION
Adds a 5th level of navigation to the site. Now pages can have great grandparents. Updates the Dasbhoards' Visualization section to the correct hierarchy now that 5 levels are available. Also updates the formatting guide with the new variable.

Site build times did not regress: before 234 sec, after 238 sec, so essentially the same.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
