### PR TITLE
Add cross-version redirects to 2.4

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -6,6 +6,7 @@ has_children: false
 has_toc: false
 permalink: /about/
 redirect_from:
+  - /404.html
   - /docs/opensearch/
   - /opensearch/
   - /opensearch/index/

--- a/_about/intro.md
+++ b/_about/intro.md
@@ -4,6 +4,8 @@ title: Intro to OpenSearch
 nav_order: 2
 permalink: /intro/
 canonical_url: https://docs.opensearch.org/latest/getting-started/intro/
+redirect_from:
+  - /getting-started/intro/
 ---
 
 # Introduction to OpenSearch

--- a/_about/quickstart.md
+++ b/_about/quickstart.md
@@ -5,6 +5,7 @@ nav_order: 3
 permalink: /quickstart/
 redirect_from: 
   - /opensearch/install/quickstart/
+  - /getting-started/quickstart/
 canonical_url: https://docs.opensearch.org/latest/getting-started/quickstart/
 ---
 

--- a/_api-reference/alias.md
+++ b/_api-reference/alias.md
@@ -3,6 +3,10 @@ layout: default
 title: Alias
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
+redirect_from:
+  - /api-reference/alias-api/
+  - /api-reference/alias/index/
+  - /opensearch/rest-api/alias/
 ---
 
 # Alias

--- a/_api-reference/analyze-apis/index.md
+++ b/_api-reference/analyze-apis/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 7
 redirect_from:
   - /opensearch/rest-api/analyze-apis/
+  - /api-reference/analyze-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/analyze-apis/
 ---
 

--- a/_api-reference/cat/cat-aliases.md
+++ b/_api-reference/cat/cat-aliases.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 1
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-aliases/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-aliases/
 ---
 
 # CAT aliases

--- a/_api-reference/cat/cat-allocation.md
+++ b/_api-reference/cat/cat-allocation.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 5
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-allocation/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-allocation/
 ---
 
 # CAT allocation

--- a/_api-reference/cat/cat-cluster_manager.md
+++ b/_api-reference/cat/cat-cluster_manager.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 30
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-cluster_manager/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-master/
 ---
 
 # CAT cluster_manager

--- a/_api-reference/cat/cat-count.md
+++ b/_api-reference/cat/cat-count.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 10
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-count/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-count/
 ---
 
 # CAT count

--- a/_api-reference/cat/cat-field-data.md
+++ b/_api-reference/cat/cat-field-data.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 15
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-field-data/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-field-data/
 ---
 
 # CAT fielddata

--- a/_api-reference/cat/cat-health.md
+++ b/_api-reference/cat/cat-health.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 20
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-health/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-health/
 ---
 
 # CAT health

--- a/_api-reference/cat/cat-indices.md
+++ b/_api-reference/cat/cat-indices.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 25
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-indices/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-indices/
 ---
 
 # CAT indices

--- a/_api-reference/cat/cat-nodeattrs.md
+++ b/_api-reference/cat/cat-nodeattrs.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 35
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-nodeattrs/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-nodeattrs/
 ---
 
 # CAT nodeattrs

--- a/_api-reference/cat/cat-nodes.md
+++ b/_api-reference/cat/cat-nodes.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 40
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-nodes/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-nodes/
 ---
 
 # CAT nodes

--- a/_api-reference/cat/cat-pending-tasks.md
+++ b/_api-reference/cat/cat-pending-tasks.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 45
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-pending-tasks/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-pending-tasks/
 ---
 
 # CAT pending tasks

--- a/_api-reference/cat/cat-plugins.md
+++ b/_api-reference/cat/cat-plugins.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 50
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-plugins/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-plugins/
 ---
 
 # CAT plugins

--- a/_api-reference/cat/cat-recovery.md
+++ b/_api-reference/cat/cat-recovery.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 50
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-recovery/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-recovery/
 ---
 
 # CAT recovery

--- a/_api-reference/cat/cat-repositories.md
+++ b/_api-reference/cat/cat-repositories.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 55
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-repositories/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-repositories/
 ---
 
 # CAT repositories

--- a/_api-reference/cat/cat-segments.md
+++ b/_api-reference/cat/cat-segments.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 55
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-segments/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-segments/
 ---
 
 # CAT segments

--- a/_api-reference/cat/cat-shards.md
+++ b/_api-reference/cat/cat-shards.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 60
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-shards/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-shards/
 ---
 
 # CAT shards

--- a/_api-reference/cat/cat-snapshots.md
+++ b/_api-reference/cat/cat-snapshots.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 65
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-snapshots/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-snapshots/
 ---
 
 # CAT snapshots

--- a/_api-reference/cat/cat-tasks.md
+++ b/_api-reference/cat/cat-tasks.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 70
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-tasks/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-tasks/
 ---
 
 # CAT tasks

--- a/_api-reference/cat/cat-templates.md
+++ b/_api-reference/cat/cat-templates.md
@@ -6,6 +6,8 @@ parent: CAT API
 nav_order: 70
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-templates/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-templates/
 ---
 
 # CAT templates

--- a/_api-reference/cat/cat-thread-pool.md
+++ b/_api-reference/cat/cat-thread-pool.md
@@ -5,6 +5,8 @@ parent: CAT API
 nav_order: 75
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-thread-pool/
+redirect_from:
+  - /opensearch/rest-api/cat/cat-thread-pool/
 ---
 
 # CAT thread pool

--- a/_api-reference/cat/index.md
+++ b/_api-reference/cat/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from:
   - /opensearch/catapis/
   - /opensearch/rest-api/cat
+  - /api-reference/cat/
+  - /opensearch/rest-api/cat/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/index/
 ---
 

--- a/_api-reference/cluster-api/cluster-allocation.md
+++ b/_api-reference/cluster-api/cluster-allocation.md
@@ -5,6 +5,8 @@ nav_order: 10
 parent: Cluster APIs
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-allocation/
+redirect_from:
+  - /opensearch/rest-api/cluster-allocation/
 ---
 
 # Cluster allocation explain

--- a/_api-reference/cluster-api/cluster-health.md
+++ b/_api-reference/cluster-api/cluster-health.md
@@ -6,6 +6,9 @@ parent: Cluster APIs
 has_children: false
 redirect_from: /api-reference/cluster-health/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-health/
+redirect_from:
+  - /api-reference/cluster-health/
+  - /opensearch/rest-api/cluster-health/
 ---
 
 # Cluster health

--- a/_api-reference/cluster-api/cluster-settings.md
+++ b/_api-reference/cluster-api/cluster-settings.md
@@ -5,6 +5,9 @@ nav_order: 50
 parent: Cluster APIs
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-settings/
+redirect_from:
+  - /api-reference/cluster-settings/
+  - /opensearch/rest-api/cluster-settings/
 ---
 
 # Cluster settings

--- a/_api-reference/cluster-api/cluster-stats.md
+++ b/_api-reference/cluster-api/cluster-stats.md
@@ -6,6 +6,7 @@ parent: Cluster APIs
 has_children: false
 redirect_from:
   - /api-reference/cluster-stats/
+  - /opensearch/rest-api/cluster-stats/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-stats/
 ---
 

--- a/_api-reference/cluster-api/index.md
+++ b/_api-reference/cluster-api/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /opensearch/api-reference/cluster-api/
+  - /api-reference/cluster-api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/index/
 ---
 

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -3,6 +3,9 @@ layout: default
 title: Count
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/api-reference/count/
+redirect_from:
+  - /api-reference/search-apis/count/
+  - /opensearch/rest-api/count/
 ---
 
 # Count

--- a/_api-reference/document-apis/bulk.md
+++ b/_api-reference/document-apis/bulk.md
@@ -4,6 +4,8 @@ title: Bulk
 parent: Document APIs
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/bulk/
+redirect_from:
+  - /opensearch/rest-api/document-apis/bulk/
 ---
 
 # Bulk

--- a/_api-reference/document-apis/delete-by-query.md
+++ b/_api-reference/document-apis/delete-by-query.md
@@ -4,6 +4,8 @@ title: Delete by query
 parent: Document APIs
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/delete-by-query/
+redirect_from:
+  - /opensearch/rest-api/document-apis/delete-by-query/
 ---
 
 # Delete by query

--- a/_api-reference/document-apis/delete-document.md
+++ b/_api-reference/document-apis/delete-document.md
@@ -4,6 +4,8 @@ title: Delete document
 parent: Document APIs
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/delete-document/
+redirect_from:
+  - /opensearch/rest-api/document-apis/delete-document/
 ---
 
 # Delete document

--- a/_api-reference/document-apis/get-documents.md
+++ b/_api-reference/document-apis/get-documents.md
@@ -4,6 +4,8 @@ title: Get document
 parent: Document APIs
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/get-documents/
+redirect_from:
+  - /opensearch/rest-api/document-apis/get-documents/
 ---
 
 # Get document

--- a/_api-reference/document-apis/index-document.md
+++ b/_api-reference/document-apis/index-document.md
@@ -4,6 +4,8 @@ title: Index document
 parent: Document APIs
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index-document/
+redirect_from:
+  - /opensearch/rest-api/document-apis/index-document/
 ---
 
 # Index document

--- a/_api-reference/document-apis/index.md
+++ b/_api-reference/document-apis/index.md
@@ -5,6 +5,8 @@ has_children: true
 nav_order: 25
 redirect_from:
   - /opensearch/rest-api/document-apis/
+  - /api-reference/document-apis/
+  - /opensearch/rest-api/document-apis/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index/
 ---
 

--- a/_api-reference/document-apis/multi-get.md
+++ b/_api-reference/document-apis/multi-get.md
@@ -4,6 +4,8 @@ title: Multi-get document
 parent: Document APIs
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/multi-get/
+redirect_from:
+  - /opensearch/rest-api/document-apis/multi-get/
 ---
 
 # Multi-get documents

--- a/_api-reference/document-apis/reindex.md
+++ b/_api-reference/document-apis/reindex.md
@@ -4,6 +4,8 @@ title: Reindex document
 parent: Document APIs
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/reindex/
+redirect_from:
+  - /opensearch/rest-api/document-apis/reindex/
 ---
 
 # Reindex document

