### PR TITLE
Document data stream backing-index modification and restore attach

### DIFF
--- a/_api-reference/index-apis/modify-data-stream.md
+++ b/_api-reference/index-apis/modify-data-stream.md
@@ -1,0 +1,106 @@
+---
+layout: default
+title: Modify data stream
+parent: Index APIs
+nav_order: 85
+---
+
+# Modify Data Stream API
+**Introduced 3.8**
+{: .label .label-purple }
+
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/8271).
+{: .warning}
+
+The Modify Data Stream API adds or removes backing indexes of a [data stream]({{site.url}}{{site.baseurl}}/im-plugin/data-streams/). It is a metadata-only operation: all actions in a request are applied atomically in a single cluster-state update, and no shards are created, deleted, restored, or relocated. Use this API to migrate a pre-existing regular index into a data stream or to detach a backing index without deleting its data.
+
+## Endpoints
+
+```json
+POST /_data_stream/_modify
+```
+
+## Query parameters
+
+The following table lists the available query parameters. All query parameters are optional.
+
+| Parameter | Data type | Description |
+| :--- | :--- | :--- |
+| `cluster_manager_timeout` | Time | The amount of time to wait for a response from the cluster manager node. Default is `30s`. |
+| `timeout` | Time | The amount of time to wait for a response from the cluster. Default is `30s`. |
+
+## Request body fields
+
+The request body must contain an `actions` array in which each element is a single-key object specifying one action. The following table lists the available request body fields.
+
+| Field | Data type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| `actions` | Array | A list of actions to perform. Each element is an object with exactly one action: `add_backing_index` or `remove_backing_index`. You must provide at least one action. | Yes |
+| `actions[].add_backing_index` | Object | Adds an existing index to the data stream as a backing index. | No |
+| `actions[].add_backing_index.data_stream` | String | The name of the data stream to modify. | Yes |
+| `actions[].add_backing_index.index` | String | The name of the index to add as a backing index. | Yes |
+| `actions[].remove_backing_index` | Object | Removes a backing index from the data stream. | No |
+| `actions[].remove_backing_index.data_stream` | String | The name of the data stream to modify. | Yes |
+| `actions[].remove_backing_index.index` | String | The name of the backing index to remove. | Yes |
+
+## Behavior
+
+Keep the following behavior in mind when modifying a data stream:
+
+- Add and remove actions change only the data stream metadata; the index and its data are not modified.
+- You can include multiple add and remove actions in a request. The actions are applied atomically, and the result is independent of the action order.
+- The data stream generation is derived from its backing indexes (the highest backing-index counter is the write index) and cannot be set directly.
+- The write index cannot be removed, and removing the last backing index is rejected.
+- An added index must map the data stream's timestamp field as a `date` or `date_nanos`. An added index is marked as hidden; a removed index is made visible again.
+- An added index need not follow the `.ds-<data_stream>-NNNNNN` naming convention, which allows you to migrate a pre-existing regular index into a data stream.
+- An index cannot be a backing index of more than one data stream.
+
+## Example request
+
+The following request removes a backing index from the `logs-foo` data stream and adds the pre-existing `legacy-logs-2023` index to it in a single atomic operation:
+
+```json
+POST /_data_stream/_modify
+{
+  "actions": [
+    {
+      "remove_backing_index": {
+        "data_stream": "logs-foo",
+        "index": ".ds-logs-foo-000001"
+      }
+    },
+    {
+      "add_backing_index": {
+        "data_stream": "logs-foo",
+        "index": "legacy-logs-2023"
+      }
+    }
+  ]
+}
+```
+{% include copy-curl.html %}
+
+## Example response
+
+```json
+{
+  "acknowledged": true
+}
+```
+
+## Response body fields
+
+The following table lists all available response body fields.
+
+| Field | Data type | Description |
+| :--- | :--- | :--- |
+| `acknowledged` | Boolean | Whether the request was acknowledged and the cluster-state update was applied. |
+
+## Required permissions
+
+If you use the Security plugin, make sure you have the appropriate permissions: `indices:admin/data_stream/modify`.
+
+## Related documentation
+
+- [Data streams]({{site.url}}{{site.baseurl}}/im-plugin/data-streams/)
+- [Data Stream Stats API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/data-stream-stats/)

--- a/_api-reference/index-apis/modify-data-stream.md
+++ b/_api-reference/index-apis/modify-data-stream.md
@@ -12,7 +12,17 @@ nav_order: 85
 This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/8271).
 {: .warning}
 
