### PR TITLE
Add cross-version redirects to 1.0

### DIFF
--- a/_clients/agents-and-ingestion-tools/index.md
+++ b/_clients/agents-and-ingestion-tools/index.md
@@ -6,6 +6,8 @@ has_children: false
 has_toc: false
 redirect_from:
   - /clients/agents-and-ingestion-tools/
+  - /tools/
+  - /tools/index/
 canonical_url: https://docs.opensearch.org/latest/tools/
 ---
 

--- a/_clients/cli.md
+++ b/_clients/cli.md
@@ -4,6 +4,8 @@ title: OpenSearch CLI
 nav_order: 52
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/tools/cli/
+redirect_from:
+  - /tools/cli/
 ---
 
 # OpenSearch CLI

--- a/_clients/logstash/advanced-config.md
+++ b/_clients/logstash/advanced-config.md
@@ -4,6 +4,8 @@ title: Advanced configurations
 parent: Logstash
 nav_order: 230
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/advanced-config/
+redirect_from:
+  - /tools/logstash/advanced-config/
 ---
 
 # Advanced configurations

--- a/_clients/logstash/common-filters.md
+++ b/_clients/logstash/common-filters.md
@@ -4,6 +4,8 @@ title: Common filter plugins
 parent: Logstash
 nav_order: 220
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/common-filters/
+redirect_from:
+  - /tools/logstash/common-filters/
 ---
 
 # Common filter plugins

--- a/_clients/logstash/execution-model.md
+++ b/_clients/logstash/execution-model.md
@@ -4,6 +4,8 @@ title: Logstash execution model
 parent: Logstash
 nav_order: 210
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/execution-model/
+redirect_from:
+  - /tools/logstash/execution-model/
 ---
 
 # Logstash execution model

--- a/_clients/logstash/index.md
+++ b/_clients/logstash/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: true
 redirect_from:
   - /clients/logstash/
+  - /tools/logstash/
+  - /tools/logstash/index/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/index/
 ---
 

--- a/_clients/logstash/ship-to-opensearch.md
+++ b/_clients/logstash/ship-to-opensearch.md
@@ -4,6 +4,8 @@ title: Ship events to OpenSearch
 parent: Logstash
 nav_order: 220
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/ship-to-opensearch/
+redirect_from:
+  - /tools/logstash/ship-to-opensearch/
 ---
 
 # Ship events to OpenSearch

--- a/_dashboards/browser-compatibility.md
+++ b/_dashboards/browser-compatibility.md
@@ -4,6 +4,12 @@ title: Browser compatibility
 parent: OpenSearch Dashboards
 nav_order: 3
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/index/
+redirect_from:
+  - /dashboards/get-started/quickstart-dashboards/
+  - /dashboards/getting-started/
+  - /dashboards/getting-started/index/
+  - /dashboards/quickstart-dashboards/
+  - /dashboards/quickstart/
 ---
 
 # Browser compatibility

--- a/_dashboards/install/docker.md
+++ b/_dashboards/install/docker.md
@@ -4,6 +4,8 @@ title: Docker
 parent: Install OpenSearch Dashboards
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/docker/
+redirect_from:
+  - /install-and-configure/install-dashboards/docker/
 ---
 
 # Run OpenSearch Dashboards using Docker

--- a/_dashboards/install/helm.md
+++ b/_dashboards/install/helm.md
@@ -4,6 +4,8 @@ title: Helm
 parent: Install OpenSearch Dashboards
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/helm/
+redirect_from:
+  - /install-and-configure/install-dashboards/helm/
 ---
 
 # Run OpenSearch Dashboards using Helm

--- a/_dashboards/install/index.md
+++ b/_dashboards/install/index.md
@@ -5,6 +5,9 @@ nav_order: 1
 has_children: true
 redirect_from:
   - /dashboards/install/
+  - /dashboards/compatibility/
+  - /install-and-configure/install-dashboards/
+  - /install-and-configure/install-dashboards/index/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/index/
 ---
 

--- a/_dashboards/install/plugins.md
+++ b/_dashboards/install/plugins.md
@@ -4,6 +4,8 @@ title: OpenSearch Dashboards plugins
 parent: Install OpenSearch Dashboards
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/plugins/
+redirect_from:
+  - /install-and-configure/install-dashboards/plugins/
 ---
 
 # Standalone plugin install

--- a/_dashboards/install/tar.md
+++ b/_dashboards/install/tar.md
@@ -4,6 +4,8 @@ title: Tarball
 parent: Install OpenSearch Dashboards
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/tar/
+redirect_from:
+  - /install-and-configure/install-dashboards/tar/
 ---
 
 # Run OpenSearch Dashboards using the tarball

--- a/_dashboards/install/tls.md
+++ b/_dashboards/install/tls.md
@@ -4,6 +4,8 @@ title: Configure TLS
 parent: Install OpenSearch Dashboards
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/tls/
+redirect_from:
+  - /install-and-configure/install-dashboards/tls/
 ---
 
 # Configure TLS for OpenSearch Dashboards

--- a/_dashboards/maptiles.md
+++ b/_dashboards/maptiles.md
@@ -4,6 +4,8 @@ title: WMS map server
 nav_order: 5
 redirect_from:
   - /docs/opensearch-dashboards/maptiles/
+  - /dashboards/visualize/maptiles/
+  - /dashboards/visualize/visualize-app/maptiles/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
 ---
 

--- a/_dashboards/notebooks.md
+++ b/_dashboards/notebooks.md
@@ -5,6 +5,9 @@ nav_order: 50
 redirect_from: /notebooks/
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/notebooks/
+redirect_from:
+  - /observability-plugin/notebooks/
+  - /observing-your-data/notebooks/
 ---
 
 # Notebooks

--- a/_dashboards/reporting.md
+++ b/_dashboards/reporting.md
@@ -3,6 +3,8 @@ layout: default
 title: Reporting
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/reporting/report-dashboard-index/
+redirect_from:
+  - /reporting/report-dashboard-index/
 ---
 
 

--- a/_im-plugin/index-rollups/index.md
+++ b/_im-plugin/index-rollups/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from: /im-plugin/index-rollups/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-rollups/index/
+redirect_from:
+  - /im-plugin/index-rollups/
 ---
 
 # Index rollups

--- a/_im-plugin/index-transforms/index.md
+++ b/_im-plugin/index-transforms/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from: /im-plugin/index-transforms/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-transforms/index/
+redirect_from:
+  - /im-plugin/index-transforms/
 ---
 
 # Index transforms

--- a/_im-plugin/ism/managedindices.md
+++ b/_im-plugin/ism/managedindices.md
@@ -5,6 +5,8 @@ nav_order: 3
 parent: Index State Management
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/ism/managedindexes/
+redirect_from:
+  - /im-plugin/ism/managedindexes/
 ---
 
 # Managed indices

