### PR TITLE
Make headings level 1 more descriptive for doc pages

### DIFF
--- a/_benchmark/FAQs.md
+++ b/_benchmark/FAQs.md
@@ -4,7 +4,7 @@ title: FAQs
 nav_order: 115
 ---
 
-# FAQs
+# OpenSearch Benchmark FAQs
 
 This section provides answers to frequently asked questions.
 

--- a/_benchmark/reference/commands/aggregate.md
+++ b/_benchmark/reference/commands/aggregate.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# aggregate
+# aggregate command
 <!-- vale on -->
 
 The `aggregate` command combines multiple test runs into a single aggregated result, providing a more streamlined way to conduct and analyze multiple test runs. There are two methods of aggregation:

--- a/_benchmark/reference/commands/compare.md
+++ b/_benchmark/reference/commands/compare.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# compare
+# compare command
 <!-- vale on -->
 
 The `compare` command helps you analyze the difference between two benchmark tests. This can help you analyze the performance impact of changes made from a previous test based on a specific Git revision.

--- a/_benchmark/reference/commands/download.md
+++ b/_benchmark/reference/commands/download.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# download
+# download command
 <!-- vale on -->
 
 Use the `download` command to select which OpenSearch distribution version to download.

--- a/_benchmark/reference/commands/generate-data.md
+++ b/_benchmark/reference/commands/generate-data.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# generate-data
+# generate-data command
 <!-- vale on -->
 
 The `generate-data` command creates synthetic datasets for benchmarking and testing. OpenSearch Benchmark supports two methods for data generation: using OpenSearch index mappings or custom Python modules with user-defined logic. For more information, see [Synthetic data generation]({{site.url}}{{site.baseurl}}/benchmark/features/synthetic-data-generation/).

--- a/_benchmark/reference/commands/info.md
+++ b/_benchmark/reference/commands/info.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# info
+# info command
 <!-- vale on -->
 
 The `info` command prints details about an OpenSearch Benchmark component.

--- a/_benchmark/reference/commands/list.md
+++ b/_benchmark/reference/commands/list.md
@@ -9,7 +9,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# list
+# list command
 <!-- vale on -->
 
 The `list` command lists the following elements used by OpenSearch Benchmark:

--- a/_benchmark/reference/commands/run.md
+++ b/_benchmark/reference/commands/run.md
@@ -10,7 +10,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# run
+# run command
 <!-- vale on -->
 
 Whether you're using the included [OpenSearch Benchmark workloads](https://github.com/opensearch-project/opensearch-benchmark-workloads) or a [custom workload]({{site.url}}{{site.baseurl}}/benchmark/creating-custom-workloads/), use the `run` command to gather data about the performance of your OpenSearch cluster according to the selected workload.

--- a/_benchmark/reference/workloads/corpora.md
+++ b/_benchmark/reference/workloads/corpora.md
@@ -8,7 +8,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# corpora
+# corpora element
 <!-- vale on -->
 
 The `corpora` element contains all the document corpora used by the workload. You can use document corpora across workloads by copying and pasting any corpora definitions. 

--- a/_benchmark/reference/workloads/indices.md
+++ b/_benchmark/reference/workloads/indices.md
@@ -8,7 +8,7 @@ redirect_from:
 ---
 
 <!-- vale off -->
-# indices
+# indices element
 <!-- vale on -->
 
 The `indices` element contains a list of all indexes used in the workload. 

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -6,7 +6,7 @@ nav_order: 30
 ---
 
 <!-- vale off -->
-# operations
+# operations element
 <!-- vale on -->
 
 The `operations` element lists the OpenSearch API operations that the workload performs and how they are parameterized. For example, you can define an operation named `create-index` that creates an index in the benchmark cluster to which OpenSearch Benchmark can write documents. The [`schedule`]({{site.url}}{{site.baseurl}}/benchmark/reference/workloads/schedule/) element then references these operations by name to specify the order in which they run.

--- a/_benchmark/reference/workloads/schedule.md
+++ b/_benchmark/reference/workloads/schedule.md
@@ -6,7 +6,7 @@ nav_order: 40
 ---
 
 <!-- vale off -->
-# schedule
+# schedule element
 <!-- vale on -->
 
 The `schedule` element contains a list of tasks that are run in a specified order during the benchmark test. Each task is an operation supported by OpenSearch Benchmark.

--- a/_benchmark/reference/workloads/test-procedures.md
+++ b/_benchmark/reference/workloads/test-procedures.md
@@ -6,7 +6,7 @@ nav_order: 50
 ---
 
 <!-- vale off -->
-# test_procedures
+# test_procedures element
 <!-- vale on -->
 
 A test procedure is a single benchmarking scenario. Each test procedure wraps a [`schedule`]({{site.url}}{{site.baseurl}}/benchmark/reference/workloads/schedule/) and adds properties such as a name and description. Use the `test_procedures` element when a workload defines multiple scenarios. When a workload defines only one scenario, specify `schedule` at the top level of `workload.json` instead and omit `test_procedures`.

--- a/_clients/opensearch-py-ml.md
+++ b/_clients/opensearch-py-ml.md
@@ -5,7 +5,7 @@ nav_order: 11
 ---
 
 <!-- vale off -->
-# opensearch-py-ml
+# opensearch-py-ml client
 <!-- vale on -->
 
 `opensearch-py-ml` is a Python client that provides a suite of data analytics and natural language processing (NLP) support tools for OpenSearch. It provides data analysts with the ability to:

--- a/_dashboards/visualize/visualization-editor/area-chart.md
+++ b/_dashboards/visualize/visualization-editor/area-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 10
 ---
 
-# Area chart
+# Area charts in the visualization editor
 
 An area chart plots data points connected by lines with the region below filled in, making it ideal for visualizing volume and composition over time. You can stack multiple series to see how each category contributes to the total.
 

