### PR TITLE
Remove /404.html redirect from index.md on 2.5

### DIFF
--- a/index.md
+++ b/index.md
@@ -2,7 +2,6 @@
 layout: home
 title: Home
 nav_order: 1
-redirect_from: /404.html
 has_children: false
 nav_exclude: true
 permalink: /


### PR DESCRIPTION
The /404.html redirect is now in _about/index.md. Having it in both index.md and _about/index.md causes a conflict where index.md wins, preventing the 404 page from redirecting to the about page.