--- a/_api-reference/document-apis/update-by-query.md
+++ b/_api-reference/document-apis/update-by-query.md
@@ -4,6 +4,8 @@ title: Update by query
 parent: Document APIs
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/update-by-query/
+redirect_from:
+  - /opensearch/rest-api/document-apis/update-by-query/
 ---
 
 # Update by query

--- a/_api-reference/document-apis/update-document.md
+++ b/_api-reference/document-apis/update-document.md
@@ -4,6 +4,8 @@ title: Update document
 parent: Document APIs
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/update-document/
+redirect_from:
+  - /opensearch/rest-api/document-apis/update-document/
 ---
 
 # Update document

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -3,6 +3,9 @@ layout: default
 title: Explain
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
+redirect_from:
+  - /api-reference/search-apis/explain/
+  - /opensearch/rest-api/explain/
 ---
 
 # Explain

--- a/_api-reference/index-apis/clone.md
+++ b/_api-reference/index-apis/clone.md
@@ -4,6 +4,8 @@ title: Clone index
 parent: Index APIs
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/clone/
+redirect_from:
+  - /opensearch/rest-api/index-apis/clone/
 ---
 
 # Clone index

--- a/_api-reference/index-apis/close-index.md
+++ b/_api-reference/index-apis/close-index.md
@@ -4,6 +4,8 @@ title: Close index
 parent: Index APIs
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/close-index/
+redirect_from:
+  - /opensearch/rest-api/index-apis/close-index/
 ---
 
 # Close index

--- a/_api-reference/index-apis/create-index.md
+++ b/_api-reference/index-apis/create-index.md
@@ -5,6 +5,7 @@ parent: Index APIs
 nav_order: 1
 redirect_from:
  - /opensearch/rest-api/index-apis/create-index/
+  - /opensearch/rest-api/create-index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/create-index/
 ---
 

--- a/_api-reference/index-apis/delete-index.md
+++ b/_api-reference/index-apis/delete-index.md
@@ -4,6 +4,8 @@ title: Delete index
 parent: Index APIs
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/delete-index/
+redirect_from:
+  - /opensearch/rest-api/index-apis/delete-index/
 ---
 
 # Delete index

--- a/_api-reference/index-apis/get-index.md
+++ b/_api-reference/index-apis/get-index.md
@@ -4,6 +4,8 @@ title: Get index
 parent: Index APIs
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/get-index/
+redirect_from:
+  - /opensearch/rest-api/index-apis/get-index/
 ---
 
 # Get index

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -4,6 +4,8 @@ title: Get settings
 parent: Index APIs
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/get-settings/
+redirect_from:
+  - /opensearch/rest-api/index-apis/get-settings/
 ---
 
 # Get settings

--- a/_api-reference/index-apis/index.md
+++ b/_api-reference/index-apis/index.md
@@ -5,6 +5,8 @@ has_children: true
 nav_order: 35
 redirect_from:
   - /opensearch/rest-api/index-apis/
+  - /api-reference/index-apis/
+  - /opensearch/rest-api/index-apis/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/index/
 ---
 

--- a/_api-reference/index-apis/open-index.md
+++ b/_api-reference/index-apis/open-index.md
@@ -4,6 +4,8 @@ title: Open index
 parent: Index APIs
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/open-index/
+redirect_from:
+  - /opensearch/rest-api/index-apis/open-index/
 ---
 
 # Open index

--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -4,6 +4,10 @@ title: Create or update mappings
 parent: Index APIs
 nav_order: 220
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/put-mapping/
+redirect_from:
+  - /opensearch/rest-api/index-apis/put-mapping/
+  - /opensearch/rest-api/index-apis/update-mapping/
+  - /opensearch/rest-api/update-mapping/
 ---
 
 # Create or update mappings

--- a/_api-reference/index-apis/shrink-index.md
+++ b/_api-reference/index-apis/shrink-index.md
@@ -4,6 +4,8 @@ title: Shrink index
 parent: Index APIs
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/shrink-index/
+redirect_from:
+  - /opensearch/rest-api/index-apis/shrink-index/
 ---
 
 # Shrink index

--- a/_api-reference/index-apis/split.md
+++ b/_api-reference/index-apis/split.md
@@ -4,6 +4,8 @@ title: Split index
 parent: Index APIs
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/split/
+redirect_from:
+  - /opensearch/rest-api/index-apis/split/
 ---
 
 # Split index

--- a/_api-reference/index-apis/update-settings.md
+++ b/_api-reference/index-apis/update-settings.md
@@ -4,6 +4,8 @@ title: Update settings
 parent: Index APIs
 nav_order: 120
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/update-settings/
+redirect_from:
+  - /opensearch/rest-api/index-apis/update-settings/
 ---
 
 # Update settings

--- a/_api-reference/index.md
+++ b/_api-reference/index.md
@@ -5,6 +5,8 @@ nav_order: 1
 has_toc: true
 redirect_from:
   - /opensearch/rest-api/
+  - /api-reference/
+  - /opensearch/rest-api/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/
 ---
 

--- a/_api-reference/ingest-apis/create-update-ingest.md
+++ b/_api-reference/ingest-apis/create-update-ingest.md
@@ -4,6 +4,10 @@ title: Create or update ingest pipeline
 parent: Ingest APIs
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/create-ingest/
+redirect_from:
+  - /api-reference/ingest-apis/create-ingest/
+  - /ingest-pipelines/create-ingest/
+  - /opensearch/rest-api/ingest-apis/create-update-ingest/
 ---
 
 # Create and update a pipeline

--- a/_api-reference/ingest-apis/delete-ingest.md
+++ b/_api-reference/ingest-apis/delete-ingest.md
@@ -4,6 +4,9 @@ title: Delete a pipeline
 parent: Ingest APIs
 nav_order: 14
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/delete-ingest/
+redirect_from:
+  - /ingest-pipelines/delete-ingest/
+  - /opensearch/rest-api/ingest-apis/delete-ingest/
 ---
 
 # Delete a pipeline

--- a/_api-reference/ingest-apis/get-ingest.md
+++ b/_api-reference/ingest-apis/get-ingest.md
@@ -4,6 +4,9 @@ title: Get ingest pipeline
 parent: Ingest APIs
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/get-ingest/
+redirect_from:
+  - /ingest-pipelines/get-ingest/
+  - /opensearch/rest-api/ingest-apis/get-ingest/
 ---
 
 ## Get ingest pipeline

--- a/_api-reference/ingest-apis/index.md
+++ b/_api-reference/ingest-apis/index.md
@@ -5,6 +5,8 @@ has_children: true
 nav_order: 40
 redirect_from:
   - /opensearch/rest-api/ingest-apis/
+  - /api-reference/ingest-apis/
+  - /opensearch/rest-api/ingest-apis/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/ingest-apis/index/
 ---
 

--- a/_api-reference/ingest-apis/simulate-ingest.md
+++ b/_api-reference/ingest-apis/simulate-ingest.md
@@ -4,6 +4,9 @@ title: Simulate an ingest pipeline
 parent: Ingest APIs
 nav_order: 13
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/simulate-ingest/
+redirect_from:
+  - /ingest-pipelines/simulate-ingest/
+  - /opensearch/rest-api/ingest-apis/simulate-ingest/
 ---
 
 # Simulate a pipeline

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -3,6 +3,9 @@ layout: default
 title: Multi-search
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
+redirect_from:
+  - /api-reference/search-apis/multi-search/
+  - /opensearch/rest-api/multi-search/
 ---
 
 # Multi-search

--- a/_api-reference/nodes-apis/index.md
+++ b/_api-reference/nodes-apis/index.md
@@ -4,6 +4,8 @@ title: Nodes APIs
 has_children: true
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/nodes-apis/index/
+redirect_from:
+  - /api-reference/nodes-apis/
 ---
 
 # Nodes API

--- a/_api-reference/rank-eval.md
+++ b/_api-reference/rank-eval.md
@@ -3,6 +3,8 @@ layout: default
 title: Ranking evaluation
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/api-reference/rank-eval/
+redirect_from:
+  - /api-reference/search-apis/rank-eval/
 ---
 
 # Ranking evaluation

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -3,6 +3,9 @@ layout: default
 title: Remote cluster information
 nav_order: 67
 canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
+redirect_from:
+  - /api-reference/cluster-api/remote-info/
+  - /opensearch/rest-api/remote-info/
 ---
 
 # Remote cluster information

--- a/_api-reference/script-apis/index.md
+++ b/_api-reference/script-apis/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 70
 redirect_from:
   - /opensearch/rest-api/script-apis/
+  - /api-reference/script-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/script-apis/index/
 ---
 

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -3,6 +3,9 @@ layout: default
 title: Scroll
 nav_order: 71
 canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
+redirect_from:
+  - /api-reference/search-apis/scroll/
+  - /opensearch/rest-api/scroll/
 ---
 
 # Scroll

--- a/_api-reference/search.md
+++ b/_api-reference/search.md
@@ -3,6 +3,9 @@ layout: default
 title: Search
 nav_order: 75
 canonical_url: https://docs.opensearch.org/latest/api-reference/search/
+redirect_from:
+  - /api-reference/search-apis/search/
+  - /opensearch/rest-api/search/
 ---
 
 # Search

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -4,7 +4,6 @@ title: Snapshot APIs
 has_children: true
 nav_order: 80
 redirect_from:
-  - /opensearch/rest-api/document-apis/
   - /opensearch/rest-api/snapshots/
   - /api-reference/snapshots/
 canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -6,6 +6,7 @@ nav_order: 80
 redirect_from:
   - /opensearch/rest-api/document-apis/
   - /opensearch/rest-api/snapshots/
+  - /api-reference/snapshots/
 canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/
 ---
 

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -3,6 +3,9 @@ layout: default
 title: Tasks
 nav_order: 85
 canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
+redirect_from:
+  - /api-reference/tasks/tasks/
+  - /opensearch/rest-api/tasks/
 ---
 
 # Tasks

