### PR TITLE
Add cross-version redirects to 3.5

### DIFF
--- a/_about/index.md
+++ b/_about/index.md
@@ -7,6 +7,7 @@ has_toc: false
 nav_exclude: true
 permalink: /about/
 redirect_from:
+  - /404.html
   - /docs/opensearch/
   - /opensearch/
   - /opensearch/index/

--- a/_aggregations/bucket/range.md
+++ b/_aggregations/bucket/range.md
@@ -4,7 +4,6 @@ title: Range
 parent: Bucket aggregations
 nav_order: 150
 redirect_from:
-  - /query-dsl/aggregations/bucket/date-range/
   - /query-dsl/aggregations/bucket/range/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/range/
 ---

--- a/_aggregations/bucket/sampler.md
+++ b/_aggregations/bucket/sampler.md
@@ -4,7 +4,7 @@ title: Sampler
 parent: Bucket aggregations
 nav_order: 170
 redirect_from:
-  - /query-dsl/aggregations/bucket/diversified-sampler/
+  - /query-dsl/aggregations/bucket/sampler/
   - /query-dsl/aggregations/bucket/sampler/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/sampler/
 ---

--- a/_aggregations/bucket/sampler.md
+++ b/_aggregations/bucket/sampler.md
@@ -5,6 +5,7 @@ parent: Bucket aggregations
 nav_order: 170
 redirect_from:
   - /query-dsl/aggregations/bucket/diversified-sampler/
+  - /query-dsl/aggregations/bucket/sampler/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/sampler/
 ---
 

--- a/_aggregations/bucket/sampler.md
+++ b/_aggregations/bucket/sampler.md
@@ -5,7 +5,6 @@ parent: Bucket aggregations
 nav_order: 170
 redirect_from:
   - /query-dsl/aggregations/bucket/sampler/
-  - /query-dsl/aggregations/bucket/sampler/
 canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/sampler/
 ---
 

--- a/_analyzers/supported-analyzers/index.md
+++ b/_analyzers/supported-analyzers/index.md
@@ -5,7 +5,7 @@ nav_order: 40
 has_children: true
 has_toc: false
 redirect_from:
-    - /analyzers/supported-analyzers/
+  - /analyzers/supported-analyzers/
 canonical_url: https://docs.opensearch.org/latest/analyzers/supported-analyzers/index/
 ---
 

--- a/_api-reference/alias/aliases-api.md
+++ b/_api-reference/alias/aliases-api.md
@@ -5,7 +5,6 @@ parent: Alias APIs
 grand_parent: Index APIs
 nav_order: 50
 redirect_from:
- - /opensearch/rest-api/alias/
  - /api-reference/index-apis/alias/
 canonical_url: https://docs.opensearch.org/latest/api-reference/alias/aliases-api/
 ---

--- a/_api-reference/index-apis/get-settings.md
+++ b/_api-reference/index-apis/get-settings.md
@@ -6,7 +6,6 @@ grand_parent: Index APIs
 nav_order: 10
 redirect_from:
   - /opensearch/rest-api/index-apis/get-settings/
-  - /opensearch/rest-api/index-apis/get-index/
 canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/get-settings/
 ---
 

--- a/_api-reference/security/index.md
+++ b/_api-reference/security/index.md
@@ -6,7 +6,6 @@ has_children: true
 redirect_from:
   - /api-reference/security-api/
   - /api-reference/security/
-  - /security-plugin/access-control/api/
 canonical_url: https://docs.opensearch.org/latest/api-reference/security/index/
 ---
 

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -5,7 +5,6 @@ has_children: true
 has_toc: false
 nav_order: 80
 redirect_from:
-  - /opensearch/rest-api/document-apis/
   - /opensearch/rest-api/snapshots/
   - /api-reference/snapshots/
 canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/

--- a/_benchmark/reference/commands/index.md
+++ b/_benchmark/reference/commands/index.md
@@ -6,9 +6,7 @@ has_children: true
 has_toc: false
 parent: Reference
 redirect_from:
