### PR TITLE
docs: Add split_when parameter to split_event processor

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/split-event.md
+++ b/_data-prepper/pipelines/configuration/processors/split-event.md
@@ -19,6 +19,7 @@ The following table describes the configuration options for the `split_event` pr
 | `field`          | String  | The event field to be split.                                                           |
 | `delimiter_regex`| String  | The regular expression used as the delimiter for splitting the field.                         |
 | `delimiter`      | String  | The delimiter used for splitting the field. If not specified, the default delimiter is used.  |
+| `split_when`     | String  | A [conditional expression]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/) that determines whether the processor will be run on the event. If the condition evaluates to `false`, the event passes through unchanged. Default is `null` (all events are processed). |
 
 # Usage
 
@@ -49,4 +50,24 @@ The input will be split into multiple events based on the `query` field, with th
 {"query" : "open", "some_other_field" : "abc" }
 {"query" : "source", "some_other_field" : "abc" }
 ```
+
+## Conditional splitting with split_when
+
+You can use `split_when` to conditionally apply the split based on event content. This is useful in multi-tenant pipelines where only certain events should be split.
+
+```yaml
+split-event-pipeline:
+  source:
+    http:
+  processor:
+    - split_event:
+        field: body
+        delimiter: "\n"
+        split_when: 'contains(/body, "\n")'
+  sink:
+    - stdout:
+```
+{% include copy.html %}
+
+In this example, the `split_event` processor only splits events where the `body` field contains a newline character. Events without newlines pass through unchanged.
 

--- a/_data-prepper/pipelines/configuration/processors/split-event.md
+++ b/_data-prepper/pipelines/configuration/processors/split-event.md
@@ -19,7 +19,7 @@ The following table describes the configuration options for the `split_event` pr
 | `field`          | String  | The event field to be split.                                                           |
 | `delimiter_regex`| String  | The regular expression used as the delimiter for splitting the field.                         |
 | `delimiter`      | String  | The delimiter used for splitting the field. If not specified, the default delimiter is used.  |
-| `split_when`     | String  | A [conditional expression]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/) that determines whether the processor will be run on the event. If the condition evaluates to `false`, the event passes through unchanged. Default is `null` (all events are processed). |
+| `split_when`     | String  | A [conditional expression]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/) that determines whether the processor is applied to the event. If the condition evaluates to `false`, the event remains unchanged. Default is `null` (all events are processed). |
 
 # Usage
 
@@ -53,7 +53,7 @@ The input will be split into multiple events based on the `query` field, with th
 
 ## Conditional splitting with split_when
 
-You can use `split_when` to conditionally apply the split based on event content. This is useful in multi-tenant pipelines where only certain events should be split.
+You can use `split_when` to conditionally apply the split based on event content. This is useful in multi-tenant pipelines where only certain events should be split. In the following example, the `split_event` processor only splits events in which the `body` field contains a new line character. Events without new lines remain unchanged:
 
 ```yaml
 split-event-pipeline:
@@ -69,5 +69,4 @@ split-event-pipeline:
 ```
 {% include copy.html %}
 
-In this example, the `split_event` processor only splits events where the `body` field contains a newline character. Events without newlines pass through unchanged.
 


### PR DESCRIPTION
Document the new split_when conditional parameter for the split_event processor. Includes configuration table entry and usage example.

Related: opensearch-project/data-prepper#6992

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
