### PR TITLE
Document previous_score_field for by_field rerank processor

### DIFF
--- a/_search-plugins/search-pipelines/rerank-processor.md
+++ b/_search-plugins/search-pipelines/rerank-processor.md
@@ -150,6 +150,8 @@ Field  | Data type | Required/Optional | Description
 `previous_score_field` | String | Optional | The field name used to store the score calculated before reranking when `keep_previous_score` is `true`. Default is `previous_score`. Only used when `keep_previous_score` is `true`.
 
 If your index already defines a `previous_score` document field, set `previous_score_field` to a different name (for example, `original_query_score`) to avoid overwriting the existing field value in search results.
+{: .note}
+
 
 ### Example 
 

--- a/_search-plugins/search-pipelines/rerank-processor.md
+++ b/_search-plugins/search-pipelines/rerank-processor.md
@@ -146,7 +146,10 @@ Field  | Data type | Required/Optional | Description
 :--- | :---  | :--- | :--- 
 `target_field` | String | Required |  Specifies the field name or a dot path to the field containing the score to use for reranking. 
 `remove_target_field` | Boolean | Optional | If `true`, the response does not include the `target_field` used to perform reranking. Default is `false`.
-`keep_previous_score` | Boolean | Optional | If `true`, the response includes a `previous_score` field, which contains the score calculated before reranking and can be useful when debugging. Default is `false`.
+`keep_previous_score` | Boolean | Optional | If `true`, the response includes a field containing the score calculated before reranking. The field name is specified by `previous_score_field`. This can be useful when debugging. Default is `false`.
+`previous_score_field` | String | Optional | The field name used to store the score calculated before reranking when `keep_previous_score` is `true`. Default is `previous_score`. Only used when `keep_previous_score` is `true`.
+
+If your index already defines a `previous_score` document field, set `previous_score_field` to a different name (for example, `original_query_score`) to avoid overwriting the existing field value in search results.
 
 ### Example 
 

--- a/_search-plugins/search-relevance/rerank-by-field-cross-encoder.md
+++ b/_search-plugins/search-relevance/rerank-by-field-cross-encoder.md
@@ -145,7 +145,7 @@ Next, create a search pipeline for reranking. In the search pipeline configurati
 - The `output_map` field specifies how the output of the model is mapped to the fields in the response:
     - The `rank_score` field in the response will store the model's relevance score, which will be used to perform reranking.
     
-When using the `by_field` rerank type, the `rank_score` field will contain the same score as the `_score` field. To remove the `rank_score` field from the search results, set `remove_target_field` to `true`. The original BM25 score, before reranking, is included for debugging purposes by setting `keep_previous_score` to `true`. This allows you to compare the original score with the reranked score to evaluate improvements in search relevance.
+When using the `by_field` rerank type, the `rank_score` field will contain the same score as the `_score` field. To remove the `rank_score` field from the search results, set `remove_target_field` to `true`. The original BM25 score, before reranking, is included for debugging purposes by setting `keep_previous_score` to `true`. By default, this score is stored in a field named `previous_score`. If your index already defines a `previous_score` document field, set `previous_score_field` to a different name so the rerank processor does not overwrite your existing field value. This allows you to compare the original score with the reranked score to evaluate improvements in search relevance.
     
 To create the search pipeline, send the following request:
 
@@ -181,8 +181,9 @@ PUT /_search/pipeline/my_pipeline
         "by_field": {
           "target_field": "rank_score",
           "remove_target_field": true,
-          "keep_previous_score" : true
-          }
+          "keep_previous_score": true,
+          "previous_score_field": "original_query_score"
+        }
       }
     
     }
