### PR TITLE
Add cross-version redirects to 2.12

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -7,6 +7,7 @@ has_toc: false
 nav_exclude: true
 permalink: /about/
 redirect_from:
+  - /404.html
   - /docs/opensearch/
   - /opensearch/
   - /opensearch/index/

--- a/_about/intro.md
+++ b/_about/intro.md
@@ -4,6 +4,8 @@ title: Intro to OpenSearch
 nav_order: 2
 permalink: /intro/
 canonical_url: https://docs.opensearch.org/latest/getting-started/intro/
+redirect_from:
+  - /getting-started/intro/
 ---
 
 # Introduction to OpenSearch

--- a/_about/quickstart.md
+++ b/_about/quickstart.md
@@ -5,6 +5,7 @@ nav_order: 3
 permalink: /quickstart/
 redirect_from: 
   - /opensearch/install/quickstart/
+  - /getting-started/quickstart/
 canonical_url: https://docs.opensearch.org/latest/getting-started/quickstart/
 ---
 

--- a/_aggregations/bucket/geohex-grid.md
+++ b/_aggregations/bucket/geohex-grid.md
@@ -8,6 +8,8 @@ redirect_from:
   - /aggregations/geohexgrid/
   - /query-dsl/aggregations/geohexgrid/
   - /query-dsl/aggregations/bucket/geohex-grid/
+  - /opensearch/geohexgrid-agg/
+  - /query-dsl/aggregations/geohexgrid-agg/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/geohex-grid/
 ---
 

--- a/_aggregations/bucket/index.md
+++ b/_aggregations/bucket/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /query-dsl/aggregations/bucket-agg/
   - /query-dsl/aggregations/bucket/
   - /aggregations/bucket-agg/
+  - /aggregations/bucket/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/index/
 ---
 

--- a/_aggregations/bucket/multi-terms.md
+++ b/_aggregations/bucket/multi-terms.md
@@ -6,6 +6,7 @@ grand_parent: Aggregations
 nav_order: 130
 redirect_from:
   - /query-dsl/aggregations/multi-terms/
+  - /query-dsl/aggregations/bucket/multi-terms/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/multi-terms/
 ---
 

--- a/_aggregations/bucket/sampler.md
+++ b/_aggregations/bucket/sampler.md
@@ -5,6 +5,8 @@ parent: Bucket aggregations
 grand_parent: Aggregations
 nav_order: 170
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/sampler/
+redirect_from:
+  - /query-dsl/aggregations/bucket/sampler/
 ---
 
 # Sampler aggregations

--- a/_aggregations/bucket/significant-terms.md
+++ b/_aggregations/bucket/significant-terms.md
@@ -5,6 +5,8 @@ parent: Bucket aggregations
 grand_parent: Aggregations
 nav_order: 180
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/significant-terms/
+redirect_from:
+  - /query-dsl/aggregations/bucket/significant-terms/
 ---
 
 # Significant terms aggregations

--- a/_aggregations/bucket/significant-text.md
+++ b/_aggregations/bucket/significant-text.md
@@ -5,6 +5,8 @@ parent: Bucket aggregations
 grand_parent: Aggregations
 nav_order: 190
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/significant-text/
+redirect_from:
+  - /query-dsl/aggregations/bucket/significant-text/
 ---
 
 # Significant text aggregations

--- a/_aggregations/bucket/terms.md
+++ b/_aggregations/bucket/terms.md
@@ -5,6 +5,8 @@ parent: Bucket aggregations
 grand_parent: Aggregations
 nav_order: 200
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/terms/
+redirect_from:
+  - /query-dsl/aggregations/bucket/terms/
 ---
 
 # Terms aggregations

--- a/_aggregations/index.md
+++ b/_aggregations/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /opensearch/aggregations/
   - /query-dsl/aggregations/
   - /aggregations/index/
+  - /query-dsl/aggregations/aggregations/
 canonical_url: https://docs.opensearch.org/latest/aggregations/
 ---
 

--- a/_aggregations/metric/index.md
+++ b/_aggregations/metric/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /query-dsl/aggregations/metric-agg/
   - /aggregations/metric-agg/
   - /query-dsl/aggregations/metric/
+  - /aggregations/metric/
 canonical_url: https://docs.opensearch.org/latest/aggregations/metric/index/
 ---
 

--- a/_aggregations/pipeline-agg.md
+++ b/_aggregations/pipeline-agg.md
@@ -6,6 +6,8 @@ has_children: false
 redirect_from:
   - /opensearch/pipeline-agg/
   - /query-dsl/aggregations/pipeline-agg/
+  - /aggregations/pipeline/
+  - /aggregations/pipeline/index/
 canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline-agg/
 ---
 

--- a/_analyzers/language-analyzers.md
+++ b/_analyzers/language-analyzers.md
@@ -4,6 +4,7 @@ title: Language analyzers
 nav_order: 10
 redirect_from:
   - /query-dsl/analyzers/language-analyzers/
+  - /analyzers/language-analyzers/index/
 canonical_url: https://docs.opensearch.org/latest/analyzers/language-analyzers/
 ---
 

--- a/_analyzers/token-filters/index.md
+++ b/_analyzers/token-filters/index.md
@@ -5,6 +5,8 @@ nav_order: 70
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/analyzers/token-filters/index/
+redirect_from:
+  - /analyzers/token-filters/
 ---
 
 # Token filters

--- a/_analyzers/tokenizers/index.md
+++ b/_analyzers/tokenizers/index.md
@@ -5,6 +5,8 @@ nav_order: 60
 has_children: false
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/analyzers/tokenizers/index/
+redirect_from:
+  - /analyzers/tokenizers/
 ---
 
 # Tokenizers

--- a/_api-reference/analyze-apis.md
+++ b/_api-reference/analyze-apis.md
@@ -6,6 +6,8 @@ nav_order: 7
 redirect_from:
   - /opensearch/rest-api/analyze-apis/
   - /api-reference/analyze-apis/
+  - /api-reference/analyze-apis/index/
+  - /api-reference/analyze-apis/perform-text-analysis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/analyze-apis/
 ---
 

--- a/_api-reference/cat/index.md
+++ b/_api-reference/cat/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /opensearch/catapis/
   - /opensearch/rest-api/cat/index/
+  - /api-reference/cat/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/index/
 ---
 

--- a/_api-reference/cluster-api/index.md
+++ b/_api-reference/cluster-api/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /opensearch/api-reference/cluster-api/
+  - /api-reference/cluster-api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/index/
 ---
 

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -4,6 +4,7 @@ title: Count
 nav_order: 21
 redirect_from:
  - /opensearch/rest-api/count/
+  - /api-reference/search-apis/count/
 canonical_url: https://docs.opensearch.org/latest/api-reference/count/
 ---
 

--- a/_api-reference/document-apis/index.md
+++ b/_api-reference/document-apis/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 25
 redirect_from:
   - /opensearch/rest-api/document-apis/index/
+  - /api-reference/document-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index/
 ---
 

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -4,6 +4,7 @@ title: Explain
 nav_order: 30
 redirect_from: 
  - /opensearch/rest-api/explain/
+  - /api-reference/search-apis/explain/
 canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
 ---
 

--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -4,8 +4,8 @@ title: Alias
 parent: Index APIs
 nav_order: 5
 redirect_from: 
- - /opensearch/rest-api/alias/
- - /api-reference/alias/
+  - /opensearch/rest-api/alias/
+  - /api-reference/alias/
   - /api-reference/alias/aliases-api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
 ---

--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -6,6 +6,7 @@ nav_order: 5
 redirect_from: 
  - /opensearch/rest-api/alias/
  - /api-reference/alias/
+  - /api-reference/alias/aliases-api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
 ---
 

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -5,6 +5,7 @@ parent: Index APIs
 nav_order: 45
 redirect_from:
   - /opensearch/rest-api/index-apis/get-index/
+  - /opensearch/rest-api/index-apis/get-settings/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/get-settings/
 ---
 

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -4,7 +4,6 @@ title: Get settings
 parent: Index APIs
 nav_order: 45
 redirect_from:
-  - /opensearch/rest-api/index-apis/get-index/
   - /opensearch/rest-api/index-apis/get-settings/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/get-settings/
 ---

--- a/_api-reference/index-apis/index.md
+++ b/_api-reference/index-apis/index.md
@@ -5,6 +5,8 @@ has_children: true
 nav_order: 35
 redirect_from:
   - /opensearch/rest-api/index-apis/