-  - /benchmark/commands/index/
   - /benchmark/reference/commands/
-  - /benchmark/commands/execute-test/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
 ---
 

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -4,7 +4,6 @@ title: Reference
 nav_order: 25
 has_children: true
 redirect_from:
-  - /benchmark/commands/index/
   - /benchmark/reference/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/index/
 ---

--- a/_benchmark/reference/metrics/index.md
+++ b/_benchmark/reference/metrics/index.md
@@ -7,6 +7,7 @@ parent: Reference
 redirect_from:
   - /benchmark/metrics/index/
   - /benchmark/reference/metrics/
+  - /benchmark/metrics/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
 ---
 

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -7,6 +7,7 @@ has_children: true
 redirect_from:
   - /benchmark/workloads/index/
   - /benchmark/reference/workloads/
+  - /benchmark/workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/index/
 ---
 

--- a/_benchmark/user-guide/index.md
+++ b/_benchmark/user-guide/index.md
@@ -25,9 +25,6 @@ more_cards:
     link: "/benchmark/user-guide/optimizing-benchmarks/index/" 
 redirect_from:
   - /benchmark/user-guide/
-  - /benchmark/configuring-benchmark/
-  - /benchmark/creating-custom-workloads/
-  - /benchmark/installing-benchmark/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/index/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
@@ -238,7 +238,7 @@ security:
   ssl: true
   verification_mode: full
   certificate_authorities:
-    - /path/to/ca.crt
+  - /path/to/ca.crt
   client_certificate: /path/to/client.crt
   client_key: /path/to/client.key
 ```

--- a/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
@@ -238,7 +238,7 @@ security:
   ssl: true
   verification_mode: full
   certificate_authorities:
-  - /path/to/ca.crt
+    - /path/to/ca.crt
   client_certificate: /path/to/client.crt
   client_key: /path/to/client.key
 ```

--- a/_benchmark/user-guide/understanding-results/summary-reports.md
+++ b/_benchmark/user-guide/understanding-results/summary-reports.md
@@ -4,8 +4,6 @@ title: Summary reports
 nav_order: 22
 grand_parent: User guide
 parent: Understanding results
-redirect_from:
-  - /benchmark/user-guide/understanding-results/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/summary-reports/
 ---
 

--- a/_dashboards/im-dashboards/datastream.md
+++ b/_dashboards/im-dashboards/datastream.md
@@ -5,7 +5,6 @@ parent: Index Management
 nav_order: 20
 redirect_from:
   - /dashboards/admin-ui-index/datastream/
-  - /opensearch/data-streams/
 canonical_url: https://docs.opensearch.org/latest/dashboards/im-dashboards/datastream/
 ---
 

--- a/_dashboards/quickstart.md
+++ b/_dashboards/quickstart.md
@@ -7,6 +7,8 @@ redirect_from:
   - /dashboards/get-started/quickstart-dashboards/
   - /dashboards/quickstart-dashboards/
   - /dashboards/browser-compatibility/
+  - /dashboards/getting-started/
+  - /dashboards/getting-started/index/
 canonical_url: https://docs.opensearch.org/latest/dashboards/quickstart/
 ---
 

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -4,6 +4,8 @@ title: Area charts
 parent: Building data visualizations
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+redirect_from:
+  - /dashboards/visualize/visualize-app/area/
 ---
 
 # Using area charts

--- a/_dashboards/visualize/geojson-regionmaps.md
+++ b/_dashboards/visualize/geojson-regionmaps.md
@@ -6,6 +6,8 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /dashboards/geojson-regionmaps/
+  - /dashboards/visualize/region-maps/
+  - /dashboards/visualize/visualize-app/region-maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/geojson-regionmaps/
 ---
 

