### PR TITLE
Add cross-version redirects to 2.16

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -7,6 +7,7 @@ has_toc: false
 nav_exclude: true
 permalink: /about/
 redirect_from:
+  - /404.html
   - /docs/opensearch/
   - /opensearch/
   - /opensearch/index/

--- a/_aggregations/bucket/index.md
+++ b/_aggregations/bucket/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /query-dsl/aggregations/bucket-agg/
   - /query-dsl/aggregations/bucket/
   - /aggregations/bucket-agg/
+  - /aggregations/bucket/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/index/
 ---
 

--- a/_aggregations/bucket/range.md
+++ b/_aggregations/bucket/range.md
@@ -4,7 +4,6 @@ title: Range
 parent: Bucket aggregations
 nav_order: 150
 redirect_from:
-  - /query-dsl/aggregations/bucket/date-range/
   - /query-dsl/aggregations/bucket/range/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/range/
 ---

--- a/_aggregations/bucket/sampler.md
+++ b/_aggregations/bucket/sampler.md
@@ -4,7 +4,7 @@ title: Sampler
 parent: Bucket aggregations
 nav_order: 170
 redirect_from:
-  - /query-dsl/aggregations/bucket/diversified-sampler/
+  - /query-dsl/aggregations/bucket/sampler/
   - /query-dsl/aggregations/bucket/sampler/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/sampler/
 ---

--- a/_aggregations/bucket/sampler.md
+++ b/_aggregations/bucket/sampler.md
@@ -5,6 +5,7 @@ parent: Bucket aggregations
 nav_order: 170
 redirect_from:
   - /query-dsl/aggregations/bucket/diversified-sampler/
+  - /query-dsl/aggregations/bucket/sampler/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/sampler/
 ---
 

--- a/_aggregations/bucket/sampler.md
+++ b/_aggregations/bucket/sampler.md
@@ -5,7 +5,6 @@ parent: Bucket aggregations
 nav_order: 170
 redirect_from:
   - /query-dsl/aggregations/bucket/sampler/
-  - /query-dsl/aggregations/bucket/sampler/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/sampler/
 ---
 

--- a/_aggregations/metric/index.md
+++ b/_aggregations/metric/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /query-dsl/aggregations/metric-agg/
   - /aggregations/metric-agg/
   - /query-dsl/aggregations/metric/
+  - /aggregations/metric/
 canonical_url: https://docs.opensearch.org/latest/aggregations/metric/index/
 ---
 

--- a/_aggregations/pipeline-agg.md
+++ b/_aggregations/pipeline-agg.md
@@ -6,6 +6,8 @@ has_children: false
 redirect_from:
   - /opensearch/pipeline-agg/
   - /query-dsl/aggregations/pipeline-agg/
+  - /aggregations/pipeline/
+  - /aggregations/pipeline/index/
 canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline-agg/
 ---
 

--- a/_analyzers/language-analyzers.md
+++ b/_analyzers/language-analyzers.md
@@ -4,6 +4,7 @@ title: Language analyzers
 nav_order: 10
 redirect_from:
   - /query-dsl/analyzers/language-analyzers/
+  - /analyzers/language-analyzers/index/
 canonical_url: https://docs.opensearch.org/latest/analyzers/language-analyzers/
 ---
 

--- a/_analyzers/token-filters/index.md
+++ b/_analyzers/token-filters/index.md
@@ -5,6 +5,8 @@ nav_order: 70
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/analyzers/token-filters/index/
+redirect_from:
+  - /analyzers/token-filters/
 ---
 
 # Token filters

--- a/_analyzers/tokenizers/index.md
+++ b/_analyzers/tokenizers/index.md
@@ -5,6 +5,8 @@ nav_order: 60
 has_children: false
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/analyzers/tokenizers/index/
+redirect_from:
+  - /analyzers/tokenizers/
 ---
 
 # Tokenizers

--- a/_api-reference/analyze-apis.md
+++ b/_api-reference/analyze-apis.md
@@ -7,6 +7,7 @@ redirect_from:
   - /api-reference/analyze-apis/perform-text-analysis/
   - /opensearch/rest-api/analyze-apis/
   - /api-reference/analyze-apis/
+  - /api-reference/analyze-apis/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/analyze-apis/
 ---
 

--- a/_api-reference/cat/cat-cluster_manager.md
+++ b/_api-reference/cat/cat-cluster_manager.md
@@ -3,7 +3,7 @@ layout: default
 title: CAT cluster manager
 parent: CAT API
 redirect_from:
- - /opensearch/rest-api/cat/cat-master/
+  - /opensearch/rest-api/cat/cat-master/
 nav_order: 30
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-cluster_manager/

--- a/_api-reference/cat/cat-repositories.md
+++ b/_api-reference/cat/cat-repositories.md
@@ -6,7 +6,7 @@ parent: CAT API
 nav_order: 52
 has_children: false
 redirect_from:
- - /opensearch/rest-api/cat/cat-repositories/
+  - /opensearch/rest-api/cat/cat-repositories/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/cat-repositories/
 ---
 

--- a/_api-reference/cat/index.md
+++ b/_api-reference/cat/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /opensearch/catapis/
   - /opensearch/rest-api/cat/index/
+  - /api-reference/cat/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cat/index/
 ---
 

--- a/_api-reference/cluster-api/cluster-allocation.md
+++ b/_api-reference/cluster-api/cluster-allocation.md
@@ -5,7 +5,7 @@ nav_order: 10
 parent: Cluster APIs
 has_children: false
 redirect_from:
- - /opensearch/rest-api/cluster-allocation/
+  - /opensearch/rest-api/cluster-allocation/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-allocation/
 ---
 

--- a/_api-reference/cluster-api/cluster-health.md
+++ b/_api-reference/cluster-api/cluster-health.md
@@ -5,8 +5,8 @@ nav_order: 40
 parent: Cluster APIs
 has_children: false
 redirect_from: 
- - /api-reference/cluster-health/
- - /opensearch/rest-api/cluster-health/
+  - /api-reference/cluster-health/
+  - /opensearch/rest-api/cluster-health/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/cluster-health/
 ---
 

--- a/_api-reference/cluster-api/index.md
+++ b/_api-reference/cluster-api/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /opensearch/api-reference/cluster-api/
+  - /api-reference/cluster-api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/index/
 ---
 

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -4,6 +4,7 @@ title: Count
 nav_order: 21
 redirect_from:
  - /opensearch/rest-api/count/
+  - /api-reference/search-apis/count/
 canonical_url: https://docs.opensearch.org/latest/api-reference/count/
 ---
 

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -3,7 +3,7 @@ layout: default
 title: Count
 nav_order: 21
 redirect_from:
- - /opensearch/rest-api/count/
+  - /opensearch/rest-api/count/
   - /api-reference/search-apis/count/
 canonical_url: https://docs.opensearch.org/latest/api-reference/count/
 ---

--- a/_api-reference/document-apis/bulk.md
+++ b/_api-reference/document-apis/bulk.md
@@ -4,7 +4,7 @@ title: Bulk
 parent: Document APIs
 nav_order: 20
 redirect_from:
- - /opensearch/rest-api/document-apis/bulk/
+  - /opensearch/rest-api/document-apis/bulk/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/bulk/
 ---
 

--- a/_api-reference/document-apis/delete-by-query.md
+++ b/_api-reference/document-apis/delete-by-query.md
@@ -4,7 +4,7 @@ title: Delete by query
 parent: Document APIs
 nav_order: 40
 redirect_from:
- - /opensearch/rest-api/document-apis/delete-by-query/
+  - /opensearch/rest-api/document-apis/delete-by-query/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/delete-by-query/
 ---
 

--- a/_api-reference/document-apis/delete-document.md
+++ b/_api-reference/document-apis/delete-document.md
@@ -4,7 +4,7 @@ title: Delete document
 parent: Document APIs
 nav_order: 15
 redirect_from: 
- - /opensearch/rest-api/document-apis/delete-document/
+  - /opensearch/rest-api/document-apis/delete-document/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/delete-document/
 ---
 

--- a/_api-reference/document-apis/get-documents.md
+++ b/_api-reference/document-apis/get-documents.md
@@ -4,7 +4,7 @@ title: Get document
 parent: Document APIs
 nav_order: 5
 redirect_from: 
- - /opensearch/rest-api/document-apis/get-documents/
+  - /opensearch/rest-api/document-apis/get-documents/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/get-documents/
 ---
 

--- a/_api-reference/document-apis/index-document.md
+++ b/_api-reference/document-apis/index-document.md
@@ -4,7 +4,7 @@ title: Index document
 parent: Document APIs
 nav_order: 1
 redirect_from: 
- - /opensearch/rest-api/document-apis/index-document/
+  - /opensearch/rest-api/document-apis/index-document/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index-document/
 ---
 

--- a/_api-reference/document-apis/index.md
+++ b/_api-reference/document-apis/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 25
 redirect_from:
   - /opensearch/rest-api/document-apis/index/
+  - /api-reference/document-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index/
 ---
 

--- a/_api-reference/document-apis/multi-get.md
+++ b/_api-reference/document-apis/multi-get.md
@@ -4,7 +4,7 @@ title: Multi-get document
 parent: Document APIs
 nav_order: 30
 redirect_from: 
- - /opensearch/rest-api/document-apis/multi-get/
+  - /opensearch/rest-api/document-apis/multi-get/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/multi-get/
 ---
 

--- a/_api-reference/document-apis/update-by-query.md
+++ b/_api-reference/document-apis/update-by-query.md
@@ -4,7 +4,7 @@ title: Update by query
 parent: Document APIs
 nav_order: 50
 redirect_from: 
- - /opensearch/rest-api/document-apis/update-by-query/
+  - /opensearch/rest-api/document-apis/update-by-query/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/update-by-query/
 ---
 

--- a/_api-reference/document-apis/update-document.md
+++ b/_api-reference/document-apis/update-document.md
@@ -4,7 +4,7 @@ title: Update document
 parent: Document APIs
 nav_order: 10
 redirect_from: 
- - /opensearch/rest-api/document-apis/update-document/
+  - /opensearch/rest-api/document-apis/update-document/
 canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/update-document/
 ---
 

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -4,6 +4,7 @@ title: Explain
 nav_order: 30
 redirect_from: 
  - /opensearch/rest-api/explain/
+  - /api-reference/search-apis/explain/
 canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
 ---
 

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -3,7 +3,7 @@ layout: default
 title: Explain
 nav_order: 30
 redirect_from: 
- - /opensearch/rest-api/explain/
+  - /opensearch/rest-api/explain/
   - /api-reference/search-apis/explain/
 canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
 ---

--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -4,8 +4,8 @@ title: Alias
 parent: Index APIs
 nav_order: 5
 redirect_from: 
- - /opensearch/rest-api/alias/
- - /api-reference/alias/
+  - /opensearch/rest-api/alias/
+  - /api-reference/alias/
   - /api-reference/alias/aliases-api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
 ---

--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -6,6 +6,7 @@ nav_order: 5
 redirect_from: 
  - /opensearch/rest-api/alias/
  - /api-reference/alias/
+  - /api-reference/alias/aliases-api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
 ---
 

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -5,7 +5,6 @@ parent: Index APIs
 nav_order: 45
 redirect_from:
   - /opensearch/rest-api/index-apis/get-settings/
-  - /opensearch/rest-api/index-apis/get-index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/get-settings/
 ---
 

--- a/_api-reference/index-apis/index.md
+++ b/_api-reference/index-apis/index.md
@@ -6,6 +6,7 @@ nav_order: 35
 redirect_from:
   - /opensearch/rest-api/index-apis/index/
   - /opensearch/rest-api/index-apis/
+  - /api-reference/index-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/index/
 ---
 

--- a/_api-reference/index-apis/update-alias.md
+++ b/_api-reference/index-apis/update-alias.md
@@ -4,6 +4,8 @@ title: Create or update alias
 parent: Index APIs
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/update-alias/
+redirect_from:
+  - /api-reference/alias/create-alias/
 ---
 
 # Create or Update Alias

--- a/_api-reference/ingest-apis/index.md
+++ b/_api-reference/ingest-apis/index.md
@@ -5,6 +5,7 @@ has_children: false
 nav_order: 40
 redirect_from:
   - /opensearch/rest-api/ingest-apis/index/
+  - /api-reference/ingest-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/ingest-apis/index/
 ---
 