+  - /api-reference/index-apis/
+  - /opensearch/rest-api/index-apis/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/index/
 ---
 

--- a/_api-reference/index-apis/put-mapping.md
+++ b/_api-reference/index-apis/put-mapping.md
@@ -6,6 +6,7 @@ nav_order: 27
 redirect_from:
   - /opensearch/rest-api/index-apis/update-mapping/
   - /opensearch/rest-api/update-mapping/
+  - /opensearch/rest-api/index-apis/put-mapping/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/put-mapping/
 ---
 

--- a/_api-reference/ingest-apis/index.md
+++ b/_api-reference/ingest-apis/index.md
@@ -5,6 +5,7 @@ has_children: false
 nav_order: 40
 redirect_from:
   - /opensearch/rest-api/ingest-apis/index/
+  - /api-reference/ingest-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/ingest-apis/index/
 ---
 

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -4,6 +4,7 @@ title: Multi-search
 nav_order: 45
 redirect_from: 
  - /opensearch/rest-api/multi-search/
+  - /api-reference/search-apis/multi-search/
 canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
 ---
 

--- a/_api-reference/nodes-apis/index.md
+++ b/_api-reference/nodes-apis/index.md
@@ -4,6 +4,8 @@ title: Nodes APIs
 has_children: true
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/nodes-apis/index/
+redirect_from:
+  - /api-reference/nodes-apis/
 ---
 
 # Nodes API

--- a/_api-reference/profile.md
+++ b/_api-reference/profile.md
@@ -3,6 +3,8 @@ layout: default
 title: Profile
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/api-reference/profile/
+redirect_from:
+  - /api-reference/search-apis/profile/
 ---
 
 # Profile

--- a/_api-reference/rank-eval.md
+++ b/_api-reference/rank-eval.md
@@ -3,6 +3,8 @@ layout: default
 title: Ranking evaluation
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/api-reference/rank-eval/
+redirect_from:
+  - /api-reference/search-apis/rank-eval/
 ---
 
 # Ranking evaluation

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -4,6 +4,7 @@ title: Remote cluster information
 nav_order: 67
 redirect_from: 
  - /opensearch/rest-api/remote-info/
+  - /api-reference/cluster-api/remote-info/
 canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
 ---
 

--- a/_api-reference/script-apis/index.md
+++ b/_api-reference/script-apis/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 70
 redirect_from:
   - /opensearch/rest-api/script-apis/
+  - /api-reference/script-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/script-apis/index/
 ---
 

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -4,6 +4,7 @@ title: Scroll
 nav_order: 71
 redirect_from:
  - /opensearch/rest-api/scroll/
+  - /api-reference/search-apis/scroll/
 canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
 ---
 

--- a/_api-reference/search-template.md
+++ b/_api-reference/search-template.md
@@ -5,6 +5,8 @@ nav_order: 80
 redirect_from:
   - /opensearch/search-template/
   - /search-plugins/search-template/
+  - /api-reference/search-apis/search-template/
+  - /api-reference/search-apis/search-template/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/search-template/
 ---
 

--- a/_api-reference/search.md
+++ b/_api-reference/search.md
@@ -4,6 +4,7 @@ title: Search
 nav_order: 75
 redirect_from:
   - /opensearch/rest-api/search/
+  - /api-reference/search-apis/search/
 canonical_url: https://docs.opensearch.org/latest/api-reference/search/
 ---
 

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -4,7 +4,6 @@ title: Snapshot APIs
 has_children: true
 nav_order: 80
 redirect_from:
-  - /opensearch/rest-api/document-apis/
   - /opensearch/rest-api/snapshots/
   - /api-reference/snapshots/
 canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -6,6 +6,7 @@ nav_order: 80
 redirect_from:
   - /opensearch/rest-api/document-apis/
   - /opensearch/rest-api/snapshots/
+  - /api-reference/snapshots/
 canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/
 ---
 

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -4,6 +4,7 @@ title: Tasks
 nav_order: 85
 redirect_from:
  - /opensearch/rest-api/tasks/
+  - /api-reference/tasks/tasks/
 canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
 ---
 

--- a/_automating-configurations/api/index.md
+++ b/_automating-configurations/api/index.md
@@ -5,6 +5,8 @@ nav_order: 40
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/automating-configurations/api/index/
+redirect_from:
+  - /automating-configurations/api/
 ---
 
 # Workflow APIs

--- a/_automating-configurations/index.md
+++ b/_automating-configurations/index.md
@@ -6,6 +6,8 @@ has_children: false
 nav_exclude: true
 redirect_from: /automating-configurations/
 canonical_url: https://docs.opensearch.org/latest/automating-configurations/index/
+redirect_from:
+  - /automating-configurations/
 ---
 
 # Automating configurations

--- a/_dashboards/dashboard/index.md
+++ b/_dashboards/dashboard/index.md
@@ -4,6 +4,8 @@ title: Creating dashboards
 nav_order: 30
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/dashboard/index/
+redirect_from:
+  - /dashboards/dashboard/
 ---
 
 # Creating dashboards

--- a/_dashboards/dashboards-assistant/index.md
+++ b/_dashboards/dashboards-assistant/index.md
@@ -5,6 +5,8 @@ nav_order: 3
 has_children: false
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/dashboards-assistant/index/
+redirect_from:
+  - /dashboards/dashboards-assistant/
 ---
 
 This is an experimental feature and is not recommended for use in a production environment. For updates on the feature's progress or to leave feedback, go to the [`dashboards-assistant` repository](https://github.com/opensearch-project/dashboards-assistant) on GitHub or the associated [OpenSearch forum thread](https://forum.opensearch.org/t/feedback-opensearch-assistant/16741).

--- a/_dashboards/dev-tools/index-dev.md
+++ b/_dashboards/dev-tools/index-dev.md
@@ -4,6 +4,10 @@ title: Dev Tools
 nav_order: 120
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index-dev/
+redirect_from:
+  - /dashboards/discover/run-queries/
+  - /dashboards/run-queries/
+  - /dashboards/visualize/run-queries/
 ---
 
 # Dev Tools

--- a/_dashboards/im-dashboards/datastream.md
+++ b/_dashboards/im-dashboards/datastream.md
@@ -5,7 +5,6 @@ parent: Index Management
 nav_order: 20
 redirect_from:
   - /dashboards/admin-ui-index/datastream/
-  - /opensearch/data-streams/
 canonical_url: https://docs.opensearch.org/latest/dashboards/im-dashboards/datastream/
 ---
 

--- a/_dashboards/im-dashboards/index.md
+++ b/_dashboards/im-dashboards/index.md
@@ -5,6 +5,7 @@ nav_order: 80
 has_children: true
 redirect_from:
   - /dashboards/admin-ui-index/
+  - /dashboards/im-dashboards/
 canonical_url: https://docs.opensearch.org/latest/dashboards/im-dashboards/index/
 ---
 

--- a/_dashboards/quickstart.md
+++ b/_dashboards/quickstart.md
@@ -5,6 +5,10 @@ nav_order: 2
 has_children: false
 redirect_from:
    - /dashboards/quickstart-dashboards/
+  - /dashboards/browser-compatibility/
+  - /dashboards/get-started/quickstart-dashboards/
+  - /dashboards/getting-started/
+  - /dashboards/getting-started/index/
 canonical_url: https://docs.opensearch.org/latest/dashboards/quickstart/
 ---
 

--- a/_dashboards/quickstart.md
+++ b/_dashboards/quickstart.md
@@ -4,7 +4,7 @@ title: OpenSearch Dashboards quickstart guide
 nav_order: 2
 has_children: false
 redirect_from:
-   - /dashboards/quickstart-dashboards/
+  - /dashboards/quickstart-dashboards/
   - /dashboards/browser-compatibility/
   - /dashboards/get-started/quickstart-dashboards/
   - /dashboards/getting-started/

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -4,6 +4,8 @@ title: Using area charts
 parent: Building data visualizations
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+redirect_from:
+  - /dashboards/visualize/visualize-app/area/
 ---
 
 # Using area charts

--- a/_dashboards/visualize/geojson-regionmaps.md
+++ b/_dashboards/visualize/geojson-regionmaps.md
@@ -6,6 +6,8 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /dashboards/geojson-regionmaps/
+  - /dashboards/visualize/region-maps/
+  - /dashboards/visualize/visualize-app/region-maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/geojson-regionmaps/
 ---
 

