### PR TITLE
Refactor query DSL documentation

### DIFF
--- a/_query-dsl/ai-vector-search/index.md
+++ b/_query-dsl/ai-vector-search/index.md
@@ -1,0 +1,21 @@
+---
+layout: default
+title: AI and vector search queries
+has_children: true
+nav_order: 55
+has_toc: false
+redirect_from:
+  - /query-dsl/ai-vector-search/
+---
+
+# AI and vector search queries
+
+AI and vector search queries use machine learning models to transform or enhance search operations. These queries convert text or other input into vector representations for similarity search, or use AI services to generate query parameters at runtime.
+
+| Query type | Description |
+| :--- | :--- |
+| [Agentic]({{site.url}}{{site.baseurl}}/query-dsl/specialized/agentic/) | Uses AI agents to dynamically plan and execute search strategies. |
+| [k-NN]({{site.url}}{{site.baseurl}}/query-dsl/specialized/k-nn/) | Performs approximate or exact nearest-neighbor search using vector embeddings. |
+| [Neural]({{site.url}}{{site.baseurl}}/query-dsl/specialized/neural/) | Converts text to dense vector embeddings at query time for semantic search. |
+| [Neural sparse]({{site.url}}{{site.baseurl}}/query-dsl/specialized/neural-sparse/) | Converts text to sparse vector embeddings at query time for semantic search. |
+| [Template]({{site.url}}{{site.baseurl}}/query-dsl/specialized/template/) | Contains placeholder variables resolved by ML inference processors at query time. |

--- a/_query-dsl/compound/index.md
+++ b/_query-dsl/compound/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Compound queries
 has_children: true
 has_toc: false
-nav_order: 40
+nav_order: 50
 redirect_from:
   - /opensearch/query-dsl/compound/index/
   - /query-dsl/query-dsl/compound/

--- a/_query-dsl/geo-and-xy/index.md
+++ b/_query-dsl/geo-and-xy/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Geographic and xy queries
 has_children: true
-nav_order: 50
+nav_order: 65
 redirect_from:
    - /opensearch/query-dsl/geo-and-xy/index/
    - /query-dsl/query-dsl/geo-and-xy/
@@ -28,9 +28,9 @@ Geographic queries search for documents that contain geospatial geometries. Thes
 
 OpenSearch provides the following geographic query types:
 
-- [**Geo-bounding box queries**]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/geo-and-xy/geo-bounding-box/): Return documents with geopoint field values that are within a bounding box. 
-- [**Geodistance queries**]({{site.url}}{{site.baseurl}}/query-dsl/geo-and-xy/geodistance/): Return documents with geopoints that are within a specified distance from the provided geopoint.
-- [**Geopolygon queries**]({{site.url}}{{site.baseurl}}/query-dsl/geo-and-xy/geopolygon/): Return documents containing geopoints that are within a polygon.
-- [**Geoshape queries**]({{site.url}}{{site.baseurl}}/query-dsl/geo-and-xy/geoshape/): Return documents that contain:
-    - Geoshapes and geopoints that have one of four spatial relations to the provided shape: `INTERSECTS`, `DISJOINT`, `WITHIN`, or `CONTAINS`.
-    - Geopoints that intersect the provided shape.
+| Query type | Description |
+| :--- | :--- |
+| [Geo-bounding box]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/geo-and-xy/geo-bounding-box/) | Returns documents with geopoint field values that are within a bounding box. |
+| [Geodistance]({{site.url}}{{site.baseurl}}/query-dsl/geo-and-xy/geodistance/) | Returns documents with geopoints that are within a specified distance from the provided geopoint. |
+| [Geopolygon]({{site.url}}{{site.baseurl}}/query-dsl/geo-and-xy/geopolygon/) | Returns documents containing geopoints that are within a polygon. |
+| [Geoshape]({{site.url}}{{site.baseurl}}/query-dsl/geo-and-xy/geoshape/) | Returns documents containing geoshapes and geopoints that have one of four spatial relations to the provided shape (`INTERSECTS`, `DISJOINT`, `WITHIN`, or `CONTAINS`) or geopoints that intersect the provided shape. |