--- a/_api-reference/msearch-template.md
+++ b/_api-reference/msearch-template.md
@@ -3,6 +3,9 @@ layout: default
 title: Multi-search Template 
 nav_order: 47
 canonical_url: https://docs.opensearch.org/latest/api-reference/msearch-template/
+redirect_from:
+  - /api-reference/search-apis/msearch-template/
+  - /api-reference/search-apis/search-template/msearch-template/
 ---
 
 # Multi-search Template 

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -3,7 +3,7 @@ layout: default
 title: Multi-search
 nav_order: 45
 redirect_from: 
- - /opensearch/rest-api/multi-search/
+  - /opensearch/rest-api/multi-search/
   - /api-reference/search-apis/multi-search/
 canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
 ---

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -4,6 +4,7 @@ title: Multi-search
 nav_order: 45
 redirect_from: 
  - /opensearch/rest-api/multi-search/
+  - /api-reference/search-apis/multi-search/
 canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
 ---
 

--- a/_api-reference/nodes-apis/index.md
+++ b/_api-reference/nodes-apis/index.md
@@ -4,6 +4,8 @@ title: Nodes APIs
 has_children: true
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/api-reference/nodes-apis/index/
+redirect_from:
+  - /api-reference/nodes-apis/
 ---
 
 # Nodes API

--- a/_api-reference/profile.md
+++ b/_api-reference/profile.md
@@ -3,6 +3,8 @@ layout: default
 title: Profile
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/api-reference/profile/
+redirect_from:
+  - /api-reference/search-apis/profile/
 ---
 
 # Profile

--- a/_api-reference/rank-eval.md
+++ b/_api-reference/rank-eval.md
@@ -3,6 +3,8 @@ layout: default
 title: Ranking evaluation
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/api-reference/rank-eval/
+redirect_from:
+  - /api-reference/search-apis/rank-eval/
 ---
 
 # Ranking evaluation

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -3,7 +3,7 @@ layout: default
 title: Remote cluster information
 nav_order: 67
 redirect_from: 
- - /opensearch/rest-api/remote-info/
+  - /opensearch/rest-api/remote-info/
   - /api-reference/cluster-api/remote-info/
 canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
 ---

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -4,6 +4,7 @@ title: Remote cluster information
 nav_order: 67
 redirect_from: 
  - /opensearch/rest-api/remote-info/
+  - /api-reference/cluster-api/remote-info/
 canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
 ---
 

--- a/_api-reference/render-template.md
+++ b/_api-reference/render-template.md
@@ -3,6 +3,9 @@ layout: default
 title: Render Template
 nav_order: 82
 canonical_url: https://docs.opensearch.org/latest/api-reference/render-template/
+redirect_from:
+  - /api-reference/search-apis/render-template/
+  - /api-reference/search-apis/search-template/render-template/
 ---
 
 # Render Template 

--- a/_api-reference/script-apis/index.md
+++ b/_api-reference/script-apis/index.md
@@ -5,6 +5,7 @@ has_children: true
 nav_order: 70
 redirect_from:
   - /opensearch/rest-api/script-apis/
+  - /api-reference/script-apis/
 canonical_url: https://docs.opensearch.org/latest/api-reference/script-apis/index/
 ---
 

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -3,7 +3,7 @@ layout: default
 title: Scroll
 nav_order: 71
 redirect_from:
- - /opensearch/rest-api/scroll/
+  - /opensearch/rest-api/scroll/
   - /api-reference/search-apis/scroll/
 canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
 ---

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -4,6 +4,7 @@ title: Scroll
 nav_order: 71
 redirect_from:
  - /opensearch/rest-api/scroll/
+  - /api-reference/search-apis/scroll/
 canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
 ---
 

--- a/_api-reference/search-template.md
+++ b/_api-reference/search-template.md
@@ -5,6 +5,8 @@ nav_order: 80
 redirect_from:
   - /opensearch/search-template/
   - /search-plugins/search-template/
+  - /api-reference/search-apis/search-template/
+  - /api-reference/search-apis/search-template/index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/search-template/
 ---
 

--- a/_api-reference/search.md
+++ b/_api-reference/search.md
@@ -4,6 +4,7 @@ title: Search
 nav_order: 75
 redirect_from:
   - /opensearch/rest-api/search/
+  - /api-reference/search-apis/search/
 canonical_url: https://docs.opensearch.org/latest/api-reference/search/
 ---
 

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -4,7 +4,6 @@ title: Snapshot APIs
 has_children: true
 nav_order: 80
 redirect_from:
-  - /opensearch/rest-api/document-apis/
   - /opensearch/rest-api/snapshots/
   - /api-reference/snapshots/
 canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -6,6 +6,7 @@ nav_order: 80
 redirect_from:
   - /opensearch/rest-api/document-apis/
   - /opensearch/rest-api/snapshots/
+  - /api-reference/snapshots/
 canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/
 ---
 

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -3,7 +3,7 @@ layout: default
 title: Tasks
 nav_order: 85
 redirect_from:
- - /opensearch/rest-api/tasks/
+  - /opensearch/rest-api/tasks/
   - /api-reference/tasks/tasks/
 canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
 ---

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -4,6 +4,7 @@ title: Tasks
 nav_order: 85
 redirect_from:
  - /opensearch/rest-api/tasks/
+  - /api-reference/tasks/tasks/
 canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
 ---
 

--- a/_api-reference/validate.md
+++ b/_api-reference/validate.md
@@ -3,6 +3,8 @@ layout: default
 title: Validate Query
 nav_order: 87
 canonical_url: https://docs.opensearch.org/latest/api-reference/validate/
+redirect_from:
+  - /api-reference/search-apis/validate/
 ---
 
 # Validate Query

--- a/_automating-configurations/api/index.md
+++ b/_automating-configurations/api/index.md
@@ -5,6 +5,8 @@ nav_order: 40
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/automating-configurations/api/index/
+redirect_from:
+  - /automating-configurations/api/
 ---
 
 # Workflow APIs

--- a/_automating-configurations/index.md
+++ b/_automating-configurations/index.md
@@ -6,6 +6,8 @@ has_children: false
 nav_exclude: true
 redirect_from: /automating-configurations/
 canonical_url: https://docs.opensearch.org/latest/automating-configurations/index/
+redirect_from:
+  - /automating-configurations/
 ---
 
 # Automating configurations

--- a/_benchmark/reference/commands/index.md
+++ b/_benchmark/reference/commands/index.md
@@ -6,6 +6,8 @@ has_children: true
 parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/index/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
+redirect_from:
+  - /benchmark/reference/commands/
 ---
 
 # OpenSearch Benchmark command reference

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -4,7 +4,6 @@ title: OpenSearch Benchmark Reference
 nav_order: 25
 has_children: true
 redirect_from:
-  - /benchmark/commands/index/
   - /benchmark/reference/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/index/
 ---

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -5,6 +5,7 @@ nav_order: 25
 has_children: true
 redirect_from:
   - /benchmark/commands/index/
+  - /benchmark/reference/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/index/
 ---
 

--- a/_benchmark/reference/metrics/index.md
+++ b/_benchmark/reference/metrics/index.md
@@ -6,6 +6,10 @@ has_children: true
 parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/metrics/index/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
+redirect_from:
+  - /benchmark/metrics/
+  - /benchmark/metrics/index/
+  - /benchmark/reference/metrics/
 ---
 
 # Metrics

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -4,6 +4,8 @@ title: Telemetry devices
 nav_order: 45
 parent: OpenSearch Benchmark Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
+redirect_from:
+  - /benchmark/user-guide/understanding-results/telemetry/
 ---
 
 # Telemetry devices

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -6,6 +6,10 @@ parent: OpenSearch Benchmark Reference
 has_children: true
 redirect_from: /benchmark/workloads/index/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/index/
+redirect_from:
+  - /benchmark/reference/workloads/
+  - /benchmark/workloads/
+  - /benchmark/workloads/index/
 ---
 
 # OpenSearch Benchmark workload reference

--- a/_benchmark/user-guide/configuring-benchmark.md
+++ b/_benchmark/user-guide/configuring-benchmark.md
@@ -5,6 +5,7 @@ nav_order: 7
 parent: User guide
 redirect_from:
   - /benchmark/configuring-benchmark/
+  - /benchmark/user-guide/install-and-configure/configuring-benchmark/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/configuring-benchmark/
 ---
 

--- a/_benchmark/user-guide/contributing-workloads.md
+++ b/_benchmark/user-guide/contributing-workloads.md
@@ -4,6 +4,8 @@ title: Sharing custom workloads
 nav_order: 11
 parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/contributing-workloads/
+redirect_from:
+  - /benchmark/user-guide/working-with-workloads/contributing-workloads/
 ---
 
 # Sharing custom workloads

--- a/_benchmark/user-guide/creating-custom-workloads.md
+++ b/_benchmark/user-guide/creating-custom-workloads.md
@@ -7,6 +7,7 @@ redirect_from:
   - /benchmark/user-guide/creating-custom-workloads/
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
+  - /benchmark/user-guide/working-with-workloads/creating-custom-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/creating-custom-workloads/
 ---
 

--- a/_benchmark/user-guide/finetine-workloads.md
+++ b/_benchmark/user-guide/finetine-workloads.md
@@ -4,6 +4,8 @@ title: Fine-tuning custom workloads
 nav_order: 12
 parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/finetine-workloads/
+redirect_from:
+  - /benchmark/user-guide/working-with-workloads/finetune-workloads/
 ---
 
 # Fine-tuning custom workloads

--- a/_benchmark/user-guide/index.md
+++ b/_benchmark/user-guide/index.md
@@ -4,6 +4,8 @@ title: User guide
 nav_order: 5
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/index/
+redirect_from:
+  - /benchmark/user-guide/
 ---
 
 # OpenSearch Benchmark User Guide

--- a/_benchmark/user-guide/installing-benchmark.md
+++ b/_benchmark/user-guide/installing-benchmark.md
@@ -5,6 +5,7 @@ nav_order: 5
 parent: User guide
 redirect_from:
   - /benchmark/installing-benchmark/
+  - /benchmark/user-guide/install-and-configure/installing-benchmark/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/installing-benchmark/
 ---
 

--- a/_benchmark/user-guide/running-workloads.md
+++ b/_benchmark/user-guide/running-workloads.md
@@ -4,6 +4,8 @@ title: Running a workload
 nav_order: 9
 parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/running-workloads/
+redirect_from:
+  - /benchmark/user-guide/working-with-workloads/running-workloads/
 ---
 
 # Running a workload

--- a/_benchmark/user-guide/target-throughput.md
+++ b/_benchmark/user-guide/target-throughput.md
@@ -4,6 +4,8 @@ title: Target throughput
 nav_order: 150
 parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/target-throughput/
+redirect_from:
+  - /benchmark/user-guide/optimizing-benchmarks/target-throughput/
 ---
 
 # Target throughput

--- a/_benchmark/user-guide/understanding-results.md
+++ b/_benchmark/user-guide/understanding-results.md
@@ -4,6 +4,8 @@ title: Understanding benchmark results
 nav_order: 22
 parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/
+redirect_from:
+  - /benchmark/user-guide/understanding-results/index/
 ---
 
 

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -5,6 +5,8 @@ nav_order: 7
 parent: User guide
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
+redirect_from:
+  - /benchmark/user-guide/understanding-workloads/
 ---
 
 # Understanding workloads

--- a/_dashboards/dashboard/index.md
+++ b/_dashboards/dashboard/index.md
@@ -4,6 +4,8 @@ title: Creating dashboards
 nav_order: 30
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/dashboard/index/
+redirect_from:
+  - /dashboards/dashboard/
 ---
 
 # Creating dashboards

--- a/_dashboards/dashboards-assistant/index.md
+++ b/_dashboards/dashboards-assistant/index.md
@@ -5,6 +5,8 @@ nav_order: 3
 has_children: false
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/dashboards-assistant/index/
+redirect_from:
+  - /dashboards/dashboards-assistant/
 ---
 
 Note that machine learning models are probabilistic and that some may perform better than others, so the OpenSearch Assistant may occasionally produce inaccurate information. We recommend evaluating outputs for accuracy as appropriate to your use case, including reviewing the output or combining it with other verification factors.