--- a/_dashboards/visualize/maps-stats-api.md
+++ b/_dashboards/visualize/maps-stats-api.md
@@ -6,6 +6,8 @@ grand_parent: Building data visualizations
 parent: Using coordinate and region maps 
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps-stats-api/
+redirect_from:
+  - /dashboards/visualize/visualize-app/maps-stats-api/
 ---
 
 # Maps Stats API

--- a/_dashboards/visualize/maps.md
+++ b/_dashboards/visualize/maps.md
@@ -6,6 +6,8 @@ parent: Using coordinate and region maps
 nav_order: 10
 redirect_from:
   - /dashboards/maps/
+  - /dashboards/maps-plugin/
+  - /dashboards/visualize/visualize-app/maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps/
 ---
 

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -6,6 +6,7 @@ parent: Using coordinate and region maps
 nav_order: 30
 redirect_from:
   - /dashboards/maptiles/
+  - /dashboards/visualize/visualize-app/maptiles/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
 ---
 

--- a/_dashboards/visualize/selfhost-maps-server.md
+++ b/_dashboards/visualize/selfhost-maps-server.md
@@ -6,6 +6,7 @@ parent: Using coordinate and region maps
 nav_order: 40
 redirect_from:
   - /dashboards/selfhost-maps-server/
+  - /dashboards/visualize/visualize-app/selfhost-maps-server/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/selfhost-maps-server/
 ---
 

--- a/_dashboards/visualize/visbuilder.md
+++ b/_dashboards/visualize/visbuilder.md
@@ -5,6 +5,7 @@ parent: Building data visualizations
 nav_order: 100
 redirect_from:
   - /dashboards/drag-drop-wizard/
+  - /dashboards/visualize/visualize-app/visbuilder/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visbuilder/
 ---
 

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -4,6 +4,9 @@ title: Building data visualizations
 nav_order: 40
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+redirect_from:
+  - /dashboards/visualize/visualize-app/
+  - /dashboards/visualize/visualize-app/index/
 ---
 
 # Building data visualizations

--- a/_field-types/index.md
+++ b/_field-types/index.md
@@ -8,6 +8,9 @@ redirect_from:
   - /opensearch/mappings/
   - /field-types/mappings/
   - /field-types/index/
+  - /field-types/mappings-use-cases/
+  - /mappings/
+  - /mappings/index/
 canonical_url: https://docs.opensearch.org/latest/mappings/
 ---
 

--- a/_field-types/supported-field-types/alias.md
+++ b/_field-types/supported-field-types/alias.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/alias/
   - /field-types/alias/
+  - /mappings/supported-field-types/alias/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/alias/
 ---
 

--- a/_field-types/supported-field-types/binary.md
+++ b/_field-types/supported-field-types/binary.md
@@ -7,6 +7,7 @@ has_children: false
 redirect_from:
   - /opensearch/supported-field-types/binary/
   - /field-types/binary/
+  - /mappings/supported-field-types/binary/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/binary/
 ---
 

--- a/_field-types/supported-field-types/boolean.md
+++ b/_field-types/supported-field-types/boolean.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/boolean/
   - /field-types/boolean/
+  - /mappings/supported-field-types/boolean/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/boolean/
 ---
 

--- a/_field-types/supported-field-types/completion.md
+++ b/_field-types/supported-field-types/completion.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/completion/
   - /field-types/completion/
+  - /mappings/supported-field-types/completion/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/completion/
 ---
 

--- a/_field-types/supported-field-types/date-nanos.md
+++ b/_field-types/supported-field-types/date-nanos.md
@@ -6,6 +6,8 @@ has_children: false
 parent: Date field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date-nanos/
+redirect_from:
+  - /mappings/supported-field-types/date-nanos/
 ---
 
 # Date nanoseconds field type

--- a/_field-types/supported-field-types/date.md
+++ b/_field-types/supported-field-types/date.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/date/
   - /field-types/date/
+  - /mappings/supported-field-types/date/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date/
 ---
 

--- a/_field-types/supported-field-types/dates.md
+++ b/_field-types/supported-field-types/dates.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/dates/
+redirect_from:
+  - /mappings/supported-field-types/dates/
 ---
 
 # Date field types

--- a/_field-types/supported-field-types/flat-object.md
+++ b/_field-types/supported-field-types/flat-object.md
@@ -7,6 +7,7 @@ parent: Object field types
 grand_parent: Supported field types
 redirect_from:
   - /field-types/flat-object/
+  - /mappings/supported-field-types/flat-object/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/
 ---
 

--- a/_field-types/supported-field-types/geo-point.md
+++ b/_field-types/supported-field-types/geo-point.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/geo-point/
   - /field-types/geo-point/
+  - /mappings/supported-field-types/geo-point/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-point/
 ---
 

--- a/_field-types/supported-field-types/geo-shape.md
+++ b/_field-types/supported-field-types/geo-shape.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/geo-shape/
   - /field-types/geo-shape/
+  - /mappings/supported-field-types/geo-shape/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-shape/
 ---
 

--- a/_field-types/supported-field-types/geographic.md
+++ b/_field-types/supported-field-types/geographic.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/geographic/
   - /field-types/geographic/
+  - /mappings/supported-field-types/geographic/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geographic/
 ---
 

--- a/_field-types/supported-field-types/index.md
+++ b/_field-types/supported-field-types/index.md
@@ -7,6 +7,9 @@ has_toc: false
 redirect_from:
   - /opensearch/supported-field-types/
   - /opensearch/supported-field-types/index/
+  - /field-types/supported-field-types/
+  - /mappings/supported-field-types/
+  - /mappings/supported-field-types/index/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/index/
 ---
 

--- a/_field-types/supported-field-types/ip.md
+++ b/_field-types/supported-field-types/ip.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/ip/
   - /field-types/ip/
+  - /mappings/supported-field-types/ip/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/ip/
 ---
 

--- a/_field-types/supported-field-types/join.md
+++ b/_field-types/supported-field-types/join.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/join/
   - /field-types/join/
+  - /mappings/supported-field-types/join/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/join/
 ---
 

--- a/_field-types/supported-field-types/keyword.md
+++ b/_field-types/supported-field-types/keyword.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/keyword/
   - /field-types/keyword/
+  - /mappings/supported-field-types/keyword/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/keyword/
 ---
 

--- a/_field-types/supported-field-types/knn-vector.md
+++ b/_field-types/supported-field-types/knn-vector.md
@@ -6,6 +6,9 @@ has_children: false
 parent: Supported field types
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/knn-vector/
+redirect_from:
+  - /mappings/supported-field-types/knn-vector/
+  - /mappings/supported-field-types/vector-field-types/
 ---
 
 # k-NN vector field type

--- a/_field-types/supported-field-types/match-only-text.md
+++ b/_field-types/supported-field-types/match-only-text.md
@@ -6,6 +6,8 @@ has_children: false
 parent: String field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/match-only-text/
+redirect_from:
+  - /mappings/supported-field-types/match-only-text/
 ---
 
 # Match-only text field type

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/nested/
   - /field-types/nested/
+  - /mappings/supported-field-types/nested/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/nested/
 ---
 

--- a/_field-types/supported-field-types/numeric.md
+++ b/_field-types/supported-field-types/numeric.md
@@ -7,6 +7,7 @@ has_children: true
 redirect_from:
   - /opensearch/supported-field-types/numeric/
   - /field-types/numeric/
+  - /mappings/supported-field-types/numeric/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/
 ---
 

--- a/_field-types/supported-field-types/object-fields.md
+++ b/_field-types/supported-field-types/object-fields.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/object-fields/
   - /field-types/object-fields/
+  - /mappings/supported-field-types/object-fields/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/
 ---
 

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from: 
   - /opensearch/supported-field-types/object/
   - /field-types/object/
+  - /mappings/supported-field-types/object/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object/
 ---
 

--- a/_field-types/supported-field-types/percolator.md
+++ b/_field-types/supported-field-types/percolator.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/percolator/
   - /field-types/percolator/
+  - /mappings/supported-field-types/percolator/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/percolator/
 ---
 

--- a/_field-types/supported-field-types/range.md
+++ b/_field-types/supported-field-types/range.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/range/
   - /field-types/range/
+  - /mappings/supported-field-types/range/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/range/
 ---
 

--- a/_field-types/supported-field-types/rank.md
+++ b/_field-types/supported-field-types/rank.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/rank/
   - /field-types/rank/
+  - /mappings/supported-field-types/rank/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/rank/
 ---
 

