### PR TITLE
fix: doc_as_update does not exist in bulk update, doc_as_upsert is meant

### DIFF
--- a/_api-reference/document-apis/bulk.md
+++ b/_api-reference/document-apis/bulk.md
@@ -360,7 +360,7 @@ To upsert a document, use one of the following options:
     { "update": { "_index": "movies", "_id": "tt0816711" } }
     { "doc" : { "title": "World War Z" }, "doc_as_upsert": true }
     ```
-1. Specify the document to update (when it exists) in the `doc` field, the document to insert (when it doesn't exist) in the `upsert` field, and leave `doc_as_update` set to `false`:
+1. Specify the document to update (when it exists) in the `doc` field, the document to insert (when it doesn't exist) in the `upsert` field, and leave `doc_as_upsert` set to `false`:
 
     ```json
     { "update": { "_index": "products", "_id": "widget-123" } }


### PR DESCRIPTION
### Description
_Describe what this change achieves._

doc_as_update is not used by neither OpenSearch [1] nor Elastic [2].

[1]: https://github.com/search?q=org%3Aopensearch-project%20doc_as_update&type=code
[2]: https://github.com/search?q=repo%3Aelastic%2Fecs%20doc_as_update&type=code

Introduced in: https://github.com/opensearch-project/documentation-website/pull/11506
Introduced in: fc5976cd95d4812656d4f8c1f6a347ff67f4f6f9

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).