--- a/_dashboards/dev-tools/index-dev.md
+++ b/_dashboards/dev-tools/index-dev.md
@@ -4,6 +4,10 @@ title: Dev Tools
 nav_order: 120
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index-dev/
+redirect_from:
+  - /dashboards/discover/run-queries/
+  - /dashboards/run-queries/
+  - /dashboards/visualize/run-queries/
 ---
 
 # Dev Tools

--- a/_dashboards/im-dashboards/datastream.md
+++ b/_dashboards/im-dashboards/datastream.md
@@ -5,7 +5,6 @@ parent: Index Management
 nav_order: 20
 redirect_from:
   - /dashboards/admin-ui-index/datastream/
-  - /opensearch/data-streams/
 canonical_url: https://docs.opensearch.org/latest/dashboards/im-dashboards/datastream/
 ---
 

--- a/_dashboards/im-dashboards/index.md
+++ b/_dashboards/im-dashboards/index.md
@@ -5,6 +5,7 @@ nav_order: 80
 has_children: true
 redirect_from:
   - /dashboards/admin-ui-index/
+  - /dashboards/im-dashboards/
 canonical_url: https://docs.opensearch.org/latest/dashboards/im-dashboards/index/
 ---
 

--- a/_dashboards/quickstart.md
+++ b/_dashboards/quickstart.md
@@ -6,6 +6,9 @@ has_children: false
 redirect_from:
   - /dashboards/get-started/quickstart-dashboards/
   - /dashboards/quickstart-dashboards/
+  - /dashboards/browser-compatibility/
+  - /dashboards/getting-started/
+  - /dashboards/getting-started/index/
 canonical_url: https://docs.opensearch.org/latest/dashboards/quickstart/
 ---
 

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -4,6 +4,8 @@ title: Area charts
 parent: Building data visualizations
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+redirect_from:
+  - /dashboards/visualize/visualize-app/area/
 ---
 
 # Using area charts

--- a/_dashboards/visualize/geojson-regionmaps.md
+++ b/_dashboards/visualize/geojson-regionmaps.md
@@ -6,6 +6,8 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /dashboards/geojson-regionmaps/
+  - /dashboards/visualize/region-maps/
+  - /dashboards/visualize/visualize-app/region-maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/geojson-regionmaps/
 ---
 

--- a/_dashboards/visualize/maps-stats-api.md
+++ b/_dashboards/visualize/maps-stats-api.md
@@ -6,6 +6,8 @@ grand_parent: Building data visualizations
 parent: Coordinate and region maps 
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps-stats-api/
+redirect_from:
+  - /dashboards/visualize/visualize-app/maps-stats-api/
 ---
 
 # Maps Stats API

--- a/_dashboards/visualize/maps.md
+++ b/_dashboards/visualize/maps.md
@@ -8,6 +8,7 @@ redirect_from:
   - /dashboards/maps-plugin/
   - /dashboards/visualize/maps/
   - /dashboards/maps/
+  - /dashboards/visualize/visualize-app/maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps/
 ---
 

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -6,6 +6,7 @@ parent: Coordinate and region maps
 nav_order: 30
 redirect_from:
   - /dashboards/maptiles/
+  - /dashboards/visualize/visualize-app/maptiles/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
 ---
 

--- a/_dashboards/visualize/selfhost-maps-server.md
+++ b/_dashboards/visualize/selfhost-maps-server.md
@@ -6,6 +6,7 @@ parent: Coordinate and region maps
 nav_order: 40
 redirect_from:
   - /dashboards/selfhost-maps-server/
+  - /dashboards/visualize/visualize-app/selfhost-maps-server/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/selfhost-maps-server/
 ---
 

--- a/_dashboards/visualize/tsvb.md
+++ b/_dashboards/visualize/tsvb.md
@@ -4,6 +4,8 @@ title: TSVB
 parent: Building data visualizations
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/tsvb/
+redirect_from:
+  - /dashboards/visualize/visualize-app/tsvb/
 ---
 
 # TSVB

--- a/_dashboards/visualize/vega.md
+++ b/_dashboards/visualize/vega.md
@@ -4,6 +4,8 @@ title: Vega
 parent: Building data visualizations
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/vega/
+redirect_from:
+  - /dashboards/visualize/visualize-app/vega/
 ---
 
 # Vega

--- a/_dashboards/visualize/visbuilder.md
+++ b/_dashboards/visualize/visbuilder.md
@@ -5,6 +5,7 @@ parent: Building data visualizations
 nav_order: 100
 redirect_from:
   - /dashboards/drag-drop-wizard/
+  - /dashboards/visualize/visualize-app/visbuilder/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visbuilder/
 ---
 

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -4,6 +4,9 @@ title: Building data visualizations
 nav_order: 40
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+redirect_from:
+  - /dashboards/visualize/visualize-app/
+  - /dashboards/visualize/visualize-app/index/
 ---
 
 # Building data visualizations

--- a/_data-prepper/managing-data-prepper/configuring-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/configuring-data-prepper.md
@@ -4,8 +4,8 @@ title: Configuring Data Prepper
 parent: Managing Data Prepper
 nav_order: 5
 redirect_from:
- - /clients/data-prepper/data-prepper-reference/
- - /monitoring-plugins/trace/data-prepper-reference/
+  - /clients/data-prepper/data-prepper-reference/
+  - /monitoring-plugins/trace/data-prepper-reference/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
 ---
 

--- a/_data-prepper/pipelines/configuration/processors/mutate-event.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-event.md
@@ -5,6 +5,8 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 65
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-event/
+redirect_from:
+  - /data-prepper/pipelines/configuration/processors/
 ---
 
 # Mutate event processors

--- a/_data-prepper/pipelines/configuration/sources/sources.md
+++ b/_data-prepper/pipelines/configuration/sources/sources.md
@@ -5,6 +5,8 @@ parent: Pipelines
 has_children: true
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/sources/
+redirect_from:
+  - /data-prepper/pipelines/configuration/sources/
 ---
 
 # Sources

--- a/_field-types/dynamic.md
+++ b/_field-types/dynamic.md
@@ -4,6 +4,8 @@ title: Dynamic parameter
 nav_order: 10
 redirect_from:
   - /opensearch/dynamic/
+  - /field-types/mapping-parameters/dynamic/
+  - /mappings/mapping-parameters/dynamic/
 canonical_url: https://docs.opensearch.org/latest/field-types/dynamic/
 ---
 

--- a/_field-types/index.md
+++ b/_field-types/index.md
@@ -8,6 +8,8 @@ redirect_from:
   - /opensearch/mappings/
   - /field-types/mappings/
   - /field-types/index/
+  - /mappings/
+  - /mappings/index/
 canonical_url: https://docs.opensearch.org/latest/mappings/
 ---
 

--- a/_field-types/metadata-fields/field-names.md
+++ b/_field-types/metadata-fields/field-names.md
@@ -4,6 +4,8 @@ title: Field names
 nav_order: 10
 parent: Metadata fields
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/field-names/
+redirect_from:
+  - /mappings/metadata-fields/field-names/
 ---
 
 # Field names

--- a/_field-types/metadata-fields/id.md
+++ b/_field-types/metadata-fields/id.md
@@ -4,6 +4,8 @@ title: ID
 nav_order: 20
 parent: Metadata fields
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/id/
+redirect_from:
+  - /mappings/metadata-fields/id/
 ---
 
 # ID

--- a/_field-types/metadata-fields/ignored.md
+++ b/_field-types/metadata-fields/ignored.md
@@ -4,6 +4,8 @@ title: Ignored
 nav_order: 25
 parent: Metadata fields
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/ignored/
+redirect_from:
+  - /mappings/metadata-fields/ignored/
 ---
 
 # Ignored

--- a/_field-types/metadata-fields/index-metadata.md
+++ b/_field-types/metadata-fields/index-metadata.md
@@ -4,6 +4,8 @@ title: Index
 nav_order: 25
 parent: Metadata fields
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/index-metadata/
+redirect_from:
+  - /mappings/metadata-fields/index-metadata/
 ---
 
 # Index

--- a/_field-types/metadata-fields/index.md
+++ b/_field-types/metadata-fields/index.md
@@ -5,6 +5,10 @@ nav_order: 90
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/index/
+redirect_from:
+  - /field-types/metadata-fields/
+  - /mappings/metadata-fields/
+  - /mappings/metadata-fields/index/
 ---
 
 # Metadata fields

--- a/_field-types/metadata-fields/meta.md
+++ b/_field-types/metadata-fields/meta.md
@@ -4,6 +4,8 @@ title: Meta
 nav_order: 30
 parent: Metadata fields
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/meta/
+redirect_from:
+  - /mappings/metadata-fields/meta/
 ---
 
 # Meta

--- a/_field-types/metadata-fields/routing.md
+++ b/_field-types/metadata-fields/routing.md
@@ -4,6 +4,8 @@ title: Routing
 nav_order: 35
 parent: Metadata fields
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/routing/
+redirect_from:
+  - /mappings/metadata-fields/routing/
 ---
 
 # Routing

--- a/_field-types/metadata-fields/source.md
+++ b/_field-types/metadata-fields/source.md
@@ -4,6 +4,8 @@ title: Source
 nav_order: 40
 parent: Metadata fields
 canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/source/
+redirect_from:
+  - /mappings/metadata-fields/source/
 ---
 
 # Source

--- a/_field-types/supported-field-types/alias.md
+++ b/_field-types/supported-field-types/alias.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/alias/
   - /field-types/alias/
+  - /mappings/supported-field-types/alias/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/alias/
 ---
 

--- a/_field-types/supported-field-types/binary.md
+++ b/_field-types/supported-field-types/binary.md
@@ -7,6 +7,7 @@ has_children: false
 redirect_from:
   - /opensearch/supported-field-types/binary/
   - /field-types/binary/
+  - /mappings/supported-field-types/binary/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/binary/
 ---
 

--- a/_field-types/supported-field-types/boolean.md
+++ b/_field-types/supported-field-types/boolean.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/boolean/
   - /field-types/boolean/
+  - /mappings/supported-field-types/boolean/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/boolean/
 ---
 

--- a/_field-types/supported-field-types/completion.md
+++ b/_field-types/supported-field-types/completion.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/completion/
   - /field-types/completion/
+  - /mappings/supported-field-types/completion/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/completion/
 ---
 

--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -6,6 +6,8 @@ has_children: false
 parent: String field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/constant-keyword/
+redirect_from:
+  - /mappings/supported-field-types/constant-keyword/
 ---
 
 # Constant keyword field type

--- a/_field-types/supported-field-types/date-nanos.md
+++ b/_field-types/supported-field-types/date-nanos.md
@@ -6,6 +6,8 @@ has_children: false
 parent: Date field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date-nanos/
+redirect_from:
+  - /mappings/supported-field-types/date-nanos/
 ---
 
 # Date nanoseconds field type

--- a/_field-types/supported-field-types/date.md
+++ b/_field-types/supported-field-types/date.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/date/
   - /field-types/date/
+  - /mappings/supported-field-types/date/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date/
 ---
 

--- a/_field-types/supported-field-types/dates.md
+++ b/_field-types/supported-field-types/dates.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/dates/
+redirect_from:
+  - /mappings/supported-field-types/dates/
 ---
 
 # Date field types

--- a/_field-types/supported-field-types/derived.md
+++ b/_field-types/supported-field-types/derived.md
@@ -5,6 +5,8 @@ nav_order: 62
 has_children: false
 parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/derived/
+redirect_from:
+  - /mappings/supported-field-types/derived/
 ---
 
 # Derived field type

--- a/_field-types/supported-field-types/flat-object.md
+++ b/_field-types/supported-field-types/flat-object.md
@@ -7,6 +7,7 @@ parent: Object field types
 grand_parent: Supported field types
 redirect_from:
   - /field-types/flat-object/
+  - /mappings/supported-field-types/flat-object/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/
 ---
 

--- a/_field-types/supported-field-types/geo-point.md
+++ b/_field-types/supported-field-types/geo-point.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/geo-point/
   - /field-types/geo-point/
+  - /mappings/supported-field-types/geo-point/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-point/
 ---
 

--- a/_field-types/supported-field-types/geo-shape.md
+++ b/_field-types/supported-field-types/geo-shape.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/geo-shape/
   - /field-types/geo-shape/
+  - /mappings/supported-field-types/geo-shape/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-shape/
 ---
 

