### PR TITLE
Correct the doc_values default for wildcard fields

### DIFF
--- a/_mappings/supported-field-types/wildcard.md
+++ b/_mappings/supported-field-types/wildcard.md
@@ -54,7 +54,7 @@ The following table lists all parameters available for `wildcard` fields.
 
 Parameter | Description
 :--- | :---
-`doc_values` | A Boolean value that specifies whether the field should be stored on disk so that it can be used for aggregations, sorting, or scripting. Default is `false`.
+`doc_values` | A Boolean value that specifies whether the field should be stored on disk so that it can be used for aggregations, sorting, or scripting. In OpenSearch 3.4 and later, the default is `true`. In OpenSearch 3.3 and earlier, the default is `false`.
 `ignore_above` | Any string longer than this integer value should not be indexed. Default is `2147483647`. Dynamically updatable.
 `normalizer` | The normalizer used to preprocess values for indexing and search. By default, no normalization occurs and the original value is used. You may use the `lowercase` normalizer to perform case-insentive matching on the field.
 `null_value` | A value to be used in place of `null`. Must be of the same type as the field. If this parameter is not specified, then the field is treated as missing when its value is `null`. Default is `null`.


### PR DESCRIPTION
### Description

Addresses user feedback submitted through the documentation feedback widget on July 22, 2026:

> the default value if doc_values has been changed in 3.0 onwards.

The documented default for `doc_values` on `wildcard` fields was out of date. The reporter was right that the default changed, but the version was wrong: it changed in **3.4**, not 3.0.

The parameter description now reads: "In OpenSearch 3.4 and later, the default is `true`. In OpenSearch 3.3 and earlier, the default is `false`."

Both clauses are kept because this page is also published for version branches where the old default is still the live one.

### Testing

The version boundary was established two independent ways rather than taking the reported version at face value:

* **Live test** against OpenSearch 3.8.0: a `wildcard` field with no explicit `doc_values` reports `"doc_values": true` under `?include_defaults=true`, and a `terms` aggregation on it succeeds. Setting `doc_values: false` explicitly makes the same aggregation fail.
* **Source bisect** of `WildcardFieldMapper.java` across release branches: `docValuesParam(..., false)` on 2.19/3.0/3.1/3.2/3.3, flipping to `true` on 3.4 and later. The change is opensearch-project/OpenSearch#19796, listed in the 3.4.0 release notes, with no backport to 3.0–3.3.

The existing derived source note ("`doc_values` must be enabled for `wildcard` fields...") was verified to still be accurate on 3.8.0 and left unchanged.

### Issues Resolved

N/A — reported through the site feedback widget.

### Check List
- [x] Commit changes are signed off (`git commit -s`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
