### PR TITLE
Backport PR #12492 to 2.19

### DIFF
--- a/FORMATTING_GUIDE.md
+++ b/FORMATTING_GUIDE.md
@@ -155,6 +155,19 @@ To insert a closed collapsible block, omit the `open` state:
 
 Collapsible blocks are useful for long responses and for the Table of Contents at the beginning of a page.
 
+To insert a collapsible Table of contents, use the following markup:
+
+````html
+<details markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
+- TOC
+{:toc}
+</details>
+````
+
 ## Dashes
 
 Use one dash for hyphens, two for en dashes, and three for em dashes:

--- a/_tuning-your-cluster/replication-plugin/api.md
+++ b/_tuning-your-cluster/replication-plugin/api.md
@@ -12,40 +12,54 @@ canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/replicatio
 
 Use these replication operations to programmatically manage cross-cluster replication.
 
-#### Table of contents
+<details markdown="block">
+  <summary>
+    Table of contents
+  </summary>
+  {: .text-delta }
 - TOC
 {:toc}
+</details>
 
 ## Start replication
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Initiate replication of an index from the leader cluster to the follower cluster. Send this request to the follower cluster.
 
 
-#### Request
+### Endpoints
 
 ```json
 PUT /_plugins/_replication/<follower-index>/_start
+```
+
+### Request body fields
+
+The following table lists the available request body fields.
+
+| Field | Data type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| `leader_alias` | String | The name of the cross-cluster connection. You define this alias when you [set up a cross-cluster connection]({{site.url}}{{site.baseurl}}/replication-plugin/get-started/#set-up-a-cross-cluster-connection). | Yes |
+| `leader_index` | String | The index on the leader cluster that you want to replicate. | Yes |
+| `use_roles` | Object | The roles to use for all subsequent backend replication tasks between the indexes. Specify a `leader_cluster_role` and `follower_cluster_role`. See [Map the leader and follower cluster roles]({{site.url}}{{site.baseurl}}/replication-plugin/permissions/#map-the-leader-and-follower-cluster-roles). | If Security plugin is enabled |
+
+### Example request
+
+```json
+PUT /_plugins/_replication/follower-01/_start
 {
-   "leader_alias":"<connection-alias-name>",
-   "leader_index":"<index-name>",
-   "use_roles":{
-      "leader_cluster_role":"<role-name>",
-      "follower_cluster_role":"<role-name>"
+   "leader_alias": "my-connection-alias",
+   "leader_index": "leader-01",
+   "use_roles": {
+      "leader_cluster_role": "cross_cluster_replication_leader_full_access",
+      "follower_cluster_role": "cross_cluster_replication_follower_full_access"
    }
 }
 ```
+{% include copy-curl.html %}
 
-Specify the following options:
-
-Options | Description | Type | Required
-:--- | :--- |:--- |:--- |
-`leader_alias` |  The name of the cross-cluster connection. You define this alias when you [set up a cross-cluster connection]({{site.url}}{{site.baseurl}}/replication-plugin/get-started/#set-up-a-cross-cluster-connection). | `string` | Yes
-`leader_index` |  The index on the leader cluster that you want to replicate. | `string` | Yes
-`use_roles` |  The roles to use for all subsequent backend replication tasks between the indexes. Specify a `leader_cluster_role` and `follower_cluster_role`. See [Map the leader and follower cluster roles]({{site.url}}{{site.baseurl}}/replication-plugin/permissions/#map-the-leader-and-follower-cluster-roles). | `string` | If Security plugin is enabled
-
-#### Example response
+### Example response
 
 ```json
 {
@@ -54,19 +68,26 @@ Options | Description | Type | Required
 ```
 
 ## Stop replication
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Terminates replication and converts the follower index to a standard index. Send this request to the follower cluster.
 
-#### Request
+### Endpoints
 
 ```json
 POST /_plugins/_replication/<follower-index>/_stop
-{}
 ```
 
-#### Example response
+### Example request
+
+```json
+POST /_plugins/_replication/follower-01/_stop
+{}
+```
+{% include copy-curl.html %}
+
+### Example response
 
 ```json
 {
@@ -75,21 +96,28 @@ POST /_plugins/_replication/<follower-index>/_stop
 ```
 
 ## Pause replication
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Pauses replication of the leader index. Send this request to the follower cluster.
 
-#### Request
+### Endpoints
 
 ```json
-POST /_plugins/_replication/<follower-index>/_pause 
-{}
+POST /_plugins/_replication/<follower-index>/_pause
 ```
 
-You can't resume replication after it's been paused for more than 12 hours. You must [stop replication]({{site.url}}{{site.baseurl}}/replication-plugin/api/#stop-replication), delete the follower index, and restart replication of the leader.
+### Example request
 
-#### Example response
+```json
+POST /_plugins/_replication/follower-01/_pause
+{}
+```
+{% include copy-curl.html %}
+
+You can't resume replication after it's been paused longer than the retention lease period. To recover, use [force-resume]({{site.url}}{{site.baseurl}}/tuning-your-cluster/replication-plugin/force-resume/), which restores the follower index from a snapshot of the leader.
+
+### Example response
 
 ```json
 {
@@ -98,19 +126,34 @@ You can't resume replication after it's been paused for more than 12 hours. You 
 ```
 
 ## Resume replication
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Resumes replication of the leader index. Send this request to the follower cluster.
 
-#### Request
+### Endpoints
 
 ```json
 POST /_plugins/_replication/<follower-index>/_resume
-{}
 ```
 
-#### Example response
+### Request body fields
+
+The following table lists the available request body fields.
+
+| Field | Data type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| `force_resume` | Boolean | When set to `true`, performs a stop-delete-start cycle to restore the follower index from the leader when retention leases have expired. Use this when replication has been paused for more than 12 hours and a normal resume fails. For more information, see [Force resume replication]({{site.url}}{{site.baseurl}}/tuning-your-cluster/replication-plugin/force-resume/). Default is `false`. | No |
+
+### Example request
+
+```json
+POST /_plugins/_replication/follower-01/_resume
+{}
+```
+{% include copy-curl.html %}
+
+### Example response
 
 ```json
 {
@@ -118,19 +161,38 @@ POST /_plugins/_replication/<follower-index>/_resume
 }
 ```
 
+### Error responses
+
+The following table describes common error responses for the resume operation.
+
+| Status code | Error | Description |
+| :--- | :--- | :--- |
+| 404 | `Retention lease doesn't exist. Use force_resume=true to restore from snapshot.` | The retention lease has expired and `force_resume` was not set to `true`. Retry the request with `"force_resume": true`. |
+| 400 | Replication is not in PAUSED state | Force resume can only be used when replication is paused. Check the replication status first. |
+| 500 | Failed to stop replication | The internal stop operation failed. Verify cluster health and retry. |
+| 500 | Failed to delete follower index | The follower index could not be deleted after stopping replication. Manual cleanup may be required. |
+| 500 | Failed to start replication | The internal start operation failed after the follower was deleted. You may need to manually start replication again. |
+
 ## Get replication status
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Gets the status of index replication. Possible statuses are `SYNCING`, `BOOTSTRAPING`, `PAUSED`, and `REPLICATION NOT IN PROGRESS`. Use the syncing details to measure replication lag. Send this request to the follower cluster.
 
-#### Request
+### Endpoints
 
 ```json
 GET /_plugins/_replication/<follower-index>/_status
 ```
 
-#### Example response
+### Example request
+
+```json
+GET /_plugins/_replication/follower-01/_status
+```
+{% include copy-curl.html %}
+
+### Example response
 
 ```json
 {
@@ -151,18 +213,25 @@ To include shard replication details in the response, add the `&verbose=true` pa
 The leader and follower checkpoint values begin as negative integers and reflect the shard count (-1 for one shard, -5 for five shards, and so on). The values increment toward positive integers with each change that you make. For example, when you make a change on the leader index, the `leader_checkpoint` becomes `0`. The `follower_checkpoint` is initially still `-1` until the follower index pulls the change from the leader, at which point it increments to `0`. If the values are the same, it means the indexes are fully synced.
 
 ## Get leader cluster stats
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Gets information about replicated leader indexes on a specified cluster. 
 
-#### Request
+### Endpoints
 
 ```json
 GET /_plugins/_replication/leader_stats
 ```
 
-#### Example response
+### Example request
+
+```json
+GET /_plugins/_replication/leader_stats
+```
+{% include copy-curl.html %}
+
+### Example response
 
 ```json
 {
@@ -198,18 +267,25 @@ GET /_plugins/_replication/leader_stats
 ```
 
 ## Get follower cluster stats
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Gets information about follower (syncing) indexes on a specified cluster. 
 
-#### Request
+### Endpoints
 
 ```json
 GET /_plugins/_replication/follower_stats
 ```
 
-#### Example response
+### Example request
+
+```json
+GET /_plugins/_replication/follower_stats
+```
+{% include copy-curl.html %}
+
+### Example response
 
 ```json
 {
@@ -256,18 +332,25 @@ GET /_plugins/_replication/follower_stats
 ```
 
 ## Get auto-follow stats
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Gets information about auto-follow activity and any replication rules configured on the specified cluster.
 
-#### Request
+### Endpoints
 
 ```json
 GET /_plugins/_replication/autofollow_stats
 ```
 
-#### Example response
+### Example request
+
+```json
+GET /_plugins/_replication/autofollow_stats
+```
+{% include copy-curl.html %}
+
+### Example response
 
 ```json
 {
@@ -293,24 +376,31 @@ GET /_plugins/_replication/autofollow_stats
 ```
 
 ## Update settings
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Updates settings on the follower index.
 
-#### Request
+### Endpoints
 
 ```json
 PUT /_plugins/_replication/<follower-index>/_update
+```
+
+### Example request
+
+```json
+PUT /_plugins/_replication/follower-01/_update
 {
-   "settings":{
+   "settings": {
       "index.number_of_shards": 4,
       "index.number_of_replicas": 2
    }
 }
 ```
+{% include copy-curl.html %}
 
-#### Example response
+### Example response
 
 ```json
 {
@@ -319,7 +409,7 @@ PUT /_plugins/_replication/<follower-index>/_update
 ```
 
 ## Create replication rule
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Automatically starts replication on indexes matching a specified pattern. If a new index on the leader cluster matches the pattern, OpenSearch automatically creates a follower index and begins replication. You can also use this API to update existing replication rules.
@@ -329,31 +419,40 @@ Send this request to the follower cluster.
 Make sure to note the names of all auto-follow patterns after you create them. The replication plugin currently does not include an API operation to retrieve a list of existing patterns.
 {: .tip }
 
-#### Request
+### Endpoints
+
+```json
+POST /_plugins/_replication/_autofollow
+```
+
+### Request body fields
+
+The following table lists the available request body fields.
+
+| Field | Data type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| `leader_alias` | String | The name of the cross-cluster connection. You define this alias when you [set up a cross-cluster connection]({{site.url}}{{site.baseurl}}/replication-plugin/get-started/#set-up-a-cross-cluster-connection). | Yes |
+| `name` | String | A name for the auto-follow pattern. | Yes |
+| `pattern` | String | An array of index patterns to match against indexes in the specified leader cluster. Supports wildcard characters. For example, `leader-*`. | Yes |
+| `use_roles` | Object | The roles to use for all subsequent backend replication tasks between the indexes. Specify a `leader_cluster_role` and `follower_cluster_role`. See [Map the leader and follower cluster roles]({{site.url}}{{site.baseurl}}/replication-plugin/permissions/#map-the-leader-and-follower-cluster-roles). | If Security plugin is enabled |
+
+### Example request
 
 ```json
 POST /_plugins/_replication/_autofollow
 {
-   "leader_alias" : "<connection-alias-name>",
-   "name": "<auto-follow-pattern-name>",
-   "pattern": "<pattern>",
-   "use_roles":{
-      "leader_cluster_role": "<role-name>",
-      "follower_cluster_role": "<role-name>"
+   "leader_alias": "my-connection-alias",
+   "name": "my-replication-rule",
+   "pattern": "leader-*",
+   "use_roles": {
+      "leader_cluster_role": "cross_cluster_replication_leader_full_access",
+      "follower_cluster_role": "cross_cluster_replication_follower_full_access"
    }
 }
 ```
+{% include copy-curl.html %}
 
-Specify the following options:
-
-Options | Description | Type | Required
-:--- | :--- |:--- |:--- |
-`leader_alias` |  The name of the cross-cluster connection. You define this alias when you [set up a cross-cluster connection]({{site.url}}{{site.baseurl}}/replication-plugin/get-started/#set-up-a-cross-cluster-connection). | `string` | Yes
-`name` |  A name for the auto-follow pattern. | `string` | Yes
-`pattern` |  An array of index patterns to match against indexes in the specified leader cluster. Supports wildcard characters. For example, `leader-*`. | `string` | Yes
-`use_roles` |  The roles to use for all subsequent backend replication tasks between the indexes. Specify a `leader_cluster_role` and `follower_cluster_role`. See [Map the leader and follower cluster roles]({{site.url}}{{site.baseurl}}/replication-plugin/permissions/#map-the-leader-and-follower-cluster-roles). | `string` | If Security plugin is enabled
-
-#### Example response
+### Example response
 
 ```json
 {
@@ -362,31 +461,40 @@ Options | Description | Type | Required
 ```
 
 ## Delete replication rule
-Introduced 1.1
+**Introduced 1.1**
 {: .label .label-purple }
 
 Deletes the specified replication rule. This operation prevents any new indexes from being replicated but does not stop existing replication that the rule has already initiated. Replicated indexes remain read-only until you stop replication.
 
 Send this request to the follower cluster.
 
-#### Request
+### Endpoints
+
+```json
+DELETE /_plugins/_replication/_autofollow
+```
+
+### Request body fields
+
+The following table lists the available request body fields.
+
+| Field | Data type | Description | Required |
+| :--- | :--- | :--- | :--- |
+| `leader_alias` | String | The name of the cross-cluster connection. You define this alias when you [set up a cross-cluster connection]({{site.url}}{{site.baseurl}}/replication-plugin/get-started/#set-up-a-cross-cluster-connection). | Yes |
+| `name` | String | The name of the pattern. | Yes |
+
+### Example request
 
 ```json
 DELETE /_plugins/_replication/_autofollow
 {
-   "leader_alias" : "<connection-alias-name>",
-   "name": "<auto-follow-pattern-name>",
+   "leader_alias": "my-connection-alias",
+   "name": "my-replication-rule"
 }
 ```
+{% include copy-curl.html %}
 
-Specify the following options:
-
-Options | Description | Type | Required
-:--- | :--- |:--- |:--- |
-`leader_alias` |  The name of the cross-cluster connection. You define this alias when you [set up a cross-cluster connection]({{site.url}}{{site.baseurl}}/replication-plugin/get-started/#set-up-a-cross-cluster-connection). | `string` | Yes
-`name` |  The name of the pattern. | `string` | Yes
-
-#### Example response
+### Example response
 
 ```json
 {

--- a/_tuning-your-cluster/replication-plugin/force-resume.md
+++ b/_tuning-your-cluster/replication-plugin/force-resume.md
@@ -1,0 +1,148 @@
+---
+layout: default
+title: Force-resume
+nav_order: 25
+parent: Cross-cluster replication
+---
+
+# Force-resume replication
+**Introduced 3.8**
+{: .label .label-purple }
+
+
+When cross-cluster replication is paused for longer than the retention lease duration (controlled by the `index.soft_deletes.retention_lease.period` setting on the leader index, which defaults to 12 hours), the leader cluster's translog no longer retains the operations needed by the follower. A normal resume request fails because the retention lease has expired. You can use the `force_resume` parameter when sending a resume request to restore the follower index from a snapshot of the leader and reestablish replication. This eliminates the need to manually stop the existing replication, delete the follower index, and start replication from the beginning.
+
+Force-resuming replication follows these steps:
+
+1. Validate that the replication is currently in a `PAUSED` state and that the retention lease has expired (making a normal resume impossible). If the retention lease has not expired, the `force_resume` flag is ignored and replication resumes normally.
+1. Stop replication by calling the existing stop replication action, which deletes replication metadata and removes the index block and the replication task.
+1. Delete the follower index so it can be restored from a snapshot.
+1. Start replication using the original connection alias and leader index configuration. This triggers a snapshot restore from the leader cluster and acquires new retention leases during the restore process.
+1. Resume translog-based replication after the restore completes. Shard replication tasks start and use the newly acquired retention leases to replicate ongoing operations from the leader.
+
+Force-resume uses the original replication permissions and does not require reconfiguration. All operations are logged for auditing.
+{: .note}
+
+## Force-resume workflow
+
+The following example demonstrates a complete force-resume workflow.
+
+### Step 1: Verify the replication status
+
+Confirm that replication is paused and identify the reason for the pause:
+
+```json
+GET /_plugins/_replication/follower-01/_status
+```
+{% include copy-curl.html %}
+
+For example, the following response shows that replication is in a user-initiated paused state:
+
+```json
+{
+  "status": "PAUSED",
+  "reason": "User initiated",
+  "leader_alias": "my-connection-alias",
+  "leader_index": "leader-01",
+  "follower_index": "follower-01"
+}
+```
+
+### Step 2: Attempt resuming replication normally
+
+Try to resume replication normally:
+
+```json
+POST /_plugins/_replication/follower-01/_resume
+{}
+```
+{% include copy-curl.html %}
+
+If the retention lease has expired, you receive the following error:
+
+```json
+{
+  "error": {
+    "root_cause": [{
+      "type": "resource_not_found_exception",
+      "reason": "Retention lease doesn't exist. Use force_resume=true to restore from snapshot."
+    }],
+    "type": "resource_not_found_exception",
+    "reason": "Retention lease doesn't exist. Use force_resume=true to restore from snapshot."
+  },
+  "status": 404
+}
+```
+
+### Step 3: Use force-resume
+
+Use force-resume to restore the follower index from a snapshot:
+
+```json
+POST /_plugins/_replication/follower-01/_resume
+{
+   "force_resume": true
+}
+```
+{% include copy-curl.html %}
+
+
+### Step 4: Monitor the resume progress
+
+After force-resume is initiated, the follower index is temporarily unavailable while the snapshot restore is in progress. To monitor its status, send the following request:
+
+```json
+GET /_plugins/_replication/follower-01/_status
+```
+{% include copy-curl.html %}
+
+During the snapshot restore, the `status` is `RESTORING`:
+
+```json
+{
+  "status": "RESTORING",
+  "reason": "User initiated",
+  "leader_alias": "my-connection-alias",
+  "leader_index": "leader-01",
+  "follower_index": "follower-01"
+}
+```
+
+After the restore completes, the `status` changes to `SYNCING`:
+
+```json
+{
+  "status": "SYNCING",
+  "reason": "User initiated",
+  "leader_alias": "my-connection-alias",
+  "leader_index": "leader-01",
+  "follower_index": "follower-01",
+  "syncing_details": {
+    "leader_checkpoint": 150,
+    "follower_checkpoint": 150,
+    "seq_no": 0
+  }
+}
+```
+
+## Failure recovery
+
+The following list describes the expected behavior if a failure occurs at any stage during force-resume:
+
+- If stop fails, the operation is aborted and the follower remains in a `PAUSED` state. No changes are made. You can retry force-resume.
+- If delete fails after stop, replication has been stopped but the follower index still exists. You can manually delete the index and start replication, or retry force-resume.
+- If start fails after delete, the follower index has been deleted and replication metadata has been removed. You need to manually start replication using the standard start replication API with the original connection alias and leader index.
+- If the snapshot restore fails, the replication task transitions to a failed state and auto-pauses. You can retry force-resume.
+
+## Limitations
+
+Note the following limitations:
+
+- During the force-resume process, the follower index is deleted and restored. It is unavailable for search queries during this time. The duration depends on the index size and network bandwidth between clusters.
+- Force-resume restores the entire index. There is no option to restore only specific shards.
+- After force-resume, the follower index is a fresh copy of the leader at the time of the snapshot restore, and replication continues from that point forward.
+- Only one resume or force-resume operation can run at a time for a given index. A second request sent while force-resume is in progress is rejected.
+
+## Related documentation
+
+- For the API reference, including the request syntax and parameters, see [Resume replication]({{site.url}}{{site.baseurl}}/tuning-your-cluster/replication-plugin/api/#resume-replication).

--- a/_tuning-your-cluster/replication-plugin/getting-started.md
+++ b/_tuning-your-cluster/replication-plugin/getting-started.md
@@ -213,7 +213,7 @@ curl -XPUT -k -H 'Content-Type: application/json' -u 'admin:<custom-admin-passwo
 If the Security plugin is disabled, omit the `use_roles` parameter. If it's enabled, however, you must specify the leader and follower cluster roles that OpenSearch will use to authenticate the request. This example uses `all_access` for simplicity, but we recommend creating a replication user on each cluster and [mapping it accordingly]({{site.url}}{{site.baseurl}}/replication-plugin/permissions/#map-the-leader-and-follower-cluster-roles).
 {: .tip }
 
-This command creates an identical read-only index named `follower-01` on the follower cluster that continuously stays updated with changes to the `leader-01` index on the leader cluster. Starting replication creates a follower index from scratch -- you can't convert an existing index to a follower index. 
+This command creates an identical read-only index named `follower-01` on the follower cluster that continuously stays updated with changes to the `leader-01` index on the leader cluster. Starting replication creates a new follower index---you can't convert an existing index to a follower index. 
 
 ## Confirm replication
 
@@ -263,7 +263,7 @@ curl -XGET -k -u 'admin:<custom-admin-password>' 'https://localhost:9200/followe
   }]
 }
 ```
-### `.replication-metadata-store` index
+### The `.replication-metadata-store` index
 
 The `.replication-metadata-store` index is a persistent data store for replication-related metadata and auto-follow rules inside of a cluster. It stores the replication metadata of each index being replicated from the leader cluster to the follower cluster.
 
@@ -302,7 +302,7 @@ curl -XPOST -k -H 'Content-Type: application/json' -u 'admin:<custom-admin-passw
 
 When replication resumes, the follower index picks up any changes that were made to the leader index while replication was paused.
 
-Note that you can't resume replication after it's been paused for more than 12 hours. You must [stop replication]({{site.url}}{{site.baseurl}}/replication-plugin/api/#stop-replication), delete the follower index, and restart replication of the leader.
+You can't resume replication after it's been paused longer than the retention lease period because the retention lease expires. To recover, use force-resume, which restores the follower index from a snapshot of the leader. For more information, see [Force-resume replication]({{site.url}}{{site.baseurl}}/tuning-your-cluster/replication-plugin/force-resume/).
 
 ## Stop replication
 


### PR DESCRIPTION
Backport of #12492 to 2.19.

Adds `force_resume` parameter documentation for the cross-cluster replication resume API, along with the accompanying `api.md` reformatting and new `force-resume.md` page.

Resolved cherry-pick conflicts in `api.md`: the 2.19 branch uses `<follower-index>` angle-bracket placeholders in endpoint paths (curly-brace placeholders were introduced on `main` by a separate change that was not backported). Per the actual scope of #12492, the reformatting was applied while preserving 2.19's existing `<follower-index>` syntax.