--- a/_dashboards/dashboard/index.md
+++ b/_dashboards/dashboard/index.md
@@ -4,6 +4,8 @@ title: Creating dashboards
 nav_order: 30
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/dashboard/index/
+redirect_from:
+  - /dashboards/dashboard/
 ---
 
 # Creating dashboards

--- a/_dashboards/discover/multi-data-sources.md
+++ b/_dashboards/discover/multi-data-sources.md
@@ -4,6 +4,8 @@ title: Adding multiple data sources
 parent: Exploring data
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/dashboards/management/multi-data-sources/
+redirect_from:
+  - /dashboards/management/multi-data-sources/
 ---
 
 # Adding multiple data sources

--- a/_dashboards/maps-plugin.md
+++ b/_dashboards/maps-plugin.md
@@ -4,6 +4,8 @@ title: Using the Maps plugin
 nav_order: 60
 redirect_from:
   - /dashboards/maps/
+  - /dashboards/visualize/maps/
+  - /dashboards/visualize/visualize-app/maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps/
 ---
 

--- a/_dashboards/quickstart-dashboards.md
+++ b/_dashboards/quickstart-dashboards.md
@@ -4,7 +4,7 @@ title: Quickstart guide for OpenSearch Dashboards
 nav_order: 10
 has_children: false
 redirect_from:
-   - /dashboards/index/
+  - /dashboards/index/
   - /dashboards/browser-compatibility/
   - /dashboards/get-started/quickstart-dashboards/
   - /dashboards/getting-started/

--- a/_dashboards/quickstart-dashboards.md
+++ b/_dashboards/quickstart-dashboards.md
@@ -5,6 +5,11 @@ nav_order: 10
 has_children: false
 redirect_from:
    - /dashboards/index/
+  - /dashboards/browser-compatibility/
+  - /dashboards/get-started/quickstart-dashboards/
+  - /dashboards/getting-started/
+  - /dashboards/getting-started/index/
+  - /dashboards/quickstart/
 canonical_url: https://docs.opensearch.org/latest/dashboards/quickstart/
 ---
 

--- a/_dashboards/reporting.md
+++ b/_dashboards/reporting.md
@@ -3,6 +3,8 @@ layout: default
 title: Creating reports with the Dashboards interface
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/reporting/report-dashboard-index/
+redirect_from:
+  - /reporting/report-dashboard-index/
 ---
 
 

--- a/_dashboards/run-queries.md
+++ b/_dashboards/run-queries.md
@@ -3,6 +3,11 @@ layout: default
 title: Running queries in the Dev Tools Console
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/run-queries/
+redirect_from:
+  - /dashboards/dev-tools/index-dev/
+  - /dashboards/dev-tools/run-queries/
+  - /dashboards/discover/run-queries/
+  - /dashboards/visualize/run-queries/
 ---
 
 # Running queries in the Dev Tools Console

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -4,6 +4,8 @@ title: Using area charts
 parent: Building data visualizations
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+redirect_from:
+  - /dashboards/visualize/visualize-app/area/
 ---
 
 # Using area charts

--- a/_dashboards/visualize/geojson-regionmaps.md
+++ b/_dashboards/visualize/geojson-regionmaps.md
@@ -6,6 +6,8 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /dashboards/geojson-regionmaps/
+  - /dashboards/visualize/region-maps/
+  - /dashboards/visualize/visualize-app/region-maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/geojson-regionmaps/
 ---
 

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -5,6 +5,9 @@ grand_parent: Building data visualizations
 parent: Using coordinate and region maps
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
+redirect_from:
+  - /dashboards/maptiles/
+  - /dashboards/visualize/visualize-app/maptiles/
 ---
 
 {%- comment -%}The `/docs/opensearch-dashboards/maptiles/` redirect is specifically to support the UI links in OpenSearch Dashboards 1.0.0.{%- endcomment -%}

--- a/_dashboards/visualize/selfhost-maps-server.md
+++ b/_dashboards/visualize/selfhost-maps-server.md
@@ -5,6 +5,9 @@ grand_parent: Building data visualizations
 parent: Using coordinate and region maps
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/selfhost-maps-server/
+redirect_from:
+  - /dashboards/selfhost-maps-server/
+  - /dashboards/visualize/visualize-app/selfhost-maps-server/
 ---
 
 # Using the self-host maps server

--- a/_dashboards/visualize/visbuilder.md
+++ b/_dashboards/visualize/visbuilder.md
@@ -5,6 +5,7 @@ parent: Building data visualizations
 nav_order: 100
 redirect_from:
   - /dashboards/drag-drop-wizard/
+  - /dashboards/visualize/visualize-app/visbuilder/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visbuilder/
 ---
 

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -4,6 +4,9 @@ title: Building data visualizations
 nav_order: 40
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+redirect_from:
+  - /dashboards/visualize/visualize-app/
+  - /dashboards/visualize/visualize-app/index/
 ---
 
 # Building data visualizations

--- a/_im-plugin/index-rollups/index.md
+++ b/_im-plugin/index-rollups/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from: /im-plugin/index-rollups/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-rollups/index/
+redirect_from:
+  - /im-plugin/index-rollups/
 ---
 
 # Index rollups

--- a/_im-plugin/index-transforms/index.md
+++ b/_im-plugin/index-transforms/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from: /im-plugin/index-transforms/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-transforms/index/
+redirect_from:
+  - /im-plugin/index-transforms/
 ---
 
 # Index transforms

--- a/_im-plugin/ism/managedindexes.md
+++ b/_im-plugin/ism/managedindexes.md
@@ -5,6 +5,8 @@ nav_order: 3
 parent: Index State Management
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/ism/managedindexes/
+redirect_from:
+  - /im-plugin/ism/managedindices/
 ---
 
 # Managed indices

--- a/_im-plugin/refresh-analyzer/index.md
+++ b/_im-plugin/refresh-analyzer/index.md
@@ -6,6 +6,9 @@ has_children: false
 redirect_from: /im-plugin/refresh-analyzer/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/refresh-analyzer/
+redirect_from:
+  - /im-plugin/refresh-analyzer/
+  - /query-dsl/analyzers/refresh-analyzer/
 ---
 
 # Refresh search analyzer

--- a/_install-and-configure/install-dashboards/docker.md
+++ b/_install-and-configure/install-dashboards/docker.md
@@ -5,6 +5,7 @@ parent: Installing OpenSearch Dashboards
 nav_order: 1
 redirect_from: 
   - /dashboards/install/docker/
+  - /opensearch/install/docker-security/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/docker/
 ---
 

--- a/_install-and-configure/install-dashboards/index.md
+++ b/_install-and-configure/install-dashboards/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from:
   - /dashboards/install/
   - /dashboards/compatibility/
+  - /dashboards/install/index/
+  - /install-and-configure/install-dashboards/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/index/
 ---
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -8,6 +8,8 @@ redirect_from:
   - /opensearch/install/compatibility/
   - /opensearch/install/important-settings/
   - /install-and-configure/index/
+  - /install-and-configure/install-opensearch/
+  - /opensearch/install/index/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/
 ---
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -7,7 +7,6 @@ redirect_from:
   - /opensearch/install/
   - /opensearch/install/compatibility/
   - /opensearch/install/important-settings/
-  - /install-and-configure/index/
   - /install-and-configure/install-opensearch/
   - /opensearch/install/index/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/

--- a/_install-and-configure/install-opensearch/rpm.md
+++ b/_install-and-configure/install-opensearch/rpm.md
@@ -4,6 +4,8 @@ title: RPM
 parent: Installing OpenSearch
 nav_order: 51
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/rpm/
+redirect_from:
+  - /opensearch/install/rpm/
 ---
 
 {% comment %}

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -3,8 +3,8 @@ layout: default
 title: Installing plugins
 nav_order: 90
 redirect_from:
-   - /opensearch/install/plugins/
-   - /install-and-configure/install-opensearch/plugins/
+  - /opensearch/install/plugins/
+  - /install-and-configure/install-opensearch/plugins/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/plugins/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/appendix/index.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/index.md
@@ -6,6 +6,10 @@ has_children: true
 nav_order: 30
 redirect_from:
   - /upgrade-opensearch/appendix/
+  - /migrate-or-upgrade/rolling-upgrade/appendix/
+  - /migrate-or-upgrade/rolling-upgrade/appendix/rolling-upgrade-lab/
+  - /migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
+  - /upgrade-opensearch/appendix/rolling-upgrade-lab/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/index/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/index.md
+++ b/_install-and-configure/upgrade-opensearch/index.md
@@ -5,6 +5,9 @@ nav_order: 4
 has_children: true
 redirect_from:
   - /upgrade-opensearch/index/
+  - /migrate-or-upgrade/
+  - /migrate-or-upgrade/index/
+  - /upgrade-or-migrate/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/index/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
+++ b/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
@@ -4,6 +4,10 @@ title: Rolling Upgrade
 parent: Upgrading OpenSearch
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/rolling-upgrade/
+redirect_from:
+  - /migrate-or-upgrade/rolling-upgrade/
+  - /rolling-upgrade/index/
+  - /upgrade-opensearch/
 ---
 
 # Rolling Upgrade

--- a/_ml-commons-plugin/api.md
+++ b/_ml-commons-plugin/api.md
@@ -4,6 +4,8 @@ title: API
 has_children: false
 nav_order: 99
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/index/
+redirect_from:
+  - /ml-commons-plugin/api/index/
 ---
 
 # ML Commons API 

--- a/_ml-commons-plugin/index.md
+++ b/_ml-commons-plugin/index.md
@@ -5,6 +5,8 @@ nav_order: 1
 has_children: false
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/
+redirect_from:
+  - /ml-commons-plugin/
 ---
 
 # ML Commons plugin

--- a/_ml-commons-plugin/model-serving-framework.md
+++ b/_ml-commons-plugin/model-serving-framework.md
@@ -4,6 +4,9 @@ title: Model-serving framework
 has_children: false
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/using-ml-models/
+redirect_from:
+  - /ml-commons-plugin/ml-framework/
+  - /ml-commons-plugin/using-ml-models/
 ---
 
 # Model-serving framework

