### PR TITLE
Add error logs section clarifying MapperParsingException is only logg…

### DIFF
--- a/_install-and-configure/configuring-opensearch/logs.md
+++ b/_install-and-configure/configuring-opensearch/logs.md
@@ -155,7 +155,7 @@ Error logs can help with troubleshooting in many situations, including the follo
 - Snapshot failures
 - Index State Management migration failures
 
-### MapperParsingException scope
+### Mapper parsing exception scope
 
 Mapper parsing exceptions are logged only when they are triggered by explicit mapping requests, such as the [Put Mapping API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/put-mapping/) requests. They are not logged when triggered by document indexing operations, such as the [Bulk API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/bulk/) or the [Index API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/index-document/) requests. For example, if a document contains a field value that conflicts with the index mapping (for example, when you send a string value in an integer field), the Bulk API returns a `mapper_parsing_exception` in the response body, but this error is not written to the error logs. To identify documents causing a `mapper_parsing_exception` during bulk indexing, inspect the Bulk API response for errors rather than relying on error logs.
 

--- a/_install-and-configure/configuring-opensearch/logs.md
+++ b/_install-and-configure/configuring-opensearch/logs.md
@@ -157,8 +157,7 @@ Error logs can help with troubleshooting in many situations, including the follo
 
 ### MapperParsingException scope
 
-`mapper_parsing_exception` errors are logged only when they are triggered by explicit mapping requests, such as the [Put Mapping API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/put-mapping/) requests. They are not logged when triggered by document indexing operations, such as the [Bulk API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/bulk/) or the [Index API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/index-document/) requests. For example, if a document contains a field value that conflicts with the index mapping (for example, when you send a string value in an integer field), the Bulk API returns a `mapper_parsing_exception` in the response body, but this error is not written to the error logs. To identify documents causing a `mapper_parsing_exception` during bulk indexing, inspect the Bulk API response for errors rather than relying on error logs.
-{: .note}
+Mapper parsing exceptions are logged only when they are triggered by explicit mapping requests, such as the [Put Mapping API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/put-mapping/) requests. They are not logged when triggered by document indexing operations, such as the [Bulk API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/bulk/) or the [Index API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/index-document/) requests. For example, if a document contains a field value that conflicts with the index mapping (for example, when you send a string value in an integer field), the Bulk API returns a `mapper_parsing_exception` in the response body, but this error is not written to the error logs. To identify documents causing a `mapper_parsing_exception` during bulk indexing, inspect the Bulk API response for errors rather than relying on error logs.
 
 ## Search request slow logs
 

--- a/_install-and-configure/configuring-opensearch/logs.md
+++ b/_install-and-configure/configuring-opensearch/logs.md
@@ -137,6 +137,31 @@ The following table lists the common plugin logger categories.
 
 
 
+## Error logs
+
+OpenSearch logs errors at the `WARN`, `ERROR`, and `FATAL` levels. Additionally, certain exceptions from the `DEBUG` level are logged, including the following:
+
+- `org.opensearch.index.mapper.MapperParsingException`
+- `org.opensearch.index.query.QueryShardException`
+- `org.opensearch.action.search.SearchPhaseExecutionException`
+- `org.opensearch.common.util.concurrent.OpenSearchRejectedExecutionException`
+- `java.lang.IllegalArgumentException`
+
+Error logs can help with troubleshooting in many situations, including the following:
+
+- Painless script compilation issues
+- Invalid queries
+- Indexing issues
+- Snapshot failures
+- Index State Management migration failures
+
+### MapperParsingException scope
+
+`MapperParsingException` errors are logged only when they are triggered by explicit mapping requests, such as the [Put Mapping API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/put-mapping/). They are **not** logged when triggered by document indexing operations, such as the [Bulk API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/bulk/) or the [Index API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/index-document/).
+
+For example, if a document contains a field value that conflicts with the index mapping (such as sending a string value for an integer field), the Bulk API returns a `mapper_parsing_exception` error in the response body, but this error is not written to the error logs. To identify documents causing `MapperParsingException` during bulk indexing, inspect the Bulk API response for errors rather than relying on error logs.
+{: .note}
+
 ## Search request slow logs
 
 New in version 2.12, OpenSearch offers request-level slow logs for search. These logs rely on thresholds to define what qualifies as "slow." All requests which exceed the threshold are logged.

--- a/_install-and-configure/configuring-opensearch/logs.md
+++ b/_install-and-configure/configuring-opensearch/logs.md
@@ -157,9 +157,7 @@ Error logs can help with troubleshooting in many situations, including the follo
 
 ### MapperParsingException scope
 
-`MapperParsingException` errors are logged only when they are triggered by explicit mapping requests, such as the [Put Mapping API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/put-mapping/). They are **not** logged when triggered by document indexing operations, such as the [Bulk API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/bulk/) or the [Index API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/index-document/).
-
-For example, if a document contains a field value that conflicts with the index mapping (such as sending a string value for an integer field), the Bulk API returns a `mapper_parsing_exception` error in the response body, but this error is not written to the error logs. To identify documents causing `MapperParsingException` during bulk indexing, inspect the Bulk API response for errors rather than relying on error logs.
+`mapper_parsing_exception` errors are logged only when they are triggered by explicit mapping requests, such as the [Put Mapping API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/put-mapping/) requests. They are not logged when triggered by document indexing operations, such as the [Bulk API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/bulk/) or the [Index API]({{site.url}}{{site.baseurl}}/api-reference/document-apis/index-document/) requests. For example, if a document contains a field value that conflicts with the index mapping (for example, when you send a string value in an integer field), the Bulk API returns a `mapper_parsing_exception` in the response body, but this error is not written to the error logs. To identify documents causing a `mapper_parsing_exception` during bulk indexing, inspect the Bulk API response for errors rather than relying on error logs.
 {: .note}
 
 ## Search request slow logs


### PR DESCRIPTION
…ed for Put Mapping requests, not bulk indexing

### Description
Adds an "Error logs" section to the logs documentation (logs.md) that documents:

- Which log levels and DEBUG-level exceptions are published to error logs
- Common troubleshooting scenarios where error logs are useful
- A clarification that MapperParsingException is only logged for explicit mapping API requests (e.g., Put Mapping), not for document indexing operations (e.g., Bulk API, Index API)

### Context

Customers have reported confusion because they expect MapperParsingException errors to appear in their error logs during bulk indexing operations. The current documentation does not clarify this scope limitation. This change makes it explicit that these exceptions are only logged when triggered by mapping-related requests, and advises users to inspect Bulk API responses directly to identify malformed documents.

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._
2.19 onwards

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