--- a/_im-plugin/refresh-analyzer/index.md
+++ b/_im-plugin/refresh-analyzer/index.md
@@ -6,6 +6,9 @@ has_children: false
 redirect_from: /im-plugin/refresh-analyzer/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/refresh-analyzer/
+redirect_from:
+  - /im-plugin/refresh-analyzer/
+  - /query-dsl/analyzers/refresh-analyzer/
 ---
 
 # Refresh search analyzer

--- a/_monitoring-plugins/ad/api.md
+++ b/_monitoring-plugins/ad/api.md
@@ -4,6 +4,8 @@ title: Anomaly detection API
 parent: Anomaly detection
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/api/
+redirect_from:
+  - /observing-your-data/ad/api/
 ---
 
 # Anomaly detection API

--- a/_monitoring-plugins/ad/index.md
+++ b/_monitoring-plugins/ad/index.md
@@ -5,6 +5,8 @@ nav_order: 46
 has_children: true
 redirect_from:
   - /monitoring-plugins/ad/
+  - /observing-your-data/ad/
+  - /observing-your-data/ad/index/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/index/
 ---
 

--- a/_monitoring-plugins/ad/security.md
+++ b/_monitoring-plugins/ad/security.md
@@ -5,6 +5,8 @@ nav_order: 10
 parent: Anomaly detection
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/security/
+redirect_from:
+  - /observing-your-data/ad/security/
 ---
 
 # Anomaly detection security

--- a/_monitoring-plugins/ad/settings.md
+++ b/_monitoring-plugins/ad/settings.md
@@ -4,6 +4,8 @@ title: Settings
 parent: Anomaly detection
 nav_order: 4
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/settings/
+redirect_from:
+  - /observing-your-data/ad/settings/
 ---
 
 # Settings

--- a/_monitoring-plugins/alerting/api.md
+++ b/_monitoring-plugins/alerting/api.md
@@ -4,6 +4,8 @@ title: API
 parent: Alerting
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/api/
+redirect_from:
+  - /observing-your-data/alerting/api/
 ---
 
 # Alerting API

--- a/_monitoring-plugins/alerting/cron.md
+++ b/_monitoring-plugins/alerting/cron.md
@@ -5,6 +5,8 @@ nav_order: 20
 parent: Alerting
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/cron/
+redirect_from:
+  - /observing-your-data/alerting/cron/
 ---
 
 # Cron expression reference

--- a/_monitoring-plugins/alerting/index.md
+++ b/_monitoring-plugins/alerting/index.md
@@ -5,6 +5,8 @@ nav_order: 34
 has_children: true
 redirect_from:
   - /monitoring-plugins/alerting/
+  - /observing-your-data/alerting/
+  - /observing-your-data/alerting/index/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/index/
 ---
 

--- a/_monitoring-plugins/alerting/monitors.md
+++ b/_monitoring-plugins/alerting/monitors.md
@@ -5,6 +5,8 @@ nav_order: 1
 parent: Alerting
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/monitors/
+redirect_from:
+  - /observing-your-data/alerting/monitors/
 ---
 
 # Monitors

--- a/_monitoring-plugins/alerting/security.md
+++ b/_monitoring-plugins/alerting/security.md
@@ -5,6 +5,8 @@ nav_order: 10
 parent: Alerting
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/security/
+redirect_from:
+  - /observing-your-data/alerting/security/
 ---
 
 # Alerting security

--- a/_monitoring-plugins/alerting/settings.md
+++ b/_monitoring-plugins/alerting/settings.md
@@ -4,6 +4,8 @@ title: Management
 parent: Alerting
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/settings/
+redirect_from:
+  - /observing-your-data/alerting/settings/
 ---
 
 # Management

--- a/_monitoring-plugins/pa/api.md
+++ b/_monitoring-plugins/pa/api.md
@@ -4,6 +4,8 @@ title: API
 parent: Performance Analyzer
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/api/
+redirect_from:
+  - /monitoring-your-cluster/pa/api/
 ---
 
 # Performance Analyzer API

--- a/_monitoring-plugins/pa/dashboards.md
+++ b/_monitoring-plugins/pa/dashboards.md
@@ -4,6 +4,8 @@ title: Create PerfTop Dashboards
 parent: Performance Analyzer
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/dashboards/
+redirect_from:
+  - /monitoring-your-cluster/pa/dashboards/
 ---
 
 # PerfTop dashboards

--- a/_monitoring-plugins/pa/index.md
+++ b/_monitoring-plugins/pa/index.md
@@ -5,6 +5,8 @@ nav_order: 58
 has_children: true
 redirect_from:
   - /monitoring-plugins/pa/
+  - /monitoring-your-cluster/pa/
+  - /monitoring-your-cluster/pa/index/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/
 ---
 

--- a/_monitoring-plugins/pa/rca/api.md
+++ b/_monitoring-plugins/pa/rca/api.md
@@ -5,6 +5,8 @@ parent: Root Cause Analysis
 grand_parent: Performance Analyzer
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/api/
+redirect_from:
+  - /monitoring-your-cluster/pa/rca/api/
 ---
 
 # RCA API

--- a/_monitoring-plugins/pa/rca/index.md
+++ b/_monitoring-plugins/pa/rca/index.md
@@ -5,6 +5,9 @@ nav_order: 50
 parent: Performance Analyzer
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/index/
+redirect_from:
+  - /monitoring-your-cluster/pa/rca/
+  - /monitoring-your-cluster/pa/rca/index/
 ---
 
 # Root Cause Analysis

--- a/_monitoring-plugins/pa/rca/reference.md
+++ b/_monitoring-plugins/pa/rca/reference.md
@@ -5,6 +5,8 @@ parent: Root Cause Analysis
 grand_parent: Performance Analyzer
 nav_order: 3
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/reference/
+redirect_from:
+  - /monitoring-your-cluster/pa/rca/reference/
 ---
 
 # RCA reference

--- a/_monitoring-plugins/pa/reference.md
+++ b/_monitoring-plugins/pa/reference.md
@@ -4,6 +4,8 @@ title: Metrics Reference
 parent: Performance Analyzer
 nav_order: 3
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/reference/
+redirect_from:
+  - /monitoring-your-cluster/pa/reference/
 ---
 
 # Metrics reference

--- a/_monitoring-plugins/trace/get-started.md
+++ b/_monitoring-plugins/trace/get-started.md
@@ -4,6 +4,9 @@ title: Get Started
 parent: Trace analytics
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/getting-started/
+redirect_from:
+  - /observability-plugin/trace/get-started/
+  - /observing-your-data/trace/getting-started/
 ---
 
 # Get started with Trace Analytics

--- a/_monitoring-plugins/trace/index.md
+++ b/_monitoring-plugins/trace/index.md
@@ -6,6 +6,9 @@ has_children: true
 has_toc: false
 redirect_from:
   - /monitoring-plugins/trace/
+  - /observability-plugin/trace/index/
+  - /observing-your-data/trace/
+  - /observing-your-data/trace/index/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/index/
 ---
 

