### PR TITLE
docs: Add flatten_separator parameter to flatten processor

### DIFF
--- a/_data-prepper/pipelines/configuration/processors/flatten.md
+++ b/_data-prepper/pipelines/configuration/processors/flatten.md
@@ -22,7 +22,7 @@ Option | Required | Type | Description
 `remove_processed_fields` | No | Boolean | When `true`, the processor removes all processed fields from the source. Default is `false`.
 `remove_list_indices` | No | Boolean | When `true`, the processor converts the fields from the source map into lists and puts the lists into the target field. Default is `false`.
 `flatten_when` | No | String | A [conditional expression]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/), such as `/some-key == "test"'`, that determines whether the `flatten` processor will be run on the event. Default is `null`, which means that all events will be processed unless otherwise stated.
-`flatten_separator` | No | String | The character used to join nested key names into flattened keys. Must be a single character. Default is `"."`.
+`flatten_separator` | No | String | The character used to join nested key names into flattened keys. Must be a single character. Default is `.`.
 `tags_on_failure` | No | List | A list of tags to add to the event metadata when the event fails to process.
 
 ## Usage
@@ -258,7 +258,7 @@ Use the `flatten_separator` option to specify a custom character for joining nes
 ```
 {% include copy.html %}
 
-For example, when the input event contains the following nested objects:
+Consider an input event that contains the following nested objects:
 
 ```json
 {

--- a/_data-prepper/pipelines/configuration/processors/flatten.md
+++ b/_data-prepper/pipelines/configuration/processors/flatten.md
@@ -22,6 +22,7 @@ Option | Required | Type | Description
 `remove_processed_fields` | No | Boolean | When `true`, the processor removes all processed fields from the source. Default is `false`.
 `remove_list_indices` | No | Boolean | When `true`, the processor converts the fields from the source map into lists and puts the lists into the target field. Default is `false`.
 `flatten_when` | No | String | A [conditional expression]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/expression-syntax/), such as `/some-key == "test"'`, that determines whether the `flatten` processor will be run on the event. Default is `null`, which means that all events will be processed unless otherwise stated.
+`flatten_separator` | No | String | The character used to join nested key names into flattened keys. Must be a single character. Default is `"."`.
 `tags_on_failure` | No | List | A list of tags to add to the event metadata when the event fails to process.
 
 ## Usage
@@ -238,5 +239,59 @@ The processor removes all indexes from the output and places them into the sourc
   "key2.key3.key4": "val2",
   "list1[].list2[].name": ["name1","name2"],
   "list1[].list2[].value": ["value1","value2"]
+}
+```
+
+### Custom separator
+
+Use the `flatten_separator` option to specify a custom character for joining nested key names. The default separator is `.`, but you can use any single character, such as `_`, as shown in the following example:
+
+```yaml
+...
+  processor:
+    - flatten:
+        source: "log"
+        target: ""
+        flatten_separator: "_"
+        remove_processed_fields: true
+...
+```
+{% include copy.html %}
+
+For example, when the input event contains the following nested objects:
+
+```json
+{
+  "timestamp": "2026-07-29T12:00:00Z",
+  "service": "user-service",
+  "log": {
+    "request": {
+      "method": "POST",
+      "url": "/api/v1/users",
+      "headers": {
+        "content_type": "application/json"
+      }
+    },
+    "response": {
+      "status": 200,
+      "body": {
+        "user_id": "usr_12345"
+      }
+    }
+  }
+}
+```
+
+The `flatten` processor flattens the `log` field using `_` as the separator and places the results at the root of the event, as shown in the following output:
+
+```json
+{
+  "timestamp": "2026-07-29T12:00:00Z",
+  "service": "user-service",
+  "request_method": "POST",
+  "request_url": "/api/v1/users",
+  "request_headers_content_type": "application/json",
+  "response_status": 200,
+  "response_body_user_id": "usr_12345"
 }
 ```


### PR DESCRIPTION
Document the new flatten_separator configuration option that allows specifying a custom character for joining nested key names. Includes configuration table entry and usage example with underscore separator.

### Description
(https://github.com/opensearch-project/data-prepper/pull/7042)

### Issues Resolved
Closes #[_Replace this text, including the brackets, with the issue number._ **Leave "Closes #" so the issue is closed properly.**]

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [ ] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