--- a/_field-types/supported-field-types/search-as-you-type.md
+++ b/_field-types/supported-field-types/search-as-you-type.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/search-as-you-type/
   - /field-types/search-as-you-type/
+  - /mappings/supported-field-types/search-as-you-type/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/
 ---
 

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/string/
   - /field-types/string/
+  - /mappings/supported-field-types/string/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/string/
 ---
 

--- a/_field-types/supported-field-types/text.md
+++ b/_field-types/supported-field-types/text.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/text/
   - /field-types/text/
+  - /mappings/supported-field-types/text/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/text/
 ---
 

--- a/_field-types/supported-field-types/token-count.md
+++ b/_field-types/supported-field-types/token-count.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/token-count/
   - /field-types/token-count/
+  - /mappings/supported-field-types/token-count/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/token-count/
 ---
 

--- a/_field-types/supported-field-types/unsigned-long.md
+++ b/_field-types/supported-field-types/unsigned-long.md
@@ -6,6 +6,8 @@ grand_parent: Supported field types
 nav_order: 15
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/unsigned-long/
+redirect_from:
+  - /mappings/supported-field-types/unsigned-long/
 ---
 
 # Unsigned long field type

--- a/_field-types/supported-field-types/xy-point.md
+++ b/_field-types/supported-field-types/xy-point.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/xy-point/
   - /field-types/xy-point/
+  - /mappings/supported-field-types/xy-point/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-point/
 ---
 

--- a/_field-types/supported-field-types/xy-shape.md
+++ b/_field-types/supported-field-types/xy-shape.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/xy-shape/
   - /field-types/xy-shape/
+  - /mappings/supported-field-types/xy-shape/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-shape/
 ---
 

--- a/_field-types/supported-field-types/xy.md
+++ b/_field-types/supported-field-types/xy.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/xy/
   - /field-types/xy/
+  - /mappings/supported-field-types/xy/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy/
 ---
 

--- a/_im-plugin/data-streams.md
+++ b/_im-plugin/data-streams.md
@@ -3,6 +3,8 @@ layout: default
 title: Data streams
 nav_order: 13
 canonical_url: https://docs.opensearch.org/latest/im-plugin/data-streams/
+redirect_from:
+  - /opensearch/data-streams/
 ---
 
 # Data streams

--- a/_im-plugin/index-transforms/index.md
+++ b/_im-plugin/index-transforms/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from: /im-plugin/index-transforms/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-transforms/index/
+redirect_from:
+  - /im-plugin/index-transforms/
 ---
 
 # Index transforms

--- a/_im-plugin/index.md
+++ b/_im-plugin/index.md
@@ -7,7 +7,6 @@ nav_exclude: true
 permalink: /im-plugin/
 redirect_from:
   - /opensearch/index-data/
-  - /opensearch/rest-api/index-apis/index/
   - /im-plugin/index/
 canonical_url: https://docs.opensearch.org/latest/im-plugin/
 ---

--- a/_im-plugin/reindex-data.md
+++ b/_im-plugin/reindex-data.md
@@ -2,8 +2,6 @@
 layout: default
 title: Reindex data
 nav_order: 15
-redirect_from:
-  - /opensearch/reindex-data/
 canonical_url: https://docs.opensearch.org/latest/im-plugin/reindex-data/
 ---
 

--- a/_ingest-pipelines/create-ingest.md
+++ b/_ingest-pipelines/create-ingest.md
@@ -5,6 +5,7 @@ nav_order: 10
 redirect_from:
   - /opensearch/rest-api/ingest-apis/create-update-ingest/
   - /api-reference/ingest-apis/create-ingest/
+  - /api-reference/ingest-apis/create-update-ingest/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/create-ingest/
 ---
 

--- a/_ingest-pipelines/index.md
+++ b/_ingest-pipelines/index.md
@@ -6,8 +6,8 @@ nav_exclude: true
 has_toc: true
 permalink: /ingest-pipelines/
 redirect_from:
-   - /api-reference/ingest-apis/ingest-pipelines/
-   - /ingest-pipelines/index/
+  - /api-reference/ingest-apis/ingest-pipelines/
+  - /ingest-pipelines/index/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/
 ---
 

--- a/_ingest-pipelines/processors/append.md
+++ b/_ingest-pipelines/processors/append.md
@@ -4,7 +4,7 @@ title: Append
 parent: Ingest processors
 nav_order: 10
 redirect_from:
-   - /api-reference/ingest-apis/processors/append/
+  - /api-reference/ingest-apis/processors/append/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/append/
 ---
  

--- a/_ingest-pipelines/processors/bytes.md
+++ b/_ingest-pipelines/processors/bytes.md
@@ -4,7 +4,7 @@ title: Bytes
 parent: Ingest processors
 nav_order: 20
 redirect_from:
-   - /api-reference/ingest-apis/processors/bytes/
+  - /api-reference/ingest-apis/processors/bytes/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/bytes/
 ---
 

--- a/_ingest-pipelines/processors/convert.md
+++ b/_ingest-pipelines/processors/convert.md
@@ -4,7 +4,7 @@ title: Convert
 parent: Ingest processors
 nav_order: 30
 redirect_from:
-   - /api-reference/ingest-apis/processors/convert/
+  - /api-reference/ingest-apis/processors/convert/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/convert/
 ---
 

--- a/_ingest-pipelines/processors/copy.md
+++ b/_ingest-pipelines/processors/copy.md
@@ -4,7 +4,7 @@ title: Copy
 parent: Ingest processors
 nav_order: 35
 redirect_from:
-   - /api-reference/ingest-apis/processors/copy/
+  - /api-reference/ingest-apis/processors/copy/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/copy/
 ---
 

--- a/_ingest-pipelines/processors/csv.md
+++ b/_ingest-pipelines/processors/csv.md
@@ -4,7 +4,7 @@ title: CSV
 parent: Ingest processors
 nav_order: 40
 redirect_from:
-   - /api-reference/ingest-apis/processors/csv/
+  - /api-reference/ingest-apis/processors/csv/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/csv/
 ---
 

--- a/_ingest-pipelines/processors/date.md
+++ b/_ingest-pipelines/processors/date.md
@@ -4,7 +4,7 @@ title: Date
 parent: Ingest processors
 nav_order: 50
 redirect_from:
-   - /api-reference/ingest-apis/processors/date/
+  - /api-reference/ingest-apis/processors/date/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/date/
 ---
 

--- a/_ingest-pipelines/processors/index-processors.md
+++ b/_ingest-pipelines/processors/index-processors.md
@@ -5,7 +5,7 @@ nav_order: 30
 has_children: true
 has_toc: false
 redirect_from:
-   - /api-reference/ingest-apis/ingest-processors/
+  - /api-reference/ingest-apis/ingest-processors/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/index-processors/
 ---
 

--- a/_ingest-pipelines/processors/ip2geo.md
+++ b/_ingest-pipelines/processors/ip2geo.md
@@ -4,7 +4,7 @@ title: IP2Geo
 parent: Ingest processors
 nav_order: 130
 redirect_from:
-   - /api-reference/ingest-apis/processors/ip2geo/
+  - /api-reference/ingest-apis/processors/ip2geo/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/ip2geo/
 ---
 

--- a/_ingest-pipelines/processors/kv.md
+++ b/_ingest-pipelines/processors/kv.md
@@ -3,8 +3,6 @@ layout: default
 title: KV
 parent: Ingest processors
 nav_order: 200
-redirect_from:
-  - /api-reference/ingest-apis/processors/lowercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/kv/
 ---
 

--- a/_ingest-pipelines/processors/kv.md
+++ b/_ingest-pipelines/processors/kv.md
@@ -4,7 +4,7 @@ title: KV
 parent: Ingest processors
 nav_order: 200
 redirect_from:
-   - /api-reference/ingest-apis/processors/lowercase/
+  - /api-reference/ingest-apis/processors/lowercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/kv/
 ---
 

--- a/_ingest-pipelines/processors/lowercase.md
+++ b/_ingest-pipelines/processors/lowercase.md
@@ -4,7 +4,7 @@ title: Lowercase
 parent: Ingest processors
 nav_order: 210
 redirect_from:
-   - /api-reference/ingest-apis/processors/lowercase/
+  - /api-reference/ingest-apis/processors/lowercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/lowercase/
 ---
 

