### PR TITLE
Feature/workspace custom

### DIFF
--- a/_dashboards/workspace/apis.md
+++ b/_dashboards/workspace/apis.md
@@ -121,6 +121,7 @@ The following table lists the available path parameters.
 | Parameter | Data type | Required | Description |
 | :--- | :--- | :--- | :--- |
 | `attributes` | Object | Required | Defines the workspace attributes. |
+| `attributes.id` | String | Optional | The ID of the workspace. |
 | `permissions` | Object | Optional | Specifies the permissions for the workspace. |
 | `settings` | Object | Optional | Specifies the settings for the workspace. |
 
@@ -132,6 +133,7 @@ curl -k -XPOST "https://localhost:5601/api/workspaces" \
   -H "osd-xsrf: true" \
   -d '{
     "attributes": {
+      "id": "my_workspace",
       "name": "test4",
       "description": "test4",
       "features": ["use-case-all"]

--- a/_dashboards/workspace/create-workspace.md
+++ b/_dashboards/workspace/create-workspace.md
@@ -22,7 +22,8 @@ To create a workspace, follow these steps:
   - **Use case and features** is required. Choose the use case that best fits your needs. If you are using Amazon OpenSearch Serverless and have enabled the [multiple data sources]({{site.url}}{{site.baseurl}}/dashboards/management/data-sources/) feature, **Essentials** is automatically assigned. 
 4. (Optional) Select the color picker to customize the color of your workspace icon.
 5. (Optional) Add a workspace description of up to 200 characters. This option is disabled when the description exceeds the character limit.
-6. Save your workspace.
+6. (Optional) Enter a custom **Workspace ID**. If left blank, an ID is auto-generated. A custom ID must be either a UUID (`xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`) or 6–20 characters using only letters, numbers, underscores (`_`), and hyphens (`-`). If a workspace with the provided ID already exists, an error is returned.
+7. Save your workspace.
   - The **Create workspace** button becomes active once you enter the information for all required fields. You become the workspace owner automatically. The system redirects you to either the collaborators page if the saved objects permission is enabled or the overview page if the saved objects permission is disabled. See [Configuring dashboard admin]({{site.url}}{{site.baseurl}}/dashboards/workspace/workspace-acl/#configuring-dashboard-administrators) for more information about permissions.
 
 To set up permissions, see [Workspace access control lists]({{site.url}}{{site.baseurl}}/dashboards/workspace/workspace-acl/) for more information.


### PR DESCRIPTION
### Description

Documents the optional custom Workspace ID field added to OpenSearch Dashboards in [opensearch-project/OpenSearch-Dashboards#11631](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11631).

- Adds step 6 to the [Create a workspace](https://docs.opensearch.org/latest/dashboards/workspace/workspace/) guide describing the optional **Workspace ID** field, accepted formats (UUID or 6–20 alphanumeric/`_`/`-` characters), and duplicate-ID error behavior.
- Adds `attributes.id` to the [Workspaces APIs](https://docs.opensearch.org/latest/dashboards/workspace/apis/) parameter table and updates the Create Workspaces API example request to include the field.

### Issues Resolved

Documents [opensearch-project/OpenSearch-Dashboards#11631](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11631)

### Version

3.8+

### Frontend features

_See screenshot in [opensearch-project/OpenSearch-Dashboards#11631](https://github.com/opensearch-project/OpenSearch-Dashboards/pull/11631) for the UI change._

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