--- a/_query-dsl/index.md
+++ b/_query-dsl/index.md
@@ -44,7 +44,7 @@ Broadly, you can classify queries into two categories---*leaf queries* and *comp
 
     - [Geographic and xy queries]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/geo-and-xy/index/): Use geographic queries to search documents that include geographic data. Use xy queries to search documents that include points and shapes in a two-dimensional coordinate system. 
 
-    - Joining queries: Use joining queries to search nested fields or return parent and child documents that match a specific query. Types of joining queries include `nested`, `has_child`, `has_parent`, and `parent_id` queries.
+    - [Joining queries]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/joining/): Use joining queries to search nested fields or return parent and child documents that match a specific query. Types of joining queries include `nested`, `has_child`, `has_parent`, and `parent_id` queries.
 
     - [Span queries]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/span-query/): Use span queries to perform precise positional searches. Span queries are low-level, specific queries that provide control over the order and proximity of specified query terms. They are primarily used to search legal documents. 
 

--- a/_query-dsl/index.md
+++ b/_query-dsl/index.md
@@ -44,7 +44,7 @@ Broadly, you can classify queries into two categories---*leaf queries* and *comp
 
     - [Geographic and xy queries]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/geo-and-xy/index/): Use geographic queries to search documents that include geographic data. Use xy queries to search documents that include points and shapes in a two-dimensional coordinate system. 
 
-    - [Joining queries]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/joining/): Use joining queries to search nested fields or return parent and child documents that match a specific query. Types of joining queries include `nested`, `has_child`, `has_parent`, and `parent_id` queries.
+    - [Joining queries]({{site.url}}{{site.baseurl}}/query-dsl/joining/): Use joining queries to search nested fields or return parent and child documents that match a specific query. Types of joining queries include `nested`, `has_child`, `has_parent`, and `parent_id` queries.
 
     - [Span queries]({{site.url}}{{site.baseurl}}/opensearch/query-dsl/span-query/): Use span queries to perform precise positional searches. Span queries are low-level, specific queries that provide control over the order and proximity of specified query terms. They are primarily used to search legal documents. 
 

--- a/_query-dsl/joining/index.md
+++ b/_query-dsl/joining/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Joining queries
 has_children: true
-nav_order: 55
+nav_order: 70
 has_toc: false
 redirect_from:
   - /query-dsl/joining/
@@ -12,13 +12,12 @@ redirect_from:
 
 OpenSearch is a distributed system in which data is spread across multiple nodes. Thus, running a SQL-like JOIN operation in OpenSearch is resource intensive. As an alternative, OpenSearch provides the following queries that perform join operations and are optimized for scaling across multiple nodes:
 