--- a/_monitoring-your-cluster/pa/index.md
+++ b/_monitoring-your-cluster/pa/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/pa/
   - /monitoring-plugins/pa/index/
+  - /monitoring-your-cluster/pa/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/
 ---
 

--- a/_monitoring-your-cluster/pa/rca/index.md
+++ b/_monitoring-your-cluster/pa/rca/index.md
@@ -6,6 +6,7 @@ parent: Performance Analyzer
 has_children: true
 redirect_from:
   - /monitoring-plugins/pa/rca/index/
+  - /monitoring-your-cluster/pa/rca/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/index/
 ---
 

--- a/_neural-search-plugin/index.md
+++ b/_neural-search-plugin/index.md
@@ -5,6 +5,10 @@ nav_order: 1
 has_children: false
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-search/
+redirect_from:
+  - /search-plugins/neural-search/
+  - /vector-search/ai-search/
+  - /vector-search/ai-search/index/
 ---
 
 # Neural Search plugin

--- a/_observing-your-data/ad/index.md
+++ b/_observing-your-data/ad/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/ad/
   - /monitoring-plugins/ad/index/
+  - /observing-your-data/ad/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/index/
 ---
 

--- a/_observing-your-data/alerting/index.md
+++ b/_observing-your-data/alerting/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/alerting/
   - /monitoring-plugins/alerting/index/
+  - /observing-your-data/alerting/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/index/
 ---
 

--- a/_observing-your-data/event-analytics.md
+++ b/_observing-your-data/event-analytics.md
@@ -4,6 +4,7 @@ title: Event analytics
 nav_order: 20
 redirect_from:
   - /observing-your-data/event-analytics/
+  - /observability-plugin/event-analytics/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/event-analytics/
 ---
 

--- a/_observing-your-data/index.md
+++ b/_observing-your-data/index.md
@@ -6,6 +6,7 @@ has_children: false
 redirect_from:
   - /observability-plugin/index/
   - /observing-your-data/index/
+  - /observing-your-data/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/
 ---
 

--- a/_observing-your-data/notebooks.md
+++ b/_observing-your-data/notebooks.md
@@ -5,6 +5,7 @@ nav_order: 50
 redirect_from: 
   - /notebooks/
   - /observability-plugin/notebooks/
+  - /dashboards/notebooks/
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/notebooks/
 ---

--- a/_observing-your-data/notifications/index.md
+++ b/_observing-your-data/notifications/index.md
@@ -6,6 +6,7 @@ has_children: false
 redirect_from:
   - /notifications-plugin/
   - /notifications-plugin/index/
+  - /observing-your-data/notifications/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/notifications/index/
 ---
 

--- a/_observing-your-data/operational-panels.md
+++ b/_observing-your-data/operational-panels.md
@@ -4,6 +4,7 @@ title: Operational panels
 nav_order: 60
 redirect_from:
   - /observing-your-data/operational-panels/
+  - /observability-plugin/operational-panels/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/operational-panels/
 ---
 

--- a/_observing-your-data/trace/getting-started.md
+++ b/_observing-your-data/trace/getting-started.md
@@ -5,6 +5,7 @@ parent: Trace analytics
 nav_order: 1
 redirect_from:
   - /observability-plugin/trace/get-started/
+  - /monitoring-plugins/trace/get-started/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/getting-started/
 ---
 

--- a/_observing-your-data/trace/index.md
+++ b/_observing-your-data/trace/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /observability-plugin/trace/index/
+  - /monitoring-plugins/trace/index/
+  - /observing-your-data/trace/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/index/
 ---
 

--- a/_observing-your-data/trace/ta-dashboards.md
+++ b/_observing-your-data/trace/ta-dashboards.md
@@ -5,6 +5,7 @@ parent: Trace analytics
 nav_order: 50
 redirect_from:
   - /observability-plugin/trace/ta-dashboards/
+  - /monitoring-plugins/trace/ta-dashboards/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/ta-dashboards/
 ---
 

--- a/_opensearch/aggregations.md
+++ b/_opensearch/aggregations.md
@@ -4,6 +4,11 @@ title: Aggregations
 nav_order: 14
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/aggregations/
+redirect_from:
+  - /aggregations/
+  - /aggregations/index/
+  - /query-dsl/aggregations/
+  - /query-dsl/aggregations/aggregations/
 ---
 
 # Aggregations

--- a/_opensearch/bucket-agg.md
+++ b/_opensearch/bucket-agg.md
@@ -5,6 +5,12 @@ parent: Aggregations
 nav_order: 2
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/index/
+redirect_from:
+  - /aggregations/bucket-agg/
+  - /aggregations/bucket/
+  - /aggregations/bucket/index/
+  - /query-dsl/aggregations/bucket-agg/
+  - /query-dsl/aggregations/bucket/
 ---
 
 # Bucket aggregations

--- a/_opensearch/common-parameters.md
+++ b/_opensearch/common-parameters.md
@@ -3,6 +3,8 @@ layout: default
 title: Common REST Parameters
 nav_order: 93
 canonical_url: https://docs.opensearch.org/latest/api-reference/common-parameters/
+redirect_from:
+  - /api-reference/common-parameters/
 ---
 
 # Common REST parameters

--- a/_opensearch/data-streams.md
+++ b/_opensearch/data-streams.md
@@ -3,6 +3,8 @@ layout: default
 title: Data streams
 nav_order: 13
 canonical_url: https://docs.opensearch.org/latest/im-plugin/data-streams/
+redirect_from:
+  - /im-plugin/data-streams/
 ---
 
 # Data streams

--- a/_opensearch/geohexgrid-agg.md
+++ b/_opensearch/geohexgrid-agg.md
@@ -5,6 +5,12 @@ parent: Aggregations
 nav_order: 4
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/geohex-grid/
+redirect_from:
+  - /aggregations/bucket/geohex-grid/
+  - /aggregations/geohexgrid/
+  - /query-dsl/aggregations/bucket/geohex-grid/
+  - /query-dsl/aggregations/geohexgrid-agg/
+  - /query-dsl/aggregations/geohexgrid/
 ---
 
 # GeoHex grid aggregations

--- a/_opensearch/index-alias.md
+++ b/_opensearch/index-alias.md
@@ -3,6 +3,8 @@ layout: default
 title: Index aliases
 nav_order: 12
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-alias/
+redirect_from:
+  - /im-plugin/index-alias/
 ---
 
 # Index aliases

--- a/_opensearch/index-templates.md
+++ b/_opensearch/index-templates.md
@@ -3,6 +3,8 @@ layout: default
 title: Index templates
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-templates/
+redirect_from:
+  - /im-plugin/index-templates/
 ---
 
 # Index templates

--- a/_opensearch/logs.md
+++ b/_opensearch/logs.md
@@ -3,6 +3,9 @@ layout: default
 title: Logs
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/logs/
+redirect_from:
+  - /install-and-configure/configuring-opensearch/logs/
+  - /monitoring-your-cluster/logs/
 ---
 
 # Logs

--- a/_opensearch/mappings.md
+++ b/_opensearch/mappings.md
@@ -3,6 +3,13 @@ layout: default
 title: Mapping
 nav_order: 13
 canonical_url: https://docs.opensearch.org/latest/mappings/
+redirect_from:
+  - /field-types/
+  - /field-types/index/
+  - /field-types/mappings-use-cases/
+  - /field-types/mappings/
+  - /mappings/
+  - /mappings/index/
 ---
 
 # Mapping

--- a/_opensearch/metric-agg.md
+++ b/_opensearch/metric-agg.md
@@ -5,6 +5,12 @@ parent: Aggregations
 nav_order: 1
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/aggregations/metric/index/
+redirect_from:
+  - /aggregations/metric-agg/
+  - /aggregations/metric/
+  - /aggregations/metric/index/
+  - /query-dsl/aggregations/metric-agg/
+  - /query-dsl/aggregations/metric/
 ---
 
 # Metric aggregations

--- a/_opensearch/pipeline-agg.md
+++ b/_opensearch/pipeline-agg.md
@@ -5,6 +5,11 @@ parent: Aggregations
 nav_order: 4
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline-agg/
+redirect_from:
+  - /aggregations/pipeline-agg/
+  - /aggregations/pipeline/
+  - /aggregations/pipeline/index/
+  - /query-dsl/aggregations/pipeline-agg/
 ---
 
 # Pipeline aggregations

--- a/_opensearch/point-in-time-api.md
+++ b/_opensearch/point-in-time-api.md
@@ -5,6 +5,10 @@ nav_order: 58
 has_children: false
 parent: Point in Time
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/point-in-time-api/
+redirect_from:
+  - /api-reference/search-apis/point-in-time-api/
+  - /search-plugins/point-in-time-api/
+  - /search-plugins/searching-data/point-in-time-api/
 ---
 
 # Point in Time API

--- a/_opensearch/point-in-time.md
+++ b/_opensearch/point-in-time.md
@@ -5,6 +5,9 @@ nav_order: 58
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/point-in-time/
+redirect_from:
+  - /search-plugins/point-in-time/
+  - /search-plugins/searching-data/point-in-time/
 ---
 
 # Point in Time

--- a/_opensearch/popular-api.md
+++ b/_opensearch/popular-api.md
@@ -3,6 +3,8 @@ layout: default
 title: Popular APIs
 nav_order: 96
 canonical_url: https://docs.opensearch.org/latest/api-reference/popular-api/
+redirect_from:
+  - /api-reference/popular-api/
 ---
 
 # Popular APIs

--- a/_opensearch/query-dsl/compound/bool.md
+++ b/_opensearch/query-dsl/compound/bool.md
@@ -5,6 +5,10 @@ parent: Compound queries
 grand_parent: Query DSL
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/query-dsl/compound/bool/
+redirect_from:
+  - /opensearch/query-dsl/bool/
+  - /query-dsl/compound/bool/
+  - /query-dsl/query-dsl/compound/bool/
 ---
 
 # Boolean queries