--- a/_monitoring-plugins/trace/ta-dashboards.md
+++ b/_monitoring-plugins/trace/ta-dashboards.md
@@ -4,6 +4,9 @@ title: OpenSearch Dashboards plugin
 parent: Trace analytics
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/ta-dashboards/
+redirect_from:
+  - /observability-plugin/trace/ta-dashboards/
+  - /observing-your-data/trace/ta-dashboards/
 ---
 
 # Trace Analytics OpenSearch Dashboards plugin

--- a/_opensearch/aggregations.md
+++ b/_opensearch/aggregations.md
@@ -4,6 +4,11 @@ title: Aggregations
 nav_order: 14
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/aggregations/
+redirect_from:
+  - /aggregations/
+  - /aggregations/index/
+  - /query-dsl/aggregations/
+  - /query-dsl/aggregations/aggregations/
 ---
 
 # Aggregations

--- a/_opensearch/bucket-agg.md
+++ b/_opensearch/bucket-agg.md
@@ -5,6 +5,12 @@ parent: Aggregations
 nav_order: 2
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/index/
+redirect_from:
+  - /aggregations/bucket-agg/
+  - /aggregations/bucket/
+  - /aggregations/bucket/index/
+  - /query-dsl/aggregations/bucket-agg/
+  - /query-dsl/aggregations/bucket/
 ---
 
 # Bucket aggregations

--- a/_opensearch/cluster.md
+++ b/_opensearch/cluster.md
@@ -3,6 +3,10 @@ layout: default
 title: Cluster formation
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/
+redirect_from:
+  - /tuning-your-cluster/
+  - /tuning-your-cluster/cluster/
+  - /tuning-your-cluster/index/
 ---
 
 # Cluster formation

--- a/_opensearch/common-parameters.md
+++ b/_opensearch/common-parameters.md
@@ -3,6 +3,8 @@ layout: default
 title: Common REST Parameters
 nav_order: 93
 canonical_url: https://docs.opensearch.org/latest/api-reference/common-parameters/
+redirect_from:
+  - /api-reference/common-parameters/
 ---
 
 # Common REST parameters

--- a/_opensearch/configuration.md
+++ b/_opensearch/configuration.md
@@ -3,6 +3,9 @@ layout: default
 title: Configuration
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index/
+redirect_from:
+  - /install-and-configure/configuring-opensearch/
+  - /install-and-configure/configuring-opensearch/index/
 ---
 
 # OpenSearch configuration

--- a/_opensearch/data-streams.md
+++ b/_opensearch/data-streams.md
@@ -3,6 +3,8 @@ layout: default
 title: Data streams
 nav_order: 13
 canonical_url: https://docs.opensearch.org/latest/im-plugin/data-streams/
+redirect_from:
+  - /im-plugin/data-streams/
 ---
 
 # Data streams

--- a/_opensearch/index-alias.md
+++ b/_opensearch/index-alias.md
@@ -3,6 +3,8 @@ layout: default
 title: Index aliases
 nav_order: 12
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-alias/
+redirect_from:
+  - /im-plugin/index-alias/
 ---
 
 # Index aliases

--- a/_opensearch/index-templates.md
+++ b/_opensearch/index-templates.md
@@ -3,6 +3,8 @@ layout: default
 title: Index templates
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-templates/
+redirect_from:
+  - /im-plugin/index-templates/
 ---
 
 # Index templates

--- a/_opensearch/index.md
+++ b/_opensearch/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /docs/opensearch/
   - /opensearch/
+  - /about/
 canonical_url: https://docs.opensearch.org/latest/getting-started/
 ---
 

--- a/_opensearch/install/docker.md
+++ b/_opensearch/install/docker.md
@@ -4,6 +4,8 @@ title: Docker
 parent: Install OpenSearch
 nav_order: 3
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/docker/
+redirect_from:
+  - /install-and-configure/install-opensearch/docker/
 ---
 
 # Docker image

--- a/_opensearch/install/helm.md
+++ b/_opensearch/install/helm.md
@@ -4,6 +4,8 @@ title: Helm
 parent: Install OpenSearch
 nav_order: 6
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/helm/
+redirect_from:
+  - /install-and-configure/install-opensearch/helm/
 ---
 
 # Run OpenSearch using Helm

--- a/_opensearch/install/index.md
+++ b/_opensearch/install/index.md
@@ -4,6 +4,8 @@ title: Install OpenSearch
 nav_order: 2
 redirect_from:
   - /opensearch/install/
+  - /install-and-configure/install-opensearch/
+  - /install-and-configure/install-opensearch/index/
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/
 ---

--- a/_opensearch/install/plugins.md
+++ b/_opensearch/install/plugins.md
@@ -4,6 +4,9 @@ title: OpenSearch plugins
 parent: Install OpenSearch
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/plugins/
+redirect_from:
+  - /install-and-configure/install-opensearch/plugins/
+  - /install-and-configure/plugins/
 ---
 
 # Standalone OpenSearch plugin installation

--- a/_opensearch/install/tar.md
+++ b/_opensearch/install/tar.md
@@ -4,6 +4,8 @@ title: Tarball
 parent: Install OpenSearch
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/tar/
+redirect_from:
+  - /install-and-configure/install-opensearch/tar/
 ---
 
 # Tarball

--- a/_opensearch/logs.md
+++ b/_opensearch/logs.md
@@ -3,6 +3,9 @@ layout: default
 title: Logs
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/logs/
+redirect_from:
+  - /install-and-configure/configuring-opensearch/logs/
+  - /monitoring-your-cluster/logs/
 ---
 
 # Logs

--- a/_opensearch/metric-agg.md
+++ b/_opensearch/metric-agg.md
@@ -5,6 +5,12 @@ parent: Aggregations
 nav_order: 1
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/aggregations/metric/index/
+redirect_from:
+  - /aggregations/metric-agg/
+  - /aggregations/metric/
+  - /aggregations/metric/index/
+  - /query-dsl/aggregations/metric-agg/
+  - /query-dsl/aggregations/metric/
 ---
 
 # Metric aggregations

--- a/_opensearch/pipeline-agg.md
+++ b/_opensearch/pipeline-agg.md
@@ -5,6 +5,11 @@ parent: Aggregations
 nav_order: 4
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline-agg/
+redirect_from:
+  - /aggregations/pipeline-agg/
+  - /aggregations/pipeline/
+  - /aggregations/pipeline/index/
+  - /query-dsl/aggregations/pipeline-agg/
 ---
 
 # Pipeline aggregations

--- a/_opensearch/popular-api.md
+++ b/_opensearch/popular-api.md
@@ -3,6 +3,8 @@ layout: default
 title: Popular APIs
 nav_order: 96
 canonical_url: https://docs.opensearch.org/latest/api-reference/popular-api/
+redirect_from:
+  - /api-reference/popular-api/
 ---
 
 # Popular APIs

