### PR TITLE
Add hybrid search pre-filtering documentation

### DIFF
--- a/_query-dsl/compound/hybrid.md
+++ b/_query-dsl/compound/hybrid.md
@@ -22,7 +22,7 @@ The following table lists all top-level parameters supported by `hybrid` queries
 Parameter | Description
 :--- | :---
 `queries` | An array of one or more query clauses that are used to match documents. A document must match at least one query clause in order to be returned in the results. The documents' relevance scores from all query clauses are combined into one score by applying a [search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/index/). The maximum number of query clauses is 5. Required.
-`filter` | A filter to apply to all the subqueries of the hybrid query. 
+`filter` | A filter to apply to all the subqueries of the hybrid query. The filter must be a single query object. To apply multiple filter conditions, combine them in a [Boolean query]({{site.url}}{{site.baseurl}}/query-dsl/compound/bool/). For more information, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/).
 
 ### Rescoring hybrid queries
 Introduced 2.18

--- a/_vector-search/ai-search/hybrid-search/index.md
+++ b/_vector-search/ai-search/hybrid-search/index.md
@@ -351,13 +351,13 @@ The response contains the matching documents:
 
 ## Filtering data
 
-Hybrid search supports two approaches to filtering: **pre-filtering** and **post-filtering**. Use the following guidance to decide which option fits your use case.
+Hybrid search supports two approaches to filtering: **pre-filtering** and **post-filtering**.
 
 | | Pre-filtering | Post-filtering |
 | :--- | :--- | :--- |
-| **What it does** | Removes documents before they are scored --- subqueries only see documents that pass the filter | Removes documents after all scoring is complete --- subqueries still score every document |
+| **What it does** | Removes documents before they are scored | Removes documents after all scoring is complete |
 | **How to use** | Add a top-level `filter` to the `hybrid` query | Add a `post_filter` to the search request |
-| **When to use** | To improve performance and relevance by excluding irrelevant documents before scoring | To narrow displayed results without affecting scoring or aggregation counts |
+| **When to use** | 95% of searches | Almost exclusively when you have faceted search with aggregations and want the facets to reflect the unfiltered query while narrowing only the displayed hits |
 
 For details on each approach, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/) and [Hybrid search with post-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/post-filtering/).
 

--- a/_vector-search/ai-search/hybrid-search/index.md
+++ b/_vector-search/ai-search/hybrid-search/index.md
@@ -349,6 +349,18 @@ The response contains the matching documents:
 ```
 {% include copy-curl.html %}
 
+## Filtering data
+
+Hybrid search supports two approaches to filtering: **pre-filtering** and **post-filtering**. Use the following guidance to decide which option fits your use case.
+
+| | Pre-filtering | Post-filtering |
+| :--- | :--- | :--- |
+| **What it does** | Removes documents before they are scored --- subqueries only see documents that pass the filter | Removes documents after all scoring is complete --- subqueries still score every document |
+| **How to use** | Add a top-level `filter` to the `hybrid` query | Add a `post_filter` to the search request |
+| **When to use** | To improve performance and relevance by excluding irrelevant documents before scoring | To narrow displayed results without affecting scoring or aggregation counts |
+
+For details on each approach, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/) and [Hybrid search with post-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/post-filtering/).
+
 ## Next steps
 
 - Explore our [tutorials]({{site.url}}{{site.baseurl}}/vector-search/tutorials/) to learn how to build AI search applications. 

--- a/_vector-search/ai-search/hybrid-search/index.md
+++ b/_vector-search/ai-search/hybrid-search/index.md
@@ -351,15 +351,10 @@ The response contains the matching documents:
 
 ## Filtering data
 
-Hybrid search supports two approaches to filtering: **pre-filtering** and **post-filtering**.
+Hybrid search supports two approaches to filtering:
 
-| | Pre-filtering | Post-filtering |
-| :--- | :--- | :--- |
-| **What it does** | Removes documents before they are scored | Removes documents after all scoring is complete |
-| **How to use** | Add a top-level `filter` to the `hybrid` query | Add a `post_filter` to the search request |
-| **When to use** | 95% of searches | Almost exclusively when you have faceted search with aggregations and want the facets to reflect the unfiltered query while narrowing only the displayed hits |
-
-For details on each approach, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/) and [Hybrid search with post-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/post-filtering/).
+- **Pre-filtering** removes documents before they are scored. To use pre-filtering, add a top-level `filter` to the `hybrid` query. This is the most common approach for filtering hybrid search results. For more information, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/)
+- **Post-filtering** removes documents after all scoring is complete. To use post-filtering, add a `post_filter` to the search request. Use this approach for faceted search with aggregations when you want the facets to reflect the unfiltered query while filtering only the displayed hits. For more information, see [Hybrid search with post-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/post-filtering/).
 
 ## Next steps
 

--- a/_vector-search/ai-search/hybrid-search/post-filtering.md
+++ b/_vector-search/ai-search/hybrid-search/post-filtering.md
@@ -20,71 +20,143 @@ Post-filtering does not impact document relevance scores or aggregation results.
 
 To filter all subqueries during query execution instead of filtering the final results, use a common filter. For more information, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/).
 
-## Example
+## Example: Faceted search with post-filtering
 
-The following example request combines two query clauses---a `term` query and a `match` query---and contains a `post_filter`:
+Post-filtering is commonly used in faceted search, where the UI displays aggregation counts (such as brand, color, and size filters) alongside search results. Using `post_filter` keeps the aggregation counts based on the full unfiltered query while narrowing only the displayed hits.
+
+Consider an index containing product documents:
 
 ```json
