### PR TITLE
Fix breadcrumbs in search results and other functionality

### DIFF
--- a/_layouts/search_layout.html
+++ b/_layouts/search_layout.html
@@ -123,30 +123,65 @@ layout: table_wrappers
         const allCheckbox = document.getElementById('categoryAll');
         return document.querySelectorAll('input[name="categoryGroup"]:checked');
     }
-    
-    function triggerSearch(query) {
+
+    /* The query in the address bar, which is the query this page is showing results for. */
+    function getUrlQuery() {
+        return new URLSearchParams(window.location.search).get('q') || '';
+    }
+
+    /* Shows the results for a query and does nothing else. Separate from `triggerSearch` so that
+       going back to an earlier search can run it again without changing the history. */
+    function runSearch(query) {
       const searchResultsHeader = document.getElementById('searchPageResultsHeader');
+      const resultsContainer = document.getElementById('searchPageResultsContainer');
+
+      if (!query) {
+        searchResultsHeader.textContent = 'Enter a search query.';
+        resultsContainer.innerHTML = '';
+        return;
+      }
+
+      if (getSelectedCategory().length === 0) {
+        searchResultsHeader.textContent = 'Select the result type for your search.';
+        resultsContainer.innerHTML = '';
+        return;
+      }
+
+      const searchType = Array.from(getSelectedCategory()).map(element => element.value).join(',');
+      searchResultsHeader.textContent = `Search results for "${truncateSentence(query, 20)}"`;
+      doResultsPageSearch(query, searchType, getDocsVersion());
+    }
+
+    /* Runs a search and puts it in the address bar, so a reload or a copied link shows the same
+       results. A new query adds a history entry, so the back button walks back through the searches;
+       the same query replaces it, because a category checkbox would otherwise add one per tick.
+       Comment in this style here, never with `//`: the build puts this script on a single line, which
+       would turn a line comment into a comment on everything after it. */
+    function triggerSearch(query) {
+      const previousQuery = getUrlQuery();
+      const url = new URL(window.location);
 
       if (query) {
-        trucatedQuery = truncateSentence(query, 20);
-        if (getSelectedCategory().length === 0) {
-            searchResultsHeader.textContent = 'Select the result type for your search.';
-            document.getElementById('searchPageResultsContainer').innerHTML = '';
-            return;
-        }
-        const selectedCategory = getSelectedCategory();
-        const searchType = Array.from(selectedCategory).map(element => element.value).join(',');
-        const urlPath = window.location.pathname;
-        const versionMatch = urlPath.match(/(\d+\.\d+)/);
-        const docsVersion = versionMatch ? versionMatch[1] : "latest";
-
-        searchResultsHeader.textContent = `Search results for "${trucatedQuery}"`;
-        doResultsPageSearch(query, searchType, docsVersion);
+        url.searchParams.set('q', query);
       } else {
-        searchResultsHeader.textContent = 'Please input a Query for searching.';
-        document.getElementById('searchPageResultsContainer').innerHTML = '';
+        url.searchParams.delete('q');
       }
+
+      if (query && query !== previousQuery) {
+        history.pushState({ q: query }, '', url);
+      } else {
+        history.replaceState({ q: query }, '', url);
+      }
+
+      runSearch(query);
     }
+
+    /* Puts the search box and the results back in step with the address bar when the reader moves
+       between two searches with the back or forward button, which does not reload the page. */
+    window.addEventListener('popstate', () => {
+      searchInput.value = getUrlQuery();
+      runSearch(searchInput.value.trim());
+    });
 
     searchInput.addEventListener('keydown', function(event) {
       if (event.key === 'Enter') {
@@ -220,15 +255,13 @@ layout: table_wrappers
     document.addEventListener('DOMContentLoaded', () => {
       const searchInput = document.getElementById('searchPageInput');
 
-      const getQueryParam = (param) => {
-          const urlParams = new URLSearchParams(window.location.search);
-          return urlParams.get(param);
-      };
-  
-      const searchQuery = getQueryParam('q');
-  
+      /* Fills the box from the address bar and searches, so that a copied link or a reload shows the
+         results it promises. `getUrlQuery` returns the query ready to use, decoded once, which is what
+         a query holding a percent sign needs: "100% recall". */
+      const searchQuery = getUrlQuery();
+
       if (searchQuery) {
-        searchInput.value = decodeURIComponent(searchQuery);
+        searchInput.value = searchQuery;
         triggerSearch(searchInput.value.trim());
       }
     });

--- a/_plugins/search-indexer.rb
+++ b/_plugins/search-indexer.rb
@@ -1,34 +1,52 @@
 # frozen_string_literal: true
 
-require "jekyll/hooks"
-require "jekyll/document"
-require "json"
+require 'jekyll/hooks'
+require 'jekyll/document'
+require 'json'
 
 ##
-# This singleton facilitates production of an indexable JSON representation of the content to populate a data source
-# to provide search functionality.
+# Writes the file that the search index is built from: one record per page, holding the page's URL,
+# title, breadcrumb, and text.
 
 module Jekyll::ContentIndexer
+  ##
+  # Every page to be written out, stored under its own URL. Keyed by URL, not a plain list, because
+  # serving the site locally rebuilds it in the same process on every save, and a list would gain
+  # another copy of the whole site each time.
+
+  @data = {}
 
   ##
-  # The collection that will get stores as the output
+  # Pattern to identify documents that should be excluded based on their URL.
+  # The 404 page and the search page are excluded.
 
-  @data = []
-
-  ##
-  # Pattern to identify documents that should be excluded based on their URL
-
-  @excluded_paths = /\.(css|js|json|map|xml|txt|yml)$/i.freeze
+  @excluded_paths = %r{\.(css|js|json|map|xml|txt|yml)$|^/(404|search)\.html$}i.freeze
 
   ##
   # Pattern to identify block HTML tags (not comprehensive)
 
-  @html_block_tags = /\s*<[?\/]?(article|blockquote|d[dlt]|div|fieldset|form|h|li|main|nav|[ou]l|p|section|table|t[rd]).*?>\s*/im.freeze
+  @html_block_tags = %r{\s*<[?/]?(article|blockquote|d[dlt]|div|fieldset|form|h|li|main|nav|[ou]l|p|section|table|t[rd]).*?>\s*}im.freeze
 
   ##
   # Pattern to identify certain HTML tags whose content should be excluded from indexing
 
-  @html_excluded_tags = /\s*<(head|style|script|h1).*?>.*?<\/\1>/im.freeze
+  @html_excluded_tags = %r{\s*<(head|style|script|h1|label|button).*?>.*?</\1>}im.freeze
+
+  ##
+  # Pattern to identify the version and status labels above a page's first paragraph
+
+  @html_label_tags = %r{\s*<p[^>]*\sclass="label\b[^"]*"[^>]*>.*?</p>}im.freeze
+
+  ##
+  # Pattern to capture the first H1, which becomes the indexed title.
+
+  @h1_tag = %r{<h1[^>]*>(.*?)</h1>}im.freeze
+
+  ##
+  # The first breadcrumb for pages in the OpenSearch section: the plain product name
+  # Keep this wording the same as `OPENSEARCH_SECTION` in `assets/js/search.js`.
+
+  OPENSEARCH_ROOT = 'OpenSearch'
 
   ##
   # Initializes the singleton by recording the site
@@ -38,57 +56,105 @@ module Jekyll::ContentIndexer
   end
 
   ##
+  # The first one or two breadcrumbs: the section the page belongs to, then the collection within it.
+  #
+  # Only the OpenSearch section holds more than one collection, so only it needs the second crumb. Each
+  # of the other five sections is a single collection.
+
+  def self.section_crumbs(page)
+    return [page.data['section-name'].to_s].reject(&:empty?) unless page.data['section'] == 'opensearch'
+
+    label = page.collection&.label if page.instance_of?(Jekyll::Document)
+    [OPENSEARCH_ROOT, @site.config.dig('opensearch_collection', 'collections', label, 'name')].compact
+  end
+
+  ##
+  # The whole breadcrumb, widest first: the section and collection, then up to the three levels of
+  # parent page that the navigation allows.
+  #
+  # The last crumb is left off when it says the same thing as the title, which is the case on the page
+  # that introduces a collection: it is named after the collection, so the breadcrumb would end where
+  # the heading begins. Case is ignored, because a collection is named in title case in `_config.yml`
+  # ("Managing Indexes") and in sentence case on the page ("Managing indexes"). The section crumb
+  # always stays: it tells the reader which set of documentation the page belongs to.
+
+  def self.breadcrumb(page, title)
+    crumbs = %w[great_grand_parent grand_parent parent].each_with_object(section_crumbs(page)) do |key, levels|
+      level = page.data[key].to_s
+      levels.push(level) unless level.empty? || levels.include?(level)
+    end
+
+    return crumbs if crumbs.length < 2
+
+    crumbs.last.strip.casecmp?(title.to_s.strip) ? crumbs[0..-2] : crumbs
+  end
+
+  ##
+  # Characters that HTML writes as an escape code. Headings are put back through this so that a title
+  # is indexed as `&` rather than as `&amp;`.
+
+  @html_entities = {
+    '&amp;' => '&', '&lt;' => '<', '&gt;' => '>', '&quot;' => '"', '&#39;' => "'"
+  }.freeze
+
+  ##
+  # The page's main heading as plain text, or the front matter `title` when the page has no heading to
+  # use.
+
+  def self.extract_heading(page)
+    title = page.data['title']
+    match = @h1_tag.match(page.content)
+    return title if match.nil?
+
+    heading = match[1]
+              .gsub(/<[^>]+>/, '')
+              .gsub(/&(?:amp|lt|gt|quot|#39);/, @html_entities)
+              .gsub(/\s+/, ' ')
+              .strip
+
+    heading.empty? ? title : heading
+  end
+
+  ##
   # Processes a Document or Page and adds it to the collection
 
   def self.add(page)
     return if @excluded_paths.match(page.url)
 
     content = page.content
-                  .gsub(@html_excluded_tags, ' ')             # Strip certain HTML blocks
-                  .gsub(@html_block_tags, "\n")               # Strip some block HTML tags, replacing with newline
-                  .gsub(/\s*<[?\/!]?[a-z]+.*?>\s*/im, ' ')    # Strip all remaining HTML tags
-                  .gsub(/\s*[\r\n]+\s*/, "\n")                # Clean line-breaks
-                  .gsub(/\s{2,}/, ' ')                        # Trim long spaces
-                  .gsub(/\s+([.:;,)!\]?])/, '\1')             # Remove spaces before some punctuations
-                  .strip                                      # Trim leading and tailing whitespaces
+                  .gsub(@html_excluded_tags, ' ')               # Strip certain HTML blocks
+                  .gsub(@html_label_tags, ' ')                  # Strip version and status labels
+                  .gsub(/<!--.*?-->/m, ' ')                     # Strip HTML comments
+                  .gsub(@html_block_tags, "\n")                 # Strip some block HTML tags, replacing with newline
+                  .gsub(%r{\s*<[?/!]?[a-z]+.*?>\s*}im, ' ')     # Strip all remaining HTML tags
+                  .gsub(/\s*[\r\n]+\s*/, "\n")                  # Clean line-breaks
+                  .gsub(/\s{2,}/, ' ')                          # Trim long spaces
+                  .gsub(/\s+([.:;,)!\]?])/, '\1')               # Remove spaces before some punctuations
+                  .strip                                        # Trim leading and tailing whitespaces
 
     return if content.empty?
 
-    url = @site.config["baseurl"] + page.url
+    url = @site.config['baseurl'] + page.url
 
-    # Produce a breadcrumb
-    ancestors = []
-    if page.instance_of?(Jekyll::Document)
-      ancestors.push(@site.config.dig("just_the_docs", "collections", page.collection&.label, "name"))
-    end
-
-    ancestors.push(page.data["grand_parent"]) unless
-      page.data["grand_parent"].nil? ||
-      page.data["grand_parent"]&.empty? ||
-      ancestors.include?(page.data["grand_parent"])     # Make sure collection name is not added
-
-    ancestors.push(page.data["parent"]) unless
-      page.data["parent"].nil? ||
-        page.data["parent"]&.empty? ||
-        ancestors.include?(page.data["parent"])         # Make sure collection name is not added
+    title = extract_heading(page)
 
     data = {
       url: url,
-      title: page.data["title"],
+      title: title,
       content: content,
-      ancestors: ancestors,
-      type: "DOCS"
+      ancestors: breadcrumb(page, title),
+      type: 'DOCS'
     }
 
-    @data.push(data)
+    @data[url] = data
   end
 
   ##
   # Saves the collection as a JSON file
 
   def self.save
-    File.open(File.join(@site.config["destination"], "search-index.json"), 'w') do |f|
-      f.puts JSON.pretty_generate(@data)
+    File.open(File.join(@site.config['destination'], 'search-index.json'), 'w') do |f|
+      f.puts JSON.pretty_generate(@data.values)
     end
   end
 end
@@ -114,5 +180,5 @@ end
 # Save the produced collection after Jekyll is done writing all its stuff
 
 Jekyll::Hooks.register :site, :post_write do |_|
-  Jekyll::ContentIndexer.save()
+  Jekyll::ContentIndexer.save
 end

--- a/_sass/_navigation-header.scss
+++ b/_sass/_navigation-header.scss
@@ -882,7 +882,7 @@ $max-container: 1440px;
                                                         text-decoration: none;
                                                         font-style: normal;
                                                         display: block;
-                                                        line-height: 1;
+                                                        line-height: 1.4;
                                                         font-weight: normal;
                                                     }
                                                 }