--- a/_opensearch/query-dsl/bool.md
+++ b/_opensearch/query-dsl/bool.md
@@ -4,6 +4,10 @@ title: Boolean queries
 parent: Query DSL
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/query-dsl/compound/bool/
+redirect_from:
+  - /opensearch/query-dsl/compound/bool/
+  - /query-dsl/compound/bool/
+  - /query-dsl/query-dsl/compound/bool/
 ---
 
 # Boolean queries

--- a/_opensearch/query-dsl/full-text.md
+++ b/_opensearch/query-dsl/full-text.md
@@ -4,6 +4,11 @@ title: Full-text queries
 parent: Query DSL
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/query-dsl/full-text/index/
+redirect_from:
+  - /opensearch/query-dsl/full-text/index/
+  - /query-dsl/full-text/
+  - /query-dsl/full-text/index/
+  - /query-dsl/query-dsl/full-text/
 ---
 
 # Full-text queries

--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -6,6 +6,9 @@ has_children: true
 redirect_from:
   - /opensearch/query-dsl/
   - /docs/opensearch/query-dsl/
+  - /query-dsl/
+  - /query-dsl/index/
+  - /query-dsl/query-dsl/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/
 ---
 

--- a/_opensearch/query-dsl/term.md
+++ b/_opensearch/query-dsl/term.md
@@ -4,6 +4,9 @@ title: Term-level queries
 parent: Query DSL
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/query-dsl/term/index/
+redirect_from:
+  - /query-dsl/term/
+  - /query-dsl/term/index/
 ---
 
 # Term-level queries

--- a/_opensearch/reindex-data.md
+++ b/_opensearch/reindex-data.md
@@ -3,6 +3,8 @@ layout: default
 title: Reindex data
 nav_order: 16
 canonical_url: https://docs.opensearch.org/latest/im-plugin/reindex-data/
+redirect_from:
+  - /api-reference/document-apis/reindex/
 ---
 
 # Reindex data

--- a/_opensearch/rest-api/alias.md
+++ b/_opensearch/rest-api/alias.md
@@ -4,6 +4,10 @@ title: Alias
 parent: REST API reference
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
+redirect_from:
+  - /api-reference/alias-api/
+  - /api-reference/alias/
+  - /api-reference/alias/index/
 ---
 
 # Alias

--- a/_opensearch/rest-api/cat/cat-aliases.md
+++ b/_opensearch/rest-api/cat/cat-aliases.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 1
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-aliases/
+redirect_from:
+  - /api-reference/cat/cat-aliases/
 ---
 
 # cat aliases

--- a/_opensearch/rest-api/cat/cat-allocation.md
+++ b/_opensearch/rest-api/cat/cat-allocation.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 5
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-allocation/
+redirect_from:
+  - /api-reference/cat/cat-allocation/
 ---
 
 # cat allocation

--- a/_opensearch/rest-api/cat/cat-count.md
+++ b/_opensearch/rest-api/cat/cat-count.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 10
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-count/
+redirect_from:
+  - /api-reference/cat/cat-count/
 ---
 
 # cat count

--- a/_opensearch/rest-api/cat/cat-field-data.md
+++ b/_opensearch/rest-api/cat/cat-field-data.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 15
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-field-data/
+redirect_from:
+  - /api-reference/cat/cat-field-data/
 ---
 
 # cat fielddata

--- a/_opensearch/rest-api/cat/cat-health.md
+++ b/_opensearch/rest-api/cat/cat-health.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 20
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-health/
+redirect_from:
+  - /api-reference/cat/cat-health/
 ---
 
 # cat health

--- a/_opensearch/rest-api/cat/cat-indices.md
+++ b/_opensearch/rest-api/cat/cat-indices.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 25
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-indices/
+redirect_from:
+  - /api-reference/cat/cat-indices/
 ---
 
 # cat indices

--- a/_opensearch/rest-api/cat/cat-master.md
+++ b/_opensearch/rest-api/cat/cat-master.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 30
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-cluster_manager/
+redirect_from:
+  - /api-reference/cat/cat-cluster_manager/
 ---
 
 # cat master

--- a/_opensearch/rest-api/cat/cat-nodeattrs.md
+++ b/_opensearch/rest-api/cat/cat-nodeattrs.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 35
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-nodeattrs/
+redirect_from:
+  - /api-reference/cat/cat-nodeattrs/
 ---
 
 # cat nodeattrs

--- a/_opensearch/rest-api/cat/cat-nodes.md
+++ b/_opensearch/rest-api/cat/cat-nodes.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 40
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-nodes/
+redirect_from:
+  - /api-reference/cat/cat-nodes/
 ---
 
 # cat nodes

--- a/_opensearch/rest-api/cat/cat-pending-tasks.md
+++ b/_opensearch/rest-api/cat/cat-pending-tasks.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 45
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-pending-tasks/
+redirect_from:
+  - /api-reference/cat/cat-pending-tasks/
 ---
 
 # cat pending tasks

--- a/_opensearch/rest-api/cat/cat-plugins.md
+++ b/_opensearch/rest-api/cat/cat-plugins.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 50
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-plugins/
+redirect_from:
+  - /api-reference/cat/cat-plugins/
 ---
 
 # cat plugins

--- a/_opensearch/rest-api/cat/cat-recovery.md
+++ b/_opensearch/rest-api/cat/cat-recovery.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 50
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-recovery/
+redirect_from:
+  - /api-reference/cat/cat-recovery/
 ---
 
 # cat recovery

--- a/_opensearch/rest-api/cat/cat-repositories.md
+++ b/_opensearch/rest-api/cat/cat-repositories.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 55
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-repositories/
+redirect_from:
+  - /api-reference/cat/cat-repositories/
 ---
 
 # cat repositories

--- a/_opensearch/rest-api/cat/cat-segments.md
+++ b/_opensearch/rest-api/cat/cat-segments.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 55
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-segments/
+redirect_from:
+  - /api-reference/cat/cat-segments/
 ---
 
 # cat segments

--- a/_opensearch/rest-api/cat/cat-shards.md
+++ b/_opensearch/rest-api/cat/cat-shards.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 60
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-shards/
+redirect_from:
+  - /api-reference/cat/cat-shards/
 ---
 
 # cat shards

--- a/_opensearch/rest-api/cat/cat-snapshots.md
+++ b/_opensearch/rest-api/cat/cat-snapshots.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 65
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-snapshots/
+redirect_from:
+  - /api-reference/cat/cat-snapshots/
 ---
 
 # cat snapshots

--- a/_opensearch/rest-api/cat/cat-tasks.md
+++ b/_opensearch/rest-api/cat/cat-tasks.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 70
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-tasks/
+redirect_from:
+  - /api-reference/cat/cat-tasks/
 ---
 
 # cat tasks

--- a/_opensearch/rest-api/cat/cat-templates.md
+++ b/_opensearch/rest-api/cat/cat-templates.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 70
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-templates/
+redirect_from:
+  - /api-reference/cat/cat-templates/
 ---
 
 # cat templates

