### PR TITLE
Add missing redirect to PPL syntax page

### DIFF
--- a/_sql-and-ppl/ppl/commands/syntax.md
+++ b/_sql-and-ppl/ppl/commands/syntax.md
@@ -4,6 +4,8 @@ title: PPL syntax
 parent: Commands
 grand_parent: PPL
 nav_order: 1
+redirect_from:
+  - /search-plugins/sql/ppl/syntax/
 ---
 
 # PPL syntax


### PR DESCRIPTION
Add redirect_from /search-plugins/sql/ppl/syntax/ to the PPL syntax page. The page moved but the redirect was never added, causing 372 404s/month when users switch versions.