--- a/_dashboards/visualize/visualization-editor/bar-chart.md
+++ b/_dashboards/visualize/visualization-editor/bar-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 15
 ---
 
-# Bar chart
+# Bar charts in the visualization editor
 
 A bar chart displays data as vertical or horizontal bars, making it ideal for comparing discrete categories. You can use a Color field to break categories into sub-groups and add threshold lines to flag values higher or lower than a target.
 

--- a/_dashboards/visualize/visualization-editor/bar-gauge-chart.md
+++ b/_dashboards/visualize/visualization-editor/bar-gauge-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 20
 ---
 
-# Bar gauge chart
+# Bar gauge charts in the visualization editor
 
 A bar gauge chart displays numeric values as horizontal or vertical bars against a scale, reducing each field to a single value. Unlike a bar chart, a bar gauge chart is designed for comparing values against defined thresholds.
 

--- a/_dashboards/visualize/visualization-editor/configuring-visualizations/thresholds.md
+++ b/_dashboards/visualize/visualization-editor/configuring-visualizations/thresholds.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 10
 ---
 
-# Thresholds
+# Thresholds in the visualization editor
 
 A threshold is a boundary value that, when reached or exceeded by a data point, triggers a visual change in color. Use thresholds to define meaningful ranges so that you can immediately understand whether values are within normal, warning, or critical zones.
 

--- a/_dashboards/visualize/visualization-editor/gauge-chart.md
+++ b/_dashboards/visualize/visualization-editor/gauge-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 25
 ---
 
-# Gauge chart
+# Gauge charts in the visualization editor
 
 A gauge chart displays a single numeric value on a semicircular arc, making it ideal for showing how a metric compares against defined thresholds or a target range.
 

--- a/_dashboards/visualize/visualization-editor/heatmap-chart.md
+++ b/_dashboards/visualize/visualization-editor/heatmap-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 30
 ---
 
-# Heatmap
+# Heatmaps in the visualization editor
 
 A heatmap uses color to represent the magnitude of values in a dataset. Each cell in the map corresponds to a combination of two dimensions, with the cell's color intensity reflecting the value associated with that combination.
 

--- a/_dashboards/visualize/visualization-editor/histogram-chart.md
+++ b/_dashboards/visualize/visualization-editor/histogram-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 35
 ---
 
-# Histogram
+# Histograms in the visualization editor
 
 A histogram displays the distribution of a numeric field by grouping values into bins (buckets) and showing the count of values in each bin as vertical bars.
 

--- a/_dashboards/visualize/visualization-editor/line-chart.md
+++ b/_dashboards/visualize/visualization-editor/line-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 40
 ---
 
-# Line chart
+# Line charts in the visualization editor
 
 A line chart plots data points connected by lines, making it ideal for visualizing trends and changes over time. You can compare multiple series on the same time axis and use a secondary Y-axis to correlate metrics with different scales.
 

--- a/_dashboards/visualize/visualization-editor/metric-chart.md
+++ b/_dashboards/visualize/visualization-editor/metric-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 45
 ---
 
-# Metric chart
+# Metric charts in the visualization editor
 
 A metric chart displays a single numeric value prominently, making it ideal for showing key performance indicators (KPIs) or summary statistics at a glance.
 

--- a/_dashboards/visualize/visualization-editor/pie-chart.md
+++ b/_dashboards/visualize/visualization-editor/pie-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 50
 ---
 
-# Pie chart
+# Pie charts in the visualization editor
 
 A pie chart displays data as proportional slices of a circle, making it ideal for visualizing part-to-whole relationships.
 

--- a/_dashboards/visualize/visualization-editor/scatter-chart.md
+++ b/_dashboards/visualize/visualization-editor/scatter-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 55
 ---
 
-# Scatter plot
+# Scatter plots in the visualization editor
 
 A scatter plot visualizes relationships between two numerical variables. Each point on the chart represents an observation from the dataset, with its position determined by the values of the two variables. You can split data by a categorical field to compare how different groups distribute across the same dimensions.
 

--- a/_dashboards/visualize/visualization-editor/state-timeline-chart.md
+++ b/_dashboards/visualize/visualization-editor/state-timeline-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 60
 ---
 
-# State timeline
+# State timelines in the visualization editor
 
 A state timeline displays a series of horizontal bars that represent state changes over time. Each bar, known as a state region, represents a specific state, and its length indicates the duration of that state.
 

--- a/_dashboards/visualize/visualization-editor/table-chart.md
+++ b/_dashboards/visualize/visualization-editor/table-chart.md
@@ -7,7 +7,7 @@ great_grand_parent: Building data visualizations
 nav_order: 65
 ---
 
-# Table
+# Tables in the visualization editor
 
 A table displays query results in a tabular format with rows and columns, making it ideal for viewing raw data or summary statistics.
 

--- a/_dashboards/visualize/visualization-editor/viz-types.md
+++ b/_dashboards/visualize/visualization-editor/viz-types.md
@@ -8,9 +8,9 @@ has_children: true
 has_toc: false
 ---
 
-# Visualization types for query-based visualizations
+# Query-based visualization types
 
-The following table lists the supported visualization types and their expected data shapes.
+The following table lists the visualization types supported by the visualization editor and their expected data shapes.
 
 | Chart type | Data shape |
 | :--- | :--- |

--- a/_dashboards/visualize/visualize-app/area.md
+++ b/_dashboards/visualize/visualize-app/area.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Area charts
+title: Area chart
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/area/
 ---
 
-# Area charts
+# Area chart
 
 An area chart is a line chart with the area below the line shaded with a color. You can stack multiple buckets to show relative proportions of a running absolute value of the variable, or superimpose buckets or different variables to compare within x-axis buckets or time values.
 