--- a/_opensearch/rest-api/cat/cat-thread-pool.md
+++ b/_opensearch/rest-api/cat/cat-thread-pool.md
@@ -6,6 +6,8 @@ grand_parent: REST API reference
 nav_order: 75
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-thread-pool/
+redirect_from:
+  - /api-reference/cat/cat-thread-pool/
 ---
 
 # cat thread pool

--- a/_opensearch/rest-api/cat/index.md
+++ b/_opensearch/rest-api/cat/index.md
@@ -6,6 +6,8 @@ nav_order: 100
 has_children: true
 redirect_from:
   - /opensearch/catapis/
+  - /api-reference/cat/
+  - /api-reference/cat/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/index/
 ---
 

--- a/_opensearch/rest-api/cluster-allocation.md
+++ b/_opensearch/rest-api/cluster-allocation.md
@@ -4,6 +4,8 @@ title: Cluster allocation explain
 parent: REST API reference
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-allocation/
+redirect_from:
+  - /api-reference/cluster-api/cluster-allocation/
 ---
 
 # Cluster allocation explain

--- a/_opensearch/rest-api/cluster-health.md
+++ b/_opensearch/rest-api/cluster-health.md
@@ -4,6 +4,9 @@ title: Cluster health
 parent: REST API reference
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-health/
+redirect_from:
+  - /api-reference/cluster-api/cluster-health/
+  - /api-reference/cluster-health/
 ---
 
 # Cluster health

--- a/_opensearch/rest-api/cluster-settings.md
+++ b/_opensearch/rest-api/cluster-settings.md
@@ -4,6 +4,9 @@ title: Cluster settings
 parent: REST API reference
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-settings/
+redirect_from:
+  - /api-reference/cluster-api/cluster-settings/
+  - /api-reference/cluster-settings/
 ---
 
 # Cluster settings

--- a/_opensearch/rest-api/count.md
+++ b/_opensearch/rest-api/count.md
@@ -4,6 +4,9 @@ title: Count
 parent: REST API reference
 nav_order: 150
 canonical_url: https://docs.opensearch.org/latest/api-reference/count/
+redirect_from:
+  - /api-reference/count/
+  - /api-reference/search-apis/count/
 ---
 
 # Count

--- a/_opensearch/rest-api/create-index.md
+++ b/_opensearch/rest-api/create-index.md
@@ -4,6 +4,9 @@ title: Create index
 parent: REST API reference
 nav_order: 3
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/create-index/
+redirect_from:
+  - /api-reference/index-apis/create-index/
+  - /opensearch/rest-api/index-apis/create-index/
 ---
 
 # Create index

--- a/_opensearch/rest-api/document-apis/bulk.md
+++ b/_opensearch/rest-api/document-apis/bulk.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/bulk/
+redirect_from:
+  - /api-reference/document-apis/bulk/
 ---
 
 # Bulk

--- a/_opensearch/rest-api/document-apis/delete-by-query.md
+++ b/_opensearch/rest-api/document-apis/delete-by-query.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/delete-by-query/
+redirect_from:
+  - /api-reference/document-apis/delete-by-query/
 ---
 
 # Delete by query

--- a/_opensearch/rest-api/document-apis/delete-document.md
+++ b/_opensearch/rest-api/document-apis/delete-document.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/delete-document/
+redirect_from:
+  - /api-reference/document-apis/delete-document/
 ---
 
 # Delete document

--- a/_opensearch/rest-api/document-apis/get-documents.md
+++ b/_opensearch/rest-api/document-apis/get-documents.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/get-documents/
+redirect_from:
+  - /api-reference/document-apis/get-documents/
 ---
 
 # Get document

--- a/_opensearch/rest-api/document-apis/index-document.md
+++ b/_opensearch/rest-api/document-apis/index-document.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index-document/
+redirect_from:
+  - /api-reference/document-apis/index-document/
 ---
 
 # Index document

--- a/_opensearch/rest-api/document-apis/index.md
+++ b/_opensearch/rest-api/document-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 nav_order: 7
 redirect_from:
   - /opensearch/rest-api/document-apis/
+  - /api-reference/document-apis/
+  - /api-reference/document-apis/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index/
 ---
 

--- a/_opensearch/rest-api/document-apis/multi-get.md
+++ b/_opensearch/rest-api/document-apis/multi-get.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/multi-get/
+redirect_from:
+  - /api-reference/document-apis/multi-get/
 ---
 
 # Multi-get documents

--- a/_opensearch/rest-api/document-apis/update-by-query.md
+++ b/_opensearch/rest-api/document-apis/update-by-query.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/update-by-query/
+redirect_from:
+  - /api-reference/document-apis/update-by-query/
 ---
 
 # Update by query

--- a/_opensearch/rest-api/document-apis/update-document.md
+++ b/_opensearch/rest-api/document-apis/update-document.md
@@ -5,6 +5,8 @@ parent: Document APIs
 grand_parent: REST API reference
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/update-document/
+redirect_from:
+  - /api-reference/document-apis/update-document/
 ---
 
 # Update document

--- a/_opensearch/rest-api/explain.md
+++ b/_opensearch/rest-api/explain.md
@@ -4,6 +4,9 @@ title: Explain
 parent: REST API reference
 nav_order: 140
 canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
+redirect_from:
+  - /api-reference/explain/
+  - /api-reference/search-apis/explain/
 ---
 
 # Explain

--- a/_opensearch/rest-api/index.md
+++ b/_opensearch/rest-api/index.md
@@ -5,6 +5,8 @@ nav_order: 99
 has_children: true
 redirect_from:
   - /opensearch/rest-api/
+  - /api-reference/
+  - /api-reference/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/
 ---
 

--- a/_opensearch/rest-api/multi-search.md
+++ b/_opensearch/rest-api/multi-search.md
@@ -4,6 +4,9 @@ title: Multi-search
 parent: REST API reference
 nav_order: 130
 canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
+redirect_from:
+  - /api-reference/multi-search/
+  - /api-reference/search-apis/multi-search/
 ---
 
 # Multi-search

--- a/_opensearch/rest-api/remote-info.md
+++ b/_opensearch/rest-api/remote-info.md
@@ -4,6 +4,9 @@ title: Remote cluster information
 parent: REST API reference
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
+redirect_from:
+  - /api-reference/cluster-api/remote-info/
+  - /api-reference/remote-info/
 ---
 
 # Remote cluster information

--- a/_opensearch/rest-api/scroll.md
+++ b/_opensearch/rest-api/scroll.md
@@ -4,6 +4,9 @@ title: Scroll
 parent: REST API reference
 nav_order: 120
 canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
+redirect_from:
+  - /api-reference/scroll/
+  - /api-reference/search-apis/scroll/
 ---
 
 # Scroll

--- a/_opensearch/rest-api/tasks.md
+++ b/_opensearch/rest-api/tasks.md
@@ -4,6 +4,9 @@ title: Tasks
 parent: REST API reference
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
+redirect_from:
+  - /api-reference/tasks/
+  - /api-reference/tasks/tasks/
 ---
 
 # Tasks