-The Modify Data Stream API adds or removes backing indexes of a [data stream]({{site.url}}{{site.baseurl}}/im-plugin/data-streams/). It is a metadata-only operation: all actions in a request are applied atomically in a single cluster-state update, and no shards are created, deleted, restored, or relocated. Use this API to migrate a pre-existing regular index into a data stream or to detach a backing index without deleting its data.
+The Modify Data Stream API adds or removes backing indexes of a [data stream]({{site.url}}{{site.baseurl}}/im-plugin/data-streams/). Use this API to migrate a pre-existing regular index into a data stream or to detach a backing index without deleting its data.
+
+The following behaviors and restrictions apply when you add or remove backing indexes:
+
+- Add and remove actions change only the data stream metadata; the index and its data remain unchanged. No shards are created, deleted, restored, or relocated.
+- You can include multiple add and remove actions in a request. All actions are applied atomically in a single cluster state update, and the result is independent of the action order.
+- The data stream generation is derived from its backing indexes (the highest backing-index counter is the write index) and cannot be set directly.
+- The write index cannot be removed, and removing the last backing index is rejected.
+- An added index must map the data stream's timestamp field as a `date` or `date_nanos`. An added index is marked as hidden; a removed index is made visible again.
+- An added index need not follow the `.ds-<data_stream>-NNNNNN` naming convention, which allows you to migrate a pre-existing regular index into a data stream.
+- An index cannot be a backing index of more than one data stream.
 
 ## Endpoints
 
@@ -31,29 +41,22 @@ The following table lists the available query parameters. All query parameters a
 
 ## Request body fields
 
-The request body must contain an `actions` array in which each element is a single-key object specifying one action. The following table lists the available request body fields.
+The following table lists the available request body fields.
 
-| Field | Data type | Description | Required |
-| :--- | :--- | :--- | :--- |
-| `actions` | Array | A list of actions to perform. Each element is an object with exactly one action: `add_backing_index` or `remove_backing_index`. You must provide at least one action. | Yes |
-| `actions[].add_backing_index` | Object | Adds an existing index to the data stream as a backing index. | No |
-| `actions[].add_backing_index.data_stream` | String | The name of the data stream to modify. | Yes |
-| `actions[].add_backing_index.index` | String | The name of the index to add as a backing index. | Yes |
-| `actions[].remove_backing_index` | Object | Removes a backing index from the data stream. | No |
-| `actions[].remove_backing_index.data_stream` | String | The name of the data stream to modify. | Yes |
-| `actions[].remove_backing_index.index` | String | The name of the backing index to remove. | Yes |
+| Field | Data type | Description |
+| :--- | :--- | :--- |
+| `actions` | Array | A list of actions to perform. You must provide at least one action. Required. |
 
-## Behavior
+Each element in the `actions` array is a single-key object that specifies one action. The following table lists the available action fields.
 
-Keep the following behavior in mind when modifying a data stream:
-
-- Add and remove actions change only the data stream metadata; the index and its data are not modified.
-- You can include multiple add and remove actions in a request. The actions are applied atomically, and the result is independent of the action order.
-- The data stream generation is derived from its backing indexes (the highest backing-index counter is the write index) and cannot be set directly.
-- The write index cannot be removed, and removing the last backing index is rejected.
-- An added index must map the data stream's timestamp field as a `date` or `date_nanos`. An added index is marked as hidden; a removed index is made visible again.
-- An added index need not follow the `.ds-<data_stream>-NNNNNN` naming convention, which allows you to migrate a pre-existing regular index into a data stream.
-- An index cannot be a backing index of more than one data stream.
+| Field | Data type | Description |
+| :--- | :--- | :--- |
+| `add_backing_index.data_stream` | String | The name of the data stream to modify. Required. |
+| `add_backing_index.index` | String | The name of the index to add as a backing index. Required. |
+| `remove_backing_index.data_stream` | String | The name of the data stream to modify. Required. |
+| `remove_backing_index.index` | String | The name of the backing index to remove. Required. |
+| `add_backing_index` | Object | Adds an existing index to the data stream as a backing index. Optional. |
+| `remove_backing_index` | Object | Removes a backing index from the data stream. Optional. |
 
 ## Example request
 
