### PR TITLE
Document all supported OSB operations in the operations reference

### DIFF
--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -696,7 +696,7 @@ Parameter | Required | Type | Description
 ## create-component-template
 <!-- vale on -->
 
-The `create-component-template` operation creates one or more [component templates]({{site.url}}{{site.baseurl}}/im-plugin/index-templates/#component-templates).
+The `create-component-template` operation creates one or more [component templates]({{site.url}}{{site.baseurl}}/api-reference/index-apis/component-template/).
 
 ### Configuration options
 
@@ -854,7 +854,7 @@ Parameter | Required | Type | Description
 ## wait-for-recovery
 <!-- vale on -->
 
-The `wait-for-recovery` operation waits until index recovery completes by polling the [Index Recovery API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/recovery/).
+The `wait-for-recovery` operation waits until index recovery completes by polling the [Index Recovery API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/recover/).
 
 ### Configuration options
 
@@ -867,7 +867,7 @@ Parameter | Required | Type | Description
 ## submit-async-search
 <!-- vale on -->
 
-The `submit-async-search` operation submits an [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async-search/) request and stores the returned async search ID under the operation `name` so later operations in the same composite can fetch or delete it.
+The `submit-async-search` operation submits an [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/) request and stores the returned async search ID under the operation `name` so later operations in the same composite can fetch or delete it.
 
 ### Configuration options
 
@@ -1003,13 +1003,13 @@ Parameter | Required | Type | Description
 ## train-knn-model
 <!-- vale on -->
 
-The `train-knn-model` operation trains a k-NN model using the [Train Model API]({{site.url}}{{site.baseurl}}/search-plugins/knn/api/#train-a-model) and polls until training completes.
+The `train-knn-model` operation trains a k-NN model using the [Train Model API]({{site.url}}{{site.baseurl}}/vector-search/api/knn/#train-a-model) and polls until training completes.
 
 ### Configuration options
 
 Parameter | Required | Type | Description
 :--- | :--- | :--- | :---
-`body` | Yes | Object | The training request body. See the [Train Model API]({{site.url}}{{site.baseurl}}/search-plugins/knn/api/#train-a-model) for body parameters.
+`body` | Yes | Object | The training request body. See the [Train Model API]({{site.url}}{{site.baseurl}}/vector-search/api/knn/#train-a-model) for body parameters.
 `model_id` | Yes | String | The model ID to train.
 `retries` | No | Integer | Maximum number of poll retries before giving up. Default is `1000`.
 `poll_period` | No | Number | Seconds between status polls. Default is `0.5`.

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -29,6 +29,7 @@ The following example shows a `bulk` operation type with a `bulk-size` of `5000`
   "bulk-size": 5000
 }
 ```
+{% include copy.html %}
 
 ### Split documents among clients
 
@@ -84,7 +85,7 @@ If `detailed-results` is `true`, the following metadata is returned:
 
 The `create-index` operation runs the [Create Index API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/create-index/). It supports the following two index creation modes:
 
-- Creating all indexes specified in the workloads `indices` section
+- Creating all indexes specified in the workload's `indices` section
 - Creating one specific index defined within the operation itself
 
 ### Usage
@@ -103,6 +104,7 @@ The following example creates all indexes defined in the `indices` section of th
   }
 }
 ```
+{% include copy.html %}
 
 The following example creates a new index with all index settings specified in the operation body:
 
@@ -127,6 +129,7 @@ The following example creates a new index with all index settings specified in t
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -142,16 +145,16 @@ Use the following options when creating a single index in the operation.
 Parameter | Required | Type | Description
 :--- | :--- | :--- | :---
 `index` | Yes | String | The index name.
-`body` | No | Request body | The request body for the Create Index API. For more information, see [Create Index API](/api-reference/index-apis/create-index/).
+`body` | No | Request body | The request body for the Create Index API. For more information, see [Create Index API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/create-index/).
 `request-params` | No | List of settings | Contains any request parameters allowed by the Create Index API. OpenSearch Benchmark does not attempt to serialize the parameters and passes them in their current state.
 
 ### Metadata
 
 The `create-index` operation returns the following metadata:
 
-`weight`: The number of indexes created by the operation.
-`unit`: Always `ops`, indicating the number of operations inside the workload.
-`success`: A Boolean indicating whether the operation has succeeded.
+- `weight`: The number of indexes created by the operation.
+- `unit`: Always `ops`, indicating the number of operations inside the workload.
+- `success`: A Boolean indicating whether the operation has succeeded.
 
 <!-- vale off -->
 ## delete-index
@@ -169,6 +172,7 @@ The following example deletes all indexes found in the `indices` section of the 
   "operation-type": "delete-index"
 }
 ```
+{% include copy.html %}
 
 The following example deletes all `logs_*` indexes:
 
@@ -185,6 +189,7 @@ The following example deletes all `logs_*` indexes:
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -207,9 +212,9 @@ Parameter | Required | Type | Description
 
 The `delete-index` operation returns the following metadata:
 
-`weight`: The number of indexes created by the operation.
-`unit`: Always `ops`, for the number of operations inside the workload.
-`success`: A Boolean indicating whether the operation has succeeded.
+- `weight`: The number of indexes created by the operation.
+- `unit`: Always `ops`, for the number of operations inside the workload.
+- `success`: A Boolean indicating whether the operation has succeeded.
 
 <!-- vale off -->
 ## cluster-health
@@ -235,6 +240,7 @@ The following example creates a `cluster-health` operation that checks for a `gr
 }
 
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -249,9 +255,9 @@ Parameter | Required | Type | Description
 
 The `cluster-health` operation returns the following metadata:
 
-`weight`: The number of indexes the `cluster-health` operation assesses. Alwasys `1`, since the operation runs once per index.
-`unit`: Always `ops`, for the number of operations inside the workload.
-`success`: A Boolean indicating whether the operation has succeeded.
+- `weight`: The number of indexes the `cluster-health` operation assesses. Always `1`, since the operation runs once per index.
+- `unit`: Always `ops`, for the number of operations inside the workload.
+- `success`: A Boolean indicating whether the operation has succeeded.
 - `cluster-status`: The current cluster status.
 - `relocating-shards`: The number of shards currently relocating to a different node.
 
@@ -272,6 +278,7 @@ The following example refreshes all `logs-*` indexes:
  "index": "logs-*"
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -306,6 +313,7 @@ The following example runs a `match_all` query inside the `search` operation:
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -331,7 +339,7 @@ The following metadata is always returned:
 If `detailed-results` is set to `true`, the following metadata is also returned:
 
 - `hits`: The total number of hits for the query.
-- `hits_relation`: Whether the number of hits is accurate (eq) or a lower bound of the actual hit count (gte).
+- `hits_relation`: Whether the number of hits is accurate (`eq`) or a lower bound of the actual hit count (`gte`).
 - `timed_out`: Whether the query has timed out. For scroll queries, this flag is `true` if the flag was `true` for any of the queries issued.
  - `took`: The value of the `took` property in the query response. For scroll queries, the value is the sum of all `took` values in all query responses.
 
@@ -393,13 +401,14 @@ The `force-merge` operation runs the [Force Merge API]({{site.url}}{{site.baseur
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
 Parameter | Required | Type | Description
 :--- | :--- | :--- | :---
 `index` | No | String | The index or indexes to force merge. If omitted, the call falls through to the underlying client's default behavior, which targets all indexes.
-`max-num-segments` | No | Integer | Target number of segments per shard. Passed as `max_num_segments` to the Force Merge API.
+`max-num-segments` | No | Integer | The target number of segments per shard. Passed as `max_num_segments` to the Force Merge API.
 `mode` | No | String | Set to `polling` to issue the force merge asynchronously and poll the Tasks API until it completes. When omitted, the call waits synchronously and may time out on large indexes.
 `poll-period` | Conditional | Number | Required when `mode` is `polling`: the time in seconds between status polls. The operation raises an error if `mode: polling` is set without this value.
 `request-params` | No | Object | Additional request parameters passed to the Force Merge API.
@@ -426,6 +435,7 @@ The `index-stats` operation runs the [Index Stats API]({{site.url}}{{site.baseur
   "retry-until-success": true
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -449,6 +459,7 @@ The `node-stats` operation runs the [Nodes Stats API]({{site.url}}{{site.baseurl
   "operation-type": "node-stats"
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -482,6 +493,7 @@ The `vector-search` operation runs k-NN vector search queries and optionally com
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -490,9 +502,9 @@ Parameter | Required | Type | Description
 `index` | Yes | String | The target index. Required: omitting it causes the underlying `search` runner to error out.
 `body` | Yes | Object | The search request body containing the k-NN query.
 `k` | No | Integer | The number of nearest neighbors to retrieve. Used for recall calculation.
-`detailed-results` | No | Boolean | Records detailed metadata.
+`detailed-results` | No | Boolean | Whether to record detailed metadata.
 `calculate-recall` | No | Boolean | Whether to compute recall@k and recall@1 against ground truth neighbors. Default is `true`.
-`neighbors` | No | Array | Ground truth neighbor IDs for recall calculation. Typically provided by the workload's param source.
+`neighbors` | No | Array | The ground truth neighbor IDs for recall calculation. Typically provided by the workload at runtime.
 
 ### Metadata
 
@@ -518,6 +530,7 @@ The `bulk-vector-data-set` operation bulk-indexes vector data from HDF5 or BigAN
   "index": "vectors"
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -551,13 +564,14 @@ The `put-pipeline` operation creates or updates an [ingest pipeline]({{site.url}
       {
         "set": {
           "field": "ingest_time",
-          "value": "{{_ingest.timestamp}}"
+          "value": {% raw %}"{{_ingest.timestamp}}"{% endraw %}
         }
       }
     ]
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -629,6 +643,7 @@ The `put-settings` operation updates [cluster settings]({{site.url}}{{site.baseu
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -768,6 +783,7 @@ The `shrink-index` operation uses the [Shrink Index API]({{site.url}}{{site.base
   }
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -867,13 +883,13 @@ Parameter | Required | Type | Description
 ## submit-async-search
 <!-- vale on -->
 
-The `submit-async-search` operation submits an [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/) request and stores the returned async search ID under the operation `name` so later operations in the same composite can fetch or delete it.
+The `submit-async-search` operation submits an [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/) request and stores the returned asynchronous search ID under the operation `name` so later operations in the same composite can fetch or delete it.
 
 ### Configuration options
 
 Parameter | Required | Type | Description
 :--- | :--- | :--- | :---
-`name` | Yes | String | The operation name. Other operations refer to this name to look up the resulting async search ID.
+`name` | Yes | String | The operation name. Other operations refer to this name to look up the resulting asynchronous search ID.
 `body` | Yes | Object | The search request body.
 `index` | No | String | The target index.
 `request-params` | No | Object | Additional request parameters forwarded to the Async Search API.
@@ -882,7 +898,7 @@ Parameter | Required | Type | Description
 ## get-async-search
 <!-- vale on -->
 
-The `get-async-search` operation retrieves results from one or more previously submitted async searches. The operation succeeds only when every referenced search has completed (`is_running: false`).
+The `get-async-search` operation retrieves results from one or more previously submitted asynchronous searches. The operation succeeds only when every referenced search has completed (`is_running: false`).
 
 ### Configuration options
 
@@ -895,7 +911,7 @@ Parameter | Required | Type | Description
 ## delete-async-search
 <!-- vale on -->
 
-The `delete-async-search` operation deletes one or more async search results.
+The `delete-async-search` operation deletes one or more asynchronous search results.
 
 ### Configuration options
 
@@ -1126,6 +1142,7 @@ The `raw-request` operation sends an arbitrary HTTP request to OpenSearch. Use t
   "body": {}
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -1153,6 +1170,7 @@ The `sleep` operation pauses execution for a specified duration.
   "duration": 30
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -1181,6 +1199,7 @@ Only a subset of operation types can appear inside `composite`: `create-point-in
   ]
 }
 ```
+{% include copy.html %}
 
 ### Configuration options
 
@@ -1199,7 +1218,7 @@ The `produce-stream-message` operation publishes messages to a configured `messa
 
 Parameter | Required | Type | Description
 :--- | :--- | :--- | :---
-`message-producer` | Yes | Producer | The producer instance (resolved by the workload param source) used to send messages.
+`message-producer` | Yes | Producer | The producer instance (resolved by the workload at runtime) used to send messages.
 `body` | Yes | String or Bytes | The newline-delimited message payload. Index-metadata lines (`{"index": {"_index": ...}}`) are skipped.
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -335,4 +335,909 @@ If `detailed-results` is set to `true`, the following metadata is also returned:
 - `timed_out`: Whether the query has timed out. For scroll queries, this flag is `true` if the flag was `true` for any of the queries issued.
  - `took`: The value of the `took` property in the query response. For scroll queries, the value is the sum of all `took` values in all query responses.
 
+<!-- vale off -->
+## paginated-search
+<!-- vale on -->
 
+The `paginated-search` operation runs a sequence of paginated search requests using the [`search_after`]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/paginate/#the-search_after-parameter) parameter. It accepts the same options as `search` plus `pages`, which controls how many pages to retrieve.
+
+### Configuration options
+
+In addition to the options listed under [`search`](#search):
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`pages` | Yes | Integer | The maximum number of pages to retrieve. If the query returns fewer matching results than the requested number of pages, the operation terminates early.
+
+### Metadata
+
+In addition to the metadata returned by `search`:
+
+- `pages`: The total number of pages retrieved.
+
+<!-- vale off -->
+## scroll-search
+<!-- vale on -->
+
+The `scroll-search` operation runs a [scroll search]({{site.url}}{{site.baseurl}}/api-reference/scroll/). It accepts the same options as `search` plus `pages`, which controls how many scroll pages to fetch.
+
+### Configuration options
+
+In addition to the options listed under [`search`](#search):
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`pages` | Yes | Integer | The maximum number of scroll pages to retrieve. If the scroll exhausts before this number is reached, the operation terminates early.
+
+### Metadata
+
+In addition to the metadata returned by `search`:
+
+- `pages`: The total number of scroll pages retrieved.
+
+<!-- vale off -->
+## force-merge
+<!-- vale on -->
+
+The `force-merge` operation runs the [Force Merge API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/force-merge/).
+
+### Usage
+
+```yml
+{
+  "name": "force-merge",
+  "operation-type": "force-merge",
+  "index": "_all",
+  "request-params": {
+    "max_num_segments": 1
+  }
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`index` | No | String | The index or indexes to force merge. If omitted, the call falls through to the underlying client's default behavior, which targets all indexes.
+`max-num-segments` | No | Integer | Target number of segments per shard. Passed as `max_num_segments` to the Force Merge API.
+`mode` | No | String | Set to `polling` to issue the force merge asynchronously and poll the Tasks API until it completes. When omitted, the call waits synchronously and may time out on large indexes.
+`poll-period` | Conditional | Number | Required when `mode` is `polling`: the time in seconds between status polls. The operation raises an error if `mode: polling` is set without this value.
+`request-params` | No | Object | Additional request parameters passed to the Force Merge API.
+
+This is an administrative operation. Metrics are not reported by default. Reporting can be forced by setting `include-in-reporting` to `true`.
+
+<!-- vale off -->
+## index-stats
+<!-- vale on -->
+
+The `index-stats` operation runs the [Index Stats API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/stats/).
+
+### Usage
+
+```yml
+{
+  "name": "index-stats",
+  "operation-type": "index-stats",
+  "index": "_all",
+  "condition": {
+    "path": "_all.total.merges.current",
+    "expected-value": 0
+  },
+  "retry-until-success": true
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`index` | No | String | The index or indexes to retrieve statistics for. Default is `_all`.
+`condition` | No | Object | A condition to check in the response. Contains `path` (dot-notation path in the response) and `expected-value`.
+`request-params` | No | Object | Request parameters passed to the Stats API.
+
+<!-- vale off -->
+## node-stats
+<!-- vale on -->
+
+The `node-stats` operation runs the [Nodes Stats API]({{site.url}}{{site.baseurl}}/api-reference/nodes-apis/nodes-stats/).
+
+### Usage
+
+```yml
+{
+  "name": "node-stats",
+  "operation-type": "node-stats"
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`request-timeout` | No | Number | Client-side timeout (in seconds) for the Nodes Stats request.
+
+<!-- vale off -->
+## vector-search
+<!-- vale on -->
+
+The `vector-search` operation runs k-NN vector search queries and optionally computes recall metrics by comparing results against ground truth neighbors.
+
+### Usage
+
+```yml
+{
+  "name": "knn-search",
+  "operation-type": "vector-search",
+  "index": "vectors",
+  "k": 100,
+  "body": {
+    "query": {
+      "knn": {
+        "embedding": {
+          "vector": [0.1, 0.2, 0.3],
+          "k": 100
+        }
+      }
+    }
+  }
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`index` | Yes | String | The target index. Required: omitting it causes the underlying `search` runner to error out.
+`body` | Yes | Object | The search request body containing the k-NN query.
+`k` | No | Integer | The number of nearest neighbors to retrieve. Used for recall calculation.
+`detailed-results` | No | Boolean | Records detailed metadata.
+`calculate-recall` | No | Boolean | Whether to compute recall@k and recall@1 against ground truth neighbors. Default is `true`.
+`neighbors` | No | Array | Ground truth neighbor IDs for recall calculation. Typically provided by the workload's param source.
+
+### Metadata
+
+- `weight`: Always `1`.
+- `unit`: Always `ops`.
+- `success`: Whether the search succeeded.
+- `recall@k`: Recall at k (if ground truth neighbors are provided).
+- `recall@1`: Recall at 1 (if ground truth neighbors are provided).
+
+<!-- vale off -->
+## bulk-vector-data-set
+<!-- vale on -->
+
+The `bulk-vector-data-set` operation bulk-indexes vector data from HDF5 or BigANN dataset files. Supports individual document retry on partial failures.
+
+### Usage
+
+```yml
+{
+  "name": "bulk-vectors",
+  "operation-type": "bulk-vector-data-set",
+  "bulk-size": 500,
+  "index": "vectors"
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`bulk-size` | No | Integer | Number of documents per bulk request.
+`index` | No | String | The target index.
+`retries` | No | Integer | Number of retry attempts after the initial request fails. Default is `0` (no retries). Each failed document is resubmitted on retry; connection timeouts also trigger a retry.
+`retry-wait-period` | No | Number | Initial wait period between retries in seconds. Default is `0.5`.
+`retry-max-wait-period` | No | Number | Maximum wait period between retries in seconds (exponential backoff is capped at this value). Default is `60`.
+`detailed-results` | No | Boolean | Records detailed per-document success/failure metadata. Default is `true`.
+`action-metadata-present` | No | Boolean | Whether the bulk body includes action metadata lines. Default is `true`.
+`unit` | No | String | Unit reported for `weight`. Default is `docs`.
+
+<!-- vale off -->
+## put-pipeline
+<!-- vale on -->
+
+The `put-pipeline` operation creates or updates an [ingest pipeline]({{site.url}}{{site.baseurl}}/ingest-pipelines/).
+
+### Usage
+
+```yml
+{
+  "name": "define-pipeline",
+  "operation-type": "put-pipeline",
+  "id": "my-pipeline",
+  "body": {
+    "description": "My ingest pipeline",
+    "processors": [
+      {
+        "set": {
+          "field": "ingest_time",
+          "value": "{{_ingest.timestamp}}"
+        }
+      }
+    ]
+  }
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`id` | Yes | String | The pipeline ID.
+`body` | Yes | Object | The pipeline definition.
+
+This is an administrative operation. Metrics are not reported by default.
+
+<!-- vale off -->
+## delete-pipeline
+<!-- vale on -->
+
+The `delete-pipeline` operation deletes an ingest pipeline.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`id` | Yes | String | The pipeline ID to delete.
+
+This is an administrative operation. Metrics are not reported by default.
+
+<!-- vale off -->
+## create-search-pipeline
+<!-- vale on -->
+
+The `create-search-pipeline` operation creates a [search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`id` | Yes | String | The search pipeline ID.
+`body` | Yes | Object | The search pipeline definition.
+
+This is an administrative operation. Metrics are not reported by default.
+
+<!-- vale off -->
+## update-concurrent-segment-search-settings
+<!-- vale on -->
+
+The `update-concurrent-segment-search-settings` operation toggles the [concurrent segment search]({{site.url}}{{site.baseurl}}/search-plugins/concurrent-segment-search/) cluster setting and, optionally, the maximum slice count. It updates `search.concurrent_segment_search.enabled` (and `search.concurrent.max_slice_count` when provided) as persistent cluster settings.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`enable` | No | Boolean | Whether concurrent segment search is enabled. Default is `false`.
+`max_slice_count` | No | Integer | Maximum number of slices per shard. If omitted, the setting is left unchanged.
+
+<!-- vale off -->
+## put-settings
+<!-- vale on -->
+
+The `put-settings` operation updates [cluster settings]({{site.url}}{{site.baseurl}}/api-reference/cluster-api/cluster-settings/).
+
+### Usage
+
+```yml
+{
+  "name": "increase-watermarks",
+  "operation-type": "put-settings",
+  "body": {
+    "transient": {
+      "cluster.routing.allocation.disk.watermark.low": "95%"
+    }
+  }
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`body` | Yes | Object | The cluster settings to apply.
+
+This is an administrative operation. Metrics are not reported by default.
+
+<!-- vale off -->
+## create-data-stream
+<!-- vale on -->
+
+The `create-data-stream` operation creates one or more [data streams]({{site.url}}{{site.baseurl}}/opensearch/data-streams/).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`data-streams` | Yes | List | A list of data stream names to create.
+`request-params` | Yes | Object | Request parameters forwarded to the Create Data Stream API. Pass an empty object (`{}`) if none are needed.
+
+<!-- vale off -->
+## delete-data-stream
+<!-- vale on -->
+
+The `delete-data-stream` operation deletes one or more data streams.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`data-streams` | Yes | List | A list of data stream names to delete.
+`only-if-exists` | Yes | Boolean | If `true`, only delete data streams that exist; if `false`, attempt to delete each one and ignore HTTP 404 responses.
+`request-params` | Yes | Object | Request parameters forwarded to the Delete Data Stream API. Pass an empty object (`{}`) if none are needed.
+
+<!-- vale off -->
+## create-composable-template
+<!-- vale on -->
+
+The `create-composable-template` operation creates one or more [composable index templates]({{site.url}}{{site.baseurl}}/im-plugin/index-templates/).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`templates` | Yes | List | A list of `[template-name, body]` pairs to create.
+`request-params` | Yes | Object | Request parameters forwarded to the API. Pass an empty object (`{}`) if none are needed.
+
+<!-- vale off -->
+## delete-composable-template
+<!-- vale on -->
+
+The `delete-composable-template` operation deletes one or more composable index templates and, optionally, the indexes they match.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`templates` | Yes | List | A list of `[template-name, delete-matching-indices, index-pattern]` triples. When `delete-matching-indices` is `true` and `index-pattern` is non-empty, indexes matching the pattern are also deleted.
+`only-if-exists` | Yes | Boolean | If `true`, only delete templates that exist; if `false`, attempt to delete each one and ignore HTTP 404 responses.
+`request-params` | Yes | Object | Request parameters forwarded to the API. Pass an empty object (`{}`) if none are needed.
+
+<!-- vale off -->
+## create-component-template
+<!-- vale on -->
+
+The `create-component-template` operation creates one or more [component templates]({{site.url}}{{site.baseurl}}/im-plugin/index-templates/#component-templates).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`templates` | Yes | List | A list of `[template-name, body]` pairs to create.
+`request-params` | Yes | Object | Request parameters forwarded to the API. Pass an empty object (`{}`) if none are needed.
+
+<!-- vale off -->
+## delete-component-template
+<!-- vale on -->
+
+The `delete-component-template` operation deletes one or more component templates.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`templates` | Yes | List | A list of component template names to delete.
+`only-if-exists` | Yes | Boolean | If `true`, only delete templates that exist; if `false`, attempt to delete each one and ignore HTTP 404 responses.
+`request-params` | Yes | Object | Request parameters forwarded to the API. Pass an empty object (`{}`) if none are needed.
+
+<!-- vale off -->
+## create-index-template
+<!-- vale on -->
+
+The `create-index-template` operation creates one or more legacy index templates.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`templates` | Yes | List | A list of `[template-name, body]` pairs to create.
+`request-params` | No | Object | Additional request parameters.
+
+<!-- vale off -->
+## delete-index-template
+<!-- vale on -->
+
+The `delete-index-template` operation deletes one or more legacy index templates and, optionally, the indexes they match.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`templates` | Yes | List | A list of `[template-name, delete-matching-indices, index-pattern]` triples.
+`only-if-exists` | No | Boolean | If `true`, only delete templates that exist. Default is `false`.
+`request-params` | No | Object | Additional request parameters.
+
+<!-- vale off -->
+## shrink-index
+<!-- vale on -->
+
+The `shrink-index` operation uses the [Shrink Index API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/shrink-index/) to reduce the number of primary shards in an index.
+
+### Usage
+
+```yml
+{
+  "name": "shrink-index",
+  "operation-type": "shrink-index",
+  "source-index": "my-index",
+  "target-index": "my-index-shrunk",
+  "target-body": {
+    "settings": {
+      "index.number_of_shards": 1,
+      "index.codec": "best_compression"
+    }
+  }
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`source-index` | Yes | String | The source index (or wildcard pattern) to shrink.
+`target-index` | Yes | String | The name for the shrunk index. When `source-index` matches multiple indexes, the matched suffix is appended to this name.
+`target-body` | Yes | Object | Settings and mappings for the target index.
+`shrink-node` | No | String | The node to allocate the source shards to before shrinking. If omitted, a random data node is chosen.
+
+<!-- vale off -->
+## create-snapshot-repository
+<!-- vale on -->
+
+The `create-snapshot-repository` operation creates a [snapshot repository]({{site.url}}{{site.baseurl}}/opensearch/snapshots/snapshot-restore/).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`repository` | Yes | String | The repository name.
+`body` | Yes | Object | The repository definition (type, settings).
+`request-params` | No | Object | Additional request parameters.
+
+<!-- vale off -->
+## delete-snapshot-repository
+<!-- vale on -->
+
+The `delete-snapshot-repository` operation deletes a snapshot repository.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`repository` | Yes | String | The repository name to delete.
+
+<!-- vale off -->
+## create-snapshot
+<!-- vale on -->
+
+The `create-snapshot` operation creates a [snapshot]({{site.url}}{{site.baseurl}}/opensearch/snapshots/snapshot-restore/).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`repository` | Yes | String | The repository name.
+`snapshot` | Yes | String | The snapshot name.
+`body` | Yes | Object | The snapshot definition.
+`wait-for-completion` | No | Boolean | Whether to wait for the snapshot to complete before returning. Default is `false`. To benchmark snapshot duration accurately, leave this `false` and follow up with `wait-for-snapshot-create`.
+`request-params` | No | Object | Additional request parameters.
+
+<!-- vale off -->
+## wait-for-snapshot-create
+<!-- vale on -->
+
+The `wait-for-snapshot-create` operation polls snapshot status until the snapshot reaches `SUCCESS`. If the snapshot ends in `FAILED`, the operation raises an assertion error. The reported metrics include snapshot size in bytes, throughput, and duration.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`repository` | Yes | String | The repository name.
+`snapshot` | Yes | String | The snapshot name.
+`completion-recheck-wait-period` | No | Number | Seconds between status polls. Default is `1`.
+
+<!-- vale off -->
+## restore-snapshot
+<!-- vale on -->
+
+The `restore-snapshot` operation restores a snapshot.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`repository` | Yes | String | The repository name.
+`snapshot` | Yes | String | The snapshot name.
+`body` | No | Object | The restore request body.
+`wait-for-completion` | No | Boolean | Whether to wait for the restore to complete before returning. Default is `false`. Pair with `wait-for-recovery` to benchmark restore duration.
+`request-params` | No | Object | Additional request parameters.
+
+<!-- vale off -->
+## wait-for-recovery
+<!-- vale on -->
+
+The `wait-for-recovery` operation waits until index recovery completes by polling the [Index Recovery API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/recovery/).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`index` | Yes | String | The index to monitor for recovery.
+`completion-recheck-wait-period` | No | Number | Seconds between recovery polls. Default is `1`.
+
+<!-- vale off -->
+## submit-async-search
+<!-- vale on -->
+
+The `submit-async-search` operation submits an [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async-search/) request and stores the returned async search ID under the operation `name` so later operations in the same composite can fetch or delete it.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`name` | Yes | String | The operation name. Other operations refer to this name to look up the resulting async search ID.
+`body` | Yes | Object | The search request body.
+`index` | No | String | The target index.
+`request-params` | No | Object | Additional request parameters forwarded to the Async Search API.
+
+<!-- vale off -->
+## get-async-search
+<!-- vale on -->
+
+The `get-async-search` operation retrieves results from one or more previously submitted async searches. The operation succeeds only when every referenced search has completed (`is_running: false`).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`retrieve-results-for` | Yes | String or List | The name of the `submit-async-search` operation (or a list of names) whose results should be retrieved.
+`request-params` | No | Object | Additional request parameters forwarded to the Async Search Get API.
+
+<!-- vale off -->
+## delete-async-search
+<!-- vale on -->
+
+The `delete-async-search` operation deletes one or more async search results.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`delete-results-for` | Yes | String or List | The name of the `submit-async-search` operation (or a list of names) whose results should be deleted.
+
+<!-- vale off -->
+## create-point-in-time
+<!-- vale on -->
+
+The `create-point-in-time` operation creates a [Point in Time (PIT)]({{site.url}}{{site.baseurl}}/search-plugins/point-in-time/) for an index. The resulting PIT ID is stored under the operation `name`, so later operations in the same composite can reference it.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`name` | Yes | String | The operation name. Other operations refer to this name to reuse the resulting PIT ID.
+`index` | Yes | String | The target index.
+`keep-alive` | No | String | How long to keep the PIT alive (for example, `5m`). Default is `1m`.
+`request-params` | No | Object | Additional request parameters forwarded to the Create PIT API.
+
+<!-- vale off -->
+## delete-point-in-time
+<!-- vale on -->
+
+The `delete-point-in-time` operation deletes one or more PITs. If `with-point-in-time-from` is set, only the PIT created by the named operation is deleted; otherwise, every PIT on the cluster is deleted.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`with-point-in-time-from` | No | String | The name of the `create-point-in-time` operation whose PIT to delete. If omitted, all PITs are deleted.
+`request-params` | No | Object | Additional request parameters forwarded to the Delete PIT API.
+
+<!-- vale off -->
+## list-all-point-in-time
+<!-- vale on -->
+
+The `list-all-point-in-time` operation lists all active PITs on the cluster.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`request-params` | No | Object | Additional request parameters forwarded to the List PIT API.
+
+<!-- vale off -->
+## create-transform
+<!-- vale on -->
+
+The `create-transform` operation creates an [index transform]({{site.url}}{{site.baseurl}}/im-plugin/index-transforms/).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`transform-id` | Yes | String | The transform ID.
+`body` | Yes | Object | The transform definition.
+
+<!-- vale off -->
+## start-transform
+<!-- vale on -->
+
+The `start-transform` operation starts a previously created transform.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`transform-id` | Yes | String | The transform ID to start.
+`timeout` | No | Number | Optional client-side timeout for the start request.
+
+<!-- vale off -->
+## wait-for-transform
+<!-- vale on -->
+
+The `wait-for-transform` operation polls the transform status until the transform reaches its next checkpoint (or stops, depending on options).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`transform-id` | Yes | String | The transform ID to monitor.
+`force` | No | Boolean | Forcefully stop the transform when polling completes. Default is `false`.
+`wait-for-checkpoint` | No | Boolean | Wait until all data has been processed through the next checkpoint. Default is `true`.
+`wait-for-completion` | No | Boolean | Block until the transform has fully stopped. Default is `true`.
+`transform-timeout` | No | Number | Overall transform runtime timeout in seconds. Default is `3600`.
+`poll-interval` | No | Number | How often (in seconds) transform stats are polled. Default is `0.5`.
+
+<!-- vale off -->
+## delete-transform
+<!-- vale on -->
+
+The `delete-transform` operation deletes a previously created transform. Missing transforms (HTTP 404) are ignored so this operation is safe to use as a cleanup step.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`transform-id` | Yes | String | The transform ID to delete.
+`force` | No | Boolean | If `true`, deletes the transform even if it is currently running. Default is `false`.
+
+<!-- vale off -->
+## train-knn-model
+<!-- vale on -->
+
+The `train-knn-model` operation trains a k-NN model using the [Train Model API]({{site.url}}{{site.baseurl}}/search-plugins/knn/api/#train-a-model) and polls until training completes.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`body` | Yes | Object | The training request body. See the [Train Model API]({{site.url}}{{site.baseurl}}/search-plugins/knn/api/#train-a-model) for body parameters.
+`model_id` | Yes | String | The model ID to train.
+`retries` | No | Integer | Maximum number of poll retries before giving up. Default is `1000`.
+`poll_period` | No | Number | Seconds between status polls. Default is `0.5`.
+
+<!-- vale off -->
+## delete-knn-model
+<!-- vale on -->
+
+The `delete-knn-model` operation deletes a trained k-NN model.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`model_id` | Yes | String | The model ID to delete.
+`ignore-if-model-does-not-exist` | No | Boolean | If `true`, treat a missing model (HTTP 404) as success. Default is `false`.
+
+<!-- vale off -->
+## register-ml-model
+<!-- vale on -->
+
+The `register-ml-model` operation registers a machine learning model using the [ML Commons API]({{site.url}}{{site.baseurl}}/ml-commons-plugin/api/model-apis/register-model/). The runner first searches for a model with a matching name; if one already exists, the existing model ID is reused. Otherwise it submits a new registration request and polls until it completes. The resulting model ID is written to `model_id.json` in the working directory so later operations can consume it.
+
+You can supply the request body in one of two ways: by setting `model-config-file` to a path on disk, or by setting `model-name`, `model-version`, and `model-format` and letting OpenSearch Benchmark assemble the body for you.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`model-config-file` | No | String | Path to a JSON file containing the full registration body. If set, the other body fields are ignored.
+`model-name` | No | String | The model name. Used to assemble the body when `model-config-file` is not set.
+`model-version` | No | String | The model version.
+`model-format` | No | String | The model format (for example, `TORCH_SCRIPT`).
+`timeout` | No | Number | Maximum seconds to wait for the registration task to complete. Default is `120`.
+
+<!-- vale off -->
+## deploy-ml-model
+<!-- vale on -->
+
+The `deploy-ml-model` operation deploys (loads) a previously registered ML model. The model ID is read from `model_id.json` in the working directory (typically written by an earlier `register-ml-model` operation), so this operation takes no required parameters.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`timeout` | No | Number | Maximum seconds to wait for the deploy task to complete. Default is `120`.
+
+<!-- vale off -->
+## create-ml-connector
+<!-- vale on -->
+
+The `create-ml-connector` operation creates an [ML connector]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/) for remote model integration.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`body` | Yes | Object | The connector definition.
+
+<!-- vale off -->
+## delete-ml-connector
+<!-- vale on -->
+
+The `delete-ml-connector` operation looks up an ML connector by name and deletes it. If no connector matches the supplied name, the operation is a no-op.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`connector_name` | Yes | String | The connector name to look up and delete.
+
+<!-- vale off -->
+## register-remote-ml-model
+<!-- vale on -->
+
+The `register-remote-ml-model` operation registers a remote ML model backed by an [ML connector]({{site.url}}{{site.baseurl}}/ml-commons-plugin/remote-models/connectors/). It polls the registration task until it completes, then writes the resulting model ID to `model_id.json` in the working directory so later operations can consume it.
+
+If `connector_id` is not set in the request body, OpenSearch Benchmark reads it from `connector_id.json` in the working directory (typically written by an earlier `create-ml-connector` operation).
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`body` | Yes | Object | The model registration request body. If `connector_id` is omitted, it is loaded from `connector_id.json`.
+
+<!-- vale off -->
+## delete-ml-model
+<!-- vale on -->
+
+The `delete-ml-model` operation looks up models by name, undeploys any that are currently deployed, and then deletes them. Multiple models with the same name (for example, across versions) are all deleted.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`model-name` | Yes | String | The model name to look up and delete.
+`number-of-hits-to-return` | No | Integer | Maximum number of matching models to fetch from the search query. Default is `1000`.
+`undeploy-timeout` | No | Number | Seconds to wait for each model to fully undeploy before deletion. Default is `10`.
+
+<!-- vale off -->
+## raw-request
+<!-- vale on -->
+
+The `raw-request` operation sends an arbitrary HTTP request to OpenSearch. Use this for operations not covered by a dedicated operation type.
+
+### Usage
+
+```yml
+{
+  "name": "check-shard-count",
+  "operation-type": "raw-request",
+  "method": "GET",
+  "path": "/_cat/shards?v",
+  "body": {}
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`method` | No | String | HTTP method (`GET`, `POST`, `PUT`, `DELETE`). Default is `GET`.
+`path` | Yes | String | The URL path. Must begin with `/`.
+`body` | No | Object | The request body.
+`request-params` | No | Object | Query string parameters.
+`headers` | No | Object | HTTP headers to include.
+`ignore` | No | List | HTTP status codes to ignore (for example, `[404]`).
+
+<!-- vale off -->
+## sleep
+<!-- vale on -->
+
+The `sleep` operation pauses execution for a specified duration.
+
+### Usage
+
+```yml
+{
+  "name": "wait-before-search",
+  "operation-type": "sleep",
+  "duration": 30
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`duration` | Yes | Number | Sleep duration in seconds.
+
+<!-- vale off -->
+## composite
+<!-- vale on -->
+
+The `composite` operation executes a structured group of inner operations as a single measured unit, optionally with parallel sub-streams. This is useful when several requests need to share state (for example, creating a PIT, searching with it, and deleting it) or when you want to measure end-to-end timings across a small workflow.
+
+Only a subset of operation types can appear inside `composite`: `create-point-in-time`, `delete-point-in-time`, `list-all-point-in-time`, `search`, `paginated-search`, `raw-request`, `sleep`, `submit-async-search`, `get-async-search`, and `delete-async-search`. Nested `stream` blocks run in parallel.
+
+### Usage
+
+```yml
+{
+  "name": "pit-search-workflow",
+  "operation-type": "composite",
+  "requests": [
+    { "operation-type": "create-point-in-time", "name": "pit", "index": "my-index" },
+    { "operation-type": "search", "body": { "query": { "match_all": {} } } },
+    { "operation-type": "delete-point-in-time", "with-point-in-time-from": "pit" }
+  ]
+}
+```
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`requests` | Yes | List | The list of inner operations or `stream` blocks to execute.
+`max-connections` | No | Integer | Upper bound on the number of concurrent in-flight requests across the composite. Defaults to unbounded.
+
+<!-- vale off -->
+## produce-stream-message
+<!-- vale on -->
+
+The `produce-stream-message` operation publishes messages to a configured `message-producer` (for example, a Kafka producer) for streaming ingestion benchmarks. The `body` is split on newlines, and each non-metadata line is sent as an individual message. Producers are configured at the workload or cluster level — the runner itself takes only the producer reference and the message payload.
+
+### Configuration options
+
+Parameter | Required | Type | Description
+:--- | :--- | :--- | :---
+`message-producer` | Yes | Producer | The producer instance (resolved by the workload param source) used to send messages.
+`body` | Yes | String or Bytes | The newline-delimited message payload. Index-metadata lines (`{"index": {"_index": ...}}`) are skipped.
+
+<!-- vale off -->
+## proto-bulk
+<!-- vale on -->
+
+The `proto-bulk` operation sends bulk index requests using the gRPC transport instead of HTTP REST. Requires gRPC to be enabled on the target cluster.
+
+### Configuration options
+
+Same as `bulk`, but uses gRPC serialization (Protocol Buffers) instead of JSON over HTTP. Use `--grpc-target-hosts` to specify the gRPC endpoint.
+
+<!-- vale off -->
+## proto-search
+<!-- vale on -->
+
+The `proto-search` operation sends search requests using gRPC transport.
+
+### Configuration options
+
+Same as `search`, but uses gRPC. Use `--grpc-target-hosts` to specify the gRPC endpoint.
+
+<!-- vale off -->
+## proto-vector-search
+<!-- vale on -->
+
+The `proto-vector-search` operation sends vector search requests using gRPC transport.
+
+### Configuration options
+
+Same as `vector-search`, but uses gRPC. Use `--grpc-target-hosts` to specify the gRPC endpoint.
+
+<!-- vale off -->
+## proto-bulk-vector-data-set
+<!-- vale on -->
+
+The `proto-bulk-vector-data-set` operation bulk-indexes vector data sets using the gRPC transport. It is the gRPC counterpart to `bulk-vector-data-set`.
+
+### Configuration options
+
+Same as `bulk-vector-data-set`, but uses gRPC serialization (Protocol Buffers) instead of JSON over HTTP. Use `--grpc-target-hosts` to specify the gRPC endpoint.


### PR DESCRIPTION
### Description

The [operations reference page](https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/common-operations/) currently documents only 6 of the 59 operation types that OpenSearch Benchmark ships with: `bulk`, `create-index`, `delete-index`, `cluster-health`, `refresh`, and `search`. Workload authors and users have to read through `osbenchmark/worker_coordinator/runner.py` to figure out the rest, which is what the linked issue is asking us to fix.

This PR expands `_benchmark/reference/workloads/operations.md` from ~336 lines to ~1,244 lines, adding sections for the remaining 53 operation types. Each new section describes what the operation does, lists its configuration options, and (where applicable) calls out non-obvious behavior such as state passed through `model_id.json`/`connector_id.json` on disk or required `name` references for composite workflows.

I cross-checked every section against `OperationType` in `osbenchmark/workload/workload.py` and the corresponding runner class — the doc and the source now have a 1:1 mapping for all 59 operation types (55 standard + 4 gRPC).

A few corrections were also made to entries that did not match the runners' actual parameter names (for example, `delete-ml-connector` takes `connector_name`, not `connector-id`; `register-ml-model` takes `model-name`/`model-version`/`model-format` or a `model-config-file`, not a single `body`; `create-snapshot`'s `wait-for-completion` default is `false`, not `true`).

### Issues Resolved

Closes https://github.com/opensearch-project/opensearch-benchmark/issues/1050

### Version

all

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).