--- a/_opensearch/rest-api/update-mapping.md
+++ b/_opensearch/rest-api/update-mapping.md
@@ -4,6 +4,10 @@ title: Update mapping
 parent: REST API reference
 nav_order: 6
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/put-mapping/
+redirect_from:
+  - /api-reference/index-apis/put-mapping/
+  - /opensearch/rest-api/index-apis/put-mapping/
+  - /opensearch/rest-api/index-apis/update-mapping/
 ---
 
 # Update mapping

--- a/_opensearch/search-template.md
+++ b/_opensearch/search-template.md
@@ -3,6 +3,11 @@ layout: default
 title: Search templates
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/search-template/
+redirect_from:
+  - /api-reference/search-apis/search-template/
+  - /api-reference/search-apis/search-template/index/
+  - /api-reference/search-template/
+  - /search-plugins/search-template/
 ---
 
 # Search templates

--- a/_opensearch/snapshot-restore.md
+++ b/_opensearch/snapshot-restore.md
@@ -3,6 +3,10 @@ layout: default
 title: Take and restore snapshots
 nav_order: 65
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/
+redirect_from:
+  - /availability-and-recovery/snapshots/snapshot-restore/
+  - /opensearch/snapshots/snapshot-restore/
+  - /tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/
 ---
 
 # Take and restore snapshots

--- a/_opensearch/units.md
+++ b/_opensearch/units.md
@@ -3,6 +3,8 @@ layout: default
 title: Supported units
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/api-reference/units/
+redirect_from:
+  - /api-reference/units/
 ---
 
 # Supported units

--- a/_opensearch/ux.md
+++ b/_opensearch/ux.md
@@ -3,6 +3,10 @@ layout: default
 title: Search experience
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/index/
+redirect_from:
+  - /search-plugins/search-options/
+  - /search-plugins/searching-data/
+  - /search-plugins/searching-data/index/
 ---
 
 # Search experience

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -5,6 +5,10 @@ nav_order: 5
 parent: k-NN
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/api/
+redirect_from:
+  - /vector-search/api/
+  - /vector-search/api/index/
+  - /vector-search/api/knn/
 ---
 
 # k-NN plugin API

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -6,6 +6,8 @@ parent: k-NN
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/
+redirect_from:
+  - /vector-search/vector-search-techniques/approximate-knn/
 ---
 
 # Approximate k-NN search

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/knn/
+  - /vector-search/vector-search-techniques/
+  - /vector-search/vector-search-techniques/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/index/
 ---
 

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -5,6 +5,9 @@ nav_order: 1
 parent: k-NN
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-index/
+redirect_from:
+  - /vector-search/creating-a-vector-db/
+  - /vector-search/creating-vector-index/
 ---
 
 # k-NN Index

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -6,6 +6,8 @@ parent: k-NN
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/
+redirect_from:
+  - /vector-search/vector-search-techniques/knn-score-script/
 ---
 
 # Exact k-NN with scoring script

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -6,6 +6,8 @@ parent: k-NN
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/
+redirect_from:
+  - /vector-search/vector-search-techniques/painless-functions/
 ---
 
 # k-NN Painless Scripting extensions

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -4,6 +4,8 @@ title: Performance tuning
 parent: k-NN
 nav_order: 8
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/performance-tuning/
+redirect_from:
+  - /vector-search/performance-tuning/
 ---
 
 # Performance tuning

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -4,6 +4,8 @@ title: Settings
 parent: k-NN
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/settings/
+redirect_from:
+  - /vector-search/settings/
 ---
 
 # k-NN settings

--- a/_search-plugins/ppl/commands.md
+++ b/_search-plugins/ppl/commands.md
@@ -4,6 +4,11 @@ title: Commands
 parent: Piped processing language
 nav_order: 4
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/functions/
+redirect_from:
+  - /observability-plugin/ppl/commands/
+  - /search-plugins/sql/ppl/functions/
+  - /sql-and-ppl/ppl/commands/index/
+  - /sql-and-ppl/ppl/functions/
 ---
 
 

--- a/_search-plugins/ppl/identifiers.md
+++ b/_search-plugins/ppl/identifiers.md
@@ -4,6 +4,10 @@ title: Identifiers
 parent: Piped processing language
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
+redirect_from:
+  - /observability-plugin/ppl/identifiers/
+  - /search-plugins/sql/identifiers/
+  - /sql-and-ppl/identifiers/
 ---
 
 

--- a/_search-plugins/ppl/index.md
+++ b/_search-plugins/ppl/index.md
@@ -6,6 +6,12 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/ppl/
+  - /observability-plugin/ppl/
+  - /observability-plugin/ppl/index/
+  - /search-plugins/sql/ppl/
+  - /search-plugins/sql/ppl/index/
+  - /sql-and-ppl/ppl/
+  - /sql-and-ppl/ppl/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
 ---
 

--- a/_search-plugins/sql/aggregations.md
+++ b/_search-plugins/sql/aggregations.md
@@ -4,6 +4,9 @@ title: Aggregation Functions
 parent: SQL
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+redirect_from:
+  - /search-plugins/sql/sql/aggregations/
+  - /sql-and-ppl/sql/aggregations/
 ---
 
 # Aggregation functions

--- a/_search-plugins/sql/basic.md
+++ b/_search-plugins/sql/basic.md
@@ -4,6 +4,9 @@ title: Basic Queries
 parent: SQL
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
+redirect_from:
+  - /search-plugins/sql/sql/basic/
+  - /sql-and-ppl/sql/basic/
 ---
 
 

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -4,6 +4,8 @@ title: SQL CLI
 parent: SQL
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
+redirect_from:
+  - /sql-and-ppl/cli/
 ---
 
 # SQL CLI

--- a/_search-plugins/sql/complex.md
+++ b/_search-plugins/sql/complex.md
@@ -4,6 +4,9 @@ title: Complex Queries
 parent: SQL
 nav_order: 6
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
+redirect_from:
+  - /search-plugins/sql/sql/complex/
+  - /sql-and-ppl/sql/complex/
 ---
 
 # Complex queries

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -4,6 +4,8 @@ title: Data Types
 parent: SQL
 nav_order: 73
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+redirect_from:
+  - /sql-and-ppl/datatypes/
 ---
 
 # Data types

--- a/_search-plugins/sql/delete.md
+++ b/_search-plugins/sql/delete.md
@@ -4,6 +4,9 @@ title: Delete
 parent: SQL
 nav_order: 12
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
+redirect_from:
+  - /search-plugins/sql/sql/delete/
+  - /sql-and-ppl/sql/delete/
 ---
 
 

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -4,6 +4,9 @@ title: Functions
 parent: SQL
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
+redirect_from:
+  - /search-plugins/sql/sql/functions/
+  - /sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/sql/
+  - /sql-and-ppl/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
 ---
 