@@ -87,14 +90,6 @@ POST /_data_stream/_modify
   "acknowledged": true
 }
 ```
-
-## Response body fields
-
-The following table lists all available response body fields.
-
-| Field | Data type | Description |
-| :--- | :--- | :--- |
-| `acknowledged` | Boolean | Whether the request was acknowledged and the cluster-state update was applied. |
 
 ## Required permissions
 

--- a/_api-reference/snapshots/restore-snapshot.md
+++ b/_api-reference/snapshots/restore-snapshot.md
@@ -44,7 +44,7 @@ All request body parameters are optional.
 
 | Parameter | Data type | Description |
 :--- | :--- | :--- 
-| `attach_to_data_stream` | Boolean | Whether to attach a restored backing index to a pre-existing data stream of the same name. This is an experimental feature, introduced in OpenSearch 3.8. When `true`, a restored index whose name matches the `.ds-<data_stream>-NNNNNN` backing-index convention is attached to a pre-existing data stream of the same name as part of the restore operation, advancing the stream generation as needed. The attached index must map the data stream's timestamp field as a `date`. When `false`, the index is restored as a standalone index, preserving the default behavior. Default is `false`. |
+| `attach_to_data_stream` (Experimental) | Boolean | Whether to attach a restored backing index to a pre-existing data stream of the same name. When `true`, a restored index whose name matches the `.ds-<data_stream>-NNNNNN` backing index convention is attached to a pre-existing data stream of the same name as part of the restore operation, advancing the stream generation as needed. The attached index must map the data stream's timestamp field as a `date`. When `false`, the index is restored as a standalone index. Default is `false`. See [Attach a restored backing index to a data stream](#attach-a-restored-backing-index-to-a-data-stream).|
 | `ignore_unavailable` | Boolean | How to handle data streams or indexes that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed. If `true`, the request ignores data streams and indexes in indexes that are missing or closed. Defaults to `false`. |
 | `ignore_index_settings` | Boolean | A comma-delimited list of index settings that you don't want to restore from a snapshot. |
 | `include_aliases` | Boolean | How to handle index aliases from the original snapshot. If `true`, index aliases from the original snapshot are restored. If `false`, aliases along with associated indexes are not restored. Defaults to `true`. |
@@ -174,11 +174,13 @@ The target cluster will restore the index and configure it to read remote segmen
 For the complete step-by-step procedure, see [Restoring snapshots across remote-backed clusters]({{site.url}}{{site.baseurl}}/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/#restoring-snapshots-across-remote-backed-clusters).
 
 ### Attach a restored backing index to a data stream
+**Introduced 3.8**
+{: .label .label-purple }
 
-This is an experimental feature, introduced in OpenSearch 3.8.
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, see the associated [GitHub issue](https://github.com/opensearch-project/OpenSearch/issues/8271).
 {: .warning}
 
-Set `attach_to_data_stream` to `true` to attach a restored backing index to a pre-existing data stream of the same name. The restored index name must match the `.ds-<data_stream>-NNNNNN` backing-index convention, and the index must map the stream's timestamp field as a `date`. The following request restores the `.ds-logs-foo-000001` backing index and attaches it to the existing `logs-foo` data stream, advancing the stream generation as needed:
+To attach a restored backing index to a pre-existing data stream with the same name, set `attach_to_data_stream` to `true`. The restored index name must match the `.ds-<data_stream>-NNNNNN` backing index convention, and the index must map the stream's timestamp field as a `date`. The following request restores the `.ds-logs-foo-000001` backing index and attaches it to the existing `logs-foo` data stream, advancing the stream generation as needed:
 
 ```json
 POST /_snapshot/my-opensearch-repo/my-first-snapshot/_restore
