### PR TITLE
[#22409] Document HTTP QUERY method support in search API

### DIFF
--- a/_api-reference/search-apis/search.md
+++ b/_api-reference/search-apis/search.md
@@ -22,7 +22,13 @@ GET /_search
 
 POST /{index}/_search
 POST /_search
+
+QUERY /{index}/_search
+QUERY /_search
 ```
+
+The QUERY method is supported as of OpenSearch 2.17 (RFC 10008 compliance). The QUERY method is safe, idempotent, and cacheable, making it suitable for search requests that carry a request body.
+{: .label .label-blue }
 
 ## Query parameters
 


### PR DESCRIPTION


### Description

Add QUERY method to the search API documentation with RFC 10008 compliance note indicating OpenSearch 2.17 support.


### Issues Resolved

* https://github.com/opensearch-project/OpenSearch/pull/22410
* https://github.com/opensearch-project/OpenSearch/issues/22409

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