--- a/_field-types/supported-field-types/geographic.md
+++ b/_field-types/supported-field-types/geographic.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/geographic/
   - /field-types/geographic/
+  - /mappings/supported-field-types/geographic/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geographic/
 ---
 

--- a/_field-types/supported-field-types/index.md
+++ b/_field-types/supported-field-types/index.md
@@ -7,6 +7,9 @@ has_toc: false
 redirect_from:
   - /opensearch/supported-field-types/
   - /opensearch/supported-field-types/index/
+  - /field-types/supported-field-types/
+  - /mappings/supported-field-types/
+  - /mappings/supported-field-types/index/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/index/
 ---
 

--- a/_field-types/supported-field-types/ip.md
+++ b/_field-types/supported-field-types/ip.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/ip/
   - /field-types/ip/
+  - /mappings/supported-field-types/ip/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/ip/
 ---
 

--- a/_field-types/supported-field-types/join.md
+++ b/_field-types/supported-field-types/join.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/join/
   - /field-types/join/
+  - /mappings/supported-field-types/join/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/join/
 ---
 

--- a/_field-types/supported-field-types/keyword.md
+++ b/_field-types/supported-field-types/keyword.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/keyword/
   - /field-types/keyword/
+  - /mappings/supported-field-types/keyword/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/keyword/
 ---
 

--- a/_field-types/supported-field-types/knn-vector.md
+++ b/_field-types/supported-field-types/knn-vector.md
@@ -6,6 +6,9 @@ has_children: false
 parent: Supported field types
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/knn-vector/
+redirect_from:
+  - /mappings/supported-field-types/knn-vector/
+  - /mappings/supported-field-types/vector-field-types/
 ---
 
 # k-NN vector field type

--- a/_field-types/supported-field-types/match-only-text.md
+++ b/_field-types/supported-field-types/match-only-text.md
@@ -6,6 +6,8 @@ has_children: false
 parent: String field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/match-only-text/
+redirect_from:
+  - /mappings/supported-field-types/match-only-text/
 ---
 
 # Match-only text field type

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/nested/
   - /field-types/nested/
+  - /mappings/supported-field-types/nested/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/nested/
 ---
 

--- a/_field-types/supported-field-types/numeric.md
+++ b/_field-types/supported-field-types/numeric.md
@@ -7,6 +7,7 @@ has_children: true
 redirect_from:
   - /opensearch/supported-field-types/numeric/
   - /field-types/numeric/
+  - /mappings/supported-field-types/numeric/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/
 ---
 

--- a/_field-types/supported-field-types/object-fields.md
+++ b/_field-types/supported-field-types/object-fields.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/object-fields/
   - /field-types/object-fields/
+  - /mappings/supported-field-types/object-fields/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/
 ---
 

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from: 
   - /opensearch/supported-field-types/object/
   - /field-types/object/
+  - /mappings/supported-field-types/object/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object/
 ---
 

--- a/_field-types/supported-field-types/percolator.md
+++ b/_field-types/supported-field-types/percolator.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/percolator/
   - /field-types/percolator/
+  - /mappings/supported-field-types/percolator/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/percolator/
 ---
 

--- a/_field-types/supported-field-types/range.md
+++ b/_field-types/supported-field-types/range.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/range/
   - /field-types/range/
+  - /mappings/supported-field-types/range/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/range/
 ---
 

--- a/_field-types/supported-field-types/rank.md
+++ b/_field-types/supported-field-types/rank.md
@@ -7,6 +7,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/rank/
   - /field-types/rank/
+  - /mappings/supported-field-types/rank/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/rank/
 ---
 

--- a/_field-types/supported-field-types/search-as-you-type.md
+++ b/_field-types/supported-field-types/search-as-you-type.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/search-as-you-type/
   - /field-types/search-as-you-type/
+  - /mappings/supported-field-types/search-as-you-type/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/
 ---
 

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/string/
   - /field-types/string/
+  - /mappings/supported-field-types/string/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/string/
 ---
 

--- a/_field-types/supported-field-types/text.md
+++ b/_field-types/supported-field-types/text.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/text/
   - /field-types/text/
+  - /mappings/supported-field-types/text/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/text/
 ---
 

--- a/_field-types/supported-field-types/token-count.md
+++ b/_field-types/supported-field-types/token-count.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/token-count/
   - /field-types/token-count/
+  - /mappings/supported-field-types/token-count/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/token-count/
 ---
 

--- a/_field-types/supported-field-types/unsigned-long.md
+++ b/_field-types/supported-field-types/unsigned-long.md
@@ -6,6 +6,8 @@ grand_parent: Supported field types
 nav_order: 15
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/unsigned-long/
+redirect_from:
+  - /mappings/supported-field-types/unsigned-long/
 ---
 
 # Unsigned long field type

--- a/_field-types/supported-field-types/wildcard.md
+++ b/_field-types/supported-field-types/wildcard.md
@@ -6,6 +6,8 @@ has_children: false
 parent: String field types
 grand_parent: Supported field types
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/wildcard/
+redirect_from:
+  - /mappings/supported-field-types/wildcard/
 ---
 
 # Wildcard field type

--- a/_field-types/supported-field-types/xy-point.md
+++ b/_field-types/supported-field-types/xy-point.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/xy-point/
   - /field-types/xy-point/
+  - /mappings/supported-field-types/xy-point/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-point/
 ---
 

--- a/_field-types/supported-field-types/xy-shape.md
+++ b/_field-types/supported-field-types/xy-shape.md
@@ -8,6 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/xy-shape/
   - /field-types/xy-shape/
+  - /mappings/supported-field-types/xy-shape/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-shape/
 ---
 

--- a/_field-types/supported-field-types/xy.md
+++ b/_field-types/supported-field-types/xy.md
@@ -8,6 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/xy/
   - /field-types/xy/
+  - /mappings/supported-field-types/xy/
 canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy/
 ---
 

--- a/_getting-started/intro.md
+++ b/_getting-started/intro.md
@@ -4,7 +4,7 @@ title: Intro to OpenSearch
 nav_order: 2
 has_math: true
 redirect_from: 
- - /intro/
+  - /intro/
 canonical_url: https://docs.opensearch.org/latest/getting-started/intro/
 ---
 

--- a/_getting-started/security.md
+++ b/_getting-started/security.md
@@ -3,6 +3,8 @@ layout: default
 title: Getting started with OpenSearch security
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/getting-started/security/
+redirect_from:
+  - /security/getting-started/
 ---
 
 # Getting started with OpenSearch security

--- a/_im-plugin/index-transforms/index.md
+++ b/_im-plugin/index-transforms/index.md
@@ -6,6 +6,8 @@ has_children: true
 redirect_from: /im-plugin/index-transforms/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/im-plugin/index-transforms/index/
+redirect_from:
+  - /im-plugin/index-transforms/
 ---
 
 # Index transforms

--- a/_im-plugin/index.md
+++ b/_im-plugin/index.md
@@ -7,7 +7,6 @@ nav_exclude: true
 permalink: /im-plugin/
 redirect_from:
   - /opensearch/index-data/
-  - /opensearch/rest-api/index-apis/index/
   - /im-plugin/index/
 canonical_url: https://docs.opensearch.org/latest/im-plugin/
 ---

--- a/_im-plugin/ism/managedindexes.md
+++ b/_im-plugin/ism/managedindexes.md
@@ -5,7 +5,7 @@ nav_order: 3
 parent: Index State Management
 has_children: false
 redirect_from: 
- - /im-plugin/ism/managedindices/
+  - /im-plugin/ism/managedindices/
 canonical_url: https://docs.opensearch.org/latest/im-plugin/ism/managedindexes/
 ---
 

--- a/_im-plugin/reindex-data.md
+++ b/_im-plugin/reindex-data.md
@@ -2,8 +2,6 @@
 layout: default
 title: Reindex data
 nav_order: 15
-redirect_from:
-  - /opensearch/reindex-data/
 canonical_url: https://docs.opensearch.org/latest/im-plugin/reindex-data/
 ---
 

--- a/_ingest-pipelines/create-ingest.md
+++ b/_ingest-pipelines/create-ingest.md
@@ -5,6 +5,7 @@ nav_order: 10
 redirect_from:
   - /opensearch/rest-api/ingest-apis/create-update-ingest/
   - /api-reference/ingest-apis/create-ingest/
+  - /api-reference/ingest-apis/create-update-ingest/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/create-ingest/
 ---
 

--- a/_ingest-pipelines/index.md
+++ b/_ingest-pipelines/index.md
@@ -6,8 +6,8 @@ nav_exclude: true
 has_toc: true
 permalink: /ingest-pipelines/
 redirect_from:
-   - /api-reference/ingest-apis/ingest-pipelines/
-   - /ingest-pipelines/index/
+  - /api-reference/ingest-apis/ingest-pipelines/
+  - /ingest-pipelines/index/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/
 ---
 

--- a/_ingest-pipelines/processors/append.md
+++ b/_ingest-pipelines/processors/append.md
@@ -4,7 +4,7 @@ title: Append
 parent: Ingest processors
 nav_order: 10
 redirect_from:
-   - /api-reference/ingest-apis/processors/append/
+  - /api-reference/ingest-apis/processors/append/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/append/
 ---
 

--- a/_ingest-pipelines/processors/bytes.md
+++ b/_ingest-pipelines/processors/bytes.md
@@ -4,7 +4,7 @@ title: Bytes
 parent: Ingest processors
 nav_order: 20
 redirect_from:
-   - /api-reference/ingest-apis/processors/bytes/
+  - /api-reference/ingest-apis/processors/bytes/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/bytes/
 ---
 

--- a/_ingest-pipelines/processors/convert.md
+++ b/_ingest-pipelines/processors/convert.md
@@ -4,7 +4,7 @@ title: Convert
 parent: Ingest processors
 nav_order: 30
 redirect_from:
-   - /api-reference/ingest-apis/processors/convert/
+  - /api-reference/ingest-apis/processors/convert/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/convert/
 ---
 

--- a/_ingest-pipelines/processors/copy.md
+++ b/_ingest-pipelines/processors/copy.md
@@ -4,7 +4,7 @@ title: Copy
 parent: Ingest processors
 nav_order: 35
 redirect_from:
-   - /api-reference/ingest-apis/processors/copy/
+  - /api-reference/ingest-apis/processors/copy/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/copy/
 ---
 

--- a/_ingest-pipelines/processors/csv.md
+++ b/_ingest-pipelines/processors/csv.md
@@ -4,7 +4,7 @@ title: CSV
 parent: Ingest processors
 nav_order: 40
 redirect_from:
-   - /api-reference/ingest-apis/processors/csv/
+  - /api-reference/ingest-apis/processors/csv/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/csv/
 ---
 

--- a/_ingest-pipelines/processors/date.md
+++ b/_ingest-pipelines/processors/date.md
@@ -4,7 +4,7 @@ title: Date
 parent: Ingest processors
 nav_order: 50
 redirect_from:
-   - /api-reference/ingest-apis/processors/date/
+  - /api-reference/ingest-apis/processors/date/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/date/
 ---
 

--- a/_ingest-pipelines/processors/index-processors.md
+++ b/_ingest-pipelines/processors/index-processors.md
@@ -5,7 +5,7 @@ nav_order: 30
 has_children: true
 has_toc: false
 redirect_from:
-   - /api-reference/ingest-apis/ingest-processors/
+  - /api-reference/ingest-apis/ingest-processors/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/index-processors/
 ---
 

--- a/_ingest-pipelines/processors/ip2geo.md
+++ b/_ingest-pipelines/processors/ip2geo.md
@@ -4,7 +4,7 @@ title: IP2Geo
 parent: Ingest processors
 nav_order: 130
 redirect_from:
-   - /api-reference/ingest-apis/processors/ip2geo/
+  - /api-reference/ingest-apis/processors/ip2geo/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/ip2geo/
 ---
 

--- a/_ingest-pipelines/processors/kv.md
+++ b/_ingest-pipelines/processors/kv.md
@@ -3,8 +3,6 @@ layout: default
 title: KV
 parent: Ingest processors
 nav_order: 200
-redirect_from:
-  - /api-reference/ingest-apis/processors/lowercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/kv/
 ---
 

--- a/_ingest-pipelines/processors/kv.md
+++ b/_ingest-pipelines/processors/kv.md
@@ -4,7 +4,7 @@ title: KV
 parent: Ingest processors
 nav_order: 200
 redirect_from:
-   - /api-reference/ingest-apis/processors/lowercase/
+  - /api-reference/ingest-apis/processors/lowercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/kv/
 ---
 

--- a/_ingest-pipelines/processors/lowercase.md
+++ b/_ingest-pipelines/processors/lowercase.md
@@ -4,7 +4,7 @@ title: Lowercase
 parent: Ingest processors
 nav_order: 210
 redirect_from:
-   - /api-reference/ingest-apis/processors/lowercase/
+  - /api-reference/ingest-apis/processors/lowercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/lowercase/
 ---
 

--- a/_ingest-pipelines/processors/remove.md
+++ b/_ingest-pipelines/processors/remove.md
@@ -4,7 +4,7 @@ title: Remove
 parent: Ingest processors
 nav_order: 230
 redirect_from:
-   - /api-reference/ingest-apis/processors/remove/
+  - /api-reference/ingest-apis/processors/remove/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove/
 ---
 

--- a/_ingest-pipelines/processors/remove_by_pattern.md
+++ b/_ingest-pipelines/processors/remove_by_pattern.md
@@ -4,7 +4,7 @@ title: Remove_by_pattern
 parent: Ingest processors
 nav_order: 225
 redirect_from:
-   - /api-reference/ingest-apis/processors/remove_by_pattern/
+  - /api-reference/ingest-apis/processors/remove_by_pattern/
   - /ingest-pipelines/processors/remove-by-pattern/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove_by_pattern/
 ---

--- a/_ingest-pipelines/processors/remove_by_pattern.md
+++ b/_ingest-pipelines/processors/remove_by_pattern.md
@@ -5,6 +5,7 @@ parent: Ingest processors
 nav_order: 225
 redirect_from:
    - /api-reference/ingest-apis/processors/remove_by_pattern/
+  - /ingest-pipelines/processors/remove-by-pattern/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove_by_pattern/
 ---
 

--- a/_ingest-pipelines/processors/rename.md
+++ b/_ingest-pipelines/processors/rename.md
@@ -4,7 +4,7 @@ title: Rename
 parent: Ingest processors
 nav_order: 230
 redirect_from:
-   - /api-reference/ingest-apis/processors/rename/
+  - /api-reference/ingest-apis/processors/rename/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/rename/
 ---
 

--- a/_ingest-pipelines/processors/sparse-encoding.md
+++ b/_ingest-pipelines/processors/sparse-encoding.md
@@ -4,7 +4,7 @@ title: Sparse encoding
 parent: Ingest processors
 nav_order: 240
 redirect_from:
-   - /api-reference/ingest-apis/processors/sparse-encoding/
+  - /api-reference/ingest-apis/processors/sparse-encoding/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/sparse-encoding/
 ---
 

--- a/_ingest-pipelines/processors/text-embedding.md
+++ b/_ingest-pipelines/processors/text-embedding.md
@@ -4,7 +4,7 @@ title: Text embedding
 parent: Ingest processors
 nav_order: 260
 redirect_from:
-   - /api-reference/ingest-apis/processors/text-embedding/
+  - /api-reference/ingest-apis/processors/text-embedding/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/text-embedding/
 ---
 

--- a/_ingest-pipelines/processors/text-image-embedding.md
+++ b/_ingest-pipelines/processors/text-image-embedding.md
@@ -4,7 +4,7 @@ title: Text/image embedding
 parent: Ingest processors
 nav_order: 270
 redirect_from:
-   - /api-reference/ingest-apis/processors/text-image-embedding/
+  - /api-reference/ingest-apis/processors/text-image-embedding/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/text-image-embedding/
 ---
 

--- a/_ingest-pipelines/processors/uppercase.md
+++ b/_ingest-pipelines/processors/uppercase.md
@@ -4,7 +4,7 @@ title: Uppercase
 parent: Ingest processors
 nav_order: 310
 redirect_from:
-   - /api-reference/ingest-apis/processors/uppercase/
+  - /api-reference/ingest-apis/processors/uppercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/uppercase/
 ---
 

--- a/_install-and-configure/additional-plugins/index.md
+++ b/_install-and-configure/additional-plugins/index.md
@@ -4,6 +4,8 @@ title: Additional plugins
 parent: Installing plugins
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/additional-plugins/index/
+redirect_from:
+  - /install-and-configure/additional-plugins/
 ---
 
 # Additional plugins

--- a/_install-and-configure/install-dashboards/index.md
+++ b/_install-and-configure/install-dashboards/index.md
@@ -7,6 +7,7 @@ redirect_from:
   - /dashboards/install/index/
   - /dashboards/compatibility/
   - /install-and-configure/install-dashboards/index/
+  - /install-and-configure/install-dashboards/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/index/
 ---
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -7,7 +7,6 @@ redirect_from:
   - /opensearch/install/
   - /opensearch/install/compatibility/
   - /opensearch/install/important-settings/
-  - /install-and-configure/index/
   - /opensearch/install/index/
   - /install-and-configure/install-opensearch/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /opensearch/install/important-settings/
   - /install-and-configure/index/
   - /opensearch/install/index/
+  - /install-and-configure/install-opensearch/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/
 ---
 

--- a/_install-and-configure/plugins.md
+++ b/_install-and-configure/plugins.md
@@ -4,8 +4,8 @@ title: Installing plugins
 nav_order: 90
 has_children: true
 redirect_from:
-   - /opensearch/install/plugins/
-   - /install-and-configure/install-opensearch/plugins/
+  - /opensearch/install/plugins/
+  - /install-and-configure/install-opensearch/plugins/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/plugins/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/appendix/index.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/index.md
@@ -6,6 +6,10 @@ has_children: true
 nav_order: 30
 redirect_from:
   - /upgrade-opensearch/appendix/
+  - /migrate-or-upgrade/rolling-upgrade/appendix/
+  - /migrate-or-upgrade/rolling-upgrade/appendix/rolling-upgrade-lab/
+  - /migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
+  - /upgrade-opensearch/appendix/rolling-upgrade-lab/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/index/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/index.md
+++ b/_install-and-configure/upgrade-opensearch/index.md
@@ -5,6 +5,9 @@ nav_order: 20
 has_children: true
 redirect_from:
   - /upgrade-opensearch/index/
+  - /migrate-or-upgrade/
+  - /migrate-or-upgrade/index/
+  - /upgrade-or-migrate/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/index/
 ---
 

--- a/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
+++ b/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
@@ -4,6 +4,10 @@ title: Rolling Upgrade
 parent: Upgrading OpenSearch
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/rolling-upgrade/
+redirect_from:
+  - /migrate-or-upgrade/rolling-upgrade/
+  - /rolling-upgrade/index/
+  - /upgrade-opensearch/
 ---
 
 # Rolling Upgrade

--- a/_integrations/index.md
+++ b/_integrations/index.md
@@ -7,6 +7,8 @@ nav_exclude: true
 permalink: /integrations/
 redirect_from:
   - /integrations/index/
+  - /dashboards/integrations/
+  - /dashboards/integrations/index/
 canonical_url: https://docs.opensearch.org/latest/integrations/
 ---
 

--- a/_ml-commons-plugin/agents-tools/index.md
+++ b/_ml-commons-plugin/agents-tools/index.md
@@ -5,6 +5,8 @@ has_children: true
 has_toc: false
 nav_order: 27
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/index/
+redirect_from:
+  - /ml-commons-plugin/agents-tools/
 ---
 
 # Agents and tools

--- a/_ml-commons-plugin/agents-tools/tools/index.md
+++ b/_ml-commons-plugin/agents-tools/tools/index.md
@@ -6,7 +6,6 @@ has_children: true
 has_toc: false
 nav_order: 20
 redirect_from: 
-  - /ml-commons-plugin/extensibility/index/
   - /ml-commons-plugin/agents-tools/tools/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/
 ---

--- a/_ml-commons-plugin/agents-tools/tools/index.md
+++ b/_ml-commons-plugin/agents-tools/tools/index.md
@@ -7,6 +7,7 @@ has_toc: false
 nav_order: 20
 redirect_from: 
   - /ml-commons-plugin/extensibility/index/
+  - /ml-commons-plugin/agents-tools/tools/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/
 ---
 

--- a/_ml-commons-plugin/api/agent-apis/index.md
+++ b/_ml-commons-plugin/api/agent-apis/index.md
@@ -7,6 +7,8 @@ has_toc: false
 nav_order: 27
 redirect_from: /ml-commons-plugin/api/agent-apis/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/agent-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/agent-apis/
 ---
 
 # Agent APIs

--- a/_ml-commons-plugin/api/connector-apis/index.md
+++ b/_ml-commons-plugin/api/connector-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/connector-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/connector-apis/
 ---
 
 # Connector APIs

--- a/_ml-commons-plugin/api/controller-apis/index.md
+++ b/_ml-commons-plugin/api/controller-apis/index.md
@@ -7,6 +7,8 @@ has_toc: false
 nav_order: 29
 redirect_from: /ml-commons-plugin/api/controller-apis/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/controller-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/controller-apis/
 ---
 
 # Controller APIs

--- a/_ml-commons-plugin/api/memory-apis/index.md
+++ b/_ml-commons-plugin/api/memory-apis/index.md
@@ -7,6 +7,8 @@ has_toc: false
 nav_order: 28
 redirect_from: /ml-commons-plugin/api/memory-apis/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/memory-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/memory-apis/
 ---
 
 # Memory APIs

--- a/_ml-commons-plugin/api/model-apis/index.md
+++ b/_ml-commons-plugin/api/model-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 nav_order: 10
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/model-apis/
 ---
 
 # Model APIs

--- a/_ml-commons-plugin/api/model-group-apis/index.md
+++ b/_ml-commons-plugin/api/model-group-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-group-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/model-group-apis/
 ---
 
 # Model group APIs

--- a/_ml-commons-plugin/api/tasks-apis/index.md
+++ b/_ml-commons-plugin/api/tasks-apis/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/tasks-apis/index/
+redirect_from:
+  - /ml-commons-plugin/api/tasks-apis/
 ---
 
 # Tasks APIs

--- a/_ml-commons-plugin/remote-models/index.md
+++ b/_ml-commons-plugin/remote-models/index.md
@@ -7,6 +7,7 @@ has_toc: false
 nav_order: 60
 redirect_from: 
   - /ml-commons-plugin/extensibility/index/
+  - /ml-commons-plugin/remote-models/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/remote-models/index/
 ---
 

--- a/_ml-commons-plugin/tutorials/build-chatbot.md
+++ b/_ml-commons-plugin/tutorials/build-chatbot.md
@@ -4,6 +4,9 @@ title: Build your own chatbot
 parent: Tutorials
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/build-chatbot/
+redirect_from:
+  - /tutorials/gen-ai/chatbots/build-chatbot/
+  - /vector-search/tutorials/chatbots/build-chatbot/
 ---
 
 # Build your own chatbot

--- a/_ml-commons-plugin/tutorials/conversational-search-cohere.md
+++ b/_ml-commons-plugin/tutorials/conversational-search-cohere.md
@@ -4,6 +4,10 @@ title: Conversational search with Cohere Command
 parent: Tutorials
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/conversational-search-cohere/
+redirect_from:
+  - /tutorials/gen-ai/rag/conversational-search-cohere/
+  - /tutorials/vector-search/rag/conversational-search/conversational-search-cohere/
+  - /vector-search/tutorials/conversational-search/conversational-search-cohere/
 ---
 
 # Conversational search using the Cohere Command model

--- a/_ml-commons-plugin/tutorials/generate-embeddings.md
+++ b/_ml-commons-plugin/tutorials/generate-embeddings.md
@@ -4,6 +4,9 @@ title: Generating embeddings
 parent: Tutorials
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/generate-embeddings/
+redirect_from:
+  - /tutorials/vector-search/vector-operations/generate-embeddings/
+  - /vector-search/tutorials/vector-operations/generate-embeddings/
 ---
 
 # Generating embeddings for arrays of objects

--- a/_ml-commons-plugin/tutorials/index.md
+++ b/_ml-commons-plugin/tutorials/index.md
@@ -5,6 +5,9 @@ has_children: true
 has_toc: false
 nav_order: 140
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/index/
+redirect_from:
+  - /ml-commons-plugin/tutorials/
+  - /tutorials/
 ---
 
 # Tutorials

