### PR TITLE
Swap permalink and redirect for migrate-or-upgrade index

### DIFF
--- a/_migrate-or-upgrade/index.md
+++ b/_migrate-or-upgrade/index.md
@@ -3,11 +3,11 @@ layout: default
 title: Migrate or upgrade
 has_children: true
 has_toc: false
-permalink: /upgrade-or-migrate/
+permalink: /migrate-or-upgrade/
 redirect_from:
   - /migrate-or-upgrade/index/
   - /upgrade-opensearch/index/
-  - /migrate-or-upgrade/
+  - /upgrade-or-migrate/
   - /upgrade-to/index/
   - /upgrade-to/
   - /upgrade-to/upgrade-to/
@@ -17,6 +17,7 @@ redirect_from:
   - /upgrade-to/dashboards-upgrade-to/
 nav_exclude: true
 ---
+
 # Migrate or upgrade OpenSearch
 
 The OpenSearch Project releases regular updates that include new features, enhancements, and bug fixes. OpenSearch uses [Semantic Versioning](https://semver.org/), which means that breaking changes are only introduced between major version releases. To learn about upcoming features and fixes, review the [OpenSearch Project Roadmap](https://github.com/orgs/opensearch-project/projects/206) on GitHub. To view a list of previous releases or to learn more about how OpenSearch uses versioning, see [Release schedule and maintenance policy](https://opensearch.org/releases.html).


### PR DESCRIPTION
Sets the canonical permalink to `/migrate-or-upgrade/` and redirects the old `/upgrade-or-migrate/` path to it. Also adds a blank line between the front matter and the H1.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).