--- a/_dashboards/visualize/maps-stats-api.md
+++ b/_dashboards/visualize/maps-stats-api.md
@@ -6,6 +6,8 @@ grand_parent: Building data visualizations
 parent: Coordinate and region maps 
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps-stats-api/
+redirect_from:
+  - /dashboards/visualize/visualize-app/maps-stats-api/
 ---
 
 # Maps Stats API

--- a/_dashboards/visualize/maps.md
+++ b/_dashboards/visualize/maps.md
@@ -8,6 +8,7 @@ redirect_from:
   - /dashboards/maps-plugin/
   - /dashboards/visualize/maps/
   - /dashboards/maps/
+  - /dashboards/visualize/visualize-app/maps/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps/
 ---
 

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -6,6 +6,7 @@ parent: Coordinate and region maps
 nav_order: 30
 redirect_from:
   - /dashboards/maptiles/
+  - /dashboards/visualize/visualize-app/maptiles/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
 ---
 

--- a/_dashboards/visualize/run-queries.md
+++ b/_dashboards/visualize/run-queries.md
@@ -6,6 +6,7 @@ redirect_from:
   - /dashboards/run-queries/
   - /dashboards/dev-tools/run-queries/
   - /dashboards/dev-tools/index-dev/
+  - /dashboards/discover/run-queries/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/run-queries/
 ---
 

--- a/_dashboards/visualize/selfhost-maps-server.md
+++ b/_dashboards/visualize/selfhost-maps-server.md
@@ -6,6 +6,7 @@ parent: Coordinate and region maps
 nav_order: 40
 redirect_from:
   - /dashboards/selfhost-maps-server/
+  - /dashboards/visualize/visualize-app/selfhost-maps-server/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/selfhost-maps-server/
 ---
 

--- a/_dashboards/visualize/tsvb.md
+++ b/_dashboards/visualize/tsvb.md
@@ -4,6 +4,8 @@ title: TSVB
 parent: Building data visualizations
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/tsvb/
+redirect_from:
+  - /dashboards/visualize/visualize-app/tsvb/
 ---
 
 # TSVB

--- a/_dashboards/visualize/vega.md
+++ b/_dashboards/visualize/vega.md
@@ -4,6 +4,8 @@ title: Vega
 parent: Building data visualizations
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/vega/
+redirect_from:
+  - /dashboards/visualize/visualize-app/vega/
 ---
 
 # Vega

--- a/_dashboards/visualize/visbuilder.md
+++ b/_dashboards/visualize/visbuilder.md
@@ -5,6 +5,7 @@ parent: Building data visualizations
 nav_order: 100
 redirect_from:
   - /dashboards/drag-drop-wizard/
+  - /dashboards/visualize/visualize-app/visbuilder/
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visbuilder/
 ---
 

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -5,6 +5,9 @@ nav_order: 40
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+redirect_from:
+  - /dashboards/visualize/visualize-app/
+  - /dashboards/visualize/visualize-app/index/
 ---
 
 # Building data visualizations

--- a/_im-plugin/index.md
+++ b/_im-plugin/index.md
@@ -7,7 +7,6 @@ nav_exclude: true
 permalink: /im-plugin/
 redirect_from:
   - /opensearch/index-data/
-  - /opensearch/rest-api/index-apis/index/
   - /im-plugin/index/
 canonical_url: https://docs.opensearch.org/latest/im-plugin/
 ---

--- a/_im-plugin/reindex-data.md
+++ b/_im-plugin/reindex-data.md
@@ -2,8 +2,6 @@
 layout: default
 title: Reindex data
 nav_order: 30
-redirect_from:
-  - /opensearch/reindex-data/
 canonical_url: https://docs.opensearch.org/latest/im-plugin/reindex-data/
 ---
 

--- a/_ingest-pipelines/processors/kv.md
+++ b/_ingest-pipelines/processors/kv.md
@@ -3,8 +3,6 @@ layout: default
 title: KV
 parent: Ingest processors
 nav_order: 200