--- a/_opensearch/query-dsl/compound/index.md
+++ b/_opensearch/query-dsl/compound/index.md
@@ -5,6 +5,10 @@ parent: Query DSL
 has_children: true
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/query-dsl/compound/index/
+redirect_from:
+  - /query-dsl/compound/
+  - /query-dsl/compound/index/
+  - /query-dsl/query-dsl/compound/
 ---
 
 # Compound queries

--- a/_opensearch/query-dsl/full-text/index.md
+++ b/_opensearch/query-dsl/full-text/index.md
@@ -5,6 +5,11 @@ parent: Query DSL
 has_children: true
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/query-dsl/full-text/index/
+redirect_from:
+  - /opensearch/query-dsl/full-text/
+  - /query-dsl/full-text/
+  - /query-dsl/full-text/index/
+  - /query-dsl/query-dsl/full-text/
 ---
 
 # Full-text queries

--- a/_opensearch/query-dsl/full-text/query-string.md
+++ b/_opensearch/query-dsl/full-text/query-string.md
@@ -5,6 +5,9 @@ parent: Full-text queries
 grand_parent: Query DSL
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/query-dsl/full-text/query-string/
+redirect_from:
+  - /query-dsl/full-text/query-string/
+  - /query-dsl/query-dsl/full-text/query-string/
 ---
 
 # Query string queries

--- a/_opensearch/query-dsl/geo-and-xy/geo-bounding-box.md
+++ b/_opensearch/query-dsl/geo-and-xy/geo-bounding-box.md
@@ -5,6 +5,9 @@ parent: Geographic and xy queries
 grand_parent: Query DSL
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/geo-bounding-box/
+redirect_from:
+  - /query-dsl/geo-and-xy/geo-bounding-box/
+  - /query-dsl/query-dsl/geo-and-xy/geo-bounding-box/
 ---
 
 # Geo-bounding box queries

--- a/_opensearch/query-dsl/geo-and-xy/index.md
+++ b/_opensearch/query-dsl/geo-and-xy/index.md
@@ -5,6 +5,11 @@ parent: Query DSL
 has_children: true
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/index/
+redirect_from:
+  - /query-dsl/geo-and-xy/
+  - /query-dsl/geo-and-xy/index/
+  - /query-dsl/query-dsl/geo-and-xy/
+  - /query-dsl/query-dsl/geo-and-xy/index/
 ---
 
 # Geographic and xy queries

--- a/_opensearch/query-dsl/geo-and-xy/xy.md
+++ b/_opensearch/query-dsl/geo-and-xy/xy.md
@@ -5,6 +5,9 @@ parent: Geographic and xy queries
 grand_parent: Query DSL
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/xy/
+redirect_from:
+  - /query-dsl/geo-and-xy/xy/
+  - /query-dsl/query-dsl/geo-and-xy/xy/
 ---
 
 # xy queries

--- a/_opensearch/query-dsl/index.md
+++ b/_opensearch/query-dsl/index.md
@@ -6,6 +6,9 @@ has_children: true
 redirect_from:
   - /opensearch/query-dsl/
   - /docs/opensearch/query-dsl/
+  - /query-dsl/
+  - /query-dsl/index/
+  - /query-dsl/query-dsl/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/
 ---
 

--- a/_opensearch/query-dsl/query-filter-context.md
+++ b/_opensearch/query-dsl/query-filter-context.md
@@ -4,6 +4,9 @@ title: Query and filter context
 parent: Query DSL
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/query-dsl/query-filter-context/
+redirect_from:
+  - /query-dsl/query-dsl/query-filter-context/
+  - /query-dsl/query-filter-context/
 ---
 
 # Query and filter context

--- a/_opensearch/query-dsl/span-query.md
+++ b/_opensearch/query-dsl/span-query.md
@@ -4,6 +4,11 @@ title: Span queries
 parent: Query DSL
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/query-dsl/span-query/
+redirect_from:
+  - /query-dsl/query-dsl/span-query/
+  - /query-dsl/span-query/
+  - /query-dsl/span/
+  - /query-dsl/span/index/
 ---
 
 # Span queries

--- a/_opensearch/query-dsl/term-vs-full-text.md
+++ b/_opensearch/query-dsl/term-vs-full-text.md
@@ -4,6 +4,9 @@ title: Term-level and full-text queries compared
 parent: Query DSL
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/query-dsl/term-vs-full-text/
+redirect_from:
+  - /query-dsl/query-dsl/term-vs-full-text/
+  - /query-dsl/term-vs-full-text/
 ---
 
 # Term-level and full-text queries compared

--- a/_opensearch/query-dsl/term.md
+++ b/_opensearch/query-dsl/term.md
@@ -4,6 +4,9 @@ title: Term-level queries
 parent: Query DSL
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/query-dsl/term/index/
+redirect_from:
+  - /query-dsl/term/
+  - /query-dsl/term/index/
 ---
 
 # Term-level queries

--- a/_opensearch/query-dsl/text-analyzers.md
+++ b/_opensearch/query-dsl/text-analyzers.md
@@ -4,6 +4,11 @@ title: Text analyzers
 parent: Query DSL
 nav_order: 75
 canonical_url: https://docs.opensearch.org/latest/analyzers/
+redirect_from:
+  - /analyzers/
+  - /analyzers/index/
+  - /analyzers/text-analyzers/
+  - /query-dsl/analyzers/text-analyzers/
 ---
 
 

--- a/_opensearch/search-template.md
+++ b/_opensearch/search-template.md
@@ -3,6 +3,11 @@ layout: default
 title: Search templates
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/search-template/
+redirect_from:
+  - /api-reference/search-apis/search-template/
+  - /api-reference/search-apis/search-template/index/
+  - /api-reference/search-template/
+  - /search-plugins/search-template/
 ---
 
 # Search templates

--- a/_opensearch/search/autocomplete.md
+++ b/_opensearch/search/autocomplete.md
@@ -4,6 +4,8 @@ title: Autocomplete
 parent: Searching data
 nav_order: 24
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/autocomplete/
+redirect_from:
+  - /search-plugins/searching-data/autocomplete/
 ---
 
 # Autocomplete functionality

--- a/_opensearch/search/did-you-mean.md
+++ b/_opensearch/search/did-you-mean.md
@@ -4,6 +4,8 @@ title: Did-you-mean
 parent: Searching data
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/did-you-mean/
+redirect_from:
+  - /search-plugins/searching-data/did-you-mean/
 ---
 
 # Did-you-mean

--- a/_opensearch/search/highlight.md
+++ b/_opensearch/search/highlight.md
@@ -4,6 +4,8 @@ title: Highlight query matches
 parent: Searching data
 nav_order: 23
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/highlight/
+redirect_from:
+  - /search-plugins/searching-data/highlight/
 ---
 
 # Highlight query matches

--- a/_opensearch/search/paginate.md
+++ b/_opensearch/search/paginate.md
@@ -4,6 +4,8 @@ title: Paginate results
 parent: Searching data
 nav_order: 21
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/paginate/
+redirect_from:
+  - /search-plugins/searching-data/paginate/
 ---
 
 ## Paginate results

--- a/_opensearch/search/sort.md
+++ b/_opensearch/search/sort.md
@@ -4,6 +4,8 @@ title: Sort results
 parent: Searching data
 nav_order: 22
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/sort/
+redirect_from:
+  - /search-plugins/searching-data/sort/
 ---
 
 ## Sort results

--- a/_opensearch/segment-replication/index.md
+++ b/_opensearch/segment-replication/index.md
@@ -5,6 +5,7 @@ nav_order: 64
 has_children: true
 redirect_from:
   - /opensearch/segment-replication/
+  - /tuning-your-cluster/segment-replication/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/segment-replication/index/
 ---
 

--- a/_opensearch/supported-field-types/alias.md
+++ b/_opensearch/supported-field-types/alias.md
@@ -5,6 +5,10 @@ nav_order: 10
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/alias/
+redirect_from:
+  - /field-types/alias/
+  - /field-types/supported-field-types/alias/
+  - /mappings/supported-field-types/alias/
 ---
 
 # Alias field type

--- a/_opensearch/supported-field-types/autocomplete.md
+++ b/_opensearch/supported-field-types/autocomplete.md
@@ -6,6 +6,9 @@ has_children: true
 has_toc: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/autocomplete/
+redirect_from:
+  - /field-types/autocomplete/
+  - /mappings/supported-field-types/autocomplete/
 ---
 
 # Autocomplete field types

--- a/_opensearch/supported-field-types/binary.md
+++ b/_opensearch/supported-field-types/binary.md
@@ -5,6 +5,10 @@ parent: Supported field types
 nav_order: 12
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/binary/
+redirect_from:
+  - /field-types/binary/
+  - /field-types/supported-field-types/binary/
+  - /mappings/supported-field-types/binary/
 ---
 
 # Binary field type

--- a/_opensearch/supported-field-types/boolean.md
+++ b/_opensearch/supported-field-types/boolean.md
@@ -5,6 +5,10 @@ nav_order: 20
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/boolean/
+redirect_from:
+  - /field-types/boolean/
+  - /field-types/supported-field-types/boolean/
+  - /mappings/supported-field-types/boolean/
 ---
 
 # Boolean field type

--- a/_opensearch/supported-field-types/completion.md
+++ b/_opensearch/supported-field-types/completion.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Autocomplete field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/completion/
+redirect_from:
+  - /field-types/completion/
+  - /field-types/supported-field-types/completion/
+  - /mappings/supported-field-types/completion/
 ---
 
 # Completion field type

--- a/_opensearch/supported-field-types/date.md
+++ b/_opensearch/supported-field-types/date.md
@@ -5,6 +5,10 @@ nav_order: 25
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date/
+redirect_from:
+  - /field-types/date/
+  - /field-types/supported-field-types/date/
+  - /mappings/supported-field-types/date/
 ---
 
 # Date field type

