### PR TITLE
Document workload group rule matching and precedence

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
+++ b/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
@@ -96,8 +96,8 @@ OpenSearch evaluates incoming requests using the following process:
 3. The most specific matching rule's value is assigned.
 4. If no rules match, no value is assigned.
 
-{: .note}
 If two or more rules remain tied after all tie-breaking logic is applied, meaning they match equally specifically and produce the same match score, then no value is assigned. OpenSearch does not choose between tied rules arbitrarily.
+{: .note}
 
 ### Rule matching examples
 

--- a/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
+++ b/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
@@ -108,9 +108,9 @@ In these examples, the `username` attribute has higher priority than the `index_
 1. **Example 1**
    A request matches three rules:
 
-   * Rule 1: `index_pattern = log`
+   * Rule 1: `index_pattern = log*`
    * Rule 2: `username = admin`
-   * Rule 3: `index_pattern = log123`
+   * Rule 3: `index_pattern = log123*`
 
    **Result**: Rule 2 applies because the `username` attribute has higher priority.
 
@@ -125,7 +125,7 @@ In these examples, the `username` attribute has higher priority than the `index_
 3. **Example 3**
    A request matches two rules:
 
-   * Rule 1: `index_pattern = log` and `username = admin`
+   * Rule 1: `index_pattern = log*` and `username = admin`
    * Rule 2: `username = admin`
 
    **Result**: Rule 1 applies because it includes both the `index_pattern` and `username` attributes, making it a more specific match.

--- a/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
+++ b/_tuning-your-cluster/availability-and-recovery/rule-based-autotagging/autotagging.md
@@ -96,6 +96,9 @@ OpenSearch evaluates incoming requests using the following process:
 3. The most specific matching rule's value is assigned.
 4. If no rules match, no value is assigned.
 
+{: .note}
+If two or more rules remain tied after all tie-breaking logic is applied, meaning they match equally specifically and produce the same match score, then no value is assigned. OpenSearch does not choose between tied rules arbitrarily.
+
 ### Rule matching examples
 
 The following examples demonstrate how OpenSearch matches attributes and resolves ties between rules.

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
@@ -54,7 +54,7 @@ The table lists the attributes in order of priority, from highest to lowest. Thi
 |:---------------------|:----------|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | `principal.username` | List      | A list of usernames to be matched to this rule. This attribute is available only when the Security plugin is enabled on the domain. The attribute supports exact matching only.                                 |
 | `principal.role`     | List      | A list of roles to be matched to this rule. This attribute is available only when the Security plugin is enabled on the domain. The attribute supports exact matching only.                                     |
-| `index_pattern`      | List      | A list of target indexes for incoming queries. Each element can be a full index name or a prefix ending in `*` to support wildcard matching (for example, `logs*`).                                |
+| `index_pattern`      | List      | A list of target indexes for incoming queries. An element that is a full index name (for example, `logs-2025`) is matched exactly; an element ending in `*` (for example, `logs*`) is matched as a prefix.                                |
 
 ## Parameters
 

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
@@ -68,16 +68,17 @@ The `workload_group` feature type contains the following parameters.
 
 ## Rule matching and precedence
 
-A single request can match more than one rule. The following sections describe how a rule matches a request and how OpenSearch decides which workload group to assign when several rules match.
+A single request can match more than one rule. OpenSearch evaluates each rule against the request and then uses precedence logic to decide which workload group to assign. 
+If no rule matches, the request runs without a workload group.
 
 ### Matching within a single rule
 
-A rule matches a request only when *every* attribute in the rule matches, so multiple attributes in one rule form a logical AND. Within a single attribute, the listed values form a logical OR: the attribute matches when the request satisfies *any one* of its values. For example, a rule with `"principal": { "role": ["role1", "role2"] }` matches a request whose user has `role1` **or** `role2`; the request does not need both roles.
+A rule matches a request only when every attribute in the rule matches, so multiple attributes in one rule form a logical `AND`. Within a single attribute, the listed values form a logical `OR`: the attribute matches when the request satisfies any one of its values. For example, a rule containing `"principal": { "role": ["role1", "role2"] }` matches a request in which a user has `role1` or `role2`.
 
+To match a request only when it carries a specific combination of values (a logical `AND` within a single attribute), create separate rules for each required value. Listing multiple values under one attribute always applies `OR` semantics.
 {: .note}
-To match a request only when it carries a specific *combination* of values (a logical AND within a single attribute), model each required value as a separate attribute or combine the conditions upstream. Listing multiple values under one attribute always applies OR semantics.
 
-Note that `principal.username` and `principal.role` are subfields of the single `principal` attribute, so all of their values are OR'd together (not AND'd). For example, the following rule combines the `principal` and `index_pattern` attributes:
+Because `principal.username` and `principal.role` are subfields of the single `principal` attribute, all of their values are combined using `OR` (not `AND`). The following example shows a rule with both `principal` and `index_pattern` attributes:
 
 ```json
 {
@@ -90,23 +91,19 @@ Note that `principal.username` and `principal.role` are subfields of the single 
 }
 ```
 
-This rule matches a request when:
+This rule matches a request that contains at least one `principal` value (a username or a role) and at least one `index_pattern` value:
 
 ```
 (user1 OR user2 OR role1 OR role2 OR role3) AND (index-1 OR index-2 OR logs-*)
 ```
