### PR TITLE
Document the ubiEventsIndex and ubiQueriesIndex parameters

### DIFF
--- a/_search-plugins/search-relevance/judgments.md
+++ b/_search-plugins/search-relevance/judgments.md
@@ -172,7 +172,7 @@ POST /_plugins/_ml/connectors/_create
 
 Implicit judgments are derived from past user interactions. SRW supports the Clicks Over Expected Clicks (COEC) click model, which uses *impression* and *click* signals to calculate judgments.
 
-Input data must follow the [UBI index schemas]({{site.url}}{{site.baseurl}}/search-plugins/ubi/schemas/). COEC uses every event in the `ubi_events` index with an `action_name` of `impression` or `click`.
+Input data must follow the [UBI index schemas]({{site.url}}{{site.baseurl}}/search-plugins/ubi/schemas/). COEC uses every event in the `ubi_events` index with an `action_name` of `impression` or `click`. Use the `ubiEventsIndex` parameter to read from a differently named index.
 
 COEC calculates an expected click-through rate (CTR) for each rank by dividing the total number of clicks by the total number of impressions observed at that rank, based on all events in `ubi_events`. This ratio represents the expected CTR for that position.
 
@@ -194,7 +194,8 @@ PUT _plugins/_search_relevance/judgments
   "name": "Implicit Judgments",
   "clickModel": "coec",
   "type": "UBI_JUDGMENT",
-  "maxRank": 20
+  "maxRank": 20,
+  "ubiEventsIndex": "customized_ubi_events_index_name"  // (optional)
 }
 ```
 {% include copy-curl.html %}
@@ -211,6 +212,7 @@ The following table lists the parameters for creating implicit judgments.
 | `maxRank` | Integer | The maximum rank to consider when including events in the judgment calculation. |
 | `startDate` | Date | An optional starting date from which behavioral data events are considered for implicit judgment generation. The format is `yyyy-MM-dd`. |
 | `endDate` | Date | An optional end date until which behavioral data events are considered for implicit judgment generation. The format is `yyyy-MM-dd`. |
+| `ubiEventsIndex` | String | An optional name of the index containing the UBI events to analyze. Default is `ubi_events`. Specify this parameter when your UBI events are stored in an index with a different name. |
 
 ## Importing judgments
 

--- a/_search-plugins/search-relevance/judgments.md
+++ b/_search-plugins/search-relevance/judgments.md
@@ -195,7 +195,7 @@ PUT _plugins/_search_relevance/judgments
   "clickModel": "coec",
   "type": "UBI_JUDGMENT",
   "maxRank": 20,
-  "ubiEventsIndex": "customized_ubi_events_index_name"  // (optional)
+  "ubiEventsIndex": "customized_ubi_events_index_name"
 }
 ```
 {% include copy-curl.html %}

--- a/_search-plugins/search-relevance/judgments.md
+++ b/_search-plugins/search-relevance/judgments.md
@@ -195,7 +195,6 @@ PUT _plugins/_search_relevance/judgments
   "clickModel": "coec",
   "type": "UBI_JUDGMENT",
   "maxRank": 20,
-  "ubiEventsIndex": "customized_ubi_events_index_name"
 }
 ```
 {% include copy-curl.html %}

--- a/_search-plugins/search-relevance/judgments.md
+++ b/_search-plugins/search-relevance/judgments.md
@@ -194,7 +194,7 @@ PUT _plugins/_search_relevance/judgments
   "name": "Implicit Judgments",
   "clickModel": "coec",
   "type": "UBI_JUDGMENT",
-  "maxRank": 20,
+  "maxRank": 20
 }
 ```
 {% include copy-curl.html %}

--- a/_search-plugins/search-relevance/query-sets.md
+++ b/_search-plugins/search-relevance/query-sets.md
@@ -48,7 +48,7 @@ POST _plugins/_search_relevance/query_sets
   "description": "Top 20 most frequent queries sourced from user searches.",
   "sampling": "topn",
   "querySetSize": 20,
-  "ubiQueriesIndex": "customized_ubi_queries_index_name"  // (optional)
+  "ubiQueriesIndex": "customized_ubi_queries_index_name"
 }
 ```
 

--- a/_search-plugins/search-relevance/query-sets.md
+++ b/_search-plugins/search-relevance/query-sets.md
@@ -48,7 +48,6 @@ POST _plugins/_search_relevance/query_sets
   "description": "Top 20 most frequent queries sourced from user searches.",
   "sampling": "topn",
   "querySetSize": 20,
-  "ubiQueriesIndex": "customized_ubi_queries_index_name"
 }
 ```
 

--- a/_search-plugins/search-relevance/query-sets.md
+++ b/_search-plugins/search-relevance/query-sets.md
@@ -14,7 +14,7 @@ Additionally, Search Relevance Workbench allows you to import a query set.
 
 ## Creating query sets
 
-If you're tracking user behavior with the UBI specification, you can choose from different sampling methods that can create query sets based on real user queries stored in the `ubi_queries` index.
+If you're tracking user behavior with the UBI specification, you can choose from different sampling methods that can create query sets based on real user queries stored in the `ubi_queries` index. Use the `ubiQueriesIndex` parameter to sample from a differently named index.
 
 Search Relevance Workbench supports three sampling methods:
 * Random: Takes a random sample of all queries.
@@ -37,6 +37,7 @@ Field | Data type |  Description
 `description` | String | A short description of the query set. The maximum length is 250 characters.
 `sampling` | String | Defines which sampler to use. Valid values are `pptss` (Probability-Proportional-to-Size-Sampling), `random`, `topn` (most frequent queries), and `manual`.
 `querySetSize` | Integer | The target number of queries in the query set. Depending on the number of unique queries in `ubi_queries`, the resulting query set may contain fewer queries. Must be a positive integer.
+`ubiQueriesIndex` | String | An optional name of the index containing the UBI queries to sample. Default is `ubi_queries`. Specify this parameter when your UBI queries are stored in an index with a different name.
 
 ### Example request: Sampling 20 queries with the Top N sampler
 
@@ -46,7 +47,8 @@ POST _plugins/_search_relevance/query_sets
   "name": "Top 20",
   "description": "Top 20 most frequent queries sourced from user searches.",
   "sampling": "topn",
-  "querySetSize": 20
+  "querySetSize": 20,
+  "ubiQueriesIndex": "customized_ubi_queries_index_name"  // (optional)
 }
 ```
 

--- a/_search-plugins/search-relevance/query-sets.md
+++ b/_search-plugins/search-relevance/query-sets.md
@@ -47,7 +47,7 @@ POST _plugins/_search_relevance/query_sets
   "name": "Top 20",
   "description": "Top 20 most frequent queries sourced from user searches.",
   "sampling": "topn",
-  "querySetSize": 20,
+  "querySetSize": 20
 }
 ```
 


### PR DESCRIPTION
### Description

Search Relevance Workbench reads UBI data from `ubi_events` and `ubi_queries` by default, and has accepted `ubiEventsIndex` and `ubiQueriesIndex` since OS 3.5 to point at differently named indexes. Neither parameter is documented on either page.

### Issues Resolved

Documents the parameters added in [search-relevance#364](https://github.com/opensearch-project/search-relevance/pull/364).

Related: [dashboards-search-relevance#907](https://github.com/opensearch-project/dashboards-search-relevance/issues/907)

### Version
3.5 and above

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