@@ -189,7 +191,7 @@ POST /_snapshot/my-opensearch-repo/my-first-snapshot/_restore
 ```
 {% include copy-curl.html %}
 
-To modify the backing indexes of a data stream without restoring from a snapshot, use the [Modify Data Stream API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/modify-data-stream/).
+To add or remove backing indexes of a data stream without restoring an index from a snapshot, use the [Modify Data Stream API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/modify-data-stream/).
 
 ## Example response
 

--- a/_api-reference/snapshots/restore-snapshot.md
+++ b/_api-reference/snapshots/restore-snapshot.md
@@ -44,6 +44,7 @@ All request body parameters are optional.
 
 | Parameter | Data type | Description |
 :--- | :--- | :--- 
+| `attach_to_data_stream` | Boolean | Whether to attach a restored backing index to a pre-existing data stream of the same name. This is an experimental feature, introduced in OpenSearch 3.8. When `true`, a restored index whose name matches the `.ds-<data_stream>-NNNNNN` backing-index convention is attached to a pre-existing data stream of the same name as part of the restore operation, advancing the stream generation as needed. The attached index must map the data stream's timestamp field as a `date`. When `false`, the index is restored as a standalone index, preserving the default behavior. Default is `false`. |
 | `ignore_unavailable` | Boolean | How to handle data streams or indexes that are missing or closed. If `false`, the request returns an error for any data stream or index that is missing or closed. If `true`, the request ignores data streams and indexes in indexes that are missing or closed. Defaults to `false`. |
 | `ignore_index_settings` | Boolean | A comma-delimited list of index settings that you don't want to restore from a snapshot. |
 | `include_aliases` | Boolean | How to handle index aliases from the original snapshot. If `true`, index aliases from the original snapshot are restored. If `false`, aliases along with associated indexes are not restored. Defaults to `true`. |
@@ -171,6 +172,24 @@ response = client.snapshot.restore(
 The target cluster will restore the index and configure it to read remote segments and translogs from the source cluster's remote store repositories.
 
 For the complete step-by-step procedure, see [Restoring snapshots across remote-backed clusters]({{site.url}}{{site.baseurl}}/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/#restoring-snapshots-across-remote-backed-clusters).
+
+### Attach a restored backing index to a data stream
+
+This is an experimental feature, introduced in OpenSearch 3.8.
+{: .warning}
+
+Set `attach_to_data_stream` to `true` to attach a restored backing index to a pre-existing data stream of the same name. The restored index name must match the `.ds-<data_stream>-NNNNNN` backing-index convention, and the index must map the stream's timestamp field as a `date`. The following request restores the `.ds-logs-foo-000001` backing index and attaches it to the existing `logs-foo` data stream, advancing the stream generation as needed:
+
+```json
+POST /_snapshot/my-opensearch-repo/my-first-snapshot/_restore
+{
+  "indices": ".ds-logs-foo-000001",
+  "attach_to_data_stream": true
+}
+```
+{% include copy-curl.html %}
+
+To modify the backing indexes of a data stream without restoring from a snapshot, use the [Modify Data Stream API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/modify-data-stream/).
 
 ## Example response
 

--- a/_im-plugin/data-streams.md
+++ b/_im-plugin/data-streams.md
@@ -36,9 +36,10 @@ PUT _index_template/logs-template
   "priority": 100
 }
 ```
+{% include copy-curl.html %}
 
 In this case, each ingested document must have an `@timestamp` field.
-You also have the ability to define your own custom timestamp field as a property in the `data_stream` object. You can also add index mappings and other settings here, the same way as you would for a regular index template.
+You also have the ability to define your own custom timestamp field as a property in the `data_stream` object. You can also add index mappings and other settings here, the same way as you would for a regular index template:
 
 ```json
 PUT _index_template/logs-template-nginx
@@ -58,6 +59,7 @@ PUT _index_template/logs-template-nginx
   }
 }
 ```
+{% include copy-curl.html %}
 
 In this case, `logs-nginx` index matches both the `logs-template` and `logs-template-nginx` templates. When you have a tie, OpenSearch selects the matching index template with the higher priority value.
 
@@ -73,7 +75,7 @@ PUT _data_stream/logs-nginx
 
 You can also directly start ingesting data without creating a data stream.
 
-Because we have a matching index template with a data_stream object, OpenSearch automatically creates the data stream:
+Because we have a matching index template with a `data_stream` object, OpenSearch automatically creates the data stream:
 
 ```json
 POST logs-staging/_doc
@@ -82,12 +84,14 @@ POST logs-staging/_doc
   "@timestamp": "2013-03-01T00:00:00"
 }
 ```
+{% include copy-curl.html %}
 
 To see information about a specific data stream:
 
 ```json
 GET _data_stream/logs-nginx
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -120,6 +124,7 @@ To see more insights about the data stream, use the `_stats` endpoint:
 ```json
 GET _data_stream/logs-nginx/_stats
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -149,6 +154,7 @@ To see information about all data streams, use the following request:
 ```json
 GET _data_stream
 ```
+{% include copy-curl.html %}
 
 ### Step 3: Ingest data into the data stream
 
