### PR TITLE
Add more explicit explanations about Operator instructions

### DIFF
--- a/_install-and-configure/install-opensearch/operator/index.md
+++ b/_install-and-configure/install-opensearch/operator/index.md
@@ -83,6 +83,9 @@ Follow these steps to deploy the cluster, verify that it is running, access it, 
     ```
     {% include copy.html %}
 
+    This example deploys a cluster without security enabled. To configure TLS and security for production use, see [Configuring security]({{site.url}}{{site.baseurl}}/install-and-configure/install-opensearch/operator/operator-security/).
+    {: .note}
+
 1. Create the cluster by running the following command:
 
     ```bash

--- a/_install-and-configure/install-opensearch/operator/operator-security.md
+++ b/_install-and-configure/install-opensearch/operator/operator-security.md
@@ -237,7 +237,7 @@ internal_users.yml: |-
 ```
 {% include copy.html %}
 
-Add the security configuration to your cluster `spec`:
+Add the following security configuration to your `cluster.yaml` file:
 
 ```yaml
 security:
@@ -253,6 +253,9 @@ security:
       generate: true
 ```
 {% include copy.html %}
+
+At a minimum, the `security.tls` section is required for the cluster to start with security enabled. Setting `generate: true` for both `transport` and `http` instructs the operator to automatically generate the required TLS certificates. The operator also automatically creates the admin and OpenSearch Dashboards credentials secrets (`<cluster-name>-admin-password` and `<cluster-name>-dashboards-password`) when they are not explicitly specified.
+{: .note}
 
 ### Changing the admin password
 


### PR DESCRIPTION
Add more explicit explanations about Operator instructions, specifying that the index page example is running without security and explaining the minimum required security block in the security file.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