--- a/_dashboards/visualize/visualize-app/bar-charts.md
+++ b/_dashboards/visualize/visualize-app/bar-charts.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Bar charts
+title: Bar chart
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/bar-charts/
 ---
 
-# Bar charts
+# Bar chart
 
 A bar chart compares values across categories by representing values as proportional bar lengths. Use vertical bars for time-series data or category comparisons, and horizontal bars when category labels are long or when comparing many categories.
 

--- a/_dashboards/visualize/visualize-app/controls.md
+++ b/_dashboards/visualize/visualize-app/controls.md
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/controls/
 ---
 
-# Controls
+# Controls visualization
 **Experimental**
 {: .label .label-purple }
 

--- a/_dashboards/visualize/visualize-app/coordinate-maps.md
+++ b/_dashboards/visualize/visualize-app/coordinate-maps.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Coordinate maps
+title: Coordinate map
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/coordinate-maps/
 ---
 
-# Coordinate maps
+# Coordinate map
 
 A coordinate map plots geographic data points on a map using latitude and longitude coordinates. Each marker represents a document with a geo_point field, and marker size indicates the aggregated value at that location.
 

--- a/_dashboards/visualize/visualize-app/data-table.md
+++ b/_dashboards/visualize/visualize-app/data-table.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Data tables
+title: Data table
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/data-table/
 ---
 
-# Data tables
+# Data table
 
 A data table displays selected fields in row-column form. You can display one or more metrics as columns, bucketed into rows, and subdivide bucket data into separate tables.
 

--- a/_dashboards/visualize/visualize-app/gauge.md
+++ b/_dashboards/visualize/visualize-app/gauge.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Gauge visualizations
+title: Gauge visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/gauge/
 ---
 
-# Gauge visualizations
+# Gauge visualization
 
 A gauge visualization displays a data field in a simulated analog instrument like a speedometer. The gauge value can be instantly compared with marked ranges or thresholds. The visualization can show a single value or multiple bucketed values.
 

--- a/_dashboards/visualize/visualize-app/goal.md
+++ b/_dashboards/visualize/visualize-app/goal.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Goal visualizations
+title: Goal visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/goal/
 ---
 
-# Goal visualizations
+# Goal visualization
 
 A goal visualization displays a value in a speedometer-like gauge. It shows the value as a proportion of a predefined goal. The visualization also displays the metric, either as an absolute value or as a percentage of the goal. The visualization can show a single value or multiple bucketed values. If bucketed, the goal is the same for all buckets.
 

--- a/_dashboards/visualize/visualize-app/heat-map.md
+++ b/_dashboards/visualize/visualize-app/heat-map.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Heat maps
+title: Heat map
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/heat-map/
 ---
 
-# Heat maps
+# Heat map
 
 A heat map displays values represented as a color or saturation gradient on a two-dimensional grid, effectively rendering a three-dimensional data display. The X and Y dimensions can be the same, as in a spatial heat map, or different---for example, months against years in a record of average temperature at a location (thus separating the cyclic and trend data for the site).
 

--- a/_dashboards/visualize/visualize-app/line-charts.md
+++ b/_dashboards/visualize/visualize-app/line-charts.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Line charts
+title: Line chart
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/line-charts/
 ---
 
-# Line charts
+# Line chart
 
 A line chart shows one or more series of numerical data points on the Y-axis plotted against a numerical field on the X-axis. The points can be connected by a line. The X-axis value can be a timeline or any other continuous or discrete number series.
 

--- a/_dashboards/visualize/visualize-app/markdown.md
+++ b/_dashboards/visualize/visualize-app/markdown.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Markdown visualizations
+title: Markdown visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/markdown/
 ---
 
-# Markdown visualizations
+# Markdown visualization
 
 A Markdown visualization renders formatted text within a dashboard panel. Use Markdown to provide titles, instructions, metric definitions, and explanatory context alongside data visualizations. Markdown supports headings, lists, bold and italic text, links, blockquotes, and code blocks (GitHub-flavored Markdown).
 

--- a/_dashboards/visualize/visualize-app/metric.md
+++ b/_dashboards/visualize/visualize-app/metric.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Metric visualizations
+title: Metric visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/metric/
 ---
 
-# Metric visualizations
+# Metric visualization
 
 A metric visualization displays a single data field. The visualization can show a single value or multiple bucketed values. Use metric visualizations for key indicators on dashboards, especially values that update frequently.
 

--- a/_dashboards/visualize/visualize-app/pie-charts.md
+++ b/_dashboards/visualize/visualize-app/pie-charts.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Pie charts
+title: Pie chart
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/pie-charts/
 ---
 
-# Pie charts
+# Pie chart
 
 A pie chart displays what percent of each condition makes up the entire count of a data field. The visualization can show a single value or multiple bucketed values.
 

--- a/_dashboards/visualize/visualize-app/ppl.md
+++ b/_dashboards/visualize/visualize-app/ppl.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: PPL visualizations
+title: PPL visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/ppl/
 ---
 
-# PPL visualizations
+# PPL visualization
 
 Piped Processing Language (PPL) visualizations enable data processing and visualization using PPL queries. Selecting **PPL** from the **New Visualization** dialog opens the Observability Logs Explorer, where you write a PPL query and map the results to a chart.
 

--- a/_dashboards/visualize/visualize-app/region-maps.md
+++ b/_dashboards/visualize/visualize-app/region-maps.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Region maps
+title: Region map
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -11,7 +11,7 @@ redirect_from:
   - /dashboards/geojson-regionmaps/
 ---
 
-# Region maps
+# Region map
 
 A region map colors geographic regions (countries, states, or counties) based on an aggregated value, using color intensity to show how a metric varies across regions.
 