@@ -208,7 +209,7 @@ POST /nyc_areas/_search?search_pipeline=my_pipeline
 ```
 {% include copy-curl.html %}
 
-In the response, the `previous_score` field contains the document's BM25 score, which it would have received if you hadn't applied the pipeline. Note that while BM25 ranked "Astoria" the highest, the cross-encoder model prioritized "Harlem" because it matched more search terms:
+In the response, the `original_query_score` field contains the document's BM25 score, which it would have received if you hadn't applied the pipeline. Note that while BM25 ranked "Astoria" the highest, the cross-encoder model prioritized "Harlem" because it matched more search terms:
 
 ```json
 {
@@ -234,7 +235,7 @@ In the response, the `previous_score` field contains the document's BM25 score, 
         "_source": {
           "area_name": "Harlem",
           "description": "Harlem is a historic neighborhood in Upper Manhattan, known for its significant African-American cultural heritage.",
-          "previous_score": 1.6489418,
+          "original_query_score": 1.6489418,
           "borough": "Manhattan",
           "facts": "Harlem was the birthplace of the Harlem Renaissance, a cultural movement that celebrated Black culture through art, music, and literature.",
           "population": 116000
@@ -247,7 +248,7 @@ In the response, the `previous_score` field contains the document's BM25 score, 
         "_source": {
           "area_name": "Astoria",
           "description": "Astoria is a neighborhood in the western part of Queens, New York City, known for its diverse community and vibrant cultural scene.",
-          "previous_score": 2.519608,
+          "original_query_score": 2.519608,
           "borough": "Queens",
           "facts": "Astoria is home to many artists and has a large Greek-American community. The area also boasts some of the best Mediterranean food in NYC.",
           "population": 93000
@@ -260,7 +261,7 @@ In the response, the `previous_score` field contains the document's BM25 score, 
         "_source": {
           "area_name": "Williamsburg",
           "description": "Williamsburg is a trendy neighborhood in Brooklyn known for its hipster culture, vibrant art scene, and excellent restaurants.",
-          "previous_score": 1.5632852,
+          "original_query_score": 1.5632852,
           "borough": "Brooklyn",
           "facts": "Williamsburg is a hotspot for young professionals and artists. The neighborhood has seen rapid gentrification over the past two decades.",
           "population": 150000

--- a/_search-plugins/search-relevance/rerank-by-field-cross-encoder.md
+++ b/_search-plugins/search-relevance/rerank-by-field-cross-encoder.md
@@ -145,7 +145,10 @@ Next, create a search pipeline for reranking. In the search pipeline configurati
 - The `output_map` field specifies how the output of the model is mapped to the fields in the response:
     - The `rank_score` field in the response will store the model's relevance score, which will be used to perform reranking.
     
-When using the `by_field` rerank type, the `rank_score` field will contain the same score as the `_score` field. To remove the `rank_score` field from the search results, set `remove_target_field` to `true`. The original BM25 score, before reranking, is included for debugging purposes by setting `keep_previous_score` to `true`. By default, this score is stored in a field named `previous_score`. If your index already defines a `previous_score` document field, set `previous_score_field` to a different name so the rerank processor does not overwrite your existing field value. This allows you to compare the original score with the reranked score to evaluate improvements in search relevance.
+When using the `by_field` rerank type, the `rank_score` field will contain the same score as the `_score` field. To remove the `rank_score` field from the search results, set `remove_target_field` to `true`.
+
+Comparing the original and reranked scores can help you evaluate improvements in search relevance. To compare the original BM25 score with the reranked score, set `keep_previous_score` to `true`. The original score is included in the search results for debugging purposes and is stored in the `previous_score` field by default. If your index already contains a document field named `previous_score`, set `previous_score_field` to a different name so that the rerank processor does not overwrite the existing field. 
+
     
 To create the search pipeline, send the following request:
 

--- a/_search-plugins/search-relevance/rerank-by-field.md
+++ b/_search-plugins/search-relevance/rerank-by-field.md
@@ -47,6 +47,8 @@ PUT /_search/pipeline/rerank_byfield_pipeline
 
 For more information about the request fields, see [Request fields]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/rerank-processor/#request-body-fields).
 
+When `keep_previous_score` is `true`, the pre-rerank score is stored in `previous_score` by default. Use `previous_score_field` to choose a different field name if `previous_score` already exists in your documents.
+
 ## Step 2: Create an index for ingestion
 
 In order to use the `rerank` processor defined in your pipeline, create an OpenSearch index and add the pipeline created in the previous step as the default pipeline:


### PR DESCRIPTION
## Summary

- Documents the new optional `previous_score_field` parameter for the `by_field` rerank processor in the rerank processor API reference.
- Updates the external cross-encoder reranking tutorial to use `previous_score_field` so the pre-rerank score does not overwrite an existing `previous_score` document field.
- Adds a short note to the rerank-by-field tutorial about choosing a custom field name when `previous_score` already exists in documents.

## Related

- opensearch-project/neural-search#1880
- opensearch-project/OpenSearch#21440

## Test plan

- [x] Verified markdown renders correctly in preview
- [x] Parameter table matches implementation in neural-search PR #1880
- [x] Cross-encoder tutorial JSON and response examples are consistent