-
-In other words, the request must match at least one `principal` value (a username or a role) **and** at least one `index_pattern` value.
 
 ### Choosing between multiple matching rules
 
 When a request matches multiple rules that resolve to different workload groups, OpenSearch selects a single group in the following order:
 
 1. **Attribute priority**: The workload group matched through the highest-priority attribute is preferred. Priority is fixed and follows the order shown in the [Attributes](#attributes) table (`principal.username`, then `principal.role`, then `index_pattern`).
-2. **Match score**: If the choice is still ambiguous, OpenSearch compares match scores. An exact match scores higher than a shorter prefix (wildcard) match, and a workload group matched by *more* of the request's values receives a higher cumulative score. For example, if a request carries three roles and one group's rules match all three while another group's rules match only two, the group matching three roles is selected.
-3. **No assignment on an unresolved tie**: If two or more workload groups remain tied after all attributes are compared (for example, two rules that each match the request through a single, equally specific role), then OpenSearch assigns no workload group. The request runs without a workload group rather than having one chosen arbitrarily.
-
-If no rule matches, no workload group is assigned and the request runs without one.
+1. **Match score**: If the choice is still ambiguous, OpenSearch compares match scores. An exact match is scored higher than a shorter prefix (wildcard) match, and a workload group matched by more of the request's values receives a higher cumulative score. For example, if a request carries three roles and one group's rules match all three while another group's rules match only two, the group matching three roles is selected.
+1. **No assignment for an unresolved tie**: If two or more workload groups remain tied after all attributes are compared (for example, two rules that each match the request through a single, equally specific role), then OpenSearch assigns no workload group. The request runs without a workload group rather than having one chosen arbitrarily.
 
 ## Updating a rule
 

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
@@ -66,6 +66,27 @@ The `workload_group` feature type contains the following parameters.
 | `description`    | String    | A description of the rule.                                                                              |
 | `workload_group` | String    | The workload group ID to apply to the requests matching this rule.                                      |
 
+## Rule matching and precedence
+
+A single request can match more than one rule. The following sections describe how a rule matches a request and how OpenSearch decides which workload group to assign when several rules match.
+
+### Matching within a single rule
+
+A rule matches a request only when *every* attribute in the rule matches, so multiple attributes in one rule form a logical AND. Within a single attribute, the listed values form a logical OR: the attribute matches when the request satisfies *any one* of its values. For example, a rule with `"principal": { "role": ["role1", "role2"] }` matches a request whose user has `role1` **or** `role2`; the request does not need both roles.
+
+{: .note}
+To match a request only when it carries a specific *combination* of values (a logical AND within a single attribute), model each required value as a separate attribute or combine the conditions upstream. Listing multiple values under one attribute always applies OR semantics.
+
+### Choosing between multiple matching rules
+
+When a request matches multiple rules that resolve to different workload groups, OpenSearch selects a single group in the following order:
+
+1. **Attribute priority**: The workload group matched through the highest-priority attribute is preferred. Priority is fixed and follows the order shown in the [Attributes](#attributes) table (`principal.username`, then `principal.role`, then `index_pattern`).
+2. **Match score**: If the choice is still ambiguous, OpenSearch compares match scores. An exact match scores higher than a shorter prefix (wildcard) match, and a workload group matched by *more* of the request's values receives a higher cumulative score. For example, if a request carries three roles and one group's rules match all three while another group's rules match only two, the group matching three roles is selected.
+3. **No assignment on an unresolved tie**: If two or more workload groups remain tied after all attributes are compared (for example, two rules that each match the request through a single, equally specific role), then OpenSearch assigns no workload group. The request runs without a workload group rather than having one chosen arbitrarily.
+
+If no rule matches, no workload group is assigned and the request runs without one.
+
 ## Updating a rule
 
 To update a rule, provide its ID in the path parameter and the updated fields in the request body. When you update a rule, only the parameters you specify are changed; all others stay the same. The following request updates a rule description and index pattern for the rule with the ID `176fd554-43e7-39eb-92cc-56615d287eae`:

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-group-rules.md
@@ -77,6 +77,27 @@ A rule matches a request only when *every* attribute in the rule matches, so mul
 {: .note}
 To match a request only when it carries a specific *combination* of values (a logical AND within a single attribute), model each required value as a separate attribute or combine the conditions upstream. Listing multiple values under one attribute always applies OR semantics.
 
+Note that `principal.username` and `principal.role` are subfields of the single `principal` attribute, so all of their values are OR'd together (not AND'd). For example, the following rule combines the `principal` and `index_pattern` attributes:
+
+```json
+{
+  "principal": {
+    "username": ["user1", "user2"],
+    "role": ["role1", "role2", "role3"]
+  },
+  "index_pattern": ["index-1", "index-2", "logs-*"],
+  "workload_group": "<id>"
+}
+```
+
+This rule matches a request when:
+
+```
+(user1 OR user2 OR role1 OR role2 OR role3) AND (index-1 OR index-2 OR logs-*)
+```
+
+In other words, the request must match at least one `principal` value (a username or a role) **and** at least one `index_pattern` value.
+
 ### Choosing between multiple matching rules
 
 When a request matches multiple rules that resolve to different workload groups, OpenSearch selects a single group in the following order:


### PR DESCRIPTION
### Description
Documents how WLM auto-tagging rules match a request and how OpenSearch resolves precedence when multiple rules match. Adds a "Rule matching and precedence" section to the workload group rules page covering:

- Matching within a single rule: multiple attributes are AND'd; multiple values within one attribute (including the `principal` username/role subfields) are OR'd.
- Choosing between multiple matching rules: attribute priority, then match score, then no assignment on an unresolved tie.

Also clarifies on the rule-based auto-tagging page that when rules remain tied after tie-breaking, no value is assigned (OpenSearch does not choose arbitrarily).

### Issues Resolved
N/A

### Version
2.19 and later

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
