### PR TITLE
Remove CNAME from the main doc branch

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-docs-beta.opensearch.org


### PR DESCRIPTION
Remove CNAME from the main doc branch because docs are not built via GitHub pages but the style guide is.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