--- a/_ingest-pipelines/processors/remove.md
+++ b/_ingest-pipelines/processors/remove.md
@@ -4,7 +4,7 @@ title: Remove
 parent: Ingest processors
 nav_order: 230
 redirect_from:
-   - /api-reference/ingest-apis/processors/remove/
+  - /api-reference/ingest-apis/processors/remove/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove/
 ---
 

--- a/_ingest-pipelines/processors/remove_by_pattern.md
+++ b/_ingest-pipelines/processors/remove_by_pattern.md
@@ -4,7 +4,7 @@ title: Remove_by_pattern
 parent: Ingest processors
 nav_order: 225
 redirect_from:
-   - /api-reference/ingest-apis/processors/remove_by_pattern/
+  - /api-reference/ingest-apis/processors/remove_by_pattern/
   - /ingest-pipelines/processors/remove-by-pattern/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove_by_pattern/
 ---

--- a/_ingest-pipelines/processors/remove_by_pattern.md
+++ b/_ingest-pipelines/processors/remove_by_pattern.md
@@ -5,6 +5,7 @@ parent: Ingest processors
 nav_order: 225
 redirect_from:
    - /api-reference/ingest-apis/processors/remove_by_pattern/
+  - /ingest-pipelines/processors/remove-by-pattern/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove_by_pattern/
 ---
 

--- a/_ingest-pipelines/processors/sparse-encoding.md
+++ b/_ingest-pipelines/processors/sparse-encoding.md
@@ -4,7 +4,7 @@ title: Sparse encoding
 parent: Ingest processors
 nav_order: 240
 redirect_from:
-   - /api-reference/ingest-apis/processors/sparse-encoding/
+  - /api-reference/ingest-apis/processors/sparse-encoding/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/sparse-encoding/
 ---
 

--- a/_ingest-pipelines/processors/text-embedding.md
+++ b/_ingest-pipelines/processors/text-embedding.md
@@ -4,7 +4,7 @@ title: Text embedding
 parent: Ingest processors
 nav_order: 260
 redirect_from:
-   - /api-reference/ingest-apis/processors/text-embedding/
+  - /api-reference/ingest-apis/processors/text-embedding/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/text-embedding/
 ---
 

--- a/_ingest-pipelines/processors/text-image-embedding.md
+++ b/_ingest-pipelines/processors/text-image-embedding.md
@@ -4,7 +4,7 @@ title: Text/image embedding
 parent: Ingest processors
 nav_order: 270
 redirect_from:
-   - /api-reference/ingest-apis/processors/text-image-embedding/
+  - /api-reference/ingest-apis/processors/text-image-embedding/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/text-image-embedding/
 ---
 

--- a/_ingest-pipelines/processors/uppercase.md
+++ b/_ingest-pipelines/processors/uppercase.md
@@ -4,7 +4,7 @@ title: Uppercase
 parent: Ingest processors
 nav_order: 310
 redirect_from:
-   - /api-reference/ingest-apis/processors/uppercase/
+  - /api-reference/ingest-apis/processors/uppercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/uppercase/
 ---
 

--- a/_install-and-configure/install-dashboards/index.md
+++ b/_install-and-configure/install-dashboards/index.md
@@ -7,6 +7,7 @@ redirect_from:
   - /dashboards/install/index/
   - /dashboards/compatibility/
   - /install-and-configure/install-dashboards/index/
+  - /install-and-configure/install-dashboards/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/index/
 ---
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -7,7 +7,6 @@ redirect_from:
   - /opensearch/install/
   - /opensearch/install/compatibility/
   - /opensearch/install/important-settings/
-  - /install-and-configure/index/
   - /opensearch/install/index/
   - /install-and-configure/install-opensearch/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /opensearch/install/important-settings/
   - /install-and-configure/index/
   - /opensearch/install/index/
+  - /install-and-configure/install-opensearch/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/
 ---
 

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -3,8 +3,8 @@ layout: default
 title: Installing plugins
 nav_order: 90
 redirect_from:
-   - /opensearch/install/plugins/
-   - /install-and-configure/install-opensearch/plugins/
+  - /opensearch/install/plugins/
+  - /install-and-configure/install-opensearch/plugins/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/plugins/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/appendix/index.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/index.md
@@ -6,6 +6,10 @@ has_children: true
 nav_order: 30
 redirect_from:
   - /upgrade-opensearch/appendix/
+  - /migrate-or-upgrade/rolling-upgrade/appendix/
+  - /migrate-or-upgrade/rolling-upgrade/appendix/rolling-upgrade-lab/
+  - /migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
+  - /upgrade-opensearch/appendix/rolling-upgrade-lab/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/index/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/index.md
+++ b/_install-and-configure/upgrade-opensearch/index.md
@@ -5,6 +5,9 @@ nav_order: 20
 has_children: true
 redirect_from:
   - /upgrade-opensearch/index/
+  - /migrate-or-upgrade/
+  - /migrate-or-upgrade/index/
+  - /upgrade-or-migrate/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/index/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
+++ b/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
@@ -4,6 +4,10 @@ title: Rolling Upgrade
 parent: Upgrading OpenSearch
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/rolling-upgrade/
+redirect_from:
+  - /migrate-or-upgrade/rolling-upgrade/
+  - /rolling-upgrade/index/
+  - /upgrade-opensearch/
 ---
 
 # Rolling Upgrade

--- a/_integrations/index.md
+++ b/_integrations/index.md
@@ -7,6 +7,8 @@ nav_exclude: true
 permalink: /integrations/
 redirect_from:
   - /integrations/index/
+  - /dashboards/integrations/
+  - /dashboards/integrations/index/
 canonical_url: https://docs.opensearch.org/latest/integrations/
 ---
 

--- a/_ml-commons-plugin/agents-tools/index.md
+++ b/_ml-commons-plugin/agents-tools/index.md
@@ -5,6 +5,8 @@ has_children: true
 has_toc: false
 nav_order: 27
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/index/
+redirect_from:
+  - /ml-commons-plugin/agents-tools/
 ---
 
 # Agents and tools

--- a/_ml-commons-plugin/agents-tools/tools/index.md
+++ b/_ml-commons-plugin/agents-tools/tools/index.md
@@ -6,7 +6,6 @@ has_children: true
 has_toc: false
 nav_order: 20
 redirect_from: 
-  - /ml-commons-plugin/extensibility/index/
   - /ml-commons-plugin/agents-tools/tools/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/
 ---

--- a/_ml-commons-plugin/agents-tools/tools/index.md
+++ b/_ml-commons-plugin/agents-tools/tools/index.md
@@ -7,6 +7,7 @@ has_toc: false
 nav_order: 20
 redirect_from: 
   - /ml-commons-plugin/extensibility/index/
+  - /ml-commons-plugin/agents-tools/tools/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/
 ---
 

--- a/_ml-commons-plugin/api/agent-apis/index.md
+++ b/_ml-commons-plugin/api/agent-apis/index.md
@@ -7,6 +7,8 @@ has_toc: false
 nav_order: 27
 redirect_from: /ml-commons-plugin/api/agent-apis/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/agent-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/agent-apis/
 ---
 
 # Agent APIs

--- a/_ml-commons-plugin/api/connector-apis/index.md
+++ b/_ml-commons-plugin/api/connector-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/connector-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/connector-apis/
 ---
 
 # Connector APIs

--- a/_ml-commons-plugin/api/controller-apis/index.md
+++ b/_ml-commons-plugin/api/controller-apis/index.md
@@ -7,6 +7,8 @@ has_toc: false
 nav_order: 29
 redirect_from: /ml-commons-plugin/api/controller-apis/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/controller-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/controller-apis/
 ---
 
 # Controller APIs

--- a/_ml-commons-plugin/api/memory-apis/index.md
+++ b/_ml-commons-plugin/api/memory-apis/index.md
@@ -7,6 +7,8 @@ has_toc: false
 nav_order: 28
 redirect_from: /ml-commons-plugin/api/memory-apis/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/memory-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/memory-apis/
 ---
 
 # Memory APIs

--- a/_ml-commons-plugin/api/model-apis/index.md
+++ b/_ml-commons-plugin/api/model-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 nav_order: 10
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/model-apis/
 ---
 
 # Model APIs

--- a/_ml-commons-plugin/api/model-group-apis/index.md
+++ b/_ml-commons-plugin/api/model-group-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-group-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/model-group-apis/
 ---
 
 # Model group APIs

--- a/_ml-commons-plugin/api/tasks-apis/index.md
+++ b/_ml-commons-plugin/api/tasks-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/tasks-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/tasks-apis/
 ---
 
 # Tasks APIs