--- a/assets/js/search.js
+++ b/assets/js/search.js
@@ -1,3 +1,55 @@
+// The first breadcrumb the indexer writes is the section the page belongs to. OpenSearch is the only
+// versioned section, so its crumb is the only one that gets a version number added.
+// Keep this wording the same as `OPENSEARCH_ROOT` in `_plugins/search-indexer.rb`.
+const OPENSEARCH_SECTION = 'OpenSearch';
+
+// Shared by the type-ahead dropdown and the results page, so it returns an array and each caller
+// escapes it its own way.
+const getBreadcrumbTrail = result => {
+    const crumbs = (result.ancestors || []).filter(crumb => crumb && crumb.trim());
+
+    if (result.type !== 'DOCS') {
+        if (result.type) crumbs.unshift(result.type);
+    } else if (crumbs[0] === OPENSEARCH_SECTION) {
+        crumbs[0] = `${OPENSEARCH_SECTION} ${result.versionLabel || result.version}`;
+    }
+
+    return crumbs;
+};
+
+// The API cuts the snippet at a fixed length, so it usually ends mid-word. Drop the half word and end
+// with an ellipsis instead. A snippet already ending in punctuation was not cut.
+// The ellipsis is a literal character, not `&hellip;`, because the results page sets this as text.
+const formatSnippet = text => {
+    if (!text) return '';
+
+    // The indexer separates blocks with a new line. Splitting on them keeps a heading from running
+    // into the text beneath it.
+    const blocks = String(text).split('\n')
+        .map(block => block.replace(/\s+/g, ' ').trim())
+        .filter(Boolean);
+    if (!blocks.length) return '';
+
+    // Only the last block can have been cut. The ellipsis goes there rather than at the very end, so
+    // a snippet that stops at a block boundary does not get two in a row.
+    const last = blocks.length - 1;
+    if (!/[.!?]["')\]]?$/.test(blocks[last])) {
+        blocks[last] = `${blocks[last].replace(/\s+\S*$/, '')}…`;
+    }
+
+    return blocks.join(' … ');
+};
+
+// The version being read, which chooses the index to search: "/2.19/..." searches the 2.19 docs and
+// "/latest/..." the current ones. Only the first part of the path is read, because page names hold
+// version numbers of their own: a looser match finds "8.11" in
+// /latest/migration-assistant/playbook-solr-8.11-to-opensearch-3/ and searches for a 8.11 index that
+// does not exist.
+const getDocsVersion = fallback => {
+    const [, segment] = window.location.pathname.split('/');
+    return /^\d+\.\d+$/.test(segment) ? segment : (fallback || 'latest');
+};
+
 (() => {
     document.addEventListener('DOMContentLoaded', () => {
         //
@@ -14,10 +66,8 @@
 
         const canSmoothScroll = 'scrollBehavior' in document.documentElement.style;
 
-        //Extract version from the URL path
-        const urlPath = window.location.pathname;
-        const versionMatch = urlPath.match(/(\d+\.\d+)/);
-        const docsVersion = versionMatch ? versionMatch[1] : elInput.getAttribute('data-docs-version');
+        // Falls back to the attribute the header sets, which every build ships as "latest".
+        const docsVersion = getDocsVersion(elInput.getAttribute('data-docs-version'));
 
         let _showingResults = false,
             animationFrame,
@@ -79,14 +129,11 @@
             while (abortControllers.length) abortControllers.pop()?.abort?.();
         };
 
+        // The element sits on its own line, so an empty one would leave a gap above the title.
         const getBreadcrumbs = result => {
-            const crumbs = [...result.ancestors].filter(crumb => crumb && crumb.trim());
-
-            if (result.type === 'DOCS') crumbs.unshift(`OpenSearch ${result.versionLabel || result.version}`);
-            else if (result.type) crumbs.unshift(result.type);
-
-            return sanitizeText(crumbs.join(' › '));
-        }
+            const trail = getBreadcrumbTrail(result);
+            return trail.length ? `<cite>${sanitizeText(trail.join(' › '))}</cite>` : '';
+        };
 
         const doSearch = async () => {
             const query = elInput.value.replace(/[^a-z0-9-_. ]+/ig, ' ');
@@ -126,10 +173,10 @@
                     ? `
                     <div class="${searchResultClassName}">
                         <a href="${sanitizeAttribute(result.url)}">
-                            <cite>${getBreadcrumbs(result)}</cite>
+                            ${getBreadcrumbs(result)}
                             ${sanitizeText(result.title || 'Unnamed Document')}
                         </a>
-                        <span>${sanitizeText(result.content?.replace?.(/\n/g, '&hellip; '))}</span>
+                        <span>${sanitizeText(formatSnippet(result.content))}</span>
                     </div>
                     `
                     : ''
@@ -300,11 +347,9 @@ window.doResultsPageSearch = async (query, type, version) => {
               const resultElement = document.createElement('div');
               resultElement.classList.add('search-page--results--display--container--item');
 
+              const trail = getBreadcrumbTrail(result);
               const contentCite = document.createElement('cite');
-              const crumbs = [...result.ancestors].filter(crumb => crumb && crumb.trim());
-              if (result.type === 'DOCS') crumbs.unshift(`OpenSearch ${result.versionLabel || result.version}`);
-              else if (result.type) crumbs.unshift(result.type);
-              contentCite.textContent = crumbs.join(' › ')?.replace?.(/</g, '&lt;');
+              contentCite.textContent = trail.join(' › ');
               contentCite.style.fontSize = '.8em';
 
               const titleLink = document.createElement('a');
@@ -313,10 +358,10 @@ window.doResultsPageSearch = async (query, type, version) => {
               titleLink.textContent = result.title;
               
               const contentSpan = document.createElement('span');
-              contentSpan.textContent = result.content;
+              contentSpan.textContent = formatSnippet(result.content);
               contentSpan.style.display = 'block';
 
-              resultElement.appendChild(contentCite);
+              if (trail.length) resultElement.appendChild(contentCite);
               resultElement.appendChild(titleLink);
               resultElement.appendChild(contentSpan);
 


### PR DESCRIPTION
Closes #12497 

This PR fixes breadcrumb paths for search results (both in the dropdown and on the search result page). Additionally, it fixes some existing search functionality. Here is the list of changes:

In the indexer (_plugins/search-indexer.rb):
1. Updates how the collections are read since the collections were rearranged. The config moved to `opensearch_collection`, so the lookup returned nil for every document. 
2. Handles the standalone sections (Data Prepper, Benchmark, Clients, and both Migration Assistant sections) as a single collection. Instead of rendering a sample Benchmark page breadcrumb as "OpenSearch 3.8 › Reference › Command reference" (the parent is nil so Benchmark does not show), renders the breadcrumb as "OpenSearch 3.8 › OpenSearch Benchmark › Reference › Command reference". Only the OpenSearch section is versioned, so only its crumb gets a version number now.
3. Includes great_grand_parent (the added navigation level) in breadcrumbs so all 4 levels are included when constructing a benchmark path.
4. Shows the page's H1 as the result instead of the front matter title. Users can now differentiate their search results for "append", for example, because the results will say "Append processor" and "append command" rather than just "append".
5. Version and status labels are not indexed as body text. 420 of production snippets begin with "Introduced 2.8" instead of the first sentence. Label and button text and HTML comments (the <!-- vale off --> directives), which previously showed up in the search results, are not indexed.
6. The search page and the 404 page are not indexed as results.
7. Serving locally duplicated the whole site in the index on every save. @data was an array in module state that outlives a build, so each rebuild appended another copy; emptying it per build instead truncated the index under --incremental. Keying by URL is correct in both modes. Duplicates in the JSON overwrite the previous ones rather than duplicating.

In the renderer (assets/js/search.js):
1. The version was matched anywhere in the path. On `/latest/migration-assistant/playbook-solr-8.11-to-opensearch-3/`, a search queried an 8.11 index that does not exist and returned nothing. Only the first path segment is read now.
2. Snippets ended mid-word because the API cuts at a fixed length. The partial word is dropped and an ellipsis is added, signifying that this is not a complete sentence.

On the results page (_layouts/search_layout.html):
1. Searching again on the results page updates the URL, so a reload or a copied link replays the query on screen rather than the previous one.
2. Each new query adds a history entry, so pressing the back button traces back through the searches instead of leaving the page. Rerunning the same query (by selecting or clearing a category checkbox) replaces its entry rather than adding one, and the back and forward buttons rerun the query to which they return.
3. Queries having a percent sign (like "100% recall") produce search results instead of a blank page. 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
