### PR TITLE
Add unitifed examples and fix fields in the PPL monitor documentation

### DIFF
--- a/_observing-your-data/alerting/ppl-monitors.md
+++ b/_observing-your-data/alerting/ppl-monitors.md
@@ -290,12 +290,15 @@ The response reports the query results and, for each trigger, whether it fired. 
 
 ## Settings
 
-The following cluster settings apply to PPL monitors. You can update these settings using the [cluster settings API]({{site.url}}{{site.baseurl}}/api-reference/cluster-settings/).
+OpenSearch supports the following PPL monitor settings. All settings are dynamic, so you can change them without restarting your cluster:
 
-Setting | Default | Description
-:--- | :--- | :---
-`plugins.alerting.monitor.max_ppl_triggers` | 10 | The maximum number of triggers allowed per PPL monitor.
-`plugins.alerting.ppl_query_max_execution_duration` | 30s | The maximum execution time allowed for a PPL query during monitor execution.
-`plugins.alerting.ppl_monitor_max_query_length` | 2000 | The maximum number of characters for a PPL query.
-`plugins.alerting.ppl_query_results_max_datarows` | 10000 | The maximum number of data rows to retrieve when executing a PPL query.
-`plugins.alerting.ppl_query_results_max_size` | 3000 | The maximum estimated size, in bytes, of query results stored in alerts and notifications. If the results exceed this size, the alert replaces them with a message stating that the PPL query results were too large.
+- `plugins.alerting.monitor.max_ppl_triggers` (Dynamic, integer): The maximum number of triggers allowed per PPL monitor. This is also the highest accepted value, so you can only lower it. Default is `10`.
+
+- `plugins.alerting.ppl_query_max_execution_duration` (Dynamic, time unit): The maximum execution time allowed for a PPL query during monitor execution. Default is `30s`.
+
+- `plugins.alerting.ppl_monitor_max_query_length` (Dynamic, long): The maximum number of characters for a PPL query. Default is `2000`.
+
+- `plugins.alerting.ppl_query_results_max_datarows` (Dynamic, long): The maximum number of data rows to retrieve when executing a PPL query. Default is `10000`.
+
+- `plugins.alerting.ppl_query_results_max_size` (Dynamic, long): The maximum estimated size, in bytes, of query results stored in alerts and notifications. If the results exceed this size, the alert replaces them with a message stating that the PPL query results were too large. Default is `3000`.
+

--- a/_observing-your-data/alerting/ppl-monitors.md
+++ b/_observing-your-data/alerting/ppl-monitors.md
@@ -30,7 +30,7 @@ To create a PPL monitor, follow these steps:
 
 ## PPL triggers
 
-PPL monitors use `PPLTrigger` objects, which differ from the Painless-script-based triggers used by other monitor types. Each PPL monitor supports up to 10 triggers.
+PPL monitors use `ppl_trigger` objects, which differ from the Painless-script-based triggers used by other monitor types. Each PPL monitor supports up to 10 triggers.
 
 ### Number of results trigger
 
@@ -77,7 +77,7 @@ To trigger an alert when any endpoint has a maximum response time above 3000 ms,
   "ppl_trigger": {
     "name": "Slow endpoint detected",
     "severity": "2",
-    "condition_type": "custom",
+    "type": "custom",
     "custom_condition": "where max_response > 3000",
     "actions": []
   }
@@ -107,7 +107,7 @@ PPL Query Results:
 
 ## Query result format
 