--- a/_ml-commons-plugin/remote-models/index.md
+++ b/_ml-commons-plugin/remote-models/index.md
@@ -7,6 +7,7 @@ has_toc: false
 nav_order: 60
 redirect_from: 
   - /ml-commons-plugin/extensibility/index/
+  - /ml-commons-plugin/remote-models/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/remote-models/index/
 ---
 

--- a/_ml-commons-plugin/using-ml-models.md
+++ b/_ml-commons-plugin/using-ml-models.md
@@ -5,8 +5,8 @@ parent: Integrating ML models
 has_children: true
 nav_order: 50
 redirect_from:
-   - /ml-commons-plugin/model-serving-framework/
-   - /ml-commons-plugin/ml-framework/
+  - /ml-commons-plugin/model-serving-framework/
+  - /ml-commons-plugin/ml-framework/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/using-ml-models/
 ---
 

--- a/_monitoring-your-cluster/job-scheduler/index.md
+++ b/_monitoring-your-cluster/job-scheduler/index.md
@@ -6,6 +6,7 @@ has_children: false
 has_toc: false
 redirect_from:
   - /job-scheduler-plugin/index/
+  - /monitoring-your-cluster/job-scheduler/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/job-scheduler/index/
 ---
 

--- a/_monitoring-your-cluster/pa/index.md
+++ b/_monitoring-your-cluster/pa/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/pa/
   - /monitoring-plugins/pa/index/
+  - /monitoring-your-cluster/pa/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/
 ---
 

--- a/_monitoring-your-cluster/pa/rca/index.md
+++ b/_monitoring-your-cluster/pa/rca/index.md
@@ -6,6 +6,7 @@ parent: Performance Analyzer
 has_children: true
 redirect_from:
   - /monitoring-plugins/pa/rca/index/
+  - /monitoring-your-cluster/pa/rca/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/index/
 ---
 

--- a/_observing-your-data/ad/index.md
+++ b/_observing-your-data/ad/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/ad/
   - /monitoring-plugins/ad/index/
+  - /observing-your-data/ad/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/index/
 ---
 

--- a/_observing-your-data/alerting/index.md
+++ b/_observing-your-data/alerting/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/alerting/
   - /monitoring-plugins/alerting/index/
+  - /observing-your-data/alerting/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/index/
 ---
 

--- a/_observing-your-data/event-analytics.md
+++ b/_observing-your-data/event-analytics.md
@@ -4,6 +4,7 @@ title: Event analytics
 nav_order: 20
 redirect_from:
   - /observing-your-data/event-analytics/
+  - /observability-plugin/event-analytics/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/event-analytics/
 ---
 

--- a/_observing-your-data/notifications/index.md
+++ b/_observing-your-data/notifications/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /notifications-plugin/
   - /notifications-plugin/index/
+  - /observing-your-data/notifications/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/notifications/index/
 ---
 

--- a/_observing-your-data/query-insights/index.md
+++ b/_observing-your-data/query-insights/index.md
@@ -5,6 +5,9 @@ nav_order: 40
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/query-insights/index/
+redirect_from:
+  - /observing-your-data/query-insights/
+  - /query-insights/
 ---
 
 # Query insights

--- a/_observing-your-data/trace/index.md
+++ b/_observing-your-data/trace/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /observability-plugin/trace/index/
   - /monitoring-plugins/trace/index/
+  - /observing-your-data/trace/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/index/
 ---
 

--- a/_query-dsl/compound/index.md
+++ b/_query-dsl/compound/index.md
@@ -7,6 +7,8 @@ nav_order: 40
 redirect_from: 
   - /query-dsl/compound/index/
   - /query-dsl/query-dsl/compound/
+  - /opensearch/query-dsl/compound/index/
+  - /query-dsl/compound/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/compound/index/
 ---
 

--- a/_query-dsl/geo-and-xy/index.md
+++ b/_query-dsl/geo-and-xy/index.md
@@ -7,6 +7,7 @@ redirect_from:
    - /opensearch/query-dsl/geo-and-xy/index/
    - /query-dsl/query-dsl/geo-and-xy/
    - /query-dsl/query-dsl/geo-and-xy/index/
+  - /query-dsl/geo-and-xy/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/index/
 ---
 

--- a/_query-dsl/geo-and-xy/index.md
+++ b/_query-dsl/geo-and-xy/index.md
@@ -4,9 +4,9 @@ title: Geographic and xy queries
 has_children: true
 nav_order: 50
 redirect_from:
-   - /opensearch/query-dsl/geo-and-xy/index/
-   - /query-dsl/query-dsl/geo-and-xy/
-   - /query-dsl/query-dsl/geo-and-xy/index/
+  - /opensearch/query-dsl/geo-and-xy/index/
+  - /query-dsl/query-dsl/geo-and-xy/
+  - /query-dsl/query-dsl/geo-and-xy/index/
   - /query-dsl/geo-and-xy/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/index/
 ---

--- a/_query-dsl/query-filter-context.md
+++ b/_query-dsl/query-filter-context.md
@@ -4,6 +4,7 @@ title: Query and filter context
 nav_order: 5
 redirect_from:
 - /query-dsl/query-dsl/query-filter-context/
+  - /opensearch/query-dsl/query-filter-context/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/query-filter-context/
 ---
 

--- a/_query-dsl/span-query.md
+++ b/_query-dsl/span-query.md
@@ -5,6 +5,8 @@ nav_order: 60
 redirect_from: 
   - /opensearch/query-dsl/span-query/
   - /query-dsl/query-dsl/span-query/
+  - /query-dsl/span/
+  - /query-dsl/span/index/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/span-query/
 ---
 

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -5,6 +5,8 @@ has_children: true
 nav_order: 65
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/index/
+redirect_from:
+  - /query-dsl/specialized/
 ---
 
 # Specialized queries

--- a/_query-dsl/specialized/neural-sparse.md
+++ b/_query-dsl/specialized/neural-sparse.md
@@ -5,6 +5,8 @@ parent: Specialized queries
 grand_parent: Query DSL
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/
+redirect_from:
+  - /query-dsl/specialized/neural-sparse/index/
 ---
 
 # Neural sparse query

--- a/_query-dsl/term-vs-full-text.md
+++ b/_query-dsl/term-vs-full-text.md
@@ -4,6 +4,7 @@ title: Term-level and full-text queries compared
 nav_order: 10
 redirect_from:
 - /query-dsl/query-dsl/term-vs-full-text
+  - /opensearch/query-dsl/term-vs-full-text/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/term-vs-full-text/
 ---
 

--- a/_query-dsl/term/index.md
+++ b/_query-dsl/term/index.md
@@ -5,6 +5,9 @@ has_children: true
 has_toc: false
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/query-dsl/term/index/
+redirect_from:
+  - /opensearch/query-dsl/term/
+  - /query-dsl/term/
 ---
 
 # Term-level queries

--- a/_search-plugins/conversational-search.md
+++ b/_search-plugins/conversational-search.md
@@ -5,6 +5,7 @@ has_children: false
 nav_order: 70
 redirect_from:
   - /ml-commons-plugin/conversational-search/
+  - /vector-search/ai-search/conversational-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/conversational-search/
 ---
 

--- a/_search-plugins/hybrid-search.md
+++ b/_search-plugins/hybrid-search.md
@@ -4,6 +4,9 @@ title: Hybrid search
 has_children: false
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/search-plugins/hybrid-search/
+redirect_from:
+  - /vector-search/ai-search/hybrid-search/
+  - /vector-search/ai-search/hybrid-search/index/
 ---
 
 # Hybrid search

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -6,6 +6,10 @@ parent: k-NN search
 grand_parent: Search methods
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/api/
+redirect_from:
+  - /vector-search/api/
+  - /vector-search/api/index/
+  - /vector-search/api/knn/
 ---
 
 # k-NN plugin API

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -7,6 +7,8 @@ grand_parent: Search methods
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/
+redirect_from:
+  - /vector-search/vector-search-techniques/approximate-knn/
 ---
 
 # Approximate k-NN search

--- a/_search-plugins/knn/filter-search-knn.md
+++ b/_search-plugins/knn/filter-search-knn.md
@@ -7,6 +7,9 @@ grand_parent: Search methods
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/filter-search-knn/
+redirect_from:
+  - /vector-search/filter-search-knn/
+  - /vector-search/filter-search-knn/index/
 ---
 
 # k-NN search with filters

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/knn/
+  - /vector-search/vector-search-techniques/
+  - /vector-search/vector-search-techniques/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/index/
 ---
 