--- a/_ml-commons-plugin/tutorials/rag-chatbot.md
+++ b/_ml-commons-plugin/tutorials/rag-chatbot.md
@@ -4,6 +4,9 @@ title: RAG chatbot
 parent: Tutorials
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/rag-chatbot/
+redirect_from:
+  - /tutorials/gen-ai/chatbots/rag-chatbot/
+  - /vector-search/tutorials/chatbots/rag-chatbot/
 ---
 
 # RAG chatbot

--- a/_ml-commons-plugin/tutorials/rag-conversational-agent.md
+++ b/_ml-commons-plugin/tutorials/rag-conversational-agent.md
@@ -4,6 +4,9 @@ title: RAG chatbot with a conversational flow agent
 parent: Tutorials
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/rag-conversational-agent/
+redirect_from:
+  - /tutorials/gen-ai/chatbots/rag-conversational-agent/
+  - /vector-search/tutorials/chatbots/rag-conversational-agent/
 ---
 
 # RAG chatbot with a conversational flow agent

--- a/_ml-commons-plugin/tutorials/reranking-cohere.md
+++ b/_ml-commons-plugin/tutorials/reranking-cohere.md
@@ -4,6 +4,9 @@ title: Reranking with Cohere Rerank
 parent: Tutorials
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/reranking-cohere/
+redirect_from:
+  - /tutorials/reranking/reranking-cohere/
+  - /vector-search/tutorials/reranking/reranking-cohere/
 ---
 
 # Reranking search results using the Cohere Rerank model

--- a/_ml-commons-plugin/tutorials/reranking-cross-encoder.md
+++ b/_ml-commons-plugin/tutorials/reranking-cross-encoder.md
@@ -4,6 +4,9 @@ title: Reranking with the MS MARCO cross-encoder
 parent: Tutorials
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/reranking-cross-encoder/
+redirect_from:
+  - /tutorials/reranking/reranking-cross-encoder/
+  - /vector-search/tutorials/reranking/reranking-cross-encoder/
 ---
 
 # Reranking search results using the MS MARCO cross-encoder model

--- a/_ml-commons-plugin/tutorials/semantic-search-byte-vectors.md
+++ b/_ml-commons-plugin/tutorials/semantic-search-byte-vectors.md
@@ -4,6 +4,9 @@ title: Semantic search using byte vectors
 parent: Tutorials
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/semantic-search-byte-vectors/
+redirect_from:
+  - /tutorials/vector-search/vector-operations/semantic-search-byte-vectors/
+  - /vector-search/tutorials/vector-operations/semantic-search-byte-vectors/
 ---
 
 # Semantic search using byte-quantized vectors

--- a/_ml-commons-plugin/using-ml-models.md
+++ b/_ml-commons-plugin/using-ml-models.md
@@ -5,8 +5,8 @@ parent: Integrating ML models
 has_children: true
 nav_order: 50
 redirect_from:
-   - /ml-commons-plugin/model-serving-framework/
-   - /ml-commons-plugin/ml-framework/
+  - /ml-commons-plugin/model-serving-framework/
+  - /ml-commons-plugin/ml-framework/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/using-ml-models/
 ---
 

--- a/_monitoring-your-cluster/job-scheduler/index.md
+++ b/_monitoring-your-cluster/job-scheduler/index.md
@@ -6,6 +6,7 @@ has_children: false
 has_toc: false
 redirect_from:
   - /job-scheduler-plugin/index/
+  - /monitoring-your-cluster/job-scheduler/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/job-scheduler/index/
 ---
 

--- a/_monitoring-your-cluster/pa/index.md
+++ b/_monitoring-your-cluster/pa/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/pa/
   - /monitoring-plugins/pa/index/
+  - /monitoring-your-cluster/pa/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/
 ---
 

--- a/_monitoring-your-cluster/pa/rca/index.md
+++ b/_monitoring-your-cluster/pa/rca/index.md
@@ -6,6 +6,7 @@ parent: Performance Analyzer
 has_children: true
 redirect_from:
   - /monitoring-plugins/pa/rca/index/
+  - /monitoring-your-cluster/pa/rca/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/index/
 ---
 

--- a/_observing-your-data/ad/index.md
+++ b/_observing-your-data/ad/index.md
@@ -37,9 +37,9 @@ A detector is an individual anomaly detection task. You can define multiple dete
 #### Example filter using query DSL
 The query is designed to retrieve documents in which the `urlPath.keyword` field matches one of the following specified values:
    