-GET /my-nlp-index/_search?search_pipeline=nlp-search-pipeline
+{
+  "name": "Nike Air Max",
+  "brand": "Nike",
+  "color": "Red",
+  "size": 10,
+  "price": 120,
+  "category": "Running Shoes"
+}
+```
+
+A user searches for "running shoes" and the application returns results with aggregations for brand, color, and size:
+
+```json
+POST /products/_search
 {
   "query": {
-    "hybrid":{
-      "queries":[
-        {
-          "match":{
-            "passage_text": "hello"
-          }
-        },
-        {
-          "term":{
-            "passage_text":{
-              "value":"planet"
-            }
-          }
-        }
-      ]
+    "match": {
+      "category": "running shoes"
     }
-
   },
-  "post_filter":{
-    "match": { "passage_text": "world" }
+  "aggs": {
+    "brands": {
+      "terms": { "field": "brand.keyword" }
+    },
+    "colors": {
+      "terms": { "field": "color.keyword" }
+    },
+    "sizes": {
+      "terms": { "field": "size" }
+    }
   }
 }
 ```
 {% include copy-curl.html %}
 
-Compare the results to the results in the [example without post-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/#example-combining-a-match-query-and-a-term-query). In the example without post-filtering, the response contains two documents. In this example, the response contains one document because the second document is filtered out:
+The response returns hits and aggregations:
+
+**Hits:**
+
+```
+Nike Air Max
+Nike Pegasus
+Adidas Adizero
+Puma Velocity
+...
+```
+
+**Aggregations:**
+
+```
+Brands:  Nike (120), Adidas (80), Puma (45)
+Colors:  Black (90), White (70), Red (55)
+Sizes:   8 (40), 9 (60), 10 (85)
+```
+
+The UI renders the aggregations as facet filters on the side. Now the user clicks "Nike" to narrow results.
+
+### Why pre-filtering removes facets
+
+If you apply the brand selection as a pre-filter, the aggregations are computed only on Nike documents:
 
 ```json
+POST /products/_search
 {
-  "took": 18,
-  "timed_out": false,
-  "_shards": {
-    "total": 2,
-    "successful": 2,
-    "skipped": 0,
-    "failed": 0
-  },
-  "hits": {
-    "total": {
-      "value": 1,
-      "relation": "eq"
-    },
-    "max_score": 0.3,
-    "hits": [
-      {
-        "_index": "my-nlp-index",
-        "_id": "1",
-        "_score": 0.3,
-        "_source": {
-          "id": "s1",
-          "passage_text": "Hello world"
-        }
+  "query": {
+    "bool": {
+      "must": {
+        "match": { "category": "running shoes" }
+      },
+      "filter": {
+        "term": { "brand.keyword": "Nike" }
       }
-    ]
+    }
+  },
+  "aggs": {
+    "brands": {
+      "terms": { "field": "brand.keyword" }
+    },
+    "colors": {
+      "terms": { "field": "color.keyword" }
+    }
   }
 }
 ```
+{% include copy-curl.html %}
+
+The aggregations become:
+
+```
+Brands:  Nike (120)
+Colors:  Black (50), White (40), Red (30)
+```
+
+Adidas and Puma disappear completely from the brand facet because those documents were excluded before aggregations were computed. The user loses the ability to see other brand options or switch to a different brand without first removing the filter.
+
+### Using post_filter to preserve facets
+
+With `post_filter`, the query and aggregations run on the full result set. The filter is applied only to the displayed hits:
+
+```json
+POST /products/_search
+{
+  "query": {
+    "match": {
+      "category": "running shoes"
+    }
+  },
+  "aggs": {
+    "brands": {
+      "terms": { "field": "brand.keyword" }
+    },
+    "colors": {
+      "terms": { "field": "color.keyword" }
+    }
+  },
+  "post_filter": {
+    "term": { "brand.keyword": "Nike" }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Now the hits contain only Nike shoes, but the aggregations still reflect the full unfiltered query:
+
+```
+Brands:  ✓ Nike (120), Adidas (80), Puma (45)
+Colors:  Black (90), White (70), Red (55)
+```
+
+The user can switch from Nike to Adidas or see how many results each brand has without issuing a different query.
 
 ## How post-filtering affects search results and scoring
 

--- a/_vector-search/ai-search/hybrid-search/post-filtering.md
+++ b/_vector-search/ai-search/hybrid-search/post-filtering.md
@@ -15,14 +15,14 @@ You can perform post-filtering on hybrid search results by providing the `post_f
 
 The `post_filter` clause is applied after the search results have been retrieved. Post-filtering is useful for applying additional filters to the search results without impacting the scoring or the order of the results. 
 
-Post-filtering does not impact document relevance scores or aggregation results.
+Post-filtering does not impact aggregation results.
 {: .note}
 
 To filter all subqueries during query execution instead of filtering the final results, use a common filter. For more information, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/).
 
 ## Example: Faceted search with post-filtering
 
-Post-filtering is commonly used in faceted search, where the UI displays aggregation counts (such as brand, color, and size filters) alongside search results. Using `post_filter` keeps the aggregation counts based on the full unfiltered query while narrowing only the displayed hits.
+Post-filtering is commonly used in faceted search, in which the UI displays aggregation counts (such as brand, color, and size filters) alongside search results. Using a `post_filter` keeps the aggregation counts based on the full unfiltered query while filtering only the displayed hits.
 
 Consider an index containing product documents:
 
@@ -37,7 +37,7 @@ Consider an index containing product documents:
 }
 ```
 
-A user searches for "running shoes" and the application returns results with aggregations for brand, color, and size:
+A user searches for "running shoes", and the application constructs a query containing aggregations for brand, color, and size:
 
 ```json
 POST /products/_search
@@ -62,9 +62,7 @@ POST /products/_search
 ```
 {% include copy-curl.html %}
 
-The response returns hits and aggregations:
-
-**Hits:**
+The response returns hits from all brands:
 
 ```
 Nike Air Max
@@ -74,7 +72,7 @@ Puma Velocity
 ...
 ```
 
-**Aggregations:**
+The response also returns aggregations that include counts for every brand, color, and size:
 
 ```
 Brands:  Nike (120), Adidas (80), Puma (45)
@@ -82,47 +80,7 @@ Colors:  Black (90), White (70), Red (55)
 Sizes:   8 (40), 9 (60), 10 (85)
 ```
 
-The UI renders the aggregations as facet filters on the side. Now the user clicks "Nike" to narrow results.
-
-### Why pre-filtering removes facets
-
-If you apply the brand selection as a pre-filter, the aggregations are computed only on Nike documents:
-
-```json
-POST /products/_search
-{
-  "query": {
-    "bool": {
-      "must": {
-        "match": { "category": "running shoes" }
-      },
-      "filter": {
-        "term": { "brand.keyword": "Nike" }
-      }
-    }
-  },
-  "aggs": {
-    "brands": {
-      "terms": { "field": "brand.keyword" }
-    },
-    "colors": {
-      "terms": { "field": "color.keyword" }
-    }
-  }
-}
-```
-{% include copy-curl.html %}
-
-The aggregations become:
-
-```
-Brands:  Nike (120)
-Colors:  Black (50), White (40), Red (30)
-```
-
-Adidas and Puma disappear completely from the brand facet because those documents were excluded before aggregations were computed. The user loses the ability to see other brand options or switch to a different brand without first removing the filter.
-
-### Using post_filter to preserve facets
+The aggregations are typically displayed as facet filters in the UI. When a user selects a specific brand (for example, `Nike`) to filter results, using a pre-filter would exclude non-Nike documents before aggregations are computed, causing other brands to disappear from the facet counts.
 
 With `post_filter`, the query and aggregations run on the full result set. The filter is applied only to the displayed hits:
 
@@ -149,14 +107,14 @@ POST /products/_search
 ```
 {% include copy-curl.html %}
 
-Now the hits contain only Nike shoes, but the aggregations still reflect the full unfiltered query:
+The hits contain only Nike products, but the aggregations still reflect the full unfiltered query:
 
 ```
-Brands:  ✓ Nike (120), Adidas (80), Puma (45)
+Brands:  Nike (120), Adidas (80), Puma (45)
 Colors:  Black (90), White (70), Red (55)
 ```
 
-The user can switch from Nike to Adidas or see how many results each brand has without issuing a different query.
+All brand options remain visible in the facet, allowing the user to switch brands or compare counts without removing the filter.
 
 ## How post-filtering affects search results and scoring
 

--- a/_vector-search/ai-search/hybrid-search/post-filtering.md
+++ b/_vector-search/ai-search/hybrid-search/post-filtering.md
@@ -18,6 +18,8 @@ The `post_filter` clause is applied after the search results have been retrieved
 Post-filtering does not impact document relevance scores or aggregation results.
 {: .note}
 
+To filter all subqueries during query execution instead of filtering the final results, use a common filter. For more information, see [Hybrid search with pre-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/pre-filtering/).
+
 ## Example
 
 The following example request combines two query clauses---a `term` query and a `match` query---and contains a `post_filter`:

--- a/_vector-search/ai-search/hybrid-search/pre-filtering.md
+++ b/_vector-search/ai-search/hybrid-search/pre-filtering.md
@@ -13,7 +13,7 @@ nav_order: 38
 
 You can perform pre-filtering on hybrid search results by providing a top-level `filter` parameter in the `hybrid` query.
 
-The `filter` is applied during query execution and is pushed down to each subquery, so only documents that match the filter are scored. Pre-filtering is useful for applying the same filter to all subqueries without duplicating it in each one.
+The `filter` is applied during query execution to each subquery, so only documents that match the filter are scored. Pre-filtering is useful for applying the same filter to all subqueries without duplicating it in each one.
 
 The `filter` must be a single query object.
 {: .note}
@@ -89,7 +89,7 @@ POST /products/_search?search_pipeline=nlp-search-pipeline
 
 ## Filtering on multiple conditions
 
-Because the `filter` must be a single query object, you combine multiple conditions in a [Boolean query]({{site.url}}{{site.baseurl}}/query-dsl/compound/bool/):
+Because the `filter` must be a single query object, combine multiple conditions using a [Boolean query]({{site.url}}{{site.baseurl}}/query-dsl/compound/bool/). The following example filters results to only in-stock shoes:
 
 ```json
 "filter": {
@@ -104,7 +104,7 @@ Because the `filter` must be a single query object, you combine multiple conditi
 
 ## Combining a common filter with subquery filters
 
-A subquery can define its own filter in addition to the common filter. In this case, OpenSearch combines the two using a logical `AND`, further narrowing that subquery's results. Subqueries without their own filter are constrained by the common filter only.
+A subquery can define its own filter in addition to the common filter. In this case, OpenSearch combines the two using a logical `AND`, further narrowing that subquery's results.
 
 In the following example, the common filter restricts all subqueries to the `shoes` category, while the `match` subquery is additionally narrowed to the `nike` brand:
 
@@ -141,5 +141,3 @@ POST /products/_search?search_pipeline=nlp-search-pipeline
 }
 ```
 {% include copy-curl.html %}
-
-As a result, the `match` subquery requires both `category: shoes` and `brand: nike`, while the `knn` subquery is constrained only to `category: shoes`.

--- a/_vector-search/ai-search/hybrid-search/pre-filtering.md
+++ b/_vector-search/ai-search/hybrid-search/pre-filtering.md
@@ -1,0 +1,145 @@
+---
+layout: default
+title: Hybrid search with pre-filtering
+parent: Hybrid search
+grand_parent: AI search
+has_children: false
+nav_order: 38
+---
+
+# Hybrid search with pre-filtering
+**Introduced 3.0**
+{: .label .label-purple }
+
+You can perform pre-filtering on hybrid search results by providing a top-level `filter` parameter in the `hybrid` query.
+
+The `filter` is applied during query execution and is pushed down to each subquery, so only documents that match the filter are scored. Pre-filtering is useful for applying the same filter to all subqueries without duplicating it in each one.
+
+The `filter` must be a single query object.
+{: .note}
+
+To filter the final results after they have been retrieved instead of filtering each subquery during execution, use a post-filter. For more information, see [Hybrid search with post-filtering]({{site.url}}{{site.baseurl}}/vector-search/ai-search/hybrid-search/post-filtering/).
+
+## Example
+
+The following example request combines a `match` query and a `knn` query and applies a common `filter` that restricts both subqueries to the `shoes` category:
+
+```json
+POST /products/_search?search_pipeline=nlp-search-pipeline
+{
+  "query": {
+    "hybrid": {
+      "filter": {
+        "term": { "category": "shoes" }
+      },
+      "queries": [
+        {
+          "match": { "description": "running shoes" }
+        },
+        {
+          "knn": {
+            "embedding": {
+              "vector": [1.23, 0.45, 0.67, ...],
+              "k": 10
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+OpenSearch applies the `category: shoes` filter to both the `match` and `knn` subqueries, which is equivalent to the following query that applies the filter to each subquery individually:
+
+```json
+POST /products/_search?search_pipeline=nlp-search-pipeline
+{
+  "query": {
+    "hybrid": {
+      "queries": [
+        {
+          "bool": {
+            "must": {
+              "match": { "description": "running shoes" }
+            },
+            "filter": {
+              "term": { "category": "shoes" }
+            }
+          }
+        },
+        {
+          "knn": {
+            "embedding": {
+              "vector": [1.23, 0.45, 0.67, ...],
+              "k": 10,
+              "filter": {
+                "term": { "category": "shoes" }
+              }
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+## Filtering on multiple conditions
+
+Because the `filter` must be a single query object, you combine multiple conditions in a [Boolean query]({{site.url}}{{site.baseurl}}/query-dsl/compound/bool/):
+
+```json
+"filter": {
+  "bool": {
+    "must": [
+      { "term": { "category": "shoes" }},
+      { "term": { "in_stock": true }}
+    ]
+  }
+}
+```
+
+## Combining a common filter with subquery filters
+
+A subquery can define its own filter in addition to the common filter. In this case, OpenSearch combines the two using a logical `AND`, further narrowing that subquery's results. Subqueries without their own filter are constrained by the common filter only.
+
+In the following example, the common filter restricts all subqueries to the `shoes` category, while the `match` subquery is additionally narrowed to the `nike` brand:
+
+```json
+POST /products/_search?search_pipeline=nlp-search-pipeline
+{
+  "query": {
+    "hybrid": {
+      "filter": {
+        "term": { "category": "shoes" }
+      },
+      "queries": [
+        {
+          "bool": {
+            "must": {
+              "match": { "description": "running shoes" }
+            },
+            "filter": {
+              "term": { "brand": "nike" }
+            }
+          }
+        },
+        {
+          "knn": {
+            "embedding": {
+              "vector": [1.23, 0.45, 0.67, ...],
+              "k": 10
+            }
+          }
+        }
+      ]
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+As a result, the `match` subquery requires both `category: shoes` and `brand: nike`, while the `knn` subquery is constrained only to `category: shoes`.


### PR DESCRIPTION
### Description
Document the hybrid query common filter as pre-filtering: add a new pre-filtering page, clarify the filter parameter in the hybrid query reference, and cross-link the post-filtering page. The filter must be a single query object; multiple conditions are combined in a bool query.

### Issues Resolved
Closes https://github.com/opensearch-project/neural-search/issues/1811

### Version
3.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