--- a/_search-plugins/knn/jni-libraries.md
+++ b/_search-plugins/knn/jni-libraries.md
@@ -7,6 +7,7 @@ grand_parent: Search methods
 has_children: false
 redirect_from:
  - /search-plugins/knn/jni-library/
+  - /vector-search/api/knn/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/jni-libraries/
 ---
 

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -6,6 +6,9 @@ parent: k-NN search
 grand_parent: Search methods
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-index/
+redirect_from:
+  - /vector-search/creating-a-vector-db/
+  - /vector-search/creating-vector-index/
 ---
 
 # k-NN index

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -7,6 +7,8 @@ grand_parent: Search methods
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/
+redirect_from:
+  - /vector-search/vector-search-techniques/knn-score-script/
 ---
 
 # Exact k-NN with scoring script

--- a/_search-plugins/knn/nested-search-knn.md
+++ b/_search-plugins/knn/nested-search-knn.md
@@ -7,6 +7,8 @@ grand_parent: Search methods
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/nested-search-knn/
+redirect_from:
+  - /vector-search/specialized-operations/nested-search-knn/
 ---
 
 # k-NN search with nested fields

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -7,6 +7,8 @@ grand_parent: Search methods
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/
+redirect_from:
+  - /vector-search/vector-search-techniques/painless-functions/
 ---
 
 # k-NN Painless Scripting extensions

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -5,6 +5,8 @@ parent: k-NN search
 grand_parent: Search methods
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/performance-tuning/
+redirect_from:
+  - /vector-search/performance-tuning/
 ---
 
 # Performance tuning

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -5,6 +5,8 @@ parent: k-NN search
 grand_parent: Search methods
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/settings/
+redirect_from:
+  - /vector-search/settings/
 ---
 
 # k-NN settings

--- a/_search-plugins/multimodal-search.md
+++ b/_search-plugins/multimodal-search.md
@@ -5,6 +5,7 @@ nav_order: 40
 has_children: false
 redirect_from:
   - /search-plugins/neural-multimodal-search/
+  - /vector-search/ai-search/multimodal-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/multimodal-search/
 ---
 

--- a/_search-plugins/neural-search-tutorial.md
+++ b/_search-plugins/neural-search-tutorial.md
@@ -5,6 +5,8 @@ has_children: false
 nav_order: 30
 redirect_from:
   - /ml-commons-plugin/semantic-search/
+  - /tutorials/vector-search/neural-search-tutorial/
+  - /vector-search/tutorials/neural-search-tutorial/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-search-tutorial/
 ---
 

--- a/_search-plugins/neural-search.md
+++ b/_search-plugins/neural-search.md
@@ -6,6 +6,8 @@ has_children: false
 has_toc: false
 redirect_from: 
   - /neural-search-plugin/index/
+  - /vector-search/ai-search/
+  - /vector-search/ai-search/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-search/
 ---
 

--- a/_search-plugins/neural-sparse-search.md
+++ b/_search-plugins/neural-sparse-search.md
@@ -5,6 +5,7 @@ nav_order: 50
 has_children: false
 redirect_from:
   - /search-plugins/sparse-search/
+  - /vector-search/ai-search/neural-sparse-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-sparse-search/
 ---
 

--- a/_search-plugins/search-pipelines/index.md
+++ b/_search-plugins/search-pipelines/index.md
@@ -5,6 +5,8 @@ nav_order: 100
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/search-pipelines/index/
+redirect_from:
+  - /search-plugins/search-pipelines/
 ---
 
 # Search pipelines

--- a/_search-plugins/searching-data/index.md
+++ b/_search-plugins/searching-data/index.md
@@ -6,6 +6,10 @@ has_children: true
 has_toc: false
 redirect_from: /opensearch/ux/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/index/
+redirect_from:
+  - /opensearch/ux/
+  - /search-plugins/search-options/
+  - /search-plugins/searching-data/
 ---
 
 # Searching data

--- a/_search-plugins/searching-data/point-in-time-api.md
+++ b/_search-plugins/searching-data/point-in-time-api.md
@@ -8,6 +8,7 @@ grand_parent: Searching data
 redirect_from:
   - /opensearch/point-in-time-api/
   - /search-plugins/point-in-time-api/
+  - /api-reference/search-apis/point-in-time-api/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/point-in-time-api/
 ---
 

--- a/_search-plugins/semantic-search.md
+++ b/_search-plugins/semantic-search.md
@@ -5,6 +5,7 @@ nav_order: 35
 has_children: false
 redirect_from:
   - /search-plugins/neural-text-search/
+  - /vector-search/ai-search/semantic-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/semantic-search/
 ---
 

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 3
 redirect_from:
  - /search-plugins/sql/cli/
+  - /sql-and-ppl/cli/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
 ---
 

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -4,6 +4,8 @@ title: Data Types
 parent: SQL and PPL
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+redirect_from:
+  - /sql-and-ppl/datatypes/
 ---
 
 # Data types

--- a/_search-plugins/sql/full-text.md
+++ b/_search-plugins/sql/full-text.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 11
 redirect_from:
   - /search-plugins/sql/sql-full-text/
+  - /sql-and-ppl/full-text/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/full-text/
 ---
 

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 10
 redirect_from:
   - /search-plugins/sql/functions/
+  - /sql-and-ppl/sql/functions/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
 ---
 

--- a/_search-plugins/sql/identifiers.md
+++ b/_search-plugins/sql/identifiers.md
@@ -5,6 +5,8 @@ parent: SQL and PPL
 nav_order: 6
 redirect_from:
   - /search-plugins/ppl/identifiers/
+  - /observability-plugin/ppl/identifiers/
+  - /sql-and-ppl/identifiers/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
 ---
 

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/sql/index/
+  - /search-plugins/sql/
+  - /sql-and-ppl/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
 ---
 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 99
 redirect_from:
   - /search-plugins/sql/limitation/
+  - /sql-and-ppl/limitation/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
 ---
 

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 95
 redirect_from:
   - /search-plugins/sql/monitoring/
+  - /sql-and-ppl/monitoring/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
 ---
 

--- a/_search-plugins/sql/ppl/functions.md
+++ b/_search-plugins/sql/ppl/functions.md
@@ -6,6 +6,10 @@ grand_parent: SQL and PPL
 nav_order: 2
 redirect_from:
  - /search-plugins/ppl/commands/
+  - /observability-plugin/ppl/commands/
+  - /search-plugins/ppl/functions/
+  - /sql-and-ppl/ppl/commands/index/
+  - /sql-and-ppl/ppl/functions/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/functions/
 ---
 

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -14,6 +14,8 @@ redirect_from:
   - /search-plugins/ppl/protocol/
   - /search-plugins/sql/ppl/index/
   - /observability-plugin/ppl/index/
+  - /sql-and-ppl/ppl/
+  - /sql-and-ppl/ppl/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
 ---
 

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -5,6 +5,8 @@ parent: PPL
 grand_parent: SQL and PPL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/syntax/
+redirect_from:
+  - /sql-and-ppl/ppl/commands/syntax/
 ---
 
 # PPL syntax

--- a/_search-plugins/sql/response-formats.md
+++ b/_search-plugins/sql/response-formats.md
@@ -4,6 +4,8 @@ title: Response formats
 parent: SQL and PPL
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/response-formats/
+redirect_from:
+  - /sql-and-ppl/response-formats/
 ---
 
 # Response formats

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 77
 redirect_from:
   - /search-plugins/sql/settings/
+  - /sql-and-ppl/settings/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
 ---
 

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -4,6 +4,9 @@ title: SQL and PPL API
 parent: SQL and PPL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/
+redirect_from:
+  - /sql-and-ppl/sql-and-ppl-api/index/
+  - /sql-and-ppl/sql-ppl-api/
 ---
 
 # SQL and PPL API

--- a/_search-plugins/sql/sql/aggregations.md
+++ b/_search-plugins/sql/sql/aggregations.md
@@ -7,6 +7,9 @@ nav_order: 11
 Redirect_from:
   - /search-plugins/sql/aggregations/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+redirect_from:
+  - /search-plugins/sql/aggregations/
+  - /sql-and-ppl/sql/aggregations/
 ---
 
 # Aggregate functions