-PPL query results contain a `schema` and `datarows` fields, as shown in the following example response:
+PPL query results contain `schema` and `datarows` fields, as shown in the following example response:
 
 ```json
 {
@@ -171,7 +171,7 @@ POST _plugins/_alerting/monitors
             "name": "Notify ops channel",
             "destination_id": "your-destination-id",
             "message_template": {
-              "source": "Monitor {{ctx.monitor.name}} detected {{ctx.ppl_query_results.size}} services with errors."
+              "source": {% raw %}"Monitor {{ctx.monitor.name}} detected {{ctx.ppl_query_results.size}} services with errors."{% endraw %}
             },
             "subject_template": {
               "source": "Alert: High Error Rate Detected"
@@ -191,7 +191,7 @@ POST _plugins/_alerting/monitors
             "name": "Page oncall",
             "destination_id": "your-destination-id",
             "message_template": {
-              "source": "Critical error threshold exceeded:\n{{#ctx.ppl_query_results}}\n  Service: {{service}}, Errors: {{error_count}}\n{{/ctx.ppl_query_results}}"
+              "source": {% raw %}"Critical error threshold exceeded:\n{{#ctx.ppl_query_results}}\n  Service: {{service}}, Errors: {{error_count}}\n{{/ctx.ppl_query_results}}"{% endraw %}
             },
             "subject_template": {
               "source": "CRITICAL: Service Error Threshold Exceeded"

--- a/_observing-your-data/alerting/ppl-monitors.md
+++ b/_observing-your-data/alerting/ppl-monitors.md
@@ -11,7 +11,40 @@ has_children: false
 
 PPL alert monitors use [Piped Processing Language (PPL)]({{site.url}}{{site.baseurl}}/sql-and-ppl/ppl/) queries to monitor your data. They are [per query monitors]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/per-query-bucket-monitors/) that use PPL instead of query DSL as the query language.
 
-## Creating a PPL monitor
+## Setup
+
+The examples on this page use an `application_logs` index containing web request logs. To follow along, create the index with the following mapping:
+
+```json
+PUT /application_logs
+{
+  "mappings": {
+    "properties": {
+      "@timestamp": { "type": "date" },
+      "endpoint": { "type": "keyword" },
+      "service": { "type": "keyword" },
+      "level": { "type": "keyword" },
+      "response_time": { "type": "integer" }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Index the sample documents:
+
+```json
+POST /application_logs/_bulk?refresh=true
+{ "index": {} }
+{ "@timestamp": "2026-01-15T10:00:00Z", "endpoint": "/api/orders", "service": "orders", "level": "ERROR", "response_time": 4200 }
+{ "index": {} }
+{ "@timestamp": "2026-01-15T10:01:00Z", "endpoint": "/api/orders", "service": "orders", "level": "ERROR", "response_time": 3600 }
+{ "index": {} }
+{ "@timestamp": "2026-01-15T10:02:00Z", "endpoint": "/api/checkout", "service": "checkout", "level": "ERROR", "response_time": 2500 }
+```
+{% include copy-curl.html %}
+
+## Creating a PPL monitor in OpenSearch Dashboards
 
 To create a PPL monitor, follow these steps:
 
@@ -21,8 +54,9 @@ To create a PPL monitor, follow these steps:
 4. In the **Query** section, enter your PPL query, for example:
 
    ```sql
-   source = web_logs | stats avg(response_time) as avg_response by endpoint
+   source = application_logs | stats avg(response_time) as avg_response by endpoint
    ```
+   {% include copy.html %}
 
 5. Add one or more triggers. For more information about configuring trigger conditions, see [PPL triggers](#ppl-triggers).
 6. Add actions to specify notifications when triggers fire. For more information, see [Actions]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/actions/).
@@ -45,7 +79,7 @@ Operator | Description
 `==` | Equal to
 `!=` | Not equal to
 
-For example, to trigger an alert when more than 50 results are returned, use the following trigger definition:
+For example, to trigger an alert when more than one result is returned, use the following trigger definition:
 
 ```json
 {
@@ -54,7 +88,7 @@ For example, to trigger an alert when more than 50 results are returned, use the
     "severity": "1",
     "type": "number_of_results",
     "num_results_condition": ">",
-    "num_results_value": 50,
+    "num_results_value": 1,
     "actions": []
   }
 }
@@ -67,7 +101,7 @@ A custom condition trigger appends a `where` clause to the base PPL query. If th
 For example, consider the following base query:
 
 ```sql
-source = web_logs | stats max(response_time) as max_response by endpoint
+source = application_logs | stats max(response_time) as max_response by endpoint
 ```
 
 To trigger an alert when any endpoint has a maximum response time above 3000 ms, use the following trigger definition:
@@ -107,17 +141,17 @@ PPL Query Results:
 
 ## Query result format
 
-PPL query results contain `schema` and `datarows` fields, as shown in the following example response:
+PPL query results contain `schema` and `datarows` fields. For example, the query `source = application_logs | where level = 'ERROR' | stats count() as error_count by endpoint` returns the following response:
 
 ```json
 {
   "schema": [
-    {"name": "endpoint", "type": "string"},
-    {"name": "error_count", "type": "integer"}
+    {"name": "error_count", "type": "bigint"},
+    {"name": "endpoint", "type": "string"}
   ],
   "datarows": [
-    ["/api/orders", 3],
-    ["/api/checkout", 1]
+    [1, "/api/checkout"],
+    [2, "/api/orders"]
   ],
   "total": 2,
   "size": 2
@@ -128,12 +162,12 @@ These results are automatically transformed into a list of maps for use in templ
 
 ```json
 [
-  {"endpoint": "/api/orders", "error_count": 3},
-  {"endpoint": "/api/checkout", "error_count": 1}
+  {"error_count": 1, "endpoint": "/api/checkout"},
+  {"error_count": 2, "endpoint": "/api/orders"}
 ]
 ```
 
-## API example
+## Creating a PPL monitor using the API
 
 The following example creates a PPL monitor with both trigger types:
 
@@ -165,7 +199,7 @@ POST _plugins/_alerting/monitors
         "severity": "1",
         "type": "number_of_results",
         "num_results_condition": ">",
-        "num_results_value": 10,
+        "num_results_value": 1,
         "actions": [
           {
             "name": "Notify ops channel",
@@ -185,7 +219,7 @@ POST _plugins/_alerting/monitors
         "name": "Critical service errors",
         "severity": "1",
         "type": "custom",
-        "custom_condition": "where error_count > 100",
+        "custom_condition": "where error_count > 1",
         "actions": [
           {
             "name": "Page oncall",
@@ -204,6 +238,55 @@ POST _plugins/_alerting/monitors
 }
 ```
 {% include copy-curl.html %}
+
+The response confirms that the monitor was created and returns its `_id`. The monitor runs on its configured schedule, and each run evaluates the triggers against the latest query results. When a trigger's condition is met, it fires and runs its actions.
+
+## Testing a PPL monitor
+
+To run a monitor immediately instead of waiting for its next scheduled run, use the Execute API with the monitor ID. Add `?dryrun=true` to evaluate the triggers without creating alerts or running actions:
+
+```json
+POST _plugins/_alerting/monitors/<monitor_id>/_execute?dryrun=true
+```
+{% include copy-curl.html %}
+
+The response reports the query results and, for each trigger, whether it fired. The `triggered` field indicates whether each trigger's condition was met. For custom condition triggers, `ppl_query_results` contains the rows that matched the condition:
+
+```json
+{
+  "monitor_name": "PPL Error Rate Monitor",
+  "period_start": 1787067810953,
+  "period_end": 1787068110953,
+  "error": null,
+  "input_results": {
+    "results": [],
+    "ppl_query_results": [
+      { "error_count": 1, "service": "checkout" },
+      { "error_count": 2, "service": "orders" }
+    ],
+    "ppl_num_results": 2,
+    "error": null
+  },
+  "trigger_results": {
+    "too_many_errors": {
+      "name": "Too many errors",
+      "triggered": true,
+      "action_results": {},
+      "ppl_query_results": [],
+      "error": null
+    },
+    "critical_service_errors": {
+      "name": "Critical service errors",
+      "triggered": true,
+      "action_results": {},
+      "ppl_query_results": [
+        { "error_count": 2, "service": "orders" }
+      ],
+      "error": null
+    }
+  }
+}
+```
 
 ## Settings
 

--- a/_observing-your-data/alerting/settings.md
+++ b/_observing-your-data/alerting/settings.md
@@ -24,9 +24,10 @@ Index | Purpose
 
 All alerting indexes are hidden by default. For a summary, make the following request:
 
-```
+```json
 GET _cat/indices?expand_wildcards=open,hidden
 ```
+{% include copy-curl.html %}
 
 ## Alerting settings
 
@@ -34,38 +35,74 @@ We don't recommend changing these settings; the defaults should work well for mo
 
 All settings are available using the OpenSearch `_cluster/settings` API. None require a restart, and all can be marked `persistent` or `transient`. To learn more about static and dynamic settings, see [Configuring OpenSearch]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/index/).
 
-Setting | Default | Description
-:--- | :--- | :---
-`plugins.scheduled_jobs.enabled` | true | Whether the Alerting plugin is enabled or not. If disabled, all monitors immediately stop running.
-`plugins.alerting.index_timeout` | 60s | The timeout for creating monitors and destinations using the REST APIs.
-`plugins.alerting.request_timeout` | 10s | The timeout for miscellaneous requests from the plugin.
-`plugins.alerting.action_throttle_max_value` | 24h | The maximum amount of time you can set for action throttling. By default, this value displays as 1440 minutes in OpenSearch Dashboards.
-`plugins.alerting.input_timeout` | 30s | How long the monitor can take to issue the search request.
-`plugins.alerting.bulk_timeout` | 120s | How long the monitor can write alerts to the alert index.
-`plugins.alerting.alert_backoff_count` | 3 | The number of retries for writing alerts before the operation fails.
-`plugins.alerting.alert_backoff_millis` | 50ms | The amount of time to wait between retries---increases exponentially after each failed retry.
-`plugins.alerting.alert_history_rollover_period` | 12h | How frequently to check whether the `.opendistro-alerting-alert-history-write` alias should roll over to a new history index and whether the Alerting plugin should delete any history indexes.
-`plugins.alerting.move_alerts_backoff_millis` | 250 | The amount of time to wait between retries---increases exponentially after each failed retry.
-`plugins.alerting.move_alerts_backoff_count` | 3 | The number of retries for moving alerts to a deleted state after their monitor or trigger has been deleted.
-`plugins.alerting.monitor.max_monitors` | 1000 | The maximum number of monitors users can create.
-`plugins.alerting.alert_history_max_age` | 30d | The oldest document to store in the `.opendistro-alert-history-<date>` index before creating a new index. If the number of alerts in this time period does not exceed `alert_history_max_docs`, alerting creates one history index per period (e.g. one index every 30 days).
-`plugins.alerting.alert_history_max_docs` | 1000 | The maximum number of alerts to store in the `.opendistro-alert-history-<date>` index before creating a new index.
-`plugins.alerting.alert_history_enabled` | true | Whether to create `.opendistro-alerting-alert-history-<date>` indexes.
-`plugins.alerting.alert_history_retention_period` | 60d | The amount of time to store history indexes before automatically deleting them.
-`plugins.alerting.destination.allow_list` | ["chime", "slack", "custom_webhook", "email", "test_action"] | The list of allowed destinations. If you don't want to allow users to a certain type of destination, you can remove it from this list, but we recommend leaving this setting as-is.
-`plugins.alerting.filter_by_backend_roles` | "false" | Restricts access to monitors by backend role. See [Alerting security]({{site.url}}{{site.baseurl}}/monitoring-plugins/alerting/security/).
-`plugins.alerting.filter_by_backend_roles_access_strategy` | "intersect" | Controls how user backend roles are compared with the backend roles associated with a monitor to determine whether a user can access the monitor. See [Alerting security documentation on filtering by backend role]({{site.url}}{{site.baseurl}}/monitoring-plugins/alerting/security/#advanced-limit-access-by-backend-role).
-`plugins.alerting.cross_cluster_monitoring_enabled` | "true" | Toggles whether cluster metrics monitors support running against remote clusters.
-`plugins.scheduled_jobs.sweeper.period` | 5m | The alerting feature uses its "job sweeper" component to periodically check for new or updated jobs. This setting is the rate at which the sweeper checks to see if any jobs (monitors) have changed and need to be rescheduled.
-`plugins.scheduled_jobs.sweeper.page_size` | 100 | The page size for the sweeper. You shouldn't need to change this value.
-`plugins.scheduled_jobs.sweeper.backoff_millis` | 50ms | The amount of time the sweeper waits between retries---increases exponentially after each failed retry.
-`plugins.scheduled_jobs.sweeper.retry_count` | 3 | The total number of times the sweeper should retry before throwing an error.
-`plugins.scheduled_jobs.request_timeout` | 10s | The timeout for the request that sweeps shards for jobs.
-`plugins.alerting.comments_enabled` | `false` | Enables or disables comments for the Alerting plugin.
-`plugins.alerting.comments_history_max_docs` | 1000 | The maximum number of comments to store in the `.opensearch-alerting-comments-history-<date>` index before creating a new index.
-`plugins.alerting.comments_history_max_age` | 30d | The oldest document to store in an `.opensearch-alerting-comments-history-<date>` index before creating a new one. If the number of comments in the specified time period does not exceed `comments_history_max_docs`, then 1 index is created per period (for example, 1 every 30 days).
-`plugins.alerting.comments_history_rollover_period` | 12h | How often to determine whether the `.opensearch-alerting-comments-history-write` alias should roll over to a new index and delete old comment history indexes.
-`plugins.alerting.comments_history_retention_period` | 60d | The amount of time to keep comment history indexes before automatic deletion.
-`plugins.alerting.max_comment_character_length` | 2000 | The maximum character length of a comment.
-`plugins.alerting.max_comments_per_alert` | 500 | The maximum number of comments that can be posted on an alert.
-`plugins.alerting.max_comments_per_notification` | 3 | The maximum number of comments per alert to include in the `ctx` Mustache template variable for alert notifications.
+OpenSearch supports the following alerting settings:
+
+- `plugins.scheduled_jobs.enabled` (Dynamic, Boolean): Whether the Alerting plugin is enabled or not. If disabled, all monitors immediately stop running. Default is `true`.
+
+- `plugins.alerting.index_timeout` (Dynamic, time unit): The timeout for creating monitors and destinations using the REST APIs. Default is `60s`.
+
+- `plugins.alerting.request_timeout` (Dynamic, time unit): The timeout for miscellaneous requests from the plugin. Default is `10s`.
+
+- `plugins.alerting.action_throttle_max_value` (Dynamic, time unit): The maximum amount of time you can set for action throttling. By default, this value displays as 1440 minutes in OpenSearch Dashboards. Default is `24h`.
+
+- `plugins.alerting.input_timeout` (Dynamic, time unit): How long the monitor can take to issue the search request. Default is `30s`.
+
+- `plugins.alerting.bulk_timeout` (Dynamic, time unit): How long the monitor can write alerts to the alert index. Default is `120s`.
+
+- `plugins.alerting.alert_backoff_count` (Dynamic, integer): The number of retries for writing alerts before the operation fails. Default is `2`.
+
+- `plugins.alerting.alert_backoff_millis` (Dynamic, time unit): The amount of time to wait between retries---increases exponentially after each failed retry. Default is `50ms`.
+
+- `plugins.alerting.alert_history_rollover_period` (Dynamic, time unit): How frequently to check whether the `.opendistro-alerting-alert-history-write` alias should roll over to a new history index and whether the Alerting plugin should delete any history indexes. Default is `12h`.
+
+- `plugins.alerting.move_alerts_backoff_millis` (Dynamic, time unit): The amount of time to wait between retries---increases exponentially after each failed retry. Default is `250ms`.
+
+- `plugins.alerting.move_alerts_backoff_count` (Dynamic, integer): The number of retries for moving alerts to a deleted state after their monitor or trigger has been deleted. Default is `3`.
+
+- `plugins.alerting.monitor.max_monitors` (Dynamic, integer): The maximum number of monitors users can create. Default is `1000`.
+
+- `plugins.alerting.alert_history_max_age` (Dynamic, time unit): The oldest document to store in the `.opendistro-alert-history-<date>` index before creating a new index. If the number of alerts in this time period does not exceed `alert_history_max_docs`, alerting creates one history index per period (for example, one index every 30 days). Default is `30d`.
+
+- `plugins.alerting.alert_history_max_docs` (Dynamic, long): The maximum number of alerts to store in the `.opendistro-alert-history-<date>` index before creating a new index. Default is `1000`.
+
+- `plugins.alerting.alert_history_enabled` (Dynamic, Boolean): Whether to create `.opendistro-alerting-alert-history-<date>` indexes. Default is `true`.
+
+- `plugins.alerting.alert_history_retention_period` (Dynamic, time unit): The amount of time to store history indexes before automatically deleting them. Default is `60d`.
+
+- `plugins.alerting.destination.allow_list` (Dynamic, list): The list of allowed destinations. If you don't want to allow users to a certain type of destination, you can remove it from this list, but we recommend leaving this setting as-is. Default is `["chime", "slack", "custom_webhook", "email", "test_action"]`.
+
+- `plugins.alerting.filter_by_backend_roles` (Dynamic, Boolean): Restricts access to monitors by backend role. See [Alerting security]({{site.url}}{{site.baseurl}}/monitoring-plugins/alerting/security/). Default is `false`.
+
+- `plugins.alerting.filter_by_backend_roles_access_strategy` (Dynamic, string): Controls how user backend roles are compared with the backend roles associated with a monitor to determine whether a user can access the monitor. Valid values are `all`, `exact`, and `intersect`. See [Alerting security documentation on filtering by backend role]({{site.url}}{{site.baseurl}}/monitoring-plugins/alerting/security/#advanced-limit-access-by-backend-role). Default is `intersect`.
+
+- `plugins.alerting.cross_cluster_monitoring_enabled` (Dynamic, Boolean): Toggles whether cluster metrics monitors support running against remote clusters. Default is `true`.
+
+- `plugins.scheduled_jobs.sweeper.period` (Dynamic, time unit): The alerting feature uses its "job sweeper" component to periodically check for new or updated jobs. This setting is the rate at which the sweeper checks to see if any jobs (monitors) have changed and need to be rescheduled. Default is `5m`.
+
+- `plugins.scheduled_jobs.sweeper.page_size` (Dynamic, integer): The page size for the sweeper. You shouldn't need to change this value. Default is `100`.
+
+- `plugins.scheduled_jobs.sweeper.backoff_millis` (Dynamic, time unit): The amount of time the sweeper waits between retries---increases exponentially after each failed retry. Default is `50ms`.
+
+- `plugins.scheduled_jobs.retry_count` (Dynamic, integer): The total number of times the sweeper should retry before throwing an error. Default is `3`.
+
+- `plugins.scheduled_jobs.request_timeout` (Dynamic, time unit): The timeout for the request that sweeps shards for jobs. Default is `10s`.
+
+- `plugins.alerting.comments_enabled` (Dynamic, Boolean): Enables or disables comments for the Alerting plugin. Default is `true`.
+
+- `plugins.alerting.comments_history_max_docs` (Dynamic, long): The maximum number of comments to store in the `.opensearch-alerting-comments-history-<date>` index before creating a new index. Default is `1000`.
+
+- `plugins.alerting.comments_history_max_age` (Dynamic, time unit): The oldest document to store in an `.opensearch-alerting-comments-history-<date>` index before creating a new one. If the number of comments in the specified time period does not exceed `comments_history_max_docs`, then 1 index is created per period (for example, 1 every 30 days). Default is `30d`.
+
+- `plugins.alerting.comments_history_rollover_period` (Dynamic, time unit): How often to determine whether the `.opensearch-alerting-comments-history-write` alias should roll over to a new index and delete old comment history indexes. Default is `12h`.
+
+- `plugins.alerting.comments_history_retention_period` (Dynamic, time unit): The amount of time to keep comment history indexes before automatic deletion. Default is `60d`.
+
+- `plugins.alerting.max_comment_character_length` (Dynamic, long): The maximum character length of a comment. Default is `2000`.
+
+- `plugins.alerting.max_comments_per_alert` (Dynamic, long): The maximum number of comments that can be posted on an alert. Default is `500`.
+
+- `plugins.alerting.max_comments_per_notification` (Dynamic, integer): The maximum number of comments per alert to include in the `ctx` Mustache template variable for alert notifications. Default is `3`.
+
+### PPL monitor settings
+
+For information about PPL monitor settings, see [PPL monitor settings]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/ppl-monitors/).


### PR DESCRIPTION
Add unitifed examples and setup to the PPL monitor documentation and change the custom `condition_type` to `type` for custom PPL trigger.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