-redirect_from:
-   - /api-reference/ingest-apis/processors/lowercase/
 canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/kv/
 ---
 

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -7,7 +7,6 @@ redirect_from:
   - /opensearch/install/
   - /opensearch/install/compatibility/
   - /opensearch/install/important-settings/
-  - /install-and-configure/index/
   - /opensearch/install/index/
   - /install-and-configure/install-opensearch/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/

--- a/_install-and-configure/install-opensearch/operator.md
+++ b/_install-and-configure/install-opensearch/operator.md
@@ -6,6 +6,7 @@ nav_order: 55
 redirect_from:
   - /clients/k8s-operator/
   - /tools/k8s-operator/
+  - /install-and-configure/install-opensearch/operator/index/
 canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/
 ---
 

--- a/_migrate-or-upgrade/rolling-upgrade/index.md
+++ b/_migrate-or-upgrade/rolling-upgrade/index.md
@@ -8,7 +8,6 @@ nav_exclude: false
 redirect_from:
  - /upgrade-opensearch/
  - /rolling-upgrade/index/
- - /migrate-or-upgrade/rolling-upgrade/appendix/
  - /install-and-configure/upgrade-opensearch/rolling-upgrade/
 canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/
 ---

--- a/_migration-assistant/index.md
+++ b/_migration-assistant/index.md
@@ -9,6 +9,7 @@ permalink: /migration-assistant/
 redirect_from:
   - /migration-assistant/index/
  
+  - /migration-assistant/overview/
 items:
   - heading: "Is Migration Assistant right for you?"
     description: "Evaluate whether Migration Assistant is right for your use case."

--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -4,6 +4,7 @@ title: Is Migration Assistant right for you?
 nav_order: 10
 redirect_from:
   - /migration-assistant/overview/is-migration-assistant-right-for-you/
+  - /migration-assistant/migration-paths/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/is-migration-assistant-right-for-you/
 ---
 

--- a/_migration-assistant/migration-phases/assessment/index.md
+++ b/_migration-assistant/migration-phases/assessment/index.md
@@ -8,6 +8,7 @@ has_toc: false
 permalink: /migration-assistant/migration-phases/assessment/
 redirect_from:
   - /migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration/
+  - /migration-assistant/migration-phases/planning-your-migration/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 ---
 

--- a/_migration-assistant/migration-phases/backfill.md
+++ b/_migration-assistant/migration-phases/backfill.md
@@ -6,6 +6,7 @@ parent: Migration phases
 permalink: /migration-assistant/migration-phases/backfill/
 redirect_from:
   - /migration-phases/backfill/
+  - /migration-phases/create-snapshot/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
 ---
 

--- a/_migration-assistant/migration-phases/deploy/index.md
+++ b/_migration-assistant/migration-phases/deploy/index.md
@@ -9,6 +9,7 @@ permalink: /migration-assistant/migration-phases/deploy/
 redirect_from:
   - /migration-assistant/getting-started-with-data-migration/
   - /deploying-migration-assistant/
+  - /migration-assistant/deploying-migration-assistant/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/
 ---
 

--- a/_migration-assistant/migration-phases/remove-migration-infrastructure.md
+++ b/_migration-assistant/migration-phases/remove-migration-infrastructure.md
@@ -6,6 +6,7 @@ parent: Migration phases
 permalink: /migration-assistant/migration-phases/remove-migration-infrastructure/
 redirect_from:
   - /migration-assistant/migration-phases/removing-migration-infrastructure/
+  - /migration-phases/removing-migration-infrastructure/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/remove-migration-infrastructure/
 ---
 

--- a/_migration-assistant/migration-phases/replay-captured-traffic.md
+++ b/_migration-assistant/migration-phases/replay-captured-traffic.md
@@ -7,6 +7,9 @@ permalink: /migration-assistant/migration-phases/replay-captured-traffic/
 redirect_from: 
   - /migration-assistant/migration-phases/using-traffic-replayer/
   - /migration-phases/using-traffic-replayer/
