### PR TITLE
Update SearchAlertsTool register parameters table

### DIFF
--- a/_ml-commons-plugin/agents-tools/tools/search-alerts-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/search-alerts-tool.md
@@ -105,7 +105,7 @@ The following table lists all tool parameters that are available when registerin
 Parameter	| Type | Description	
 :--- | :--- | :---
 `alertIds`	| Array	| The ID of the alert to search for.
-`alertIndex` | String | Name of the alert index to search from (default is null).
+`alertIndex` | String | The name of the alert index to search (default is `null`).
 `monitorId`	| String	| The ID of the monitor by which to filter the alerts.
 `monitorIds` | Array | A list of monitor IDs by which to filter the alerts.
 `workflowIds`	| Array | A list of workflow IDs by which to filter the alerts.

--- a/_ml-commons-plugin/agents-tools/tools/search-alerts-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/search-alerts-tool.md
@@ -105,7 +105,9 @@ The following table lists all tool parameters that are available when registerin
 Parameter	| Type | Description	
 :--- | :--- | :---
 `alertIds`	| Array	| The ID of the alert to search for.
-`monitorId`	| String	| The name of the monitor by which to filter the alerts.
+`alertIndex` | String | Name of the alert index to search from (default is null).
+`monitorId`	| String	| The ID of the monitor by which to filter the alerts.
+`monitorIds` | Array | A list of monitor IDs by which to filter the alerts.
 `workflowIds`	| Array | A list of workflow IDs by which to filter the alerts.
 `alertState` |	String	| The alert state by which to filter the alerts. Valid values are `ALL`, `ACTIVE`, `ERROR`, `COMPLETED`, and `ACKNOWLEDGED`. Default is `ALL`.
 `severityLevel` | String| The severity level by which to filter the alerts. Valid values are `ALL`, `1`, `2`, and `3`. Default is `ALL`.


### PR DESCRIPTION
### Description

1. The `monitorId` parameter has mistake in description. It requires passing monitor ID, not the monitor name. I tested it locally, to make sure.

2. The table was missing `monitorIds` and `alertIndex` parameters, which were already exposed to MCP client via tool description.

Related with adding missing input schema to the tool: https://github.com/opensearch-project/skills/pull/769 – it's a good time to also fix inconsistencies between documentation and tool properties/descriptions.

### Issues Resolved

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