--- a/_search-plugins/sql/sql/basic.md
+++ b/_search-plugins/sql/sql/basic.md
@@ -7,6 +7,9 @@ nav_order: 5
 Redirect_from:
   - /search-plugins/sql/basic/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
+redirect_from:
+  - /search-plugins/sql/basic/
+  - /sql-and-ppl/sql/basic/
 ---
 
 

--- a/_search-plugins/sql/sql/complex.md
+++ b/_search-plugins/sql/sql/complex.md
@@ -7,6 +7,9 @@ nav_order: 6
 Redirect_from:
   - /search-plugins/sql/complex/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
+redirect_from:
+  - /search-plugins/sql/complex/
+  - /sql-and-ppl/sql/complex/
 ---
 
 # Complex queries

--- a/_search-plugins/sql/sql/delete.md
+++ b/_search-plugins/sql/sql/delete.md
@@ -7,6 +7,9 @@ nav_order: 12
 Redirect_from:
   - /search-plugins/sql/delete/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
+redirect_from:
+  - /search-plugins/sql/delete/
+  - /sql-and-ppl/sql/delete/
 ---
 
 

--- a/_search-plugins/sql/sql/index.md
+++ b/_search-plugins/sql/sql/index.md
@@ -8,6 +8,9 @@ has_toc: false
 redirect_from:
   - /search-plugins/sql/sql/index/
 
+  - /search-plugins/sql/sql/
+  - /sql-and-ppl/sql/
+  - /sql-and-ppl/sql/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/index/
 ---
 

--- a/_search-plugins/sql/sql/jdbc.md
+++ b/_search-plugins/sql/sql/jdbc.md
@@ -7,6 +7,7 @@ nav_order: 71
 redirect_from:
   - /search-plugins/sql/jdbc/
 
+  - /sql-and-ppl/sql/jdbc/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
 ---
 

--- a/_search-plugins/sql/sql/metadata.md
+++ b/_search-plugins/sql/sql/metadata.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 9
 redirect_from:
   - /search-plugins/sql/metadata/
+  - /sql-and-ppl/sql/metadata/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
 ---
 

--- a/_search-plugins/sql/sql/odbc.md
+++ b/_search-plugins/sql/sql/odbc.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 72
 redirect_from:
   - /search-plugins/sql/odbc/
+  - /sql-and-ppl/sql/odbc/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
 ---
 

--- a/_search-plugins/sql/sql/partiql.md
+++ b/_search-plugins/sql/sql/partiql.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 8
 redirect_from:
   - /search-plugins/sql/partiql/
+  - /sql-and-ppl/sql/partiql/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
 ---
 

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 88
 redirect_from:
   - /search-plugins/sql/troubleshoot/
+  - /sql-and-ppl/troubleshoot/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
 ---
 

--- a/_security-analytics/sec-analytics-config/log-types.md
+++ b/_security-analytics/sec-analytics-config/log-types.md
@@ -4,6 +4,9 @@ title: Supported log types
 parent: Setting up Security Analytics
 nav_order: 16
 canonical_url: https://docs.opensearch.org/latest/security-analytics/sec-analytics-config/log-types/
+redirect_from:
+  - /security-analytics/log-types-reference/
+  - /security-analytics/log-types-reference/index/
 ---
 
 

--- a/_security/access-control/cross-cluster-search.md
+++ b/_security/access-control/cross-cluster-search.md
@@ -6,6 +6,7 @@ nav_order: 105
 redirect_from:
  - /security/access-control/cross-cluster-search/
  - /security-plugin/access-control/cross-cluster-search/
+  - /search-plugins/cross-cluster-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/cross-cluster-search/
 ---
 

--- a/_security/access-control/index.md
+++ b/_security/access-control/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-plugin/access-control/index/
+  - /security/access-control/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/index/
 ---
 

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /security/audit-logs/index/
   - /security-plugin/audit-logs/index/
+  - /security/audit-logs/
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/index/
 ---
 

--- a/_security/configuration/disable.md
+++ b/_security/configuration/disable.md
@@ -5,6 +5,7 @@ parent: Configuration
 nav_order: 40
 redirect_from: 
  - /security-plugin/configuration/disable/
+  - /security/configuration/disable-enable-security/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/disable-enable-security/
 ---
 

--- a/_security/configuration/index.md
+++ b/_security/configuration/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /security-plugin/configuration/
   - /security-plugin/configuration/index/
+  - /security/configuration/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/index/
 ---
 

--- a/_security/multi-tenancy/tenant-index.md
+++ b/_security/multi-tenancy/tenant-index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security/multi-tenancy/
+  - /security-plugin/access-control/multi-tenancy/
+  - /security/access-control/multi-tenancy/
 canonical_url: https://docs.opensearch.org/latest/security/multi-tenancy/tenant-index/
 ---
 

--- a/_tools/grafana.md
+++ b/_tools/grafana.md
@@ -4,6 +4,8 @@ title: Grafana
 nav_order: 200
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/tools/grafana/
+redirect_from:
+  - /clients/grafana/
 ---
 
 # Grafana support

--- a/_tools/k8s-operator.md
+++ b/_tools/k8s-operator.md
@@ -4,6 +4,10 @@ title: OpenSearch Kubernetes Operator
 nav_order: 80
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/tools/k8s-operator/
+redirect_from:
+  - /clients/k8s-operator/
+  - /install-and-configure/install-opensearch/operator/
+  - /install-and-configure/install-opensearch/operator/index/
 ---
 
 The OpenSearch Kubernetes Operator is an open-source kubernetes operator that helps automate the deployment and provisioning of OpenSearch and OpenSearch Dashboards in a containerized environment. The operator can manage multiple OpenSearch clusters that can be scaled up and down depending on your needs. 

--- a/_tools/logstash/index.md
+++ b/_tools/logstash/index.md
@@ -7,6 +7,7 @@ has_toc: true
 redirect_from:
   - /clients/logstash/
   - /clients/logstash/index/
+  - /tools/logstash/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/index/
 ---
 

--- a/_tools/logstash/read-from-opensearch.md
+++ b/_tools/logstash/read-from-opensearch.md
@@ -5,6 +5,7 @@ parent: Logstash
 nav_order: 220
 redirect_from:
  - /clients/logstash/ship-to-opensearch/
+  - /clients/logstash/read-from-opensearch/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/read-from-opensearch/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/index.md
@@ -5,6 +5,8 @@ nav_order: 20
 has_children: true
 has_toc: true
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/index/
+redirect_from:
+  - /tuning-your-cluster/availability-and-recovery/
 ---
 
 # Availability and recovery

--- a/_tuning-your-cluster/availability-and-recovery/remote-store/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/remote-store/index.md
@@ -7,6 +7,7 @@ parent: Availability and recovery
 redirect_from: 
   - /opensearch/remote/
   - /tuning-your-cluster/availability-and-recovery/remote/
+  - /tuning-your-cluster/availability-and-recovery/remote-store/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/segment-replication/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/segment-replication/index.md
@@ -8,6 +8,8 @@ datatable: true
 redirect_from:
   - /opensearch/segment-replication/
   - /opensearch/segment-replication/index/
+  - /tuning-your-cluster/availability-and-recovery/segment-replication/
+  - /tuning-your-cluster/segment-replication/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/segment-replication/index/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
@@ -7,6 +7,7 @@ parent: Availability and recovery
 redirect_from: 
   - /opensearch/snapshots/
   - /opensearch/snapshots/index/
+  - /tuning-your-cluster/availability-and-recovery/snapshots/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/index/
 ---

--- a/_tuning-your-cluster/replication-plugin/index.md
+++ b/_tuning-your-cluster/replication-plugin/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /replication-plugin/
   - /replication-plugin/index/
+  - /tuning-your-cluster/replication-plugin/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/replication-plugin/index/
 ---
 


### PR DESCRIPTION
Add backward redirects from all locations of a file so users can navigate to the same file between versions.

## Problem

When users switch between documentation versions (e.g., from `/latest/` to `/2.19/`), they get a 404 if the page path changed between versions. This accounts for 73% of all 404 errors on the documentation site (~9,300/month).

## Solution

For each page on `main` that has `redirect_from` entries (indicating it moved from an old path), add those paths as `redirect_from` on the corresponding file in older branches. This way, when a user switches versions, the newer path resolves correctly on the older branch.

## Safety checks

- Only adds redirects for paths that don't already resolve to an existing file on this branch
- Never adds a redirect that matches the file's own URL
- Skips files that already have `redirect_to`
- Never duplicates existing redirects