### PR TITLE
Update CSP configuration docs to reflect yml-based config

### DIFF
--- a/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
+++ b/.github/vale/styles/Vocab/OpenSearch/Words/accept.txt
@@ -26,6 +26,7 @@ Boolean
 [Cc]heckpointing
 [Cc]entiseconds?
 [Cc]lasspath
+[Cc]lickjack(ing)?
 [Cc]odec
 [Cc]omposable
 [Cc]onfig

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -1,58 +1,108 @@
 ---
 layout: default
-title: Configuring CSP rules for frame ancestors
+title: Configuring CSP rules
 parent: Settings and administration
 nav_order: 60
 has_children: false
 ---
 
-# Configuring CSP rules for frame ancestors
+# Configuring CSP rules
 Introduced 2.13
 {: .label .label-purple }
 
-Content Security Policy (CSP) is a security standard intended to prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks resulting from the launch of malicious content in the trusted webpage context. OpenSearch Dashboards supports configuring CSP rules in the `opensearch_dashboards.yml` file by using the `csp.rules` key. A change in the YAML file requires a server restart, which may interrupt service availability. You can, however, dynamically configure the `frame-ancestors` directive in the CSP rules through the `applicationConfig` plugin without restarting the server. Support for other directives is evaluated based on security ramifications.
+Content Security Policy (CSP) is a security standard intended to prevent cross-site scripting (XSS), clickjacking, and other code injection attacks. OpenSearch Dashboards enforces CSP by sending a `Content-Security-Policy` response header on every page load.
+
+You can configure CSP rules in `opensearch_dashboards.yml`. A server restart is required after any change.
 
 ## Configuration
 
-The `applicationConfig` plugin provides read and write APIs that allow OpenSearch Dashboards users to manage dynamic configurations as key-value pairs in an index. The `cspHandler` plugin registers a pre-response handler to `HttpServiceSetup`, which gets the `frame-ancestors` value from the dependent `applicationConfig` plugin and then rewrites it to the CSP header. Enable both plugins in your `opensearch_dashboards.yml` file to use this feature. The configuration is shown in the following example. Refer to [`cspHandler` plugin](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/csp_handler/README.md) for more information.
+Add the following keys to `opensearch_dashboards.yml` to configure CSP. All `allowed*Sources` values are appended to the strict policy defaults for that directive.
+
+```yaml
+# Enable strict CSP enforcement.
+csp.enable: true
+
+# Append trusted origins to frame-ancestors (controls iframe embedding).
+csp.allowedFrameAncestorSources: ["https://portal.example.com"]
+
+# Append trusted origins to connect-src (fetch/XHR calls from the browser).
+csp.allowedConnectSources: ["https://api.example.com"]
+
+# Append trusted origins to img-src.
+csp.allowedImgSources: ["https://cdn.example.com"]
+
+# Relax specific directives back to their non-strict defaults
+# while keeping the rest of the policy strict.
+csp.loosenCspDirectives: ["style-src"]
+```
+
+Setting | Type | Description
+:--- | :--- | :---
+`csp.enable` | Boolean | Enables strict CSP enforcement. Default: `true`.
+`csp.allowedFrameAncestorSources` | Array of strings | Origins appended to the `frame-ancestors` directive. Use to allow embedding Dashboards in an iframe.
+`csp.allowedConnectSources` | Array of strings | Origins appended to `connect-src`. Use to allow browser-initiated requests (fetch, XHR, WebSocket) to external endpoints.
+`csp.allowedImgSources` | Array of strings | Origins appended to `img-src`. Use to allow images from external CDNs or tile servers.
+`csp.loosenCspDirectives` | Array of strings | Directive names to relax back to their non-strict default values.
+
+## Enable site embedding
+
+To embed OpenSearch Dashboards in an iframe on another site, add that site to `csp.allowedFrameAncestorSources`:
+
+```yaml
+csp.allowedFrameAncestorSources: ["https://portal.example.com"]
+```
+
+This produces the following `frame-ancestors` directive in the response header:
 
 ```
+frame-ancestors 'self' https://portal.example.com
+```
+
+## Report-only mode
+
+To audit a new CSP policy without enforcing it, enable the `Content-Security-Policy-Report-Only` header. Violations are reported but no content is blocked.
+
+```yaml
+csp-report-only.isEmitting: true
+csp-report-only.allowedFrameAncestorSources: ["https://portal.example.com"]
+csp-report-only.allowedConnectSources: ["https://api.example.com"]
+csp-report-only.allowedImgSources: ["https://cdn.example.com"]
+```
+
+## Fine-grained access control
+
+CSP configuration is managed through `opensearch_dashboards.yml` and requires access to the server's file system. Only administrators with access to the server configuration should modify these settings.
+
+When the Security plugin is enabled, ensure that any related index permissions are restricted to trusted administrator accounts.
+
+## Deprecated: applicationConfig approach (2.13–2.16)
+
+**Deprecated.** In OpenSearch Dashboards 2.13–2.16, the `frame-ancestors` directive could be set dynamically via a REST API using the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional—the API still accepts values but they are not applied to the `Content-Security-Policy` header. Use the `csp.*` settings above instead.
+
+The following is documented for reference only.
+
+Enable the plugins in `opensearch_dashboards.yml`:
+
+```yaml
 application_config.enabled: true
 csp_handler.enabled: true
 ```
 