--- a/_dashboards/visualize/visualize-app/tag-cloud.md
+++ b/_dashboards/visualize/visualize-app/tag-cloud.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Tag clouds
+title: Tag cloud
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/tag-cloud/
 ---
 
-# Tag clouds
+# Tag cloud
 
 A tag cloud displays a group of text fields (bucket labels, called _tags_ in the visualization) from the data. The font size of each tag corresponds to the magnitude of the bucket in the data. For example, if the visualization specifies `Average`, the font size of the tag in the tag cloud is proportional to the bucketed field's average value.
 

--- a/_dashboards/visualize/visualize-app/timeline.md
+++ b/_dashboards/visualize/visualize-app/timeline.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Timeline visualizations
+title: Timeline visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/timeline/
 ---
 
-# Timeline visualizations
+# Timeline visualization
 
 **Timeline** is an expression-based data visualization tool in OpenSearch Dashboards that you can use to create time-series visualizations using a simple expression language. Unlike other visualization types that use a graphical interface, **Timeline** uses a text-based expression syntax to define data sources, transformations, and display options. With this syntax, you can compare multiple time series, apply mathematical functions, and overlay data from different time periods.
 

--- a/_dashboards/visualize/visualize-app/tsvb.md
+++ b/_dashboards/visualize/visualize-app/tsvb.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: TSVB visualizations
+title: TSVB visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/tsvb/
 ---
 
-# TSVB visualizations
+# TSVB visualization
 
 The Time-Series Visual Builder (TSVB) is a data visualization tool in OpenSearch Dashboards for creating detailed time-series visualizations. TSVB supports adding annotations or markers at specific time points based on index data, making connections between multiple indexes, and building visualizations that display data over time. TSVB supports the following visualization types: Area, Line, Metric, Gauge, Markdown, and Data Table.
 

--- a/_dashboards/visualize/visualize-app/vega.md
+++ b/_dashboards/visualize/visualize-app/vega.md
@@ -1,6 +1,6 @@
 ---
 layout: default
-title: Vega visualizations
+title: Vega visualization
 parent: Visualization types
 grand_parent: Creating visualizations in the Visualize application
 great_grand_parent: Building data visualizations
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/vega/
 ---
 