+  - /migration-assistant/migration-phases/live-traffic-migration/using-traffic-Replayer/
+  - /migration-assistant/migration-phases/using-traffic-Replayer/
+  - /migration-phases/using-traffic-Replayer/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
 ---
 

--- a/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
+++ b/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
@@ -5,6 +5,8 @@ nav_order: 8
 parent: Migration phases
 permalink: /migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
+redirect_from:
+  - /migration-assistant/migration-phases/switch-traffic-to-target/
 ---
 
 # Switching traffic from the source cluster

--- a/_ml-commons-plugin/agents-tools/tools/index.md
+++ b/_ml-commons-plugin/agents-tools/tools/index.md
@@ -6,7 +6,6 @@ has_children: true
 has_toc: false
 nav_order: 20
 redirect_from: 
-  - /ml-commons-plugin/extensibility/index/
   - /ml-commons-plugin/agents-tools/tools/
   - /ml-commons-plugin/agents-tools/tools/cat-index-tool/
 canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/

--- a/_monitoring-your-cluster/job-scheduler/jobs.md
+++ b/_monitoring-your-cluster/job-scheduler/jobs.md
@@ -4,7 +4,7 @@ title: Jobs API
 parent: Job Scheduler
 nav_order: 10
 redirect_from:
-    - /monitoring-plugins/job-scheduler/api/
+  - /monitoring-plugins/job-scheduler/api/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/job-scheduler/jobs/
 ---
 

--- a/_monitoring-your-cluster/job-scheduler/locks.md
+++ b/_monitoring-your-cluster/job-scheduler/locks.md
@@ -3,8 +3,6 @@ layout: default
 title: Locks API
 parent: Job Scheduler
 nav_order: 20
-redirect_from:
-    - /monitoring-plugins/job-scheduler/api/
 canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/job-scheduler/locks/
 ---
 

--- a/_observing-your-data/exploring-observability-data/index.md
+++ b/_observing-your-data/exploring-observability-data/index.md
@@ -5,6 +5,8 @@ nav_order: 40
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/observing-your-data/exploring-observability-data/index/
+redirect_from:
+  - /observing-your-data/exploring-observability-data/
 ---
 
 # Exploring observability data

--- a/_search-plugins/ubi/schemas.md
+++ b/_search-plugins/ubi/schemas.md
@@ -6,6 +6,8 @@ grand_parent: Optimizing search quality
 has_children: false
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/search-plugins/ubi/schemas/
+redirect_from:
+  - /search-plugins/ubi/data-structures/
 ---
 
 # UBI index schemas

--- a/_sql-and-ppl/functions.md
+++ b/_sql-and-ppl/functions.md
@@ -2,8 +2,6 @@
 layout: default
 title: Functions
 nav_order: 10
-redirect_from:
-  - /search-plugins/sql/functions/
 canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/functions/
 ---
 

--- a/_tools/logstash/read-from-opensearch.md
+++ b/_tools/logstash/read-from-opensearch.md
@@ -5,7 +5,6 @@ parent: Logstash
 nav_order: 220
 redirect_from:
   - /clients/logstash/read-from-opensearch/
-  - /clients/logstash/ship-to-opensearch/
 canonical_url: https://docs.opensearch.org/latest/tools/logstash/read-from-opensearch/
 ---
 

--- a/_troubleshoot/index.md
+++ b/_troubleshoot/index.md
@@ -80,7 +80,7 @@ output.elasticsearch:
   username: "admin"
   password: "admin"
   ssl.certificate_authorities:
-    - /full/path/to/root-ca.pem
+  - /full/path/to/root-ca.pem
   ssl.certificate: "/full/path/to/client.pem"
   ssl.key: "/full/path/to/client-key.pem"
 ```

--- a/_troubleshoot/index.md
+++ b/_troubleshoot/index.md
@@ -80,7 +80,7 @@ output.elasticsearch:
   username: "admin"
   password: "admin"
   ssl.certificate_authorities:
-  - /full/path/to/root-ca.pem
+    - /full/path/to/root-ca.pem
   ssl.certificate: "/full/path/to/client.pem"
   ssl.key: "/full/path/to/client-key.pem"
 ```

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-groups.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-groups.md
@@ -6,6 +6,7 @@ parent: Workload management
 grand_parent: Availability and recovery
 redirect_from:
   - /tuning-your-cluster/availability-and-recovery/workload-management/workload-groups/
