### PR TITLE
Remove unused collections and self-referential redirects

### DIFF
--- a/_benchmark/user-guide/concepts.md
+++ b/_benchmark/user-guide/concepts.md
@@ -4,8 +4,6 @@ title: Concepts
 nav_order: 3
 parent: User guide
 has_toc: false
-redirect_from: 
-  - /benchmark/user-guide/concepts/
 ---
 
 # OpenSearch Benchmark concepts

--- a/_config.yml
+++ b/_config.yml
@@ -107,9 +107,6 @@ collections:
   troubleshoot:
     permalink: /:collection/:path/
     output: true
-  external_links:
-    permalink: /:collection/:path/
-    output: true
   developer-documentation:
     permalink: /:collection/:path/
     output: true
@@ -119,13 +116,7 @@ collections:
   automating-configurations:
     permalink: /:collection/:path/
     output: true
-  dashboards-assistant:
-    permalink: /:collection/:path/
-    output: true
   getting-started:
-    permalink: /:collection/:path/
-    output: true
-  workspace:
     permalink: /:collection/:path/
     output: true
   vector-search:

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -5,7 +5,6 @@ parent: Installing OpenSearch
 nav_order: 5
 redirect_from: 
   - /opensearch/install/docker/
-  - /install-and-configure/install-opensearch/docker/
 ---
 
 # Docker

--- a/_mappings/mapping-explosion.md
+++ b/_mappings/mapping-explosion.md
@@ -3,8 +3,6 @@ layout: default
 title: Mapping explosion
 nav_order: 110
 has_children: false
-redirect_from:
-  - /mappings/mapping-explosion/
 ---
 
 # Mapping explosion

--- a/_observing-your-data/alerting/composite-monitors.md
+++ b/_observing-your-data/alerting/composite-monitors.md
@@ -5,8 +5,6 @@ nav_order: 25
 parent: Monitors
 grand_parent: Alerting
 has_children: false
-redirect_from:
- - /observing-your-data/alerting/composite-monitors/
 ---
 
 # Composite monitors

--- a/_observing-your-data/app-analytics.md
+++ b/_observing-your-data/app-analytics.md
@@ -2,8 +2,6 @@
 layout: default
 title: Application analytics
 nav_order: 30
-redirect_from:
-  - /observing-your-data/app-analytics/
 ---
 
 # Application analytics

--- a/_search-plugins/async/security.md
+++ b/_search-plugins/async/security.md
@@ -5,8 +5,6 @@ nav_order: 2
 parent: Asynchronous search
 grand_parent: Improving search performance
 has_children: false
-redirect_from:
- - /search-plugins/async/security/
 ---
 
 # Asynchronous search security

--- a/_security/access-control/default-action-groups.md
+++ b/_security/access-control/default-action-groups.md
@@ -4,7 +4,6 @@ title: Default action groups
 parent: Access control
 nav_order: 80
 redirect_from:
- - /security/access-control/default-action-groups/
  - /security-plugin/access-control/default-action-groups/
 ---
 

--- a/_security/access-control/document-level-security.md
+++ b/_security/access-control/document-level-security.md
@@ -4,7 +4,6 @@ title: Document-level security
 parent: Access control
 nav_order: 90
 redirect_from:
-- /security/access-control/document-level-security/
 - /security-plugin/access-control/document-level-security/
 ---
 

--- a/_security/access-control/field-level-security.md
+++ b/_security/access-control/field-level-security.md
@@ -4,7 +4,6 @@ title: Field-level security
 parent: Access control
 nav_order: 95
 redirect_from:
- - /security/access-control/field-level-security/
  - /security-plugin/access-control/field-level-security/
 ---
 

--- a/_security/access-control/field-masking.md
+++ b/_security/access-control/field-masking.md
@@ -4,7 +4,6 @@ title: Field masking
 parent: Access control
 nav_order: 100
 redirect_from:
- - /security/access-control/field-masking/
  - /security-plugin/access-control/field-masking/
 ---
 

--- a/_security/access-control/impersonation.md
+++ b/_security/access-control/impersonation.md
@@ -4,7 +4,6 @@ title: User impersonation
 parent: Access control
 nav_order: 105
 redirect_from:
- - /security/access-control/impersonation/
  - /security-plugin/access-control/impersonation/
 ---
 

--- a/_security/access-control/users-roles.md
+++ b/_security/access-control/users-roles.md
@@ -4,7 +4,6 @@ title: Defining users and roles
 parent: Access control
 nav_order: 70
 redirect_from:
- - /security/access-control/users-roles/
  - /security-plugin/access-control/users-roles/
 ---
 

--- a/_security/audit-logs/field-reference.md
+++ b/_security/audit-logs/field-reference.md
@@ -4,7 +4,6 @@ title: Audit log field reference
 parent: Audit logs
 nav_order: 130
 redirect_from:
-  - /security/audit-logs/field-reference/
   - /security-plugin/audit-logs/field-reference/
 ---
 

--- a/_security/audit-logs/storage-types.md
+++ b/_security/audit-logs/storage-types.md
@@ -4,7 +4,6 @@ title: Audit log storage types
 parent: Audit logs
 nav_order: 135
 redirect_from:
-  - /security/audit-logs/storage-types/
   - /security-plugin/audit-logs/storage-types/
 ---
 

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/workload-groups.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/workload-groups.md
@@ -7,7 +7,6 @@ grand_parent: Availability and recovery
 redirect_from:
   - /tuning-your-cluster/availability-and-recovery/workload-management/workload-group-lifecycle-api/
   - /tuning-your-cluster/availability-and-recovery/workload-management/query-group-lifecycle-api/
-  - /tuning-your-cluster/availability-and-recovery/workload-management/workload-groups/
 ---
 
 # Workload groups

--- a/_tutorials/gen-ai/chatbots/build-chatbot.md
+++ b/_tutorials/gen-ai/chatbots/build-chatbot.md
@@ -9,7 +9,6 @@ nav_order: 170
 redirect_from:
   - /ml-commons-plugin/tutorials/build-chatbot/
   - /vector-search/tutorials/chatbots/build-chatbot/
-  - /tutorials/gen-ai/chatbots/build-chatbot/ 
 ---
 
 # Build your own chatbot

--- a/_tutorials/gen-ai/chatbots/rag-chatbot.md
+++ b/_tutorials/gen-ai/chatbots/rag-chatbot.md
@@ -9,7 +9,6 @@ has_toc: false
 redirect_from:
   - /ml-commons-plugin/tutorials/rag-chatbot/
   - /vector-search/tutorials/chatbots/rag-chatbot/
-  - /tutorials/gen-ai/chatbots/rag-chatbot/
 ---
 
 # RAG chatbot

--- a/_tutorials/gen-ai/chatbots/rag-conversational-agent.md
+++ b/_tutorials/gen-ai/chatbots/rag-conversational-agent.md
@@ -9,7 +9,6 @@ has_toc: false
 redirect_from:
   - /ml-commons-plugin/tutorials/rag-conversational-agent/
   - /vector-search/tutorials/chatbots/rag-conversational-agent/
-  - /tutorials/gen-ai/chatbots/rag-conversational-agent/
 ---
 
 # RAG chatbot with a conversational flow agent

--- a/_vector-search/creating-vector-index.md
+++ b/_vector-search/creating-vector-index.md
@@ -5,7 +5,6 @@ nav_order: 20
 redirect_from:
   - /vector-search/creating-a-vector-db/
   - /search-plugins/knn/knn-index/
-  - /vector-search/creating-vector-index/
 ---
 
 # Creating a vector index


### PR DESCRIPTION
Removes unused collections (collections that have been removed so they are not displayed but they are still declared in the config file) and self-referential redirects (a redirect pointing to itself).

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