@@ -161,11 +167,14 @@ POST logs-redis/_doc
   "@timestamp": "2013-03-01T00:00:00"
 }
 ```
+{% include copy-curl.html %}
 
 ### Step 4: Searching a data stream
 
 You can search a data stream just like you search a regular index or an index alias.
 The search operation applies to all of the backing indexes (all data present in the stream).
+
+The following request searches the `logs-redis` data stream for documents matching `login`:
 
 ```json
 GET logs-redis/_search
@@ -177,6 +186,7 @@ GET logs-redis/_search
   }
 }
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -212,7 +222,9 @@ GET logs-redis/_search
 }
 ```
 
-### Step 5: Rollover a data stream
+You can also query a data stream directly using [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/index/), [SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/), or [PPL]({{site.url}}{{site.baseurl}}/search-plugins/sql/ppl/index/).
+
+### Step 5: Roll over a data stream
 
 A rollover operation creates a new backing index that becomes the data stream’s new write index.
 
@@ -221,6 +233,7 @@ To perform manual rollover operation on the data stream:
 ```json
 POST logs-redis/_rollover
 ```
+{% include copy-curl.html %}
 
 #### Example response
 
@@ -267,6 +280,7 @@ To delete a data stream and all of its hidden backing indexes:
 ```json
 DELETE _data_stream/{name_of_data_stream}
 ```
+{% include copy-curl.html %}
 
 You can use wildcards to delete more than one data stream.
 
@@ -276,7 +290,6 @@ We recommend deleting data from a data stream using an ISM policy.
 
 You can add or remove backing indexes of an existing data stream using the [Modify Data Stream API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/modify-data-stream/). This is a metadata-only operation that lets you migrate a pre-existing regular index into a data stream or detach a backing index without deleting its data. You can also attach a restored backing index to a data stream during a snapshot restore by setting `attach_to_data_stream` to `true` in the [Restore Snapshot API]({{site.url}}{{site.baseurl}}/api-reference/snapshots/restore-snapshot/).
 
-Both features are experimental in OpenSearch 3.8.
-{: .note}
+## Data stream permissions
 
-You can also use [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/index/), [SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/), and [PPL]({{site.url}}{{site.baseurl}}/search-plugins/sql/ppl/index/) to query your data stream directly. You can also use the Security plugin to define granular permissions for the data stream name.
+Use the Security plugin to define granular permissions for the data stream name. For more information, see [Permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/).

--- a/_im-plugin/data-streams.md
+++ b/_im-plugin/data-streams.md
@@ -272,4 +272,11 @@ You can use wildcards to delete more than one data stream.
 
 We recommend deleting data from a data stream using an ISM policy.
 
+### Step 8: Modify the backing indexes of a data stream
+
+You can add or remove backing indexes of an existing data stream using the [Modify Data Stream API]({{site.url}}{{site.baseurl}}/api-reference/index-apis/modify-data-stream/). This is a metadata-only operation that lets you migrate a pre-existing regular index into a data stream or detach a backing index without deleting its data. You can also attach a restored backing index to a data stream during a snapshot restore by setting `attach_to_data_stream` to `true` in the [Restore Snapshot API]({{site.url}}{{site.baseurl}}/api-reference/snapshots/restore-snapshot/).
+
+Both features are experimental in OpenSearch 3.8.
+{: .note}
+
 You can also use [asynchronous search]({{site.url}}{{site.baseurl}}/search-plugins/async/index/), [SQL]({{site.url}}{{site.baseurl}}/search-plugins/sql/index/), and [PPL]({{site.url}}{{site.baseurl}}/search-plugins/sql/ppl/index/) to query your data stream directly. You can also use the Security plugin to define granular permissions for the data stream name.


### PR DESCRIPTION
Adds Modify Data Stream API reference (POST /_data_stream/_modify), documents the experimental `attach_to_data_stream` restore parameter, and links both from the data streams guide.

### Description
  Documents two experimental features added in OpenSearch 3.8:
  - **Modify Data Stream API** — new reference page for `POST /_data_stream/_modify`, a metadata-only API to add/remove backing indexes of a data stream.
  - **`attach_to_data_stream` restore parameter** — new request body field on the Restore Snapshot API that attaches a restored `.ds-<stream>-NNNNNN` backing index to a pre-existing data stream.
  
 Both are cross-linked from the Data streams guide.
  
### Issues Resolved
 Closes #12858
  
### Version
 3.8

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