--- a/_opensearch/supported-field-types/geo-point.md
+++ b/_opensearch/supported-field-types/geo-point.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Geographic field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-point/
+redirect_from:
+  - /field-types/geo-point/
+  - /field-types/supported-field-types/geo-point/
+  - /mappings/supported-field-types/geo-point/
 ---
 
 # Geopoint field type

--- a/_opensearch/supported-field-types/geo-shape.md
+++ b/_opensearch/supported-field-types/geo-shape.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Geographic field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-shape/
+redirect_from:
+  - /field-types/geo-shape/
+  - /field-types/supported-field-types/geo-shape/
+  - /mappings/supported-field-types/geo-shape/
 ---
 
 # Geoshape field type

--- a/_opensearch/supported-field-types/geographic.md
+++ b/_opensearch/supported-field-types/geographic.md
@@ -6,6 +6,10 @@ has_children: true
 has_toc: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geographic/
+redirect_from:
+  - /field-types/geographic/
+  - /field-types/supported-field-types/geographic/
+  - /mappings/supported-field-types/geographic/
 ---
 
 # Geographic field types

--- a/_opensearch/supported-field-types/index.md
+++ b/_opensearch/supported-field-types/index.md
@@ -6,6 +6,9 @@ has_children: true
 has_toc: false
 redirect_from:
   - /opensearch/supported-field-types/
+  - /field-types/supported-field-types/
+  - /mappings/supported-field-types/
+  - /mappings/supported-field-types/index/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/index/
 ---
 

--- a/_opensearch/supported-field-types/ip.md
+++ b/_opensearch/supported-field-types/ip.md
@@ -5,6 +5,10 @@ nav_order: 30
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/ip/
+redirect_from:
+  - /field-types/ip/
+  - /field-types/supported-field-types/ip/
+  - /mappings/supported-field-types/ip/
 ---
 
 # IP address field type

--- a/_opensearch/supported-field-types/join.md
+++ b/_opensearch/supported-field-types/join.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Object field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/join/
+redirect_from:
+  - /field-types/join/
+  - /field-types/supported-field-types/join/
+  - /mappings/supported-field-types/join/
 ---
 
 # Join field type

--- a/_opensearch/supported-field-types/keyword.md
+++ b/_opensearch/supported-field-types/keyword.md
@@ -6,6 +6,10 @@ has_children: false
 parent: String field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/keyword/
+redirect_from:
+  - /field-types/keyword/
+  - /field-types/supported-field-types/keyword/
+  - /mappings/supported-field-types/keyword/
 ---
 
 # Keyword field type

--- a/_opensearch/supported-field-types/nested.md
+++ b/_opensearch/supported-field-types/nested.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Object field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/nested/
+redirect_from:
+  - /field-types/nested/
+  - /field-types/supported-field-types/nested/
+  - /mappings/supported-field-types/nested/
 ---
 
 # Nested field type

--- a/_opensearch/supported-field-types/numeric.md
+++ b/_opensearch/supported-field-types/numeric.md
@@ -5,6 +5,10 @@ parent: Supported field types
 nav_order: 15
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/
+redirect_from:
+  - /field-types/numeric/
+  - /field-types/supported-field-types/numeric/
+  - /mappings/supported-field-types/numeric/
 ---
 
 # Numeric field types

--- a/_opensearch/supported-field-types/object-fields.md
+++ b/_opensearch/supported-field-types/object-fields.md
@@ -6,6 +6,10 @@ has_children: true
 has_toc: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/
+redirect_from:
+  - /field-types/object-fields/
+  - /field-types/supported-field-types/object-fields/
+  - /mappings/supported-field-types/object-fields/
 ---
 
 # Object field types

--- a/_opensearch/supported-field-types/object.md
+++ b/_opensearch/supported-field-types/object.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Object field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object/
+redirect_from:
+  - /field-types/object/
+  - /field-types/supported-field-types/object/
+  - /mappings/supported-field-types/object/
 ---
 
 # Object field type

--- a/_opensearch/supported-field-types/percolator.md
+++ b/_opensearch/supported-field-types/percolator.md
@@ -5,6 +5,10 @@ nav_order: 65
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/percolator/
+redirect_from:
+  - /field-types/percolator/
+  - /field-types/supported-field-types/percolator/
+  - /mappings/supported-field-types/percolator/
 ---
 
 # Percolator field type

--- a/_opensearch/supported-field-types/range.md
+++ b/_opensearch/supported-field-types/range.md
@@ -5,6 +5,10 @@ nav_order: 35
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/range/
+redirect_from:
+  - /field-types/range/
+  - /field-types/supported-field-types/range/
+  - /mappings/supported-field-types/range/
 ---
 
 # Range field types

--- a/_opensearch/supported-field-types/rank.md
+++ b/_opensearch/supported-field-types/rank.md
@@ -5,6 +5,10 @@ nav_order: 60
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/rank/
+redirect_from:
+  - /field-types/rank/
+  - /field-types/supported-field-types/rank/
+  - /mappings/supported-field-types/rank/
 ---
 
 # Rank field types

--- a/_opensearch/supported-field-types/search-as-you-type.md
+++ b/_opensearch/supported-field-types/search-as-you-type.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Autocomplete field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/
+redirect_from:
+  - /field-types/search-as-you-type/
+  - /field-types/supported-field-types/search-as-you-type/
+  - /mappings/supported-field-types/search-as-you-type/
 ---
 
 # Search-as-you-type field type

--- a/_opensearch/supported-field-types/string.md
+++ b/_opensearch/supported-field-types/string.md
@@ -6,6 +6,10 @@ has_children: true
 has_toc: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/string/
+redirect_from:
+  - /field-types/string/
+  - /field-types/supported-field-types/string/
+  - /mappings/supported-field-types/string/
 ---
 
 # String field types

--- a/_opensearch/supported-field-types/text.md
+++ b/_opensearch/supported-field-types/text.md
@@ -6,6 +6,10 @@ has_children: false
 parent: String field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/text/
+redirect_from:
+  - /field-types/supported-field-types/text/
+  - /field-types/text/
+  - /mappings/supported-field-types/text/
 ---
 
 # Text field type

--- a/_opensearch/supported-field-types/token-count.md
+++ b/_opensearch/supported-field-types/token-count.md
@@ -6,6 +6,10 @@ has_children: false
 parent: String field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/token-count/
+redirect_from:
+  - /field-types/supported-field-types/token-count/
+  - /field-types/token-count/
+  - /mappings/supported-field-types/token-count/
 ---
 
 # Token count field type

--- a/_opensearch/supported-field-types/xy-point.md
+++ b/_opensearch/supported-field-types/xy-point.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Cartesian field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-point/
+redirect_from:
+  - /field-types/supported-field-types/xy-point/
+  - /field-types/xy-point/
+  - /mappings/supported-field-types/xy-point/
 ---
 
 # xy point field type

--- a/_opensearch/supported-field-types/xy-shape.md
+++ b/_opensearch/supported-field-types/xy-shape.md
@@ -6,6 +6,10 @@ has_children: false
 parent: Cartesian field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-shape/
+redirect_from:
+  - /field-types/supported-field-types/xy-shape/
+  - /field-types/xy-shape/
+  - /mappings/supported-field-types/xy-shape/
 ---
 
 # xy shape field type

--- a/_opensearch/supported-field-types/xy.md
+++ b/_opensearch/supported-field-types/xy.md
@@ -6,6 +6,10 @@ has_children: true
 has_toc: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy/
+redirect_from:
+  - /field-types/supported-field-types/xy/
+  - /field-types/xy/
+  - /mappings/supported-field-types/xy/
 ---
 
 # Cartesian field types

--- a/_opensearch/units.md
+++ b/_opensearch/units.md
@@ -3,6 +3,8 @@ layout: default
 title: Supported units
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/api-reference/units/
+redirect_from:
+  - /api-reference/units/
 ---
 
 # Supported units

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -5,6 +5,10 @@ nav_order: 30
 parent: k-NN
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/api/
+redirect_from:
+  - /vector-search/api/
+  - /vector-search/api/index/
+  - /vector-search/api/knn/
 ---
 
 # k-NN plugin API

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -6,6 +6,8 @@ parent: k-NN
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/
+redirect_from:
+  - /vector-search/vector-search-techniques/approximate-knn/
 ---
 
 # Approximate k-NN search

--- a/_search-plugins/knn/filter-search-knn.md
+++ b/_search-plugins/knn/filter-search-knn.md
@@ -6,6 +6,9 @@ parent: k-NN
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/filter-search-knn/
+redirect_from:
+  - /vector-search/filter-search-knn/
+  - /vector-search/filter-search-knn/index/
 ---
 
 # k-NN search with filters

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/knn/
+  - /vector-search/vector-search-techniques/
+  - /vector-search/vector-search-techniques/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/index/
 ---
 

--- a/_search-plugins/knn/jni-libraries.md
+++ b/_search-plugins/knn/jni-libraries.md
@@ -5,6 +5,8 @@ nav_order: 35
 parent: k-NN
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/jni-libraries/
+redirect_from:
+  - /vector-search/api/knn/
 ---
 
 # JNI libraries

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -5,6 +5,9 @@ nav_order: 5
 parent: k-NN
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-index/
+redirect_from:
+  - /vector-search/creating-a-vector-db/
+  - /vector-search/creating-vector-index/
 ---
 
 # k-NN Index

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -6,6 +6,8 @@ parent: k-NN
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/
+redirect_from:
+  - /vector-search/vector-search-techniques/knn-score-script/
 ---
 
 # Exact k-NN with scoring script

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -6,6 +6,8 @@ parent: k-NN
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/
+redirect_from:
+  - /vector-search/vector-search-techniques/painless-functions/
 ---
 
 # k-NN Painless Scripting extensions

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -4,6 +4,8 @@ title: Performance tuning
 parent: k-NN
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/performance-tuning/
+redirect_from:
+  - /vector-search/performance-tuning/
 ---
 
 # Performance tuning

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -4,6 +4,8 @@ title: Settings
 parent: k-NN
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/settings/
+redirect_from:
+  - /vector-search/settings/
 ---
 
 # k-NN settings

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -4,6 +4,8 @@ title: SQL and PPL CLI
 parent: SQL and PPL
 nav_order: 3
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
+redirect_from:
+  - /sql-and-ppl/cli/
 ---
 
 # SQL and PPL CLI

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -4,6 +4,8 @@ title: Data Types
 parent: SQL and PPL
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+redirect_from:
+  - /sql-and-ppl/datatypes/
 ---
 
 # Data types