-
-- Queries for searching [nested]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/nested/) fields:
-    - `nested` queries: Act as wrappers for other queries to search [nested]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/nested/) fields. The nested field objects are searched as though they were indexed as separate documents.
-- Queries for searching documents connected by a [join]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/join/) field type, which establishes a parent/child relationship between documents in the same index:
-    - [`has_child`]({{site.url}}{{site.baseurl}}/query-dsl/joining/has-child/) queries: Search for parent documents whose child documents match the query.
-    - [`has_parent`]({{site.url}}{{site.baseurl}}/query-dsl/joining/has-parent/) queries: Search for child documents whose parent documents match the query.
-    - [`parent_id`]({{site.url}}{{site.baseurl}}/query-dsl/joining/parent-id/) queries: Search for child documents that are joined to a specific parent document. 
+| Query type | Description |
+| :--- | :--- |
+| [`nested`]({{site.url}}{{site.baseurl}}/query-dsl/joining/nested/) | Acts as a wrapper for other queries to search [nested]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/nested/) fields. The nested field objects are searched as though they were indexed as separate documents. |
+| [`has_child`]({{site.url}}{{site.baseurl}}/query-dsl/joining/has-child/) | Searches for parent documents whose child documents match the query. Requires a [join]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/join/) field type. |
+| [`has_parent`]({{site.url}}{{site.baseurl}}/query-dsl/joining/has-parent/) | Searches for child documents whose parent documents match the query. Requires a [join]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/join/) field type. |
+| [`parent_id`]({{site.url}}{{site.baseurl}}/query-dsl/joining/parent-id/) | Searches for child documents that are joined to a specific parent document. Requires a [join]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/join/) field type. |
 
 If [`search.allow_expensive_queries`]({{site.url}}{{site.baseurl}}/query-dsl/index/#expensive-queries) is set to `false`, then joining queries are not executed.
 {: .important}

--- a/_query-dsl/joining/nested.md
+++ b/_query-dsl/joining/nested.md
@@ -2,7 +2,7 @@
 layout: default
 title: Nested
 parent: Joining queries
-nav_order: 30
+nav_order: 5
 ---
 
 # Nested query

--- a/_query-dsl/match-all.md
+++ b/_query-dsl/match-all.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Match all queries
-nav_order: 65
+nav_order: 20
 ---
 
 # Match all queries

--- a/_query-dsl/minimum-should-match.md
+++ b/_query-dsl/minimum-should-match.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Minimum should match
-nav_order: 70
+nav_order: 80
 redirect_from:
 - /query-dsl/query-dsl/minimum-should-match/
 ---

--- a/_query-dsl/regex-syntax.md
+++ b/_query-dsl/regex-syntax.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Regular expression syntax
-nav_order: 100
+nav_order: 95
 ---
 
 # Regular expression syntax

--- a/_query-dsl/rescore.md
+++ b/_query-dsl/rescore.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Rescore
-nav_order: 99
+nav_order: 90
 ---
 
 # Rescore

--- a/_query-dsl/rewrite-parameter.md
+++ b/_query-dsl/rewrite-parameter.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Rewrite
-nav_order: 80
+nav_order: 85
 ---
 
 # Rewrite

--- a/_query-dsl/span/index.md
+++ b/_query-dsl/span/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Span queries
 has_children: true
 has_toc: false
-nav_order: 60
+nav_order: 75
 redirect_from: 
   - /opensearch/query-dsl/span-query/
   - /query-dsl/query-dsl/span-query/
@@ -17,23 +17,17 @@ You can use span queries to perform precise positional searches. Span queries ar
 
 Span queries include the following query types:
 
-- [**Span containing**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-containing/): Returns larger spans that contain smaller spans within them. Useful for finding specific terms or phrases within a broader context. The opposite of `span_within` query.
-
-- [**Span field masking**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-field-masking/): Allows span queries to work across different fields by making one field appear as another. Particularly useful when the same text is indexed using different analyzers.
-
-- [**Span first**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-first/): Matches terms or phrases that appear within a specified number of positions from the start of a field. Useful for finding content at the beginning of text.
-
-- [**Span multi-term**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-multi-term/): Enables multi-term queries (like `prefix`, `wildcard`, or `fuzzy`) to work within span queries. Allows for more flexible matching patterns in span searches.
-
-- [**Span near**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-near/): Finds terms or phrases that appear within a specified distance of each other. You can require matches to appear in a specific order and control how many words can appear between them.
-
-- [**Span not**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-not/): Excludes matches that overlap with another span query. Useful for finding terms when they do not appear in specific phrases or contexts.
-
-- [**Span or**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-or/): Matches documents that satisfy any of the provided span queries. Combines multiple span patterns with OR logic.
-
-- [**Span term**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-term/): The basic building block for span queries. Matches a single term while maintaining position information for use in other span queries.
-
-- [**Span within**]({{site.url}}{{site.baseurl}}/query-dsl/span/span-within/): Returns smaller spans that are enclosed by larger spans. The opposite of the `span_containing` query.
+| Query type | Description |
+| :--- | :--- |
+| [Span containing]({{site.url}}{{site.baseurl}}/query-dsl/span/span-containing/) | Returns larger spans that contain smaller spans within them. The opposite of the `span_within` query. |
+| [Span field masking]({{site.url}}{{site.baseurl}}/query-dsl/span/span-field-masking/) | Allows span queries to work across different fields by making one field appear as another. Useful when the same text is indexed using different analyzers. |
+| [Span first]({{site.url}}{{site.baseurl}}/query-dsl/span/span-first/) | Matches terms or phrases that appear within a specified number of positions from the start of a field. |
+| [Span multi-term]({{site.url}}{{site.baseurl}}/query-dsl/span/span-multi-term/) | Enables multi-term queries (like `prefix`, `wildcard`, or `fuzzy`) to work within span queries. |
+| [Span near]({{site.url}}{{site.baseurl}}/query-dsl/span/span-near/) | Finds terms or phrases that appear within a specified distance of each other. Supports requiring matches to appear in a specific order. |
+| [Span not]({{site.url}}{{site.baseurl}}/query-dsl/span/span-not/) | Excludes matches that overlap with another span query. |
+| [Span or]({{site.url}}{{site.baseurl}}/query-dsl/span/span-or/) | Matches documents that satisfy any of the provided span queries. |
+| [Span term]({{site.url}}{{site.baseurl}}/query-dsl/span/span-term/) | Matches a single term while maintaining position information for use in other span queries. |
+| [Span within]({{site.url}}{{site.baseurl}}/query-dsl/span/span-within/) | Returns smaller spans that are enclosed by larger spans. The opposite of the `span_containing` query. |
 
 ## Setup
 

--- a/_query-dsl/specialized/agentic.md
+++ b/_query-dsl/specialized/agentic.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Agentic
-parent: Specialized queries
+parent: AI and vector search queries
 nav_order: 2
 ---
 

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -2,7 +2,7 @@
 layout: default
 title: Specialized queries
 has_children: true
-nav_order: 65
+nav_order: 60
 has_toc: false
 redirect_from:
   - /query-dsl/specialized/
@@ -10,28 +10,16 @@ redirect_from:
 
 # Specialized queries
 
-OpenSearch supports the following specialized queries:
+Specialized queries provide advanced scoring, filtering, and utility functions beyond standard full-text and term queries.
 
-- [`agentic`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/agentic/): Uses natural language questions that are automatically planned and executed by an agent with a large language model.
+For AI and vector search queries (k-NN, Neural, Neural sparse, Agentic, Template), see [AI and vector search queries]({{site.url}}{{site.baseurl}}/query-dsl/specialized/ai-vector-search/).
 
-- [`distance_feature`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/distance-feature/): Calculates document scores based on the dynamically calculated distance between the origin and a document's `date`, `date_nanos`, or `geo_point` fields. This query can skip non-competitive hits.
-
-- [`knn`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/k-nn/): Used for searching raw vectors during [vector search]({{site.url}}{{site.baseurl}}/vector-search/).
-
-- [`more_like_this`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/more-like-this/): Finds documents similar to the provided text, document, or collection of documents.
-
-- [`neural`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/neural/): Used for searching by text or image in [vector search]({{site.url}}{{site.baseurl}}/search-plugins/neural-search/).
-
-- [`neural_sparse`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/neural-sparse/): Used for vector field search in [sparse neural search]({{site.url}}{{site.baseurl}}/search-plugins/neural-sparse-search/).
-
-- `percolate`: Finds queries (stored as documents) that match the provided document.
-
-- [`rank_feature`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/rank-feature/): Calculates scores based on the values of numeric features. This query can skip non-competitive hits.
-
-- [`script`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script/): Uses a script as a filter.
-
-- [`script_score`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script-score/): Calculates a custom score for matching documents using a script.
-
-- [`template`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/template/): Allows you to use Mustache templating in queries.
-
-- [`wrapper`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/wrapper/): Accepts other queries as JSON or YAML strings.
+| Query type | Description |
+| :--- | :--- |
+| [`distance_feature`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/distance-feature/) | Calculates document scores based on the dynamically calculated distance between the origin and a document's `date`, `date_nanos`, or `geo_point` fields. This query can skip non-competitive hits. |
+| [`more_like_this`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/more-like-this/) | Finds documents similar to the provided text, document, or collection of documents. |
+| [`percolate`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/percolate/) | Finds queries (stored as documents) that match the provided document. |
+| [`rank_feature`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/rank-feature/) | Calculates scores based on the values of numeric features. This query can skip non-competitive hits. |
+| [`script`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script/) | Uses a script as a filter. |
+| [`script_score`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/script-score/) | Calculates a custom score for matching documents using a script. |
+| [`wrapper`]({{site.url}}{{site.baseurl}}/query-dsl/specialized/wrapper/) | Accepts other queries as JSON or YAML strings. |

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -12,7 +12,7 @@ redirect_from:
 
 Specialized queries provide advanced scoring, filtering, and utility functions beyond standard full-text and term queries.
 
-For AI and vector search queries (k-NN, Neural, Neural sparse, Agentic, Template), see [AI and vector search queries]({{site.url}}{{site.baseurl}}/query-dsl/specialized/ai-vector-search/).
+For AI and vector search queries (k-NN, Neural, Neural sparse, Agentic, Template), see [AI and vector search queries]({{site.url}}{{site.baseurl}}/query-dsl/ai-vector-search/).
 
 | Query type | Description |
 | :--- | :--- |

--- a/_query-dsl/specialized/k-nn/index.md
+++ b/_query-dsl/specialized/k-nn/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: k-NN
-parent: Specialized queries
+parent: AI and vector search queries
 has_children: true
 nav_order: 15
 redirect_from:

--- a/_query-dsl/specialized/k-nn/k-nn-explain.md
+++ b/_query-dsl/specialized/k-nn/k-nn-explain.md
@@ -2,7 +2,7 @@
 layout: default
 title: k-NN query explain
 parent: k-NN
-grand_parent: Specialized queries
+grand_parent: AI and vector search queries
 nav_order: 10
 ---
 

--- a/_query-dsl/specialized/neural-sparse/index.md
+++ b/_query-dsl/specialized/neural-sparse/index.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Neural sparse
-parent: Specialized queries
+parent: AI and vector search queries
 has_children: true
 nav_order: 55
 redirect_from:

--- a/_query-dsl/specialized/neural-sparse/neural-sparse-explain.md
+++ b/_query-dsl/specialized/neural-sparse/neural-sparse-explain.md
@@ -2,7 +2,7 @@
 layout: default
 title: Neural sparse ANN explain
 parent: Neural sparse
-grand_parent: Specialized queries
+grand_parent: AI and vector search queries
 nav_order: 10
 ---
 

--- a/_query-dsl/specialized/neural.md
+++ b/_query-dsl/specialized/neural.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Neural
-parent: Specialized queries
+parent: AI and vector search queries
 nav_order: 50
 ---
 

--- a/_query-dsl/specialized/template.md
+++ b/_query-dsl/specialized/template.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: Template
-parent: Specialized queries
+parent: AI and vector search queries
 nav_order: 70
 ---
 
@@ -14,6 +14,9 @@ Use a `template` query to create search queries that contain placeholder variabl
 For example, you might use a template query when working with the [ml_inference search request processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/ml-inference-search-request/), which converts text input into vector embeddings during the search process. The processor will replace the placeholders with the generated values before the final query is executed.
 
 For a complete example, see [Query rewriting using template queries]({{site.url}}{{site.baseurl}}/search-plugins/search-relevance/template-query/).
+
+This page documents the `template` query, which uses placeholder variables resolved by search request processors (such as ML inference) at runtime. If you want to create reusable, parameterized queries using Mustache syntax (`{{variable}}`), see [Search Template API]({{site.url}}{{site.baseurl}}/api-reference/search-apis/search-template/).
+{: .note}
 
 ## Example
 

--- a/_query-dsl/term/index.md
+++ b/_query-dsl/term/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Term-level queries
 has_children: true
 has_toc: false
-nav_order: 20
+nav_order: 40
 redirect_from:
   - /opensearch/query-dsl/term/
   - /query-dsl/term/

--- a/_search-plugins/search-relevance/explore-experiment-results.md
+++ b/_search-plugins/search-relevance/explore-experiment-results.md
@@ -8,7 +8,7 @@ has_children: false
 ---
 
 # Exploring search evaluation results
-Introduced 3.2
+**Introduced 3.2**
 {: .label .label-purple }
 
 In addition to retrieving the experiment results using the API, you can explore the results visually. The Search Relevance Workbench comes with dashboards that you can install to review search evaluation and hybrid search optimization experiment results.

--- a/_search-plugins/search-relevance/regularly-scheduled-experiments.md
+++ b/_search-plugins/search-relevance/regularly-scheduled-experiments.md
@@ -8,7 +8,7 @@ has_children: false
 ---
 
 # Monitoring search quality
-Introduced 3.4
+**Introduced 3.4**
 {: .label .label-purple }
 
 Search quality is not static. Even if your ranking algorithms remain unchanged, the indexed data evolves, signals such as popularity and recency fluctuate, and user queries shift over time.

--- a/_search-plugins/search-relevance/rerank-by-field-cross-encoder.md
+++ b/_search-plugins/search-relevance/rerank-by-field-cross-encoder.md
@@ -8,7 +8,7 @@ nav_order: 30
 ---
 
 # Reranking by a field using an externally hosted cross-encoder model
-Introduced 2.18
+**Introduced 2.18**
 {: .label .label-purple }
 
 In this tutorial, you'll learn how to use a cross-encoder model hosted on Amazon SageMaker to rerank search results and improve search relevance. 

--- a/_search-plugins/search-relevance/rerank-by-field.md
+++ b/_search-plugins/search-relevance/rerank-by-field.md
@@ -8,7 +8,7 @@ nav_order: 20
 ---
 
 # Reranking search results by a field
-Introduced 2.18
+**Introduced 2.18**
 {: .label .label-purple }
 
 You can use a `by_field` rerank type to rerank search results by a document field. Reranking search results by a field is useful if a model has already run and produced a numerical score for your documents or if a previous search response processor was applied and you want to rerank documents differently based on an aggregated field.

--- a/_search-plugins/search-relevance/rerank-cross-encoder.md
+++ b/_search-plugins/search-relevance/rerank-cross-encoder.md
@@ -8,7 +8,7 @@ nav_order: 10
 ---
 
 # Reranking search results using a cross-encoder model
-Introduced 2.12
+**Introduced 2.12**
 {: .label .label-purple }
 
 You can rerank search results using a cross-encoder model in order to improve search relevance. To implement reranking, you need to configure a [search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/index/) that runs at search time. The search pipeline intercepts search results and applies the [`rerank` processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/rerank-processor/) to them. The `rerank` processor evaluates the search results and sorts them based on the new scores provided by the cross-encoder model. 

--- a/_search-plugins/search-relevance/reranking-search-results.md
+++ b/_search-plugins/search-relevance/reranking-search-results.md
@@ -7,7 +7,7 @@ nav_order: 50
 ---
 
 # Reranking search results
-Introduced 2.12
+**Introduced 2.12**
 {: .label .label-purple }
 
 You can rerank search results using a [`rerank` processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/rerank-processor/) in order to improve search relevance. To implement reranking, you need to configure a [search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/index/) that runs at search time. The search pipeline intercepts search results and applies the `rerank` processor to them. The `rerank` processor evaluates the search results and sorts them based on the new scores.

--- a/_search-plugins/search-relevance/template-query.md
+++ b/_search-plugins/search-relevance/template-query.md
@@ -9,7 +9,7 @@ has_toc: false
 ---
 
 # Template queries
-Introduced 2.19
+**Introduced 2.19**
 {: .label .label-purple }
 
 A template query allows you to create queries with dynamic placeholders that are resolved by search request processors during query execution. This is particularly useful when your query parameters need to be generated or transformed during the search process, such as when using machine learning (ML) inference to convert text into vector embeddings.


### PR DESCRIPTION
This PR reorders the pages in the query DSL section and creates a new query category for AI and vector search queries. Additionally, it disambiguates template queries and search template API to avoid user confusion.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