--- a/_search-plugins/sql/jdbc.md
+++ b/_search-plugins/sql/jdbc.md
@@ -4,6 +4,9 @@ title: JDBC Driver
 parent: SQL
 nav_order: 71
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
+redirect_from:
+  - /search-plugins/sql/sql/jdbc/
+  - /sql-and-ppl/sql/jdbc/
 ---
 
 # JDBC driver

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -4,6 +4,8 @@ title: Limitations
 parent: SQL
 nav_order: 18
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
+redirect_from:
+  - /sql-and-ppl/limitation/
 ---
 
 # Limitations

--- a/_search-plugins/sql/metadata.md
+++ b/_search-plugins/sql/metadata.md
@@ -4,6 +4,9 @@ title: Metadata Queries
 parent: SQL
 nav_order: 9
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
+redirect_from:
+  - /search-plugins/sql/sql/metadata/
+  - /sql-and-ppl/sql/metadata/
 ---
 
 # Metadata queries

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -4,6 +4,8 @@ title: Monitoring
 parent: SQL
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
+redirect_from:
+  - /sql-and-ppl/monitoring/
 ---
 
 # Monitoring

--- a/_search-plugins/sql/odbc.md
+++ b/_search-plugins/sql/odbc.md
@@ -4,6 +4,9 @@ title: ODBC Driver
 parent: SQL
 nav_order: 72
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
+redirect_from:
+  - /search-plugins/sql/sql/odbc/
+  - /sql-and-ppl/sql/odbc/
 ---
 
 # ODBC driver

--- a/_search-plugins/sql/partiql.md
+++ b/_search-plugins/sql/partiql.md
@@ -4,6 +4,9 @@ title: JSON Support
 parent: SQL
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
+redirect_from:
+  - /search-plugins/sql/sql/partiql/
+  - /sql-and-ppl/sql/partiql/
 ---
 
 # JSON Support

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -4,6 +4,8 @@ title: Settings
 parent: SQL
 nav_order: 16
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
+redirect_from:
+  - /sql-and-ppl/settings/
 ---
 
 # Settings

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -4,6 +4,8 @@ title: Troubleshooting
 parent: SQL
 nav_order: 17
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
+redirect_from:
+  - /sql-and-ppl/troubleshoot/
 ---
 
 # Troubleshooting

--- a/_search-plugins/sql/workbench.md
+++ b/_search-plugins/sql/workbench.md
@@ -4,6 +4,8 @@ title: Query Workbench
 parent: SQL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/dashboards/query-workbench/
+redirect_from:
+  - /dashboards/query-workbench/
 ---
 
 # Query Workbench

--- a/_security-plugin/access-control/api.md
+++ b/_security-plugin/access-control/api.md
@@ -4,6 +4,8 @@ title: API
 parent: Access control
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/security/access-control/api/
+redirect_from:
+  - /security/access-control/api/
 ---
 
 # API

--- a/_security-plugin/access-control/cross-cluster-search.md
+++ b/_security-plugin/access-control/cross-cluster-search.md
@@ -4,6 +4,9 @@ title: Cross-cluster search
 parent: Access control
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/search-plugins/cross-cluster-search/
+redirect_from:
+  - /search-plugins/cross-cluster-search/
+  - /security/access-control/cross-cluster-search/
 ---
 
 # Cross-cluster search

--- a/_security-plugin/access-control/default-action-groups.md
+++ b/_security-plugin/access-control/default-action-groups.md
@@ -4,6 +4,8 @@ title: Default action groups
 parent: Access control
 nav_order: 51
 canonical_url: https://docs.opensearch.org/latest/security/access-control/default-action-groups/
+redirect_from:
+  - /security/access-control/default-action-groups/
 ---
 
 # Default action groups

--- a/_security-plugin/access-control/document-level-security.md
+++ b/_security-plugin/access-control/document-level-security.md
@@ -4,6 +4,8 @@ title: Document-level security
 parent: Access control
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/security/access-control/document-level-security/
+redirect_from:
+  - /security/access-control/document-level-security/
 ---
 
 # Document-level security

--- a/_security-plugin/access-control/field-level-security.md
+++ b/_security-plugin/access-control/field-level-security.md
@@ -4,6 +4,8 @@ title: Field-level security
 parent: Access control
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/security/access-control/field-level-security/
+redirect_from:
+  - /security/access-control/field-level-security/
 ---
 
 # Field-level security

--- a/_security-plugin/access-control/field-masking.md
+++ b/_security-plugin/access-control/field-masking.md
@@ -4,6 +4,8 @@ title: Field masking
 parent: Access control
 nav_order: 12
 canonical_url: https://docs.opensearch.org/latest/security/access-control/field-masking/
+redirect_from:
+  - /security/access-control/field-masking/
 ---
 
 # Field masking

--- a/_security-plugin/access-control/impersonation.md
+++ b/_security-plugin/access-control/impersonation.md
@@ -4,6 +4,8 @@ title: User impersonation
 parent: Access control
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/security/access-control/impersonation/
+redirect_from:
+  - /security/access-control/impersonation/
 ---
 
 # User impersonation

--- a/_security-plugin/access-control/index.md
+++ b/_security-plugin/access-control/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-plugin/access-control/
+  - /security/access-control/
+  - /security/access-control/index/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/index/
 ---
 

--- a/_security-plugin/access-control/multi-tenancy.md
+++ b/_security-plugin/access-control/multi-tenancy.md
@@ -4,6 +4,10 @@ title: OpenSearch Dashboards multi-tenancy
 parent: Access control
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/security/multi-tenancy/tenant-index/
+redirect_from:
+  - /security/access-control/multi-tenancy/
+  - /security/multi-tenancy/
+  - /security/multi-tenancy/tenant-index/
 ---
 
 # OpenSearch Dashboards multi-tenancy

--- a/_security-plugin/access-control/permissions.md
+++ b/_security-plugin/access-control/permissions.md
@@ -4,6 +4,8 @@ title: Permissions
 parent: Access control
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/security/access-control/permissions/
+redirect_from:
+  - /security/access-control/permissions/
 ---
 
 # Permissions

--- a/_security-plugin/access-control/users-roles.md
+++ b/_security-plugin/access-control/users-roles.md
@@ -4,6 +4,8 @@ title: Users and roles
 parent: Access control
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/security/access-control/users-roles/
+redirect_from:
+  - /security/access-control/users-roles/
 ---
 
 # Users and roles

--- a/_security-plugin/audit-logs/field-reference.md
+++ b/_security-plugin/audit-logs/field-reference.md
@@ -4,6 +4,8 @@ title: Audit log field reference
 parent: Audit Logs
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/field-reference/
+redirect_from:
+  - /security/audit-logs/field-reference/
 ---
 
 # Audit log field reference

--- a/_security-plugin/audit-logs/index.md
+++ b/_security-plugin/audit-logs/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-plugin/audit-logs/
+  - /security/audit-logs/
+  - /security/audit-logs/index/
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/index/
 ---
 