-  - /domain/{id}/short
-  - /sub_dir/{id}/short
-  - /abcd/123/{id}/xyz
+   - /domain/{id}/short
+   - /sub_dir/{id}/short
+   - /abcd/123/{id}/xyz
 
    ```json
    {

--- a/_observing-your-data/ad/index.md
+++ b/_observing-your-data/ad/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/ad/
   - /monitoring-plugins/ad/index/
+  - /observing-your-data/ad/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/index/
 ---
 

--- a/_observing-your-data/ad/index.md
+++ b/_observing-your-data/ad/index.md
@@ -37,9 +37,9 @@ A detector is an individual anomaly detection task. You can define multiple dete
 #### Example filter using query DSL
 The query is designed to retrieve documents in which the `urlPath.keyword` field matches one of the following specified values:
    
-   - /domain/{id}/short
-   - /sub_dir/{id}/short
-   - /abcd/123/{id}/xyz
+  - /domain/{id}/short
+  - /sub_dir/{id}/short
+  - /abcd/123/{id}/xyz
 
    ```json
    {

--- a/_observing-your-data/alerting/composite-monitors.md
+++ b/_observing-your-data/alerting/composite-monitors.md
@@ -6,7 +6,7 @@ parent: Monitors
 grand_parent: Alerting
 has_children: false
 redirect_from:
- - /observing-your-data/alerting/composite-monitors/
+  - /observing-your-data/alerting/composite-monitors/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/composite-monitors/
 ---
 

--- a/_observing-your-data/alerting/index.md
+++ b/_observing-your-data/alerting/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/alerting/
   - /monitoring-plugins/alerting/index/
+  - /observing-your-data/alerting/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/index/
 ---
 

--- a/_observing-your-data/notifications/index.md
+++ b/_observing-your-data/notifications/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /notifications-plugin/
   - /notifications-plugin/index/
+  - /observing-your-data/notifications/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/notifications/index/
 ---
 

--- a/_observing-your-data/query-insights/index.md
+++ b/_observing-your-data/query-insights/index.md
@@ -5,6 +5,9 @@ nav_order: 40
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/query-insights/index/
+redirect_from:
+  - /observing-your-data/query-insights/
+  - /query-insights/
 ---
 
 # Query insights

--- a/_observing-your-data/trace/index.md
+++ b/_observing-your-data/trace/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /observability-plugin/trace/index/
   - /monitoring-plugins/trace/index/
+  - /observing-your-data/trace/
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/index/
 ---
 

--- a/_query-dsl/geo-and-xy/index.md
+++ b/_query-dsl/geo-and-xy/index.md
@@ -4,10 +4,10 @@ title: Geographic and xy queries
 has_children: true
 nav_order: 50
 redirect_from:
-   - /opensearch/query-dsl/geo-and-xy/index/
-   - /query-dsl/query-dsl/geo-and-xy/
-   - /query-dsl/query-dsl/geo-and-xy/index/
-   - /query-dsl/geo-and-xy/
+  - /opensearch/query-dsl/geo-and-xy/index/
+  - /query-dsl/query-dsl/geo-and-xy/
+  - /query-dsl/query-dsl/geo-and-xy/index/
+  - /query-dsl/geo-and-xy/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/index/
 ---
 

--- a/_query-dsl/joining/index.md
+++ b/_query-dsl/joining/index.md
@@ -4,6 +4,8 @@ title: Joining queries
 has_children: true
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/query-dsl/joining/index/
+redirect_from:
+  - /query-dsl/joining/
 ---
 
 # Joining queries

--- a/_query-dsl/span-query.md
+++ b/_query-dsl/span-query.md
@@ -5,6 +5,8 @@ nav_order: 60
 redirect_from: 
   - /opensearch/query-dsl/span-query/
   - /query-dsl/query-dsl/span-query/
+  - /query-dsl/span/
+  - /query-dsl/span/index/
 canonical_url: https://docs.opensearch.org/latest/query-dsl/span-query/
 ---
 

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -5,6 +5,8 @@ has_children: true
 nav_order: 65
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/index/
+redirect_from:
+  - /query-dsl/specialized/
 ---
 
 # Specialized queries

--- a/_query-dsl/specialized/neural-sparse.md
+++ b/_query-dsl/specialized/neural-sparse.md
@@ -4,6 +4,8 @@ title: Neural sparse
 parent: Specialized queries
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/
+redirect_from:
+  - /query-dsl/specialized/neural-sparse/index/
 ---
 
 # Neural sparse query

--- a/_search-plugins/async/security.md
+++ b/_search-plugins/async/security.md
@@ -6,7 +6,7 @@ parent: Asynchronous search
 grand_parent: Improving search performance
 has_children: false
 redirect_from:
- - /search-plugins/async/security/
+  - /search-plugins/async/security/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/async/security/
 ---
 

--- a/_search-plugins/caching/index.md
+++ b/_search-plugins/caching/index.md
@@ -5,6 +5,8 @@ parent: Improving search performance
 has_children: true
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/search-plugins/caching/index/
+redirect_from:
+  - /search-plugins/caching/
 ---
 
 # Caching

--- a/_search-plugins/conversational-search.md
+++ b/_search-plugins/conversational-search.md
@@ -5,6 +5,7 @@ has_children: false
 nav_order: 70
 redirect_from:
   - /ml-commons-plugin/conversational-search/
+  - /vector-search/ai-search/conversational-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/conversational-search/
 ---
 

--- a/_search-plugins/cross-cluster-search.md
+++ b/_search-plugins/cross-cluster-search.md
@@ -3,8 +3,8 @@ layout: default
 title: Cross-cluster search
 nav_order: 65
 redirect_from:
- - /security/access-control/cross-cluster-search/
- - /security-plugin/access-control/cross-cluster-search/
+  - /security/access-control/cross-cluster-search/
+  - /security-plugin/access-control/cross-cluster-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/cross-cluster-search/
 ---
 

--- a/_search-plugins/hybrid-search.md
+++ b/_search-plugins/hybrid-search.md
@@ -4,6 +4,9 @@ title: Hybrid search
 has_children: false
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/search-plugins/hybrid-search/
+redirect_from:
+  - /vector-search/ai-search/hybrid-search/
+  - /vector-search/ai-search/hybrid-search/index/
 ---
 
 # Hybrid search

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -5,6 +5,10 @@ nav_order: 30
 parent: k-NN search
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/api/
+redirect_from:
+  - /vector-search/api/
+  - /vector-search/api/index/
+  - /vector-search/api/knn/
 ---
 
 # k-NN plugin API

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -6,6 +6,8 @@ parent: k-NN search
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/
+redirect_from:
+  - /vector-search/vector-search-techniques/approximate-knn/
 ---
 
 # Approximate k-NN search

--- a/_search-plugins/knn/filter-search-knn.md
+++ b/_search-plugins/knn/filter-search-knn.md
@@ -6,6 +6,9 @@ parent: k-NN search
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/filter-search-knn/
+redirect_from:
+  - /vector-search/filter-search-knn/
+  - /vector-search/filter-search-knn/index/
 ---
 
 # k-NN search with filters

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/knn/
+  - /vector-search/vector-search-techniques/
+  - /vector-search/vector-search-techniques/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/index/
 ---
 

--- a/_search-plugins/knn/jni-libraries.md
+++ b/_search-plugins/knn/jni-libraries.md
@@ -5,7 +5,7 @@ nav_order: 35
 parent: k-NN search
 has_children: false
 redirect_from:
- - /search-plugins/knn/jni-library/
+  - /search-plugins/knn/jni-library/
   - /vector-search/api/knn/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/jni-libraries/
 ---

--- a/_search-plugins/knn/jni-libraries.md
+++ b/_search-plugins/knn/jni-libraries.md
@@ -6,6 +6,7 @@ parent: k-NN search
 has_children: false
 redirect_from:
  - /search-plugins/knn/jni-library/
+  - /vector-search/api/knn/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/jni-libraries/
 ---
 

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -5,6 +5,9 @@ nav_order: 5
 parent: k-NN search
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-index/
+redirect_from:
+  - /vector-search/creating-a-vector-db/
+  - /vector-search/creating-vector-index/
 ---
 
 # k-NN index

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -6,6 +6,8 @@ parent: k-NN search
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/
+redirect_from:
+  - /vector-search/vector-search-techniques/knn-score-script/
 ---
 
 # Exact k-NN with scoring script

--- a/_search-plugins/knn/knn-vector-quantization.md
+++ b/_search-plugins/knn/knn-vector-quantization.md
@@ -6,6 +6,8 @@ parent: k-NN search
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-vector-quantization/
+redirect_from:
+  - /vector-search/optimizing-storage/knn-vector-quantization/
 ---
 
 # k-NN vector quantization

--- a/_search-plugins/knn/nested-search-knn.md
+++ b/_search-plugins/knn/nested-search-knn.md
@@ -6,6 +6,8 @@ parent: k-NN search
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/nested-search-knn/
+redirect_from:
+  - /vector-search/specialized-operations/nested-search-knn/
 ---
 
 # k-NN search with nested fields

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -6,6 +6,8 @@ parent: k-NN search
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/
+redirect_from:
+  - /vector-search/vector-search-techniques/painless-functions/
 ---
 
 # k-NN Painless Scripting extensions

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -4,6 +4,8 @@ title: Performance tuning
 parent: k-NN search
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/performance-tuning/
+redirect_from:
+  - /vector-search/performance-tuning/
 ---
 
 # Performance tuning

--- a/_search-plugins/knn/radial-search-knn.md
+++ b/_search-plugins/knn/radial-search-knn.md
@@ -6,6 +6,8 @@ parent: k-NN search
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/radial-search-knn/
+redirect_from:
+  - /vector-search/specialized-operations/radial-search-knn/
 ---
 
 # Radial search

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -4,6 +4,8 @@ title: Settings
 parent: k-NN search
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/settings/
+redirect_from:
+  - /vector-search/settings/
 ---
 
 # k-NN settings

--- a/_search-plugins/multimodal-search.md
+++ b/_search-plugins/multimodal-search.md
@@ -5,6 +5,7 @@ nav_order: 40
 has_children: false
 redirect_from:
   - /search-plugins/neural-multimodal-search/
+  - /vector-search/ai-search/multimodal-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/multimodal-search/
 ---
 

--- a/_search-plugins/neural-search-tutorial.md
+++ b/_search-plugins/neural-search-tutorial.md
@@ -5,6 +5,8 @@ has_children: false
 nav_order: 30
 redirect_from:
   - /ml-commons-plugin/semantic-search/
+  - /tutorials/vector-search/neural-search-tutorial/
+  - /vector-search/tutorials/neural-search-tutorial/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-search-tutorial/
 ---
 

--- a/_search-plugins/neural-search.md
+++ b/_search-plugins/neural-search.md
@@ -6,6 +6,8 @@ has_children: false
 has_toc: false
 redirect_from: 
   - /neural-search-plugin/index/
+  - /vector-search/ai-search/
+  - /vector-search/ai-search/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-search/
 ---
 

--- a/_search-plugins/neural-sparse-search.md
+++ b/_search-plugins/neural-sparse-search.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /search-plugins/neural-sparse-search/
   - /search-plugins/sparse-search/
+  - /vector-search/ai-search/neural-sparse-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-sparse-search/
 ---
 

--- a/_search-plugins/neural-sparse-with-pipelines.md
+++ b/_search-plugins/neural-sparse-with-pipelines.md
@@ -5,6 +5,8 @@ parent: Neural sparse search
 nav_order: 10
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-sparse-with-pipelines/
+redirect_from:
+  - /vector-search/ai-search/neural-sparse-with-pipelines/
 ---
 
 # Configuring ingest pipelines for neural sparse search

--- a/_search-plugins/neural-sparse-with-raw-vectors.md
+++ b/_search-plugins/neural-sparse-with-raw-vectors.md
@@ -5,6 +5,8 @@ parent: Neural sparse search
 nav_order: 20
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-sparse-with-raw-vectors/
+redirect_from:
+  - /vector-search/ai-search/neural-sparse-with-raw-vectors/
 ---
 
 # Using raw vectors for neural sparse search

--- a/_search-plugins/search-pipelines/index.md
+++ b/_search-plugins/search-pipelines/index.md
@@ -5,6 +5,8 @@ nav_order: 100
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/search-pipelines/index/
+redirect_from:
+  - /search-plugins/search-pipelines/
 ---
 
 # Search pipelines

--- a/_search-plugins/searching-data/index.md
+++ b/_search-plugins/searching-data/index.md
@@ -6,6 +6,10 @@ has_children: true
 has_toc: false
 redirect_from: /opensearch/ux/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/index/
+redirect_from:
+  - /opensearch/ux/
+  - /search-plugins/search-options/
+  - /search-plugins/searching-data/
 ---
 
 # Searching data

--- a/_search-plugins/searching-data/point-in-time-api.md
+++ b/_search-plugins/searching-data/point-in-time-api.md
@@ -8,6 +8,7 @@ grand_parent: Searching data
 redirect_from:
   - /opensearch/point-in-time-api/
   - /search-plugins/point-in-time-api/
+  - /api-reference/search-apis/point-in-time-api/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/point-in-time-api/
 ---
 

--- a/_search-plugins/semantic-search.md
+++ b/_search-plugins/semantic-search.md
@@ -5,6 +5,7 @@ nav_order: 35
 has_children: false
 redirect_from:
   - /search-plugins/neural-text-search/
+  - /vector-search/ai-search/semantic-search/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/semantic-search/
 ---
 

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 3
 redirect_from:
  - /search-plugins/sql/cli/
+  - /sql-and-ppl/cli/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
 ---
 

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -4,7 +4,7 @@ title: SQL and PPL CLI
 parent: SQL and PPL
 nav_order: 3
 redirect_from:
- - /search-plugins/sql/cli/
+  - /search-plugins/sql/cli/
   - /sql-and-ppl/cli/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
 ---

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -4,6 +4,8 @@ title: Data Types
 parent: SQL and PPL
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+redirect_from:
+  - /sql-and-ppl/datatypes/
 ---
 
 # Data types

--- a/_search-plugins/sql/full-text.md
+++ b/_search-plugins/sql/full-text.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 11
 redirect_from:
   - /search-plugins/sql/sql-full-text/
+  - /sql-and-ppl/full-text/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/full-text/
 ---
 

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 10
 redirect_from:
   - /search-plugins/sql/functions/
+  - /sql-and-ppl/sql/functions/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
 ---
 

--- a/_search-plugins/sql/identifiers.md
+++ b/_search-plugins/sql/identifiers.md
@@ -6,6 +6,7 @@ nav_order: 6
 redirect_from:
   - /observability-plugin/ppl/identifiers/
   - /search-plugins/ppl/identifiers/
+  - /sql-and-ppl/identifiers/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
 ---
 

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -6,6 +6,8 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/sql/index/
+  - /search-plugins/sql/
+  - /sql-and-ppl/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
 ---
 

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 99
 redirect_from:
   - /search-plugins/sql/limitation/
+  - /sql-and-ppl/limitation/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
 ---
 

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 95
 redirect_from:
   - /search-plugins/sql/monitoring/
+  - /sql-and-ppl/monitoring/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
 ---
 

--- a/_search-plugins/sql/ppl/functions.md
+++ b/_search-plugins/sql/ppl/functions.md
@@ -7,6 +7,9 @@ nav_order: 2
 redirect_from:
   - /observability-plugin/ppl/commands/
   - /search-plugins/ppl/commands/
+  - /search-plugins/ppl/functions/
+  - /sql-and-ppl/ppl/commands/index/
+  - /sql-and-ppl/ppl/functions/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/functions/
 ---
 

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -14,6 +14,8 @@ redirect_from:
   - /search-plugins/ppl/protocol/
   - /search-plugins/sql/ppl/index/
   - /observability-plugin/ppl/index/
+  - /sql-and-ppl/ppl/
+  - /sql-and-ppl/ppl/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
 ---
 

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -5,6 +5,8 @@ parent: PPL
 grand_parent: SQL and PPL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/syntax/
+redirect_from:
+  - /sql-and-ppl/ppl/commands/syntax/
 ---
 
 # PPL syntax

--- a/_search-plugins/sql/response-formats.md
+++ b/_search-plugins/sql/response-formats.md
@@ -4,6 +4,8 @@ title: Response formats
 parent: SQL and PPL
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/response-formats/
+redirect_from:
+  - /sql-and-ppl/response-formats/
 ---
 
 # Response formats

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 77
 redirect_from:
   - /search-plugins/sql/settings/
+  - /sql-and-ppl/settings/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
 ---
 

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -4,6 +4,9 @@ title: SQL and PPL API
 parent: SQL and PPL
 nav_order: 1
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/
+redirect_from:
+  - /sql-and-ppl/sql-and-ppl-api/index/
+  - /sql-and-ppl/sql-ppl-api/
 ---
 
 # SQL and PPL API

--- a/_search-plugins/sql/sql/aggregations.md
+++ b/_search-plugins/sql/sql/aggregations.md
@@ -7,6 +7,9 @@ nav_order: 11
 Redirect_from:
   - /search-plugins/sql/aggregations/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+redirect_from:
+  - /search-plugins/sql/aggregations/
+  - /sql-and-ppl/sql/aggregations/
 ---
 
 # Aggregate functions

--- a/_search-plugins/sql/sql/basic.md
+++ b/_search-plugins/sql/sql/basic.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 5
 redirect_from:
   - /search-plugins/sql/basic/
+  - /sql-and-ppl/sql/basic/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
 ---
 

--- a/_search-plugins/sql/sql/complex.md
+++ b/_search-plugins/sql/sql/complex.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 6
 redirect_from:
   - /search-plugins/sql/complex/
+  - /sql-and-ppl/sql/complex/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
 ---
 

--- a/_search-plugins/sql/sql/delete.md
+++ b/_search-plugins/sql/sql/delete.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 12
 redirect_from:
   - /search-plugins/sql/delete/
+  - /sql-and-ppl/sql/delete/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
 ---
 

--- a/_search-plugins/sql/sql/index.md
+++ b/_search-plugins/sql/sql/index.md
@@ -7,6 +7,9 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/sql/sql/index/
+  - /search-plugins/sql/sql/
+  - /sql-and-ppl/sql/
+  - /sql-and-ppl/sql/index/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/index/
 ---
 

--- a/_search-plugins/sql/sql/jdbc.md
+++ b/_search-plugins/sql/sql/jdbc.md
@@ -7,6 +7,7 @@ nav_order: 71
 redirect_from:
   - /search-plugins/sql/jdbc/
 
+  - /sql-and-ppl/sql/jdbc/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
 ---
 

--- a/_search-plugins/sql/sql/metadata.md
+++ b/_search-plugins/sql/sql/metadata.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 9
 redirect_from:
   - /search-plugins/sql/metadata/
+  - /sql-and-ppl/sql/metadata/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
 ---
 

--- a/_search-plugins/sql/sql/odbc.md
+++ b/_search-plugins/sql/sql/odbc.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 72
 redirect_from:
   - /search-plugins/sql/odbc/
+  - /sql-and-ppl/sql/odbc/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
 ---
 

--- a/_search-plugins/sql/sql/partiql.md
+++ b/_search-plugins/sql/sql/partiql.md
@@ -6,6 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 8
 redirect_from:
   - /search-plugins/sql/partiql/
+  - /sql-and-ppl/sql/partiql/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
 ---
 

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -5,6 +5,7 @@ parent: SQL and PPL
 nav_order: 88
 redirect_from:
   - /search-plugins/sql/troubleshoot/
+  - /sql-and-ppl/troubleshoot/
 canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
 ---
 

--- a/_search-plugins/text-chunking.md
+++ b/_search-plugins/text-chunking.md
@@ -3,6 +3,8 @@ layout: default
 title: Text chunking
 nav_order: 65
 canonical_url: https://docs.opensearch.org/latest/search-plugins/text-chunking/
+redirect_from:
+  - /vector-search/ingesting-data/text-chunking/
 ---
 
 # Text chunking

--- a/_search-plugins/vector-search.md
+++ b/_search-plugins/vector-search.md
@@ -5,6 +5,9 @@ nav_order: 22
 has_children: false
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/search-plugins/vector-search/
+redirect_from:
+  - /vector-search/
+  - /vector-search/index/
 ---
 
 # Vector search

--- a/_security-analytics/log-types-reference/index.md
+++ b/_security-analytics/log-types-reference/index.md
@@ -5,6 +5,7 @@ has_children: yes
 nav_order: 16
 redirect_from:
    - /security-analytics/sec-analytics-config/log-types/
+  - /security-analytics/log-types-reference/
 canonical_url: https://docs.opensearch.org/latest/security-analytics/log-types-reference/index/
 ---
 

--- a/_security-analytics/log-types-reference/index.md
+++ b/_security-analytics/log-types-reference/index.md
@@ -4,7 +4,7 @@ title: Supported log types
 has_children: yes
 nav_order: 16
 redirect_from:
-   - /security-analytics/sec-analytics-config/log-types/
+  - /security-analytics/sec-analytics-config/log-types/
   - /security-analytics/log-types-reference/
 canonical_url: https://docs.opensearch.org/latest/security-analytics/log-types-reference/index/
 ---

--- a/_security-analytics/sec-analytics-config/log-types.md
+++ b/_security-analytics/sec-analytics-config/log-types.md
@@ -4,7 +4,7 @@ title: Working with log types
 parent: Setting up Security Analytics
 nav_order: 14
 redirect_from: 
-   - /security-analytics/sec-analytics-config/custom-log-type/
+  - /security-analytics/sec-analytics-config/custom-log-type/
 canonical_url: https://docs.opensearch.org/latest/security-analytics/sec-analytics-config/log-types/
 ---
 

--- a/_security-analytics/threat-intelligence/index.md
+++ b/_security-analytics/threat-intelligence/index.md
@@ -4,6 +4,8 @@ title: Threat intelligence
 nav_order: 40
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/security-analytics/threat-intelligence/index/
+redirect_from:
+  - /security-analytics/threat-intelligence/
 ---
 
 # Threat intelligence

--- a/_security/access-control/api.md
+++ b/_security/access-control/api.md
@@ -4,7 +4,7 @@ title: API
 parent: Access control
 nav_order: 120
 redirect_from: 
- - /security-plugin/access-control/api/
+  - /security-plugin/access-control/api/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/api/
 ---
 

--- a/_security/access-control/authentication-tokens.md
+++ b/_security/access-control/authentication-tokens.md
@@ -4,8 +4,8 @@ title: Authorization tokens
 parent: Access control
 nav_order: 125
 redirect_from:
- - /security/access-control/authorization-tokens/
- - /security-plugin/access-control/authorization-tokens/
+  - /security/access-control/authorization-tokens/
+  - /security-plugin/access-control/authorization-tokens/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/authentication-tokens/
 ---
 

--- a/_security/access-control/default-action-groups.md
+++ b/_security/access-control/default-action-groups.md
@@ -4,8 +4,8 @@ title: Default action groups
 parent: Access control
 nav_order: 115
 redirect_from:
- - /security/access-control/default-action-groups/
- - /security-plugin/access-control/default-action-groups/
+  - /security/access-control/default-action-groups/
+  - /security-plugin/access-control/default-action-groups/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/default-action-groups/
 ---
 

--- a/_security/access-control/field-level-security.md
+++ b/_security/access-control/field-level-security.md
@@ -4,8 +4,8 @@ title: Field-level security
 parent: Access control
 nav_order: 90
 redirect_from:
- - /security/access-control/field-level-security/
- - /security-plugin/access-control/field-level-security/
+  - /security/access-control/field-level-security/
+  - /security-plugin/access-control/field-level-security/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/field-level-security/
 ---
 

--- a/_security/access-control/field-masking.md
+++ b/_security/access-control/field-masking.md
@@ -4,8 +4,8 @@ title: Field masking
 parent: Access control
 nav_order: 95
 redirect_from:
- - /security/access-control/field-masking/
- - /security-plugin/access-control/field-masking/
+  - /security/access-control/field-masking/
+  - /security-plugin/access-control/field-masking/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/field-masking/
 ---
 

--- a/_security/access-control/impersonation.md
+++ b/_security/access-control/impersonation.md
@@ -4,8 +4,8 @@ title: User impersonation
 parent: Access control
 nav_order: 100
 redirect_from:
- - /security/access-control/impersonation/
- - /security-plugin/access-control/impersonation/
+  - /security/access-control/impersonation/
+  - /security-plugin/access-control/impersonation/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/impersonation/
 ---
 

--- a/_security/access-control/index.md
+++ b/_security/access-control/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-plugin/access-control/index/
+  - /security/access-control/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/index/
 ---
 

--- a/_security/access-control/users-roles.md
+++ b/_security/access-control/users-roles.md
@@ -4,8 +4,8 @@ title: Defining users and roles
 parent: Access control
 nav_order: 85
 redirect_from:
- - /security/access-control/users-roles/
- - /security-plugin/access-control/users-roles/
+  - /security/access-control/users-roles/
+  - /security-plugin/access-control/users-roles/
 canonical_url: https://docs.opensearch.org/latest/security/access-control/users-roles/
 ---
 

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /security/audit-logs/index/
   - /security-plugin/audit-logs/index/
+  - /security/audit-logs/
 canonical_url: https://docs.opensearch.org/latest/security/audit-logs/index/
 ---
 

--- a/_security/authentication-backends/proxy.md
+++ b/_security/authentication-backends/proxy.md
@@ -4,7 +4,7 @@ title: Proxy-based authentication
 parent: Authentication backends
 nav_order: 65
 redirect_from:
- - /security-plugin/configuration/proxy/
+  - /security-plugin/configuration/proxy/
 canonical_url: https://docs.opensearch.org/latest/security/authentication-backends/proxy/
 ---
 

--- a/_security/configuration/configuration.md
+++ b/_security/configuration/configuration.md
@@ -4,7 +4,7 @@ title: Configuring the Security backend
 parent: Configuration
 nav_order: 5
 redirect_from:
- - /security-plugin/configuration/configuration/
+  - /security-plugin/configuration/configuration/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/configuration/
 ---
 

--- a/_security/configuration/disable-enable-security.md
+++ b/_security/configuration/disable-enable-security.md
@@ -5,7 +5,7 @@ parent: Configuration
 nav_order: 40
 has_toc: true
 redirect_from: 
- - /security-plugin/configuration/disable/
+  - /security-plugin/configuration/disable/
   - /security/configuration/disable/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/disable-enable-security/
 ---

--- a/_security/configuration/disable-enable-security.md
+++ b/_security/configuration/disable-enable-security.md
@@ -6,6 +6,7 @@ nav_order: 40
 has_toc: true
 redirect_from: 
  - /security-plugin/configuration/disable/
+  - /security/configuration/disable/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/disable-enable-security/
 ---
 

--- a/_security/configuration/index.md
+++ b/_security/configuration/index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /security-plugin/configuration/
   - /security-plugin/configuration/index/
+  - /security/configuration/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/index/
 ---
 

--- a/_security/configuration/system-indices.md
+++ b/_security/configuration/system-indices.md
@@ -4,7 +4,7 @@ title: System indexes
 parent: Configuration
 nav_order: 4
 redirect_from:
- - /security-plugin/configuration/system-indices/
+  - /security-plugin/configuration/system-indices/
 canonical_url: https://docs.opensearch.org/latest/security/configuration/system-indices/
 ---
 

--- a/_security/multi-tenancy/tenant-index.md
+++ b/_security/multi-tenancy/tenant-index.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from:
   - /security/multi-tenancy/
   - /security-plugin/access-control/multi-tenancy/
+  - /security/access-control/multi-tenancy/
 canonical_url: https://docs.opensearch.org/latest/security/multi-tenancy/tenant-index/
 ---
 

--- a/_tools/k8s-operator.md
+++ b/_tools/k8s-operator.md
@@ -5,6 +5,8 @@ nav_order: 80
 has_children: false
 redirect_from:
   - /clients/k8s-operator/
+  - /install-and-configure/install-opensearch/operator/
+  - /install-and-configure/install-opensearch/operator/index/
 canonical_url: https://docs.opensearch.org/latest/tools/k8s-operator/
 ---
 

--- a/_tools/logstash/advanced-config.md
+++ b/_tools/logstash/advanced-config.md
@@ -4,7 +4,7 @@ title: Advanced configurations
 parent: Logstash
 nav_order: 230
 redirect_from:
- - /clients/logstash/advanced-config/
+  - /clients/logstash/advanced-config/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/advanced-config/
 ---
 

--- a/_tools/logstash/common-filters.md
+++ b/_tools/logstash/common-filters.md
@@ -4,7 +4,7 @@ title: Common filter plugins
 parent: Logstash
 nav_order: 220
 redirect_from:
- - /clients/logstash/common-filters/
+  - /clients/logstash/common-filters/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/common-filters/
 ---
 

--- a/_tools/logstash/execution-model.md
+++ b/_tools/logstash/execution-model.md
@@ -4,7 +4,7 @@ title: Logstash execution model
 parent: Logstash
 nav_order: 210
 redirect_from:
- - /clients/logstash/execution-model/
+  - /clients/logstash/execution-model/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/execution-model/
 ---
 

--- a/_tools/logstash/index.md
+++ b/_tools/logstash/index.md
@@ -7,6 +7,7 @@ has_toc: true
 redirect_from:
   - /clients/logstash/
   - /clients/logstash/index/
+  - /tools/logstash/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/index/
 ---
 

--- a/_tools/logstash/read-from-opensearch.md
+++ b/_tools/logstash/read-from-opensearch.md
@@ -5,7 +5,6 @@ parent: Logstash
 nav_order: 220
 redirect_from:
   - /clients/logstash/read-from-opensearch/
-  - /clients/logstash/ship-to-opensearch/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/read-from-opensearch/
 ---
 

--- a/_tools/logstash/ship-to-opensearch.md
+++ b/_tools/logstash/ship-to-opensearch.md
@@ -4,7 +4,7 @@ title: Ship events to OpenSearch
 parent: Logstash
 nav_order: 220
 redirect_from:
- - /clients/logstash/ship-to-opensearch/
+  - /clients/logstash/ship-to-opensearch/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/ship-to-opensearch/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/index.md
@@ -5,6 +5,8 @@ nav_order: 20
 has_children: true
 has_toc: true
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/index/
+redirect_from:
+  - /tuning-your-cluster/availability-and-recovery/
 ---
 
 # Availability and recovery

--- a/_tuning-your-cluster/availability-and-recovery/remote-store/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/remote-store/index.md
@@ -7,6 +7,7 @@ parent: Availability and recovery
 redirect_from: 
   - /opensearch/remote/
   - /tuning-your-cluster/availability-and-recovery/remote/
+  - /tuning-your-cluster/availability-and-recovery/remote-store/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/segment-replication/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/segment-replication/index.md
@@ -8,6 +8,8 @@ datatable: true
 redirect_from:
   - /opensearch/segment-replication/
   - /opensearch/segment-replication/index/
+  - /tuning-your-cluster/availability-and-recovery/segment-replication/
+  - /tuning-your-cluster/segment-replication/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/segment-replication/index/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
@@ -7,6 +7,7 @@ parent: Availability and recovery
 redirect_from: 
   - /opensearch/snapshots/
   - /opensearch/snapshots/index/
+  - /tuning-your-cluster/availability-and-recovery/snapshots/
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/index/
 ---

--- a/_tuning-your-cluster/replication-plugin/index.md
+++ b/_tuning-your-cluster/replication-plugin/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /replication-plugin/
   - /replication-plugin/index/
+  - /tuning-your-cluster/replication-plugin/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/replication-plugin/index/
 ---
 


### PR DESCRIPTION
Add backward redirects from all locations of a file so users can navigate to the same file between versions.

## Problem

When users switch between documentation versions (e.g., from `/latest/` to `/2.19/`), they get a 404 if the page path changed between versions. This accounts for 73% of all 404 errors on the documentation site (~9,300/month).

## Solution

For each page on `main` that has `redirect_from` entries (indicating it moved from an old path), add those paths as `redirect_from` on the corresponding file in older branches. This way, when a user switches versions, the newer path resolves correctly on the older branch.

## Safety checks

- Only adds redirects for paths that don't already resolve to an existing file on this branch
- Never adds a redirect that matches the file's own URL
- Skips files that already have `redirect_to`
- Never duplicates existing redirects