### PR TITLE
Add document index and cluster level delayed allocation timeout setting 

### DIFF
--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -33,7 +33,7 @@ OpenSearch supports the following cluster-level routing and shard allocation set
 
 - `cluster.routing.allocation.node_initial_primaries_recoveries` (Dynamic, integer): Sets the number of recoveries for unassigned primaries after a node restart. Default is `4`. 
 
-- `cluster.routing.allocation.unassigned.node_left.delayed_timeout` (Dynamic, time unit): Sets the default amount of time OpenSearch waits before allocating a replica shard that became unassigned because a node left the cluster. This helps avoid unnecessary shard recoveries during rolling upgrades, node restarts, and transient network failures. This setting applies when the index-level `index.unassigned.node_left.delayed_timeout` setting is not configured. Set to `0` to skip the delayed-allocation wait for indexes that don't set their own value. Default is `1m`.
+- `cluster.routing.allocation.unassigned.node_left.delayed_timeout` (Dynamic, time unit): Sets the default amount of time OpenSearch waits before allocating a replica shard that became unassigned after a node leaves the cluster. Delaying allocation helps avoid unnecessary shard recoveries during rolling upgrades, node restarts, and transient network failures. This setting applies only to indexes for which the index-level `index.unassigned.node_left.delayed_timeout` setting is not configured. Set to `0` to disable delayed allocation for indexes that use the cluster default. Default is `1m`.
 
 - `cluster.routing.allocation.same_shard.host` (Dynamic, Boolean): When set to `true`, multiple copies of a shard are prevented from being allocated to distinct nodes on the same host. Default is `false`. 
 

--- a/_install-and-configure/configuring-opensearch/cluster-settings.md
+++ b/_install-and-configure/configuring-opensearch/cluster-settings.md
@@ -33,6 +33,8 @@ OpenSearch supports the following cluster-level routing and shard allocation set
 
 - `cluster.routing.allocation.node_initial_primaries_recoveries` (Dynamic, integer): Sets the number of recoveries for unassigned primaries after a node restart. Default is `4`. 
 
+- `cluster.routing.allocation.unassigned.node_left.delayed_timeout` (Dynamic, time unit): Sets the default amount of time OpenSearch waits before allocating a replica shard that became unassigned because a node left the cluster. This helps avoid unnecessary shard recoveries during rolling upgrades, node restarts, and transient network failures. This setting applies when the index-level `index.unassigned.node_left.delayed_timeout` setting is not configured. Set to `0` to skip the delayed-allocation wait for indexes that don't set their own value. Default is `1m`.
+
 - `cluster.routing.allocation.same_shard.host` (Dynamic, Boolean): When set to `true`, multiple copies of a shard are prevented from being allocated to distinct nodes on the same host. Default is `false`. 
 
 - `cluster.routing.rebalance.enable` (Dynamic, string): Enables or disables rebalancing for specific kinds of shards.
@@ -386,4 +388,3 @@ For practical examples and step-by-step configuration guides, see [Remote-backed
   Default is `DOCUMENT`.
 
 - `cluster.index.restrict.replication.type` (Dynamic, Boolean): When enabled, restricts the creation of indices with specific replication types to ensure consistency across the cluster. This setting helps enforce replication policies and prevents incompatible replication configurations. Default is `false`.
-

--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -340,7 +340,7 @@ OpenSearch supports the following dynamic index-level index settings:
 
 - `index.routing.allocation.enable` (String): Specifies options for the index’s shard allocation. Available options are `all` (allow allocation for all shards), `primaries` (allow allocation only for primary shards), `new_primaries` (allow allocation only for new primary shards), and `none` (do not allow allocation). Default is `all`.
 
-- `index.unassigned.node_left.delayed_timeout` (Dynamic, time unit): Sets the amount of time OpenSearch waits before allocating a replica shard that became unassigned because a node left the cluster. This setting overrides the cluster-level `cluster.routing.allocation.unassigned.node_left.delayed_timeout` setting. If neither setting is configured, the default is `1m`. Set to `0` to skip the delayed-allocation wait for the index.
+- `index.unassigned.node_left.delayed_timeout` (Dynamic, time unit): Sets the amount of time OpenSearch waits before allocating a replica shard that became unassigned because a node left the cluster. This setting overrides the cluster-level `cluster.routing.allocation.unassigned.node_left.delayed_timeout` setting. If neither setting is configured, the default is `1m`. Set to `0` to disable delayed allocation for the index.
 
 - `index.routing.rebalance.enable` (String): Enables shard rebalancing for the index. Available options are `all` (allow rebalancing for all shards), `primaries` (allow rebalancing only for primary shards), `replicas` (allow rebalancing only for replicas), and `none` (do not allow rebalancing). Default is `all`.
 

--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -340,6 +340,8 @@ OpenSearch supports the following dynamic index-level index settings:
 
 - `index.routing.allocation.enable` (String): Specifies options for the index’s shard allocation. Available options are `all` (allow allocation for all shards), `primaries` (allow allocation only for primary shards), `new_primaries` (allow allocation only for new primary shards), and `none` (do not allow allocation). Default is `all`.
 
+- `index.unassigned.node_left.delayed_timeout` (Dynamic, time unit): Sets the amount of time OpenSearch waits before allocating a replica shard that became unassigned because a node left the cluster. This setting overrides the cluster-level `cluster.routing.allocation.unassigned.node_left.delayed_timeout` setting. If neither setting is configured, the default is `1m`. Set to `0` to skip the delayed-allocation wait for the index.
+
 - `index.routing.rebalance.enable` (String): Enables shard rebalancing for the index. Available options are `all` (allow rebalancing for all shards), `primaries` (allow rebalancing only for primary shards), `replicas` (allow rebalancing only for replicas), and `none` (do not allow rebalancing). Default is `all`.
 
 - `index.gc_deletes` (Time unit): The amount of time to retain a deleted document's version number. Default is `60s`.


### PR DESCRIPTION
### Description
Add node delay index/cluster settings

Adds documentation for: 

-  _cluster.routing.allocation.unassigned.node_left.delayed_timeout_  
 
-  _index.unassigned.node_left.delayed_timeout_  



### Issues Resolved
Closes #22373
 
 
### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
