### PR TITLE
Fix diagnose flag syntax for securityadmin.sh

### DIFF
--- a/_security/configuration/security-admin.md
+++ b/_security/configuration/security-admin.md
@@ -300,6 +300,7 @@ Name | Description
 Name | Description
 :--- | :---
 `-dci` | Delete the Security plugin configuration index and exit. This option is useful if the cluster state is red due to a corrupted Security plugin index.
+`-dg,--diagnose` | Log a diagnostic trace to a file. The script prints the location of the generated file.
 `-esa` | Enable shard allocation and exit. This option is useful if you disabled shard allocation while performing a full cluster restart and need to recreate the Security plugin index.
 `-w` | Displays information about the used admin certificate.
 `-rl` | By default, the Security plugin caches authenticated users, along with their roles and permissions, for one hour. This option reloads the current Security plugin configuration stored in your cluster, invalidating any cached users, roles, and permissions.

--- a/_troubleshoot/security-admin.md
+++ b/_troubleshoot/security-admin.md
@@ -96,10 +96,10 @@ You must use an admin certificate when executing the script. To learn more, see 
 
 ## Use the diagnose option
 
-For more information about why `securityadmin.sh` is not executing, add the `--diagnose` option:
+For more information about why `securityadmin.sh` is not executing, add the `--diagnose` option (or its short form, `-dg`):
 
 ```
-./securityadmin.sh -diagnose -cd ../../../config/opensearch-security/ -cacert ... -cert ... -key ... -keypass ...
+./securityadmin.sh --diagnose -cd ../../../config/opensearch-security/ -cacert ... -cert ... -key ... -keypass ...
 ```
 
 The script prints the location of the generated diagnostic file.


### PR DESCRIPTION
### Description

Addresses user feedback submitted through the documentation feedback widget on July 13, 2026:

> "diagnose" is ambiguous is it one dash or two?

The troubleshooting page contradicted itself. The prose referred to `--diagnose` (two dashes) but the command example used `-diagnose` (one dash), so readers had no way to tell which was correct.

Changes:
* Corrected the example command to `--diagnose` and noted the `-dg` short form, so the example matches the surrounding prose.
* Added `-dg,--diagnose` to the options reference table in `_security/configuration/security-admin.md`, where it was missing entirely. A reader consulting the canonical options reference had no way to look up the flag, which is arguably the root cause of the confusion.

### Testing

The canonical option names were confirmed two ways:
* `SecurityAdmin.java` in `opensearch-project/security` registers the option as `Option.builder("dg").longOpt("diagnose")`, so `-dg` and `--diagnose` are the registered forms.
* The help output from the script on a running cluster confirms: `-dg,--diagnose    Log diagnostic trace into a file`.

Worth noting: Apache Commons CLI is lenient and does accept the old `-diagnose` spelling at runtime, so the previous example was not broken — it was undocumented, non-canonical syntax that contradicted the prose. This change standardizes on the registered forms rather than relying on parser leniency.

### Issues Resolved

N/A — reported through the site feedback widget.

### Check List
- [x] Commit changes are signed off (`git commit -s`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