+  - /tuning-your-cluster/availability-and-recovery/workload-management/workload-group-lifecycle-api/
 canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/workload-management/workload-groups/
 ---
 

--- a/_tutorials/reranking/reranking-by-field.md
+++ b/_tutorials/reranking/reranking-by-field.md
@@ -4,7 +4,6 @@ title: Reranking search results by a field
 parent: Reranking search results
 nav_order: 120
 redirect_from:
-  - /ml-commons-plugin/tutorials/reranking-cohere/
   - /vector-search/tutorials/reranking/reranking-by-field/
 canonical_url: https://docs.opensearch.org/latest/tutorials/reranking/reranking-by-field/
 ---

--- a/_tutorials/vector-search/index.md
+++ b/_tutorials/vector-search/index.md
@@ -6,8 +6,6 @@ has_toc: false
 nav_order: 10
 redirect_from:
   - /vector-search/tutorials/
-  - /ml-commons-plugin/tutorials/
-  - /ml-commons-plugin/tutorials/index/
   - /tutorials/vector-search/
 vector_search_101:
   - heading: "Getting started with vector search"

--- a/_vector-search/ai-search/neural-sparse-custom.md
+++ b/_vector-search/ai-search/neural-sparse-custom.md
@@ -5,8 +5,6 @@ parent: Neural sparse search
 grand_parent: AI search
 nav_order: 20
 has_children: false
-redirect_from:
-  - /search-plugins/neural-sparse-with-pipelines/
 canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/neural-sparse-custom/
 ---
 

--- a/_vector-search/ai-search/neural-sparse-search.md
+++ b/_vector-search/ai-search/neural-sparse-search.md
@@ -5,9 +5,7 @@ parent: AI search
 nav_order: 50
 has_children: true
 redirect_from:
-  - /search-plugins/neural-sparse-search/
   - /search-plugins/sparse-search/
-  - /search-plugins/neural-sparse-search/
 canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/neural-sparse-search/
 ---
 

--- a/_vector-search/ai-search/neural-sparse-search.md
+++ b/_vector-search/ai-search/neural-sparse-search.md
@@ -6,6 +6,7 @@ nav_order: 50
 has_children: true
 redirect_from:
   - /search-plugins/sparse-search/
+  - /search-plugins/neural-sparse-search/
 canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/neural-sparse-search/
 ---
 

--- a/_vector-search/optimizing-storage/faiss-16-bit-quantization.md
+++ b/_vector-search/optimizing-storage/faiss-16-bit-quantization.md
@@ -7,6 +7,8 @@ nav_order: 20
 has_children: false
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/vector-search/optimizing-storage/faiss-16-bit-quantization/
+redirect_from:
+  - /vector-search/optimizing-storage/faiss-scalar-quantization/
 ---
 
 # Faiss 16-bit scalar quantization 


### PR DESCRIPTION
Add backward redirects from all locations of a file so users can navigate to the same file between versions.

## Problem

When users switch between documentation versions (e.g., from `/latest/` to `/2.19/`), they get a 404 if the page path changed between versions. This accounts for 73% of all 404 errors on the documentation site (~9,300/month).

## Solution

For each page on `main` that has `redirect_from` entries (indicating it moved from an old path), add those paths as `redirect_from` on the corresponding file in older branches. This way, when a user switches versions, the newer path resolves correctly on the older branch.

## Safety checks

- Only adds redirects for paths that don't already resolve to an existing file on this branch
- Never adds a redirect that matches the file's own URL
- Skips files that already have `redirect_to`
- Never duplicates existing redirects