--- a/_search-plugins/sql/full-text.md
+++ b/_search-plugins/sql/full-text.md
@@ -4,6 +4,8 @@ title: Full-Text Search
 parent: SQL and PPL
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/full-text/
+redirect_from:
+  - /sql-and-ppl/full-text/
 ---
 
 # Full-text search

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -4,6 +4,8 @@ title: Functions
 parent: SQL and PPL
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
+redirect_from:
+  - /sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/identifiers.md
+++ b/_search-plugins/sql/identifiers.md
@@ -4,6 +4,10 @@ title: Identifiers
 parent: SQL and PPL
 nav_order: 6
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
+redirect_from:
+  - /observability-plugin/ppl/identifiers/
+  - /search-plugins/ppl/identifiers/
+  - /sql-and-ppl/identifiers/
 ---
 
 

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/sql/
+  - /sql-and-ppl/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
 ---
 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -4,6 +4,8 @@ title: Limitations
 parent: SQL and PPL
 nav_order: 99
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
+redirect_from:
+  - /sql-and-ppl/limitation/
 ---
 
 # Limitations

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -4,6 +4,8 @@ title: Monitoring
 parent: SQL and PPL
 nav_order: 95
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
+redirect_from:
+  - /sql-and-ppl/monitoring/
 ---
 
 # Monitoring

--- a/_search-plugins/sql/ppl/functions.md
+++ b/_search-plugins/sql/ppl/functions.md
@@ -5,6 +5,12 @@ parent: PPL &ndash; Piped Processing Language
 grand_parent: SQL and PPL
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/functions/
+redirect_from:
+  - /observability-plugin/ppl/commands/
+  - /search-plugins/ppl/commands/
+  - /search-plugins/ppl/functions/
+  - /sql-and-ppl/ppl/commands/index/
+  - /sql-and-ppl/ppl/functions/
 ---
 
 # Commands

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -9,6 +9,12 @@ redirect_from:
   - /search-plugins/sql/ppl
   - /search-plugins/ppl
   - /observability-plugin/ppl
+  - /observability-plugin/ppl/index/
+  - /search-plugins/ppl/endpoint/
+  - /search-plugins/ppl/index/
+  - /search-plugins/ppl/protocol/
+  - /sql-and-ppl/ppl/
+  - /sql-and-ppl/ppl/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
 ---
 

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -5,6 +5,8 @@ parent: PPL &ndash; Piped Processing Language
 grand_parent: SQL and PPL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/syntax/
+redirect_from:
+  - /sql-and-ppl/ppl/commands/syntax/
 ---
 
 # PPL syntax

--- a/_search-plugins/sql/response-formats.md
+++ b/_search-plugins/sql/response-formats.md
@@ -4,6 +4,8 @@ title: Response formats
 parent: SQL and PPL
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/response-formats/
+redirect_from:
+  - /sql-and-ppl/response-formats/
 ---
 
 # Response formats

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -4,6 +4,8 @@ title: Settings
 parent: SQL and PPL
 nav_order: 77
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
+redirect_from:
+  - /sql-and-ppl/settings/
 ---
 
 # Settings

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -4,6 +4,9 @@ title: SQL/PPL API
 parent: SQL and PPL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/
+redirect_from:
+  - /sql-and-ppl/sql-and-ppl-api/index/
+  - /sql-and-ppl/sql-ppl-api/
 ---
 
 # SQL/PPL API

--- a/_search-plugins/sql/sql/aggregations.md
+++ b/_search-plugins/sql/sql/aggregations.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+redirect_from:
+  - /search-plugins/sql/aggregations/
+  - /sql-and-ppl/sql/aggregations/
 ---
 
 # Aggregate functions

--- a/_search-plugins/sql/sql/basic.md
+++ b/_search-plugins/sql/sql/basic.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
+redirect_from:
+  - /search-plugins/sql/basic/
+  - /sql-and-ppl/sql/basic/
 ---
 
 

--- a/_search-plugins/sql/sql/complex.md
+++ b/_search-plugins/sql/sql/complex.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 6
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
+redirect_from:
+  - /search-plugins/sql/complex/
+  - /sql-and-ppl/sql/complex/
 ---
 
 # Complex queries

--- a/_search-plugins/sql/sql/delete.md
+++ b/_search-plugins/sql/sql/delete.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 12
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
+redirect_from:
+  - /search-plugins/sql/delete/
+  - /sql-and-ppl/sql/delete/
 ---
 
 

--- a/_search-plugins/sql/sql/index.md
+++ b/_search-plugins/sql/sql/index.md
@@ -7,6 +7,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/sql/sql
+  - /sql-and-ppl/sql/
+  - /sql-and-ppl/sql/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/index/
 ---
 

--- a/_search-plugins/sql/sql/jdbc.md
+++ b/_search-plugins/sql/sql/jdbc.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 71
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
+redirect_from:
+  - /search-plugins/sql/jdbc/
+  - /sql-and-ppl/sql/jdbc/
 ---
 
 # JDBC driver

--- a/_search-plugins/sql/sql/metadata.md
+++ b/_search-plugins/sql/sql/metadata.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 9
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
+redirect_from:
+  - /search-plugins/sql/metadata/
+  - /sql-and-ppl/sql/metadata/
 ---
 
 # Metadata queries

--- a/_search-plugins/sql/sql/odbc.md
+++ b/_search-plugins/sql/sql/odbc.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 72
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
+redirect_from:
+  - /search-plugins/sql/odbc/
+  - /sql-and-ppl/sql/odbc/
 ---
 
 # ODBC driver

--- a/_search-plugins/sql/sql/partiql.md
+++ b/_search-plugins/sql/sql/partiql.md
@@ -5,6 +5,9 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 8
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
+redirect_from:
+  - /search-plugins/sql/partiql/
+  - /sql-and-ppl/sql/partiql/
 ---
 
 # JSON Support

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -4,6 +4,8 @@ title: Troubleshooting
 parent: SQL and PPL
 nav_order: 88
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
+redirect_from:
+  - /sql-and-ppl/troubleshoot/
 ---
 
 # Troubleshooting

--- a/_search-plugins/sql/workbench.md
+++ b/_search-plugins/sql/workbench.md
@@ -5,6 +5,8 @@ parent: SQL
 grand_parent: SQL and PPL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/dashboards/query-workbench/
+redirect_from:
+  - /dashboards/query-workbench/
 ---
 
 # Query Workbench

--- a/_security-analytics/index.md
+++ b/_security-analytics/index.md
@@ -6,6 +6,7 @@ has_children: false
 has_toc: false
 redirect_from:
   - /security-analytics/index/
+  - /security-analytics/
 canonical_url: https://docs.opensearch.org/latest/security-analytics/
 ---
 

--- a/_security/access-control/cross-cluster-search.md
+++ b/_security/access-control/cross-cluster-search.md
@@ -4,6 +4,9 @@ title: Cross-cluster search
 parent: Access control
 nav_order: 105
 canonical_url: https://docs.opensearch.org/latest/search-plugins/cross-cluster-search/
+redirect_from:
+  - /search-plugins/cross-cluster-search/
+  - /security-plugin/access-control/cross-cluster-search/
 ---
 
 # Cross-cluster search

--- a/_security/access-control/default-action-groups.md
+++ b/_security/access-control/default-action-groups.md
@@ -4,6 +4,8 @@ title: Default action groups
 parent: Access control
 nav_order: 115
 canonical_url: https://docs.opensearch.org/latest/security/access-control/default-action-groups/
+redirect_from:
+  - /security-plugin/access-control/default-action-groups/
 ---
 
 # Default action groups

--- a/_security/access-control/document-level-security.md
+++ b/_security/access-control/document-level-security.md
@@ -4,6 +4,8 @@ title: Document-level security
 parent: Access control
 nav_order: 85
 canonical_url: https://docs.opensearch.org/latest/security/access-control/document-level-security/
+redirect_from:
+  - /security-plugin/access-control/document-level-security/
 ---
 
 # Document-level security (DLS)

--- a/_security/access-control/field-level-security.md
+++ b/_security/access-control/field-level-security.md
@@ -4,6 +4,8 @@ title: Field-level security
 parent: Access control
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/security/access-control/field-level-security/
+redirect_from:
+  - /security-plugin/access-control/field-level-security/
 ---
 
 # Field-level security

--- a/_security/access-control/field-masking.md
+++ b/_security/access-control/field-masking.md
@@ -4,6 +4,8 @@ title: Field masking
 parent: Access control
 nav_order: 95
 canonical_url: https://docs.opensearch.org/latest/security/access-control/field-masking/
+redirect_from:
+  - /security-plugin/access-control/field-masking/
 ---
 
 # Field masking

--- a/_security/access-control/impersonation.md
+++ b/_security/access-control/impersonation.md
@@ -4,6 +4,8 @@ title: User impersonation
 parent: Access control
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/security/access-control/impersonation/
+redirect_from:
+  - /security-plugin/access-control/impersonation/
 ---
 
 # User impersonation

--- a/_security/access-control/index.md
+++ b/_security/access-control/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security/access-control/
+  - /security-plugin/access-control/index/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/index/
 ---
 

--- a/_security/access-control/users-roles.md
+++ b/_security/access-control/users-roles.md
@@ -4,6 +4,8 @@ title: Users and roles
 parent: Access control
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/security/access-control/users-roles/
+redirect_from:
+  - /security-plugin/access-control/users-roles/
 ---
 
 # Users and roles