-## Enable site embedding for OpenSearch Dashboards
+Set, delete, or get `frame-ancestors` via cURL:
 
-To enable site embedding for OpenSearch Dashboards, update the `frame-ancestors` directive in the CSP rules using cURL. When using cURL commands with single quotation marks in the `data-raw` parameter, escape them with a backslash (`\`). For example, use `'\''` to represent `'`. The configuration is shown in the following example. Refer to [`applicationConfig` plugin](https://github.com/opensearch-project/OpenSearch-Dashboards/blob/main/src/plugins/application_config/README.md) for more information.
+```bash
+# Set
+curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors' \
+  -X POST \
+  -H 'Accept: application/json' \
+  -H 'Content-Type: application/json' \
+  -H 'osd-xsrf: osd-fetch' \
+  --data-raw '{"newValue":"'\''self'\'' https://portal.example.com"}'
 
-```
-curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors' -X POST -H 'Accept: application/json' -H 'Content-Type: application/json' -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty' --data-raw '{"newValue":"{new site}"}'
-```
+# Delete
+curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors' \
+  -X DELETE -H 'osd-xsrf: osd-fetch'
 
-## Delete `frame-ancestors` in the CSP rules
-
-Use the following cURL command to delete `frame-ancestors` in the CSP rules:
-
-```
-curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors' -X DELETE -H 'osd-xsrf: osd-fetch' -H 'Sec-Fetch-Dest: empty'
-```
-
-## Get `frame-ancestors` in the CSP rules
-
-Use the following cURL command to get `frame-ancestors` in the CSP rules:
-
-```
+# Get
 curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors'
 ```
-
-## Precedence
-
-Dynamic configurations override YAML configurations, except for empty CSP rules. To prevent `clickjacking`, a `frame-ancestors: self` directive is automatically added to YAML-defined rules when necessary.
-
-## Fine-grained access control
-
-When the Security plugin is enabled, only users with write permissions to the configuration index `.opensearch_dashboards_config` are able to call the mutating APIs. The API calls must have a valid cookie containing the security information. To construct the cURL command, you can use a `Copy as cURL` option from the network tab of a browser development tool. For GET APIs, you can find an existing GET XHR request with type `json` from the network tab, copy it as cURL, and then replace it with the `appconfig` API names. Similarly, for POST and DELETE APIs, you can find an existing POST XHR request and update the API name and the value of `--data-raw` accordingly. DELETE APIs must have their request method updated to `-X DELETE`.
-
-An example of the `Copy as cURL` option in Firefox is shown in the following image.
-
-![Copying as cURL in Firefox]({{site.url}}{{site.baseurl}}/images/dashboards/copy-as-curl.png)

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -1,22 +1,21 @@
 ---
 layout: default
-title: Configuring CSP rules
+title: CSP rules
 parent: Settings and administration
 nav_order: 60
 has_children: false
 ---
 
-# Configuring CSP rules
+# CSP rules
 Introduced 2.13
 {: .label .label-purple }
 
-Content Security Policy (CSP) is a security standard intended to prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks. OpenSearch Dashboards enforces CSP by sending a `Content-Security-Policy` response header on every page load.
+Content Security Policy (CSP) is a security standard intended to prevent cross-site scripting (XSS), clickjacking, and other code injection attacks. OpenSearch Dashboards enforces CSP by sending a `Content-Security-Policy` response header on every page load.
 
-You can configure CSP rules in `opensearch_dashboards.yml`. A server restart is required after any change.
 
 ## Configuration
 
-Add the following keys to `opensearch_dashboards.yml` to configure CSP. All `allowed*Sources` values are appended to the strict policy defaults for that directive.
+To configure CSP, add the following keys to `opensearch_dashboards.yml`. All `allowed*Sources` values are appended to the strict policy defaults for that directive:
 
 ```yaml
 # Enable strict CSP enforcement.
@@ -35,22 +34,30 @@ csp.allowedImgSources: ["https://cdn.example.com"]
 # while keeping the rest of the policy strict.
 csp.loosenCspDirectives: ["style-src"]
 ```
+{% include copy.html %}
+
+Then restart OpenSearch for the changes to take effect.
+
+## CSP settings 
+
+The following table describes the available CSP settings.
 
 Setting | Type | Description
 :--- | :--- | :---
-`csp.enable` | Boolean | Enables strict CSP enforcement. Default: `true`.
+`csp.enable` | Boolean | Enables strict CSP enforcement. Default is `true`.
 `csp.allowedFrameAncestorSources` | Array of strings | Origins appended to the `frame-ancestors` directive. Use to allow embedding Dashboards in an iframe.
-`csp.allowedConnectSources` | Array of strings | Origins appended to `connect-src`. Use to allow browser-initiated requests (fetch, XHR, WebSocket) to external endpoints.
+`csp.allowedConnectSources` | Array of strings | Origins appended to `connect-src`. Use to allow browser-initiated requests to external endpoints (fetch, XHR, or WebSocket).
 `csp.allowedImgSources` | Array of strings | Origins appended to `img-src`. Use to allow images from external CDNs or tile servers.
 `csp.loosenCspDirectives` | Array of strings | Directive names to relax back to their non-strict default values.
 
-## Enable site embedding
+## Enabling site embedding
 
 To embed OpenSearch Dashboards in an iframe on another site, add that site to `csp.allowedFrameAncestorSources`:
 
 ```yaml
 csp.allowedFrameAncestorSources: ["https://portal.example.com"]
 ```
+{% include copy.html %}
 
 This produces the following `frame-ancestors` directive in the response header:
 
@@ -60,7 +67,7 @@ frame-ancestors 'self' https://portal.example.com
 
 ## Report-only mode
 
-To audit a new CSP policy without enforcing it, enable the `Content-Security-Policy-Report-Only` header. Violations are reported but no content is blocked.
+To audit a new CSP policy without enforcing it, enable the `Content-Security-Policy-Report-Only` header. Violations are reported but no content is blocked:
 
 ```yaml
 csp-report-only.isEmitting: true
@@ -68,35 +75,8 @@ csp-report-only.allowedFrameAncestorSources: ["https://portal.example.com"]
 csp-report-only.allowedConnectSources: ["https://api.example.com"]
 csp-report-only.allowedImgSources: ["https://cdn.example.com"]
 ```
+{% include copy.html %}
 
-## Deprecated: ApplicationConfig approach (2.13–2.16)
+## Configuring CSP rules using applicationConfig (deprecated)
 
-**Deprecated.** In OpenSearch Dashboards 2.13–2.16, the `frame-ancestors` directive could be set dynamically using a REST API through the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional—the API still accepts values but they are not applied to the `Content-Security-Policy` header. Use the `csp.*` settings described earlier instead.
-
-The following is documented for reference only.
-
-Enable the plugins in `opensearch_dashboards.yml`:
-
-```yaml
-application_config.enabled: true
-csp_handler.enabled: true
-```
-
-Set, delete, or get `frame-ancestors` using cURL:
-
-```bash
-# Set
-curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors' \
-  -X POST \
-  -H 'Accept: application/json' \
-  -H 'Content-Type: application/json' \
-  -H 'osd-xsrf: osd-fetch' \
-  --data-raw '{"newValue":"'\''self'\'' https://portal.example.com"}'
-
-# Delete
-curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors' \
-  -X DELETE -H 'osd-xsrf: osd-fetch'
-
-# Get
-curl '{osd endpoint}/api/appconfig/csp.rules.frame-ancestors'
-```
+**Deprecated.** In OpenSearch Dashboards 2.13--2.16, you could set the `frame-ancestors` directive dynamically using a REST API using the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional. Use the `csp.*` settings instead.

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -69,12 +69,6 @@ csp-report-only.allowedConnectSources: ["https://api.example.com"]
 csp-report-only.allowedImgSources: ["https://cdn.example.com"]
 ```
 
-## Fine-grained access control
-
-CSP configuration is managed through `opensearch_dashboards.yml` and requires access to the server's file system. Only administrators with access to the server configuration should modify these settings.
-
-When the Security plugin is enabled, ensure that any related index permissions are restricted to trusted administrator accounts.
-
 ## Deprecated: applicationConfig approach (2.13–2.16)
 
 **Deprecated.** In OpenSearch Dashboards 2.13–2.16, the `frame-ancestors` directive could be set dynamically via a REST API using the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional—the API still accepts values but they are not applied to the `Content-Security-Policy` header. Use the `csp.*` settings above instead.

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -10,7 +10,7 @@ has_children: false
 Introduced 2.13
 {: .label .label-purple }
 
-Content Security Policy (CSP) is a security standard intended to prevent cross-site scripting (XSS), clickjacking, and other code injection attacks. OpenSearch Dashboards enforces CSP by sending a `Content-Security-Policy` response header on every page load.
+Content Security Policy (CSP) is a security standard intended to prevent cross-site scripting (XSS), `clickjacking`, and other code injection attacks. OpenSearch Dashboards enforces CSP by sending a `Content-Security-Policy` response header on every page load.
 
 You can configure CSP rules in `opensearch_dashboards.yml`. A server restart is required after any change.
 
@@ -69,9 +69,9 @@ csp-report-only.allowedConnectSources: ["https://api.example.com"]
 csp-report-only.allowedImgSources: ["https://cdn.example.com"]
 ```
 
-## Deprecated: applicationConfig approach (2.13–2.16)
+## Deprecated: ApplicationConfig approach (2.13–2.16)
 
-**Deprecated.** In OpenSearch Dashboards 2.13–2.16, the `frame-ancestors` directive could be set dynamically via a REST API using the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional—the API still accepts values but they are not applied to the `Content-Security-Policy` header. Use the `csp.*` settings above instead.
+**Deprecated.** In OpenSearch Dashboards 2.13–2.16, the `frame-ancestors` directive could be set dynamically using a REST API through the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional—the API still accepts values but they are not applied to the `Content-Security-Policy` header. Use the `csp.*` settings described earlier instead.
 
 The following is documented for reference only.
 
@@ -82,7 +82,7 @@ application_config.enabled: true
 csp_handler.enabled: true
 ```
 
-Set, delete, or get `frame-ancestors` via cURL:
+Set, delete, or get `frame-ancestors` using cURL:
 
 ```bash
 # Set

--- a/_dashboards/csp/csp-dynamic-configuration.md
+++ b/_dashboards/csp/csp-dynamic-configuration.md
@@ -79,4 +79,4 @@ csp-report-only.allowedImgSources: ["https://cdn.example.com"]
 
 ## Configuring CSP rules using applicationConfig (deprecated)
 
-**Deprecated.** In OpenSearch Dashboards 2.13--2.16, you could set the `frame-ancestors` directive dynamically using a REST API using the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional. Use the `csp.*` settings instead.
+**Deprecated.** In OpenSearch Dashboards 2.13--2.16, you could set the `frame-ancestors` directive dynamically through a REST API by using the `applicationConfig` and `cspHandler` plugins. This approach is no longer functional. Use the `csp.*` settings instead.

--- a/_dashboards/management/management-index.md
+++ b/_dashboards/management/management-index.md
@@ -9,7 +9,7 @@ has_children: true
 Introduced 2.10
 {: .label .label-purple }
 
-**Dashboards management** is the central hub for managing and customizing OpenSearch data directly within OpenSearch Dashboards. 
+**Dashboards Management** is the central hub for managing and customizing OpenSearch data directly within OpenSearch Dashboards. Unlike deployment-level settings that administrators configure, **Dashboards Management** is an in-product application that you access from OpenSearch Dashboards. Use it to configure data access, such as index patterns, data sources, saved objects, and advanced settings, without editing configuration files or accessing the host. 
 
 OpenSearch and OpenSearch Dashboards permissions govern access to individual features. If you do not have the appropriate access permissions, consult your administrator.
 {: .warning}
@@ -23,3 +23,7 @@ You can access the following applications in **Dashboards Management**:
 - **[Saved Objects](https://opensearch.org/blog/enhancement-multiple-data-source-import-saved-object/):** The Saved Objects tool helps you organize and manage your saved objects. Saved objects are files that store data, such as dashboards, visualizations, and maps, for later use.
 - **[Advanced Settings]({{site.url}}{{site.baseurl}}/dashboards/management/advanced-settings/):** The Advanced Settings tool gives you the flexibility to personalize the behavior of OpenSearch Dashboards. The tool is divided into settings sections, such as General, Accessibility, and Notifications, and you can use it to customize and optimize many of your Dashboards settings.
 - **[Resource Access Management]({{site.url}}{{site.baseurl}}/dashboards/management/resource-sharing/):** The Resource Access Management tool provides fine-grained access control for plugin-defined resources such as machine learning (ML) model groups, anomaly detectors, and report definitions. You can share resources with specific users, roles, or backend roles and control their access levels.
+
+## Related documentation
+
+- To configure deployment-level settings, such as branding and network compression, by editing the `opensearch_dashboards.yml` file, see [Settings and administration]({{site.url}}{{site.baseurl}}/dashboards/settings-and-administration/).

--- a/_dashboards/settings-and-administration.md
+++ b/_dashboards/settings-and-administration.md
@@ -1,0 +1,20 @@
+---
+layout: default
+title: Settings and administration
+nav_order: 130
+has_children: true
+has_toc: false
+---
+
+# Settings and administration
+
+Configure and administer OpenSearch Dashboards at the deployment level by editing the `opensearch_dashboards.yml` configuration file. This documentation is intended for OpenSearch Dashboards administrators. The following settings are available:
+
+- [Custom branding]({{site.url}}{{site.baseurl}}/dashboards/branding/): Replace the default OpenSearch logo and other branding elements with your own.
+- [Network compression]({{site.url}}{{site.baseurl}}/dashboards/compression/): Compress JavaScript and CSS bundles to reduce network transfer sizes.
+- [Configuring CSP rules]({{site.url}}{{site.baseurl}}/dashboards/csp/csp-dynamic-configuration/): Enforce Content Security Policy (CSP) rules to protect against cross-site scripting and other code injection attacks.
+- [Search telemetry]({{site.url}}{{site.baseurl}}/dashboards/search-telemetry/): Analyze search request performance in OpenSearch Dashboards.
+
+## Related documentation
+
+- To configure data access, index patterns, saved objects, and other settings from within the Dashboards UI, see [Dashboards management]({{site.url}}{{site.baseurl}}/dashboards/management/management-index/).


### PR DESCRIPTION
## Summary

- Replaces the deprecated `applicationConfig` + `cspHandler` plugin approach with the current `csp.*` and `csp-report-only.*` yml settings
- Adds a settings reference table for all new CSP keys
- Adds a report-only mode section
- Moves the old plugin-based approach to a deprecated section for reference

## Context

The `cspHandler` pre-response handler was removed in 2.17 as part of the Dynamic Config Service migration. The old API still accepts values but no longer applies them to the CSP header. The current way to configure CSP is via `opensearch_dashboards.yml`.

## Test plan

- [ ] Review rendered markdown on GitHub
- [ ] Verify yml examples match `config/opensearch_dashboards.yml` in the OSD repo