-# Vega visualizations
+# Vega visualization
 
 [Vega](https://vega.github.io/vega/) and [Vega-Lite](https://vega.github.io/vega-lite/) are open-source, declarative language visualization tools that you can use to create custom data visualizations with your OpenSearch data and [Vega data](https://vega.github.io/vega/docs/data/). These tools are ideal for advanced users comfortable with writing OpenSearch queries directly. You define data sources inline within your Vega specification. 
 

--- a/_data-prepper/pipelines/cidrcontains.md
+++ b/_data-prepper/pipelines/cidrcontains.md
@@ -7,7 +7,7 @@ nav_order: 5
 ---
 
 <!-- vale off -->
-# cidrContains()
+# cidrContains() function
 <!-- vale on -->
 
 The `cidrContains()` function is used to check if an IP address is contained within a specified Classless Inter-Domain Routing (CIDR) block or range of CIDR blocks. It accepts two or more arguments:

--- a/_data-prepper/pipelines/contains.md
+++ b/_data-prepper/pipelines/contains.md
@@ -7,7 +7,7 @@ nav_order: 10
 ---
 
 <!-- vale off -->
-# contains()
+# contains() function
 <!-- vale on -->
 
 The `contains()` function is used to check if a substring exists within a given string or the value of a field in an event. It takes two arguments:

--- a/_data-prepper/pipelines/generate-uuid.md
+++ b/_data-prepper/pipelines/generate-uuid.md
@@ -7,7 +7,7 @@ nav_order: 11
 ---
 
 <!-- vale off -->
-# generateUuid()
+# generateUuid() function
 <!-- vale on -->
 
 The `generateUuid()` function takes no arguments and returns a randomly generated [UUID version 4](https://www.rfc-editor.org/rfc/rfc4122) string, for example, `"550e8400-e29b-41d4-a716-446655440000"`. Each call produces a unique value using a cryptographically strong random number generator, so collision probability is negligible in practice.

--- a/_data-prepper/pipelines/get-eventtype.md
+++ b/_data-prepper/pipelines/get-eventtype.md
@@ -7,7 +7,7 @@ nav_order: 12
 ---
 
 <!-- vale off -->
-# getEventType()
+# getEventType() function
 <!-- vale on -->
 
 The `getEventType()` function returns the internal event type of the current event. This function is particularly useful when working with unified sources that can receive multiple types of telemetry data, such as the [OTLP source]({{site.url}}{{site.baseurl}}/data-prepper/pipelines/configuration/sources/otlp-source/).

--- a/_data-prepper/pipelines/get-metadata.md
+++ b/_data-prepper/pipelines/get-metadata.md
@@ -7,7 +7,7 @@ nav_order: 15
 ---
 
 <!-- vale off -->
-# getMetadata()
+# getMetadata() function
 <!-- vale on -->
 
 The `getMetadata()` function takes one literal string argument and looks up specific keys in event metadata. 

--- a/_data-prepper/pipelines/has-tags.md
+++ b/_data-prepper/pipelines/has-tags.md
@@ -7,7 +7,7 @@ nav_order: 20
 ---
 
 <!-- vale off -->
-# hasTags()
+# hasTags() function
 <!-- vale on -->
 
 The `hasTags()` function takes one or more string type arguments and returns `true` if all of the arguments passed are present in an event's tags. If an argument does not exist in the event's tags, then the function returns `false`. 

--- a/_data-prepper/pipelines/join.md
+++ b/_data-prepper/pipelines/join.md
@@ -7,7 +7,7 @@ nav_order: 25
 ---
 
 <!-- vale off -->
-# join()
+# join() function
 <!-- vale on -->
 
 

--- a/_data-prepper/pipelines/length.md
+++ b/_data-prepper/pipelines/length.md
@@ -7,7 +7,7 @@ nav_order: 30
 ---
 
 <!-- vale off -->
-# length()
+# length() function
 <!-- vale on -->
 
 The `length()` function takes one argument of the JSON pointer type and returns the length of the passed value. For example, `length(/message)` returns a length of `10` when a key message exists in the event and has a value of `1234567890`.

--- a/_data-prepper/pipelines/pipelines.md
+++ b/_data-prepper/pipelines/pipelines.md
@@ -8,7 +8,7 @@ redirect_from:
   - /clients/data-prepper/pipelines/
 ---
 
-# Pipelines
+# Data Prepper pipelines
 
 Pipelines are critical components that streamline the process of acquiring, transforming, and loading data from various sources into a centralized data repository or processing system. The following diagram illustrates how OpenSearch Data Prepper ingests data into OpenSearch.
 

--- a/_data-prepper/pipelines/startswith.md
+++ b/_data-prepper/pipelines/startswith.md
@@ -7,7 +7,7 @@ nav_order: 40
 ---
 
 <!-- vale off -->
-# startsWith()
+# startsWith() function
 <!-- vale on -->
 
 The `startsWith()` function checks whether a string starts with the given string. It takes two arguments:

--- a/_data-prepper/pipelines/sublist.md
+++ b/_data-prepper/pipelines/sublist.md
@@ -7,7 +7,7 @@ nav_order: 50
 ---
 
 <!-- vale off -->
-# subList()
+# subList() function
 <!-- vale on -->
 
 The `subList(<key>, <start_index, inclusive>, <end_index, exclusive>)` function extracts a sublist from a list field in an event. It takes the following arguments:

--- a/_data-prepper/pipelines/substring-after-last.md
+++ b/_data-prepper/pipelines/substring-after-last.md
@@ -7,7 +7,7 @@ nav_order: 70
 ---
 
 <!-- vale off -->
-# substringAfterLast()
+# substringAfterLast() function
 <!-- vale on -->
 
 The `substringAfterLast()` function is used to extract the portion of a string that follows the last occurrence of a specified delimiter. It takes two arguments:

--- a/_data-prepper/pipelines/substring-after.md
+++ b/_data-prepper/pipelines/substring-after.md
@@ -7,7 +7,7 @@ nav_order: 60
 ---
 
 <!-- vale off -->
-# substringAfter()
+# substringAfter() function
 <!-- vale on -->
 
 The `substringAfter()` function is used to extract the portion of a string that follows the first occurrence of a specified delimiter. It takes two arguments:

--- a/_data-prepper/pipelines/substring-before-last.md
+++ b/_data-prepper/pipelines/substring-before-last.md
@@ -7,7 +7,7 @@ nav_order: 90
 ---
 
 <!-- vale off -->
-# substringBeforeLast()
+# substringBeforeLast() function
 <!-- vale on -->
 
 The `substringBeforeLast()` function is used to extract the portion of a string that precedes the last occurrence of a specified delimiter. It takes two arguments:

--- a/_data-prepper/pipelines/substring-before.md
+++ b/_data-prepper/pipelines/substring-before.md
@@ -7,7 +7,7 @@ nav_order: 80
 ---
 
 <!-- vale off -->
-# substringBefore()
+# substringBefore() function
 <!-- vale on -->
 
 The `substringBefore()` function is used to extract the portion of a string that precedes the first occurrence of a specified delimiter. It takes two arguments:

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -6,7 +6,7 @@ parent: Index State Management
 has_children: false
 ---
 
-# Policies
+# ISM policies
 
 Policies are JSON documents that define the following:
 

--- a/_install-and-configure/install-opensearch/debian.md
+++ b/_install-and-configure/install-opensearch/debian.md
@@ -13,7 +13,7 @@ The following liquid syntax declares a variable, major_version_mask, which is tr
 {% assign version_parts = site.opensearch_major_minor_version | split: "." %}
 {% assign major_version_mask = version_parts[0] | append: ".x" %}
 
-# Debian
+# Installing OpenSearch on Debian
 
 Installing OpenSearch using the Advanced Packaging Tool (APT) package manager simplifies the process considerably compared to the [Tarball]({{site.url}}{{site.baseurl}}/opensearch/install/tar/) method. Several technical considerations, such as the installation path, location of configuration files, and creation of a service managed by `systemd`, as examples, are handled automatically by the package manager.
 

--- a/_install-and-configure/install-opensearch/docker.md
+++ b/_install-and-configure/install-opensearch/docker.md
@@ -7,7 +7,7 @@ redirect_from:
   - /opensearch/install/docker/
 ---
 
-# Docker
+# Installing OpenSearch with Docker
 
 [Docker](https://www.docker.com/) greatly simplifies the process of configuring and managing your OpenSearch clusters. You can pull official images from [Docker Hub](https://hub.docker.com/u/opensearchproject) or [Amazon Elastic Container Registry (Amazon ECR)](https://gallery.ecr.aws/opensearchproject/) and quickly deploy a cluster using [Docker Compose](https://github.com/docker/compose) and any of the sample Docker Compose files included in this guide. Experienced OpenSearch users can further customize their deployment by creating a custom Docker Compose file.
 

--- a/_install-and-configure/install-opensearch/helm.md
+++ b/_install-and-configure/install-opensearch/helm.md
@@ -7,7 +7,7 @@ redirect_from:
   - /opensearch/install/helm/
 ---
 
-# Helm
+# Installing OpenSearch with Helm
 
 Helm is a package manager that allows you to easily install and manage OpenSearch in a Kubernetes cluster. You can define your OpenSearch configurations in a YAML file and use Helm to deploy your applications in a version-controlled and reproducible way.
 

--- a/_install-and-configure/install-opensearch/rpm.md
+++ b/_install-and-configure/install-opensearch/rpm.md
@@ -13,7 +13,7 @@ The following liquid syntax declares a variable, major_version_mask, which is tr
 {% assign version_parts = site.opensearch_major_minor_version | split: "." %}
 {% assign major_version_mask = version_parts[0] | append: ".x" %}
 
-# RPM
+# Installing OpenSearch using RPM
 
 Installing OpenSearch using RPM Package Manager (RPM) simplifies the process considerably compared to the [Tarball]({{site.url}}{{site.baseurl}}/opensearch/install/tar/) method. Several technical considerations, such as the installation path, location of configuration files, and creation of a service managed by `systemd`, as examples, are handled automatically by the package manager.
 

--- a/_install-and-configure/install-opensearch/tar.md
+++ b/_install-and-configure/install-opensearch/tar.md
@@ -7,7 +7,7 @@ redirect_from:
   - /opensearch/install/tar/
 ---
 
-# Tarball
+# Installing OpenSearch from a tarball
 
 Installing OpenSearch from a tarball, also known as a tar archive, may appeal to users who want granular control over installation details like file permissions and installation paths.
 

--- a/_install-and-configure/install-opensearch/windows.md
+++ b/_install-and-configure/install-opensearch/windows.md
@@ -5,7 +5,7 @@ parent: Installing OpenSearch
 nav_order: 65
 ---
 
-# Windows
+# Installing OpenSearch on Windows
 
 The following sections describe installing OpenSearch on Windows from a zip archive.
 

--- a/_mappings/supported-field-types/knn-spaces.md
+++ b/_mappings/supported-field-types/knn-spaces.md
@@ -9,7 +9,7 @@ nav_order: 10
 has_math: true
 ---
 
-# Spaces
+# Vector spaces
 
 In vector search, a _space_ defines how the distance (or similarity) between two vectors is calculated. The choice of space affects how nearest neighbors are determined during search operations. 
 

--- a/_migration-assistant-classic/architecture.md
+++ b/_migration-assistant-classic/architecture.md
@@ -5,9 +5,9 @@ nav_order: 15
 permalink: /classic/migration-assistant/architecture/
 ---
 
-# Architecture
+# Migration Assistant (classic) architecture
 
-The Migration Assistant architecture is based on the use of an AWS Cloud infrastructure, but most tools are designed to be cloud independent. A local containerized version of this solution is also available.
+The Migration Assistant (classic) architecture is based on the use of an AWS Cloud infrastructure, but most tools are designed to be cloud independent. A local containerized version of this solution is also available.
 
 The design deployed on AWS uses the following architecture.
 

--- a/_migration-assistant/playbooks/index.md
+++ b/_migration-assistant/playbooks/index.md
@@ -7,7 +7,7 @@ has_toc: false
 permalink: /migration-assistant/playbooks/
 ---
 
-# Playbooks
+# Migration Assistant playbooks
 
 Playbooks are step-by-step migration guides for specific source and target combinations. Each playbook provides the complete sequence of commands and configuration required for that migration path.
 

--- a/_query-dsl/rescore.md
+++ b/_query-dsl/rescore.md
@@ -4,7 +4,7 @@ title: Rescore
 nav_order: 90
 ---
 
-# Rescore
+# Rescore parameter
 
 The `rescore` parameter improves search precision by reordering only the highest-ranked documents returned from your initial query. Rather than applying an expensive algorithm to all documents in the index, rescoring focuses computational resources on reranking a smaller window of top results using a secondary scoring method.
 

--- a/_query-dsl/rewrite-parameter.md
+++ b/_query-dsl/rewrite-parameter.md
@@ -4,7 +4,7 @@ title: Rewrite
 nav_order: 85
 ---
 
-# Rewrite
+# Rewrite parameter
 
 Multi-term queries like `wildcard`, `prefix`, `regexp`, `fuzzy`, and `range` expand internally into sets of terms. The `rewrite` parameter allows you to control how these term expansions are executed and scored.
 

--- a/_query-dsl/specialized/percolate.md
+++ b/_query-dsl/specialized/percolate.md
@@ -5,7 +5,7 @@ parent: Specialized queries
 nav_order: 55
 ---
 
-# Percolate
+# Percolate query
 
 Use the `percolate` query to find stored queries that match a given document. This operation is the opposite of a regular search: instead of finding documents that match a query, you find queries that match a document. `percolate` queries are often used for alerting, notifications, and reverse search use cases.
 

--- a/_query-dsl/specialized/wrapper.md
+++ b/_query-dsl/specialized/wrapper.md
@@ -6,7 +6,7 @@ parent: Specialized queries
 nav_order: 80
 ---
 
-# Wrapper
+# Wrapper query
 
 The `wrapper` query lets you submit a complete query in Base64-encoded JSON format. It is useful when the query must be embedded in contexts that only support string values.
 

--- a/_search-plugins/searching-data/autocomplete.md
+++ b/_search-plugins/searching-data/autocomplete.md
@@ -7,7 +7,7 @@ redirect_from:
   - /opensearch/search/autocomplete/
 ---
 
-# Autocomplete functionality
+# Autocomplete
 
 Autocomplete shows suggestions to users while they type.
 

--- a/_sql-and-ppl/ppl/commands/ad.md
+++ b/_sql-and-ppl/ppl/commands/ad.md
@@ -8,7 +8,7 @@ nav_order: 2
 
 <!-- vale off -->
 
-# ad (Deprecated)
+# ad command (Deprecated)
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/addcoltotals.md
+++ b/_sql-and-ppl/ppl/commands/addcoltotals.md
@@ -8,7 +8,7 @@ nav_order: 3
 
 <!-- vale off -->
 
-# addcoltotals
+# addcoltotals command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/addtotals.md
+++ b/_sql-and-ppl/ppl/commands/addtotals.md
@@ -8,7 +8,7 @@ nav_order: 4
 
 <!-- vale off -->
 
-# addtotals
+# addtotals command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/append.md
+++ b/_sql-and-ppl/ppl/commands/append.md
@@ -8,7 +8,7 @@ nav_order: 5
 
 <!-- vale off -->
 
-# append
+# append command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/appendcol.md
+++ b/_sql-and-ppl/ppl/commands/appendcol.md
@@ -8,7 +8,7 @@ nav_order: 6
 
 <!-- vale off -->
 
-# appendcol
+# appendcol command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/appendpipe.md
+++ b/_sql-and-ppl/ppl/commands/appendpipe.md
@@ -8,7 +8,7 @@ nav_order: 7
 
 <!-- vale off -->
 
-# appendpipe
+# appendpipe command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/bin.md
+++ b/_sql-and-ppl/ppl/commands/bin.md
@@ -8,7 +8,7 @@ nav_order: 8
 
 <!-- vale off -->
 
-# bin
+# bin command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/chart.md
+++ b/_sql-and-ppl/ppl/commands/chart.md
@@ -8,7 +8,7 @@ nav_order: 9
 
 <!-- vale off -->
 
-# chart
+# chart command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/convert.md
+++ b/_sql-and-ppl/ppl/commands/convert.md
@@ -8,7 +8,7 @@ nav_order: 10
 
 <!-- vale off -->
 
-# convert
+# convert command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/dedup.md
+++ b/_sql-and-ppl/ppl/commands/dedup.md
@@ -8,7 +8,7 @@ nav_order: 11
 
 <!-- vale off -->
 
-# dedup
+# dedup command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/describe.md
+++ b/_sql-and-ppl/ppl/commands/describe.md
@@ -8,7 +8,7 @@ nav_order: 12
 
 <!-- vale off -->
 
-# describe
+# describe command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/eval.md
+++ b/_sql-and-ppl/ppl/commands/eval.md
@@ -8,7 +8,7 @@ nav_order: 13
 
 <!-- vale off -->
 
-# eval
+# eval command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/eventstats.md
+++ b/_sql-and-ppl/ppl/commands/eventstats.md
@@ -8,7 +8,7 @@ nav_order: 14
 
 <!-- vale off -->
 
-# eventstats
+# eventstats command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/expand.md
+++ b/_sql-and-ppl/ppl/commands/expand.md
@@ -8,7 +8,7 @@ nav_order: 15
 
 <!-- vale off -->
 
-# expand
+# expand command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/explain.md
+++ b/_sql-and-ppl/ppl/commands/explain.md
@@ -8,7 +8,7 @@ nav_order: 16
 
 <!-- vale off -->
 
-# explain
+# explain command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/fieldformat.md
+++ b/_sql-and-ppl/ppl/commands/fieldformat.md
@@ -8,7 +8,7 @@ nav_order: 17
 
 <!-- vale off -->
 
-# fieldformat
+# fieldformat command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/fields.md
+++ b/_sql-and-ppl/ppl/commands/fields.md
@@ -8,7 +8,7 @@ nav_order: 18
 
 <!-- vale off -->
 
-# fields
+# fields command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/fillnull.md
+++ b/_sql-and-ppl/ppl/commands/fillnull.md
@@ -8,7 +8,7 @@ nav_order: 19
 
 <!-- vale off -->
 
-# fillnull
+# fillnull command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/flatten.md
+++ b/_sql-and-ppl/ppl/commands/flatten.md
@@ -8,7 +8,7 @@ nav_order: 20
 
 <!-- vale off -->
 
-# flatten
+# flatten command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/graphlookup.md
+++ b/_sql-and-ppl/ppl/commands/graphlookup.md
@@ -8,7 +8,7 @@ nav_order: 21
 
 <!-- vale off -->
 
-# graphLookup
+# graphLookup command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/grok.md
+++ b/_sql-and-ppl/ppl/commands/grok.md
@@ -8,7 +8,7 @@ nav_order: 22
 
 <!-- vale off -->
 
-# grok
+# grok command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/head.md
+++ b/_sql-and-ppl/ppl/commands/head.md
@@ -8,7 +8,7 @@ nav_order: 23
 
 <!-- vale off -->
 
-# head
+# head command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/join.md
+++ b/_sql-and-ppl/ppl/commands/join.md
@@ -8,7 +8,7 @@ nav_order: 25
 
 <!-- vale off -->
 
-# join
+# join command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/kmeans.md
+++ b/_sql-and-ppl/ppl/commands/kmeans.md
@@ -8,7 +8,7 @@ nav_order: 26
 
 <!-- vale off -->
 
-# kmeans (Deprecated)
+# kmeans command (Deprecated)
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/lookup.md
+++ b/_sql-and-ppl/ppl/commands/lookup.md
@@ -8,7 +8,7 @@ nav_order: 27
 
 <!-- vale off -->
 
-# lookup
+# lookup command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/ml.md
+++ b/_sql-and-ppl/ppl/commands/ml.md
@@ -8,7 +8,7 @@ nav_order: 28
 
 <!-- vale off -->
 
-# ml
+# ml command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/multisearch.md
+++ b/_sql-and-ppl/ppl/commands/multisearch.md
@@ -8,7 +8,7 @@ nav_order: 29
 
 <!-- vale off -->
 
-# multisearch
+# multisearch command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/mvcombine.md
+++ b/_sql-and-ppl/ppl/commands/mvcombine.md
@@ -8,7 +8,7 @@ nav_order: 30
 
 <!-- vale off -->
 
-# mvcombine
+# mvcombine command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/mvexpand.md
+++ b/_sql-and-ppl/ppl/commands/mvexpand.md
@@ -8,7 +8,7 @@ nav_order: 31
 
 <!-- vale off -->
 
-# mvexpand
+# mvexpand command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/nomv.md
+++ b/_sql-and-ppl/ppl/commands/nomv.md
@@ -8,7 +8,7 @@ nav_order: 32
 
 <!-- vale off -->
 
-# nomv
+# nomv command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/parse.md
+++ b/_sql-and-ppl/ppl/commands/parse.md
@@ -8,7 +8,7 @@ nav_order: 33
 
 <!-- vale off -->
 
-# parse
+# parse command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/patterns.md
+++ b/_sql-and-ppl/ppl/commands/patterns.md
@@ -8,7 +8,7 @@ nav_order: 34
 
 <!-- vale off -->
 
-# patterns
+# patterns command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/rare.md
+++ b/_sql-and-ppl/ppl/commands/rare.md
@@ -8,7 +8,7 @@ nav_order: 35
 
 <!-- vale off -->
 
-# rare
+# rare command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/regex.md
+++ b/_sql-and-ppl/ppl/commands/regex.md
@@ -8,7 +8,7 @@ nav_order: 36
 
 <!-- vale off -->
 
-# regex
+# regex command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/rename.md
+++ b/_sql-and-ppl/ppl/commands/rename.md
@@ -8,7 +8,7 @@ nav_order: 37
 
 <!-- vale off -->
 
-# rename
+# rename command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/replace.md
+++ b/_sql-and-ppl/ppl/commands/replace.md
@@ -8,7 +8,7 @@ nav_order: 38
 
 <!-- vale off -->
 
-# replace
+# replace command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/reverse.md
+++ b/_sql-and-ppl/ppl/commands/reverse.md
@@ -8,7 +8,7 @@ nav_order: 39
 
 <!-- vale off -->
 
-# reverse
+# reverse command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/rex.md
+++ b/_sql-and-ppl/ppl/commands/rex.md
@@ -8,7 +8,7 @@ nav_order: 40
 
 <!-- vale off -->
 
-# rex
+# rex command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/search.md
+++ b/_sql-and-ppl/ppl/commands/search.md
@@ -8,7 +8,7 @@ nav_order: 41
 
 <!-- vale off -->
 
-# search
+# search command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/showdatasources.md
+++ b/_sql-and-ppl/ppl/commands/showdatasources.md
@@ -8,7 +8,7 @@ nav_order: 42
 
 <!-- vale off -->
 
-# show datasources
+# show datasources command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/sort.md
+++ b/_sql-and-ppl/ppl/commands/sort.md
@@ -8,7 +8,7 @@ nav_order: 43
 
 <!-- vale off -->
 
-# sort
+# sort command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/spath.md
+++ b/_sql-and-ppl/ppl/commands/spath.md
@@ -8,7 +8,7 @@ nav_order: 44
 
 <!-- vale off -->
 
-# spath
+# spath command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/stats.md
+++ b/_sql-and-ppl/ppl/commands/stats.md
@@ -8,7 +8,7 @@ nav_order: 45
 
 <!-- vale off -->
 
-# stats
+# stats command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/streamstats.md
+++ b/_sql-and-ppl/ppl/commands/streamstats.md
@@ -8,7 +8,7 @@ nav_order: 46
 
 <!-- vale off -->
 
-# streamstats
+# streamstats command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/subquery.md
+++ b/_sql-and-ppl/ppl/commands/subquery.md
@@ -8,7 +8,7 @@ nav_order: 47
 
 <!-- vale off -->
 
-# subquery
+# subquery command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/table.md
+++ b/_sql-and-ppl/ppl/commands/table.md
@@ -8,7 +8,7 @@ nav_order: 48
 
 <!-- vale off -->
 
-# table
+# table command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/timechart.md
+++ b/_sql-and-ppl/ppl/commands/timechart.md
@@ -8,7 +8,7 @@ nav_order: 49
 
 <!-- vale off -->
 
-# timechart
+# timechart command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/top.md
+++ b/_sql-and-ppl/ppl/commands/top.md
@@ -8,7 +8,7 @@ nav_order: 50
 
 <!-- vale off -->
 
-# top {#top-command}
+# top command 
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/transpose.md
+++ b/_sql-and-ppl/ppl/commands/transpose.md
@@ -8,7 +8,7 @@ nav_order: 51
 
 <!-- vale off -->
 
-# transpose
+# transpose command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/trendline.md
+++ b/_sql-and-ppl/ppl/commands/trendline.md
@@ -8,7 +8,7 @@ nav_order: 52
 
 <!-- vale off -->
 
-# trendline
+# trendline command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/commands/where.md
+++ b/_sql-and-ppl/ppl/commands/where.md
@@ -8,7 +8,7 @@ nav_order: 53
 
 <!-- vale off -->
 
-# where
+# where command
 
 <!-- vale on -->
 

--- a/_sql-and-ppl/ppl/functions/expressions.md
+++ b/_sql-and-ppl/ppl/functions/expressions.md
@@ -6,7 +6,7 @@ grand_parent: PPL
 nav_order: 7
 ---
 
-# Expressions
+# Expressions in PPL
 
 Expressions, particularly value expressions, return a scalar value. Expressions have different types and forms. For example, there are literal values as atomic expressions, as well as arithmetic, predicate, and function expressions built on top of them. You can use expressions in different clauses, such as arithmetic expressions in the `Filter` or `Stats` commands.
 

--- a/_sql-and-ppl/ppl/subsearch.md
+++ b/_sql-and-ppl/ppl/subsearch.md
@@ -7,7 +7,7 @@ redirect_from:
   - /search-plugins/sql/ppl/subsearch/
 ---
 
-# Subsearch
+# Subsearch in PPL queries
 
 This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).    
 {: .warning}


### PR DESCRIPTION
Make headings level 1 more descriptive for doc pages for better search experience.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
