### PR TITLE
docs: add percentage type support for node.search.cache.size

### DIFF
--- a/_tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot.md
@@ -25,7 +25,7 @@ A `warm` node reserves storage for the cache to perform searchable snapshot quer
 
 Parameter | Type | Description
 :--- | :--- | :---
-`node.search.cache.size` | String | Specifies the cache size either as an absolute byte value (for example, `7kb` or `6gb`, using the units described in [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/)) or as a percentage of the total disk space (for example, `10%`).
+`node.search.cache.size` | String | Specifies the cache size as either an absolute byte size (for example, `7kb` or `6gb`) or a percentage of the total disk space (for example, `10%`). For more information about byte size units, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
 
 ## Searchable snapshot index settings
 

--- a/_tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot.md
@@ -25,7 +25,7 @@ A `warm` node reserves storage for the cache to perform searchable snapshot quer
 
 Parameter | Type | Description
 :--- | :--- | :---
-`node.search.cache.size` | Byte size | Specify the units for byte size. For example, `7kb` or `6gb`. For more information, see [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/).
+`node.search.cache.size` | String | Specifies the cache size either as an absolute byte value (for example, `7kb` or `6gb`, using the units described in [Supported units]({{site.url}}{{site.baseurl}}/opensearch/units/)) or as a percentage of the total disk space (for example, `10%`).
 
 ## Searchable snapshot index settings
 


### PR DESCRIPTION
### Description

The description for `node.search.cache.size` currently states that only byte-size values are supported. However, this parameter also accepts percentage values.

This PR changes the data type of `node.search.cache.size` to `String` and updates the description to indicate that it supports either percentage values or [Supported Units](https://docs.opensearch.org/latest/api-reference/units/)

### Version

All version that have support to Searchable Snapshot.

### Frontend features

https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/searchable_snapshot/#configuring-a-node-to-use-searchable-snapshots

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