--- a/_security/audit-logs/field-reference.md
+++ b/_security/audit-logs/field-reference.md
@@ -4,6 +4,8 @@ title: Audit log field reference
 parent: Audit logs
 nav_order: 130
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/field-reference/
+redirect_from:
+  - /security-plugin/audit-logs/field-reference/
 ---
 
 # Audit log field reference

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security/audit-logs/
+  - /security-plugin/audit-logs/index/
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/index/
 ---
 

--- a/_security/audit-logs/storage-types.md
+++ b/_security/audit-logs/storage-types.md
@@ -4,6 +4,8 @@ title: Audit log storage types
 parent: Audit logs
 nav_order: 135
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/storage-types/
+redirect_from:
+  - /security-plugin/audit-logs/storage-types/
 ---
 
 # Audit log storage types

--- a/_security/authentication-backends/authc-index.md
+++ b/_security/authentication-backends/authc-index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security/authentication-backends/
+  - /security-plugin/configuration/concepts/
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/authc-index/
 ---
 

--- a/_security/authentication-backends/openid-connect.md
+++ b/_security/authentication-backends/openid-connect.md
@@ -4,6 +4,8 @@ title: OpenID Connect
 parent: Authentication backends
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/openid-connect/
+redirect_from:
+  - /security-plugin/configuration/openid-connect/
 ---
 
 # OpenID Connect

--- a/_security/authentication-backends/proxy.md
+++ b/_security/authentication-backends/proxy.md
@@ -4,6 +4,8 @@ title: Proxy-based authentication
 parent: Authentication backends
 nav_order: 65
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/proxy/
+redirect_from:
+  - /security-plugin/configuration/proxy/
 ---
 
 # Proxy-based authentication

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -4,6 +4,8 @@ title: Configuring the Security backend
 parent: Configuration
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/security/configuration/configuration/
+redirect_from:
+  - /security-plugin/configuration/configuration/
 ---
 
 # Configuring the Security backend

--- a/_security/configuration/disable.md
+++ b/_security/configuration/disable.md
@@ -4,6 +4,9 @@ title: Disabling security
 parent: Configuration
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/security/configuration/disable-enable-security/
+redirect_from:
+  - /security-plugin/configuration/disable/
+  - /security/configuration/disable-enable-security/
 ---
 
 # Disabling security

--- a/_security/configuration/generate-certificates.md
+++ b/_security/configuration/generate-certificates.md
@@ -4,6 +4,8 @@ title: Generating self-signed certificates
 parent: Configuration
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/security/configuration/generate-certificates/
+redirect_from:
+  - /security-plugin/configuration/generate-certificates/
 ---
 
 # Generating self-signed certificates

--- a/_security/configuration/index.md
+++ b/_security/configuration/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /security-plugin/configuration/
   - /security-plugin/configuration/index/
+  - /security/configuration/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/index/
 ---
 

--- a/_security/configuration/security-admin.md
+++ b/_security/configuration/security-admin.md
@@ -4,6 +4,8 @@ title: Applying changes to configuration files
 parent: Configuration
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/security/configuration/security-admin/
+redirect_from:
+  - /security-plugin/configuration/security-admin/
 ---
 
 # Applying changes to configuration files

--- a/_security/configuration/system-indices.md
+++ b/_security/configuration/system-indices.md
@@ -4,6 +4,8 @@ title: System indexes
 parent: Configuration
 nav_order: 4
 canonical_url: https://docs.opensearch.org/latest/security/configuration/system-indices/
+redirect_from:
+  - /security-plugin/configuration/system-indices/
 ---
 
 # System indexes

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -4,6 +4,8 @@ title: Configuring TLS certificates
 parent: Configuration
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/security/configuration/tls/
+redirect_from:
+  - /security-plugin/configuration/tls/
 ---
 
 # Configuring TLS certificates

--- a/_security/configuration/yaml.md
+++ b/_security/configuration/yaml.md
@@ -4,6 +4,8 @@ title: Modifying the YAML files
 parent: Configuration
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/security/configuration/yaml/
+redirect_from:
+  - /security-plugin/configuration/yaml/
 ---
 
 # Modifying the YAML files

--- a/_security/multi-tenancy/tenant-index.md
+++ b/_security/multi-tenancy/tenant-index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security/multi-tenancy/
+  - /security-plugin/access-control/multi-tenancy/
+  - /security/access-control/multi-tenancy/
 canonical_url: https://docs.opensearch.org/latest/security/multi-tenancy/tenant-index/
 ---
 

--- a/_tools/grafana.md
+++ b/_tools/grafana.md
@@ -4,6 +4,8 @@ title: Grafana
 nav_order: 200
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/tools/grafana/
+redirect_from:
+  - /clients/grafana/
 ---
 
 # Grafana support

--- a/_tools/index.md
+++ b/_tools/index.md
@@ -5,6 +5,8 @@ nav_order: 50
 has_children: false
 redirect_from:
   - /clients/agents-and-ingestion-tools/
+  - /clients/agents-and-ingestion-tools/index/
+  - /tools/
 canonical_url: https://docs.opensearch.org/latest/tools/
 ---
 

--- a/_tools/k8s-operator.md
+++ b/_tools/k8s-operator.md
@@ -4,6 +4,10 @@ title: OpenSearch Kubernetes Operator
 nav_order: 80
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/tools/k8s-operator/
+redirect_from:
+  - /clients/k8s-operator/
+  - /install-and-configure/install-opensearch/operator/
+  - /install-and-configure/install-opensearch/operator/index/
 ---
 
 The OpenSearch Kubernetes Operator is an open-source kubernetes operator that helps automate the deployment and provisioning of OpenSearch and OpenSearch Dashboards in a containerized environment. The operator can manage multiple OpenSearch clusters that can be scaled up and down depending on your needs. 

--- a/_tools/logstash/advanced-config.md
+++ b/_tools/logstash/advanced-config.md
@@ -4,6 +4,8 @@ title: Advanced configurations
 parent: Logstash
 nav_order: 230
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/advanced-config/
+redirect_from:
+  - /clients/logstash/advanced-config/
 ---
 
 # Advanced configurations

--- a/_tools/logstash/common-filters.md
+++ b/_tools/logstash/common-filters.md
@@ -4,6 +4,8 @@ title: Common filter plugins
 parent: Logstash
 nav_order: 220
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/common-filters/
+redirect_from:
+  - /clients/logstash/common-filters/
 ---
 
 # Common filter plugins

--- a/_tools/logstash/execution-model.md
+++ b/_tools/logstash/execution-model.md
@@ -4,6 +4,8 @@ title: Logstash execution model
 parent: Logstash
 nav_order: 210
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/execution-model/
+redirect_from:
+  - /clients/logstash/execution-model/
 ---
 
 # Logstash execution model

--- a/_tools/logstash/index.md
+++ b/_tools/logstash/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: true
 redirect_from:
   - /clients/logstash/
+  - /clients/logstash/index/
+  - /tools/logstash/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/index/
 ---
 

--- a/_tools/logstash/read-from-opensearch.md
+++ b/_tools/logstash/read-from-opensearch.md
@@ -4,6 +4,8 @@ title: Read from OpenSearch
 parent: Logstash
 nav_order: 220
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/read-from-opensearch/
+redirect_from:
+  - /clients/logstash/read-from-opensearch/
 ---
 
 # Read from OpenSearch

--- a/_tools/logstash/ship-to-opensearch.md
+++ b/_tools/logstash/ship-to-opensearch.md
@@ -4,6 +4,8 @@ title: Ship events to OpenSearch
 parent: Logstash
 nav_order: 220
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/ship-to-opensearch/
+redirect_from:
+  - /clients/logstash/ship-to-opensearch/
 ---
 
 # Ship events to OpenSearch

--- a/_troubleshoot/index.md
+++ b/_troubleshoot/index.md
@@ -5,6 +5,8 @@ nav_order: 1
 has_toc: false
 redirect_from: /troubleshoot/
 canonical_url: https://docs.opensearch.org/latest/troubleshoot/
+redirect_from:
+  - /troubleshoot/
 ---
 
 # Common issues

--- a/_tuning-your-cluster/availability-and-recovery/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/index.md
@@ -5,6 +5,8 @@ nav_order: 20
 has_children: true
 has_toc: true
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/index/
+redirect_from:
+  - /tuning-your-cluster/availability-and-recovery/
 ---
 
 # Availability and recovery

--- a/_tuning-your-cluster/availability-and-recovery/remote.md
+++ b/_tuning-your-cluster/availability-and-recovery/remote.md
@@ -5,6 +5,8 @@ nav_order: 40
 parent: Availability and Recovery
 redirect_from: 
   - /opensearch/remote/
+  - /tuning-your-cluster/availability-and-recovery/remote-store/
+  - /tuning-your-cluster/availability-and-recovery/remote-store/index/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
@@ -7,6 +7,7 @@ parent: Availability and Recovery
 redirect_from: 
   - /opensearch/snapshots/
   - /opensearch/snapshots/index/
+  - /tuning-your-cluster/availability-and-recovery/snapshots/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/index/
 ---

--- a/_tuning-your-cluster/cluster.md
+++ b/_tuning-your-cluster/cluster.md
@@ -4,6 +4,8 @@ title: Creating a cluster
 nav_order: 8
 redirect_from: 
   - /opensearch/cluster/
+  - /tuning-your-cluster/
+  - /tuning-your-cluster/index/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/
 ---
 


### PR DESCRIPTION
Add backward redirects from all locations of a file so users can navigate to the same file between versions.

## Problem

When users switch between documentation versions (e.g., from `/latest/` to `/2.19/`), they get a 404 if the page path changed between versions. This accounts for 73% of all 404 errors on the documentation site (~9,300/month).

## Solution

For each page on `main` that has `redirect_from` entries (indicating it moved from an old path), add those paths as `redirect_from` on the corresponding file in older branches. This way, when a user switches versions, the newer path resolves correctly on the older branch.

## Safety checks

- Only adds redirects for paths that don't already resolve to an existing file on this branch
- Never adds a redirect that matches the file's own URL
- Skips files that already have `redirect_to`
- Never duplicates existing redirects