--- a/_security-plugin/audit-logs/storage-types.md
+++ b/_security-plugin/audit-logs/storage-types.md
@@ -4,6 +4,8 @@ title: Audit log storage types
 parent: Audit Logs
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/storage-types/
+redirect_from:
+  - /security/audit-logs/storage-types/
 ---
 
 # Audit log storage types

--- a/_security-plugin/configuration/client-auth.md
+++ b/_security-plugin/configuration/client-auth.md
@@ -4,6 +4,9 @@ title: Client certificate authentication
 parent: Configuration
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/client-auth/
+redirect_from:
+  - /security/authentication-backends/client-auth/
+  - /security/configuration/client-auth/
 ---
 
 # Client certificate authentication

--- a/_security-plugin/configuration/concepts.md
+++ b/_security-plugin/configuration/concepts.md
@@ -4,6 +4,9 @@ title: Authentication flow
 parent: Configuration
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/authc-index/
+redirect_from:
+  - /security/authentication-backends/
+  - /security/authentication-backends/authc-index/
 ---
 
 # Authentication flow

--- a/_security-plugin/configuration/configuration.md
+++ b/_security-plugin/configuration/configuration.md
@@ -4,6 +4,8 @@ title: Backend configuration
 parent: Configuration
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/security/configuration/configuration/
+redirect_from:
+  - /security/configuration/configuration/
 ---
 
 # Backend configuration

--- a/_security-plugin/configuration/disable.md
+++ b/_security-plugin/configuration/disable.md
@@ -4,6 +4,9 @@ title: Disable security
 parent: Configuration
 nav_order: 99
 canonical_url: https://docs.opensearch.org/latest/security/configuration/disable-enable-security/
+redirect_from:
+  - /security/configuration/disable-enable-security/
+  - /security/configuration/disable/
 ---
 
 # Disable security

--- a/_security-plugin/configuration/generate-certificates.md
+++ b/_security-plugin/configuration/generate-certificates.md
@@ -4,6 +4,8 @@ title: Generate certificates
 parent: Configuration
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/security/configuration/generate-certificates/
+redirect_from:
+  - /security/configuration/generate-certificates/
 ---
 
 # Generate certificates

--- a/_security-plugin/configuration/index.md
+++ b/_security-plugin/configuration/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-plugin/configuration/
+  - /security/configuration/
+  - /security/configuration/index/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/index/
 ---
 

--- a/_security-plugin/configuration/ldap.md
+++ b/_security-plugin/configuration/ldap.md
@@ -4,6 +4,9 @@ title: Active Directory and LDAP
 parent: Configuration
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/ldap/
+redirect_from:
+  - /security/authentication-backends/ldap/
+  - /security/configuration/ldap/
 ---
 
 # Active Directory and LDAP

--- a/_security-plugin/configuration/openid-connect.md
+++ b/_security-plugin/configuration/openid-connect.md
@@ -4,6 +4,8 @@ title: OpenID Connect
 parent: Configuration
 nav_order: 32
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/openid-connect/
+redirect_from:
+  - /security/authentication-backends/openid-connect/
 ---
 
 # OpenID Connect

--- a/_security-plugin/configuration/proxy.md
+++ b/_security-plugin/configuration/proxy.md
@@ -4,6 +4,8 @@ title: Proxy-based authentication
 parent: Configuration
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/proxy/
+redirect_from:
+  - /security/authentication-backends/proxy/
 ---
 
 # Proxy-based authentication

--- a/_security-plugin/configuration/saml.md
+++ b/_security-plugin/configuration/saml.md
@@ -4,6 +4,9 @@ title: SAML
 parent: Configuration
 nav_order: 31
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/saml/
+redirect_from:
+  - /security/authentication-backends/saml/
+  - /security/configuration/saml/
 ---
 
 # SAML

--- a/_security-plugin/configuration/security-admin.md
+++ b/_security-plugin/configuration/security-admin.md
@@ -4,6 +4,8 @@ title: Apply changes with securityadmin.sh
 parent: Configuration
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/security/configuration/security-admin/
+redirect_from:
+  - /security/configuration/security-admin/
 ---
 
 # Apply changes using securityadmin.sh

--- a/_security-plugin/configuration/system-indices.md
+++ b/_security-plugin/configuration/system-indices.md
@@ -4,6 +4,8 @@ title: System indices
 parent: Configuration
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/security/configuration/system-indices/
+redirect_from:
+  - /security/configuration/system-indices/
 ---
 
 # System indices

--- a/_security-plugin/configuration/tls.md
+++ b/_security-plugin/configuration/tls.md
@@ -4,6 +4,8 @@ title: TLS certificates
 parent: Configuration
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/security/configuration/tls/
+redirect_from:
+  - /security/configuration/tls/
 ---
 
 # Configure TLS certificates

--- a/_security-plugin/configuration/yaml.md
+++ b/_security-plugin/configuration/yaml.md
@@ -4,6 +4,8 @@ title: YAML files
 parent: Configuration
 nav_order: 3
 canonical_url: https://docs.opensearch.org/latest/security/configuration/yaml/
+redirect_from:
+  - /security/configuration/yaml/
 ---
 
 # YAML files

--- a/_security-plugin/index.md
+++ b/_security-plugin/index.md
@@ -6,6 +6,8 @@ has_children: false
 has_toc: false
 redirect_from:
   - /security-plugin/
+  - /security/
+  - /security/index/
 canonical_url: https://docs.opensearch.org/latest/security/
 ---
 

--- a/_troubleshoot/index.md
+++ b/_troubleshoot/index.md
@@ -5,6 +5,8 @@ nav_order: 1
 has_toc: false
 redirect_from: /troubleshoot/
 canonical_url: https://docs.opensearch.org/latest/troubleshoot/
+redirect_from:
+  - /troubleshoot/
 ---
 
 # Common issues

--- a/_upgrade-to/index.md
+++ b/_upgrade-to/index.md
@@ -4,6 +4,11 @@ title: About the process
 nav_order: 1
 redirect_from:
   - /upgrade-to/
+  - /install-and-configure/upgrade-opensearch/index/
+  - /migrate-or-upgrade/
+  - /migrate-or-upgrade/index/
+  - /upgrade-opensearch/index/
+  - /upgrade-or-migrate/
 canonical_url: https://docs.opensearch.org/latest/upgrade-to/
 ---
 


### PR DESCRIPTION
Add backward redirects from all locations of a file so users can navigate to the same file between versions.

## Problem

When users switch between documentation versions (e.g., from `/latest/` to `/2.19/`), they get a 404 if the page path changed between versions. This accounts for 73% of all 404 errors on the documentation site (~9,300/month).

## Solution

For each page on `main` that has `redirect_from` entries (indicating it moved from an old path), add those paths as `redirect_from` on the corresponding file in older branches. This way, when a user switches versions, the newer path resolves correctly on the older branch.

## Safety checks

- Only adds redirects for paths that don't already resolve to an existing file on this branch
- Never adds a redirect that matches the file's own URL
- Skips files that already have `redirect_to`
- Never duplicates existing redirects