### PR TITLE
Document the URL_DOWNLOAD threat intelligence source type

### DIFF
--- a/_security-analytics/threat-intelligence/api/source.md
+++ b/_security-analytics/threat-intelligence/api/source.md
@@ -27,7 +27,7 @@ PUT _plugins/_security_analytics/threat_intel/sources/{source_id}
 
 | Field  | Type  | Description  |
 | :---  | :--- | :---- |
-| `type`  | String | The type of threat intelligence source. Valid values are `S3_CUSTOM`, `IOC_UPLOAD`, and `URL_DOWNLOAD`. You can only create `S3_CUSTOM` and `IOC_UPLOAD` sources using this API.  |
+| `type`  | String | The type of threat intelligence source. Valid values are `S3_CUSTOM` and `IOC_UPLOAD`. |
 | `name`  | String   | The name of the threat intelligence source.   |
 | `format`  | String   | The format of the threat intelligence data, such as `STIX2`.   |
 | `description`    | String   | A description of the threat intelligence source.  |

--- a/_security-analytics/threat-intelligence/api/source.md
+++ b/_security-analytics/threat-intelligence/api/source.md
@@ -14,6 +14,8 @@ The threat intelligence Source API updates and returns information about tasks r
 
 Creates or updates a threat intelligence source and loads indicators of compromise (IOCs) from that source.
 
+You can create sources of type `S3_CUSTOM` and `IOC_UPLOAD`. The `URL_DOWNLOAD` type is reserved for built-in feeds that OpenSearch creates automatically and cannot be created using this API. For more information, see [URL_DOWNLOAD type sources](#url_download-type-sources).
+
 ### Endpoints
 
 ```json
@@ -25,7 +27,7 @@ PUT _plugins/_security_analytics/threat_intel/sources/{source_id}
 
 | Field  | Type  | Description  |
 | :---  | :--- | :---- |
-| `type`  | String | The type of threat intelligence source, such as `S3_CUSTOM` or `IOC_UPLOAD`.   |
+| `type`  | String | The type of threat intelligence source. Valid values are `S3_CUSTOM`, `IOC_UPLOAD`, and `URL_DOWNLOAD`. You can only create `S3_CUSTOM` and `IOC_UPLOAD` sources using this API.  |
 | `name`  | String   | The name of the threat intelligence source.   |
 | `format`  | String   | The format of the threat intelligence data, such as `STIX2`.   |
 | `description`    | String   | A description of the threat intelligence source.  |
@@ -40,6 +42,11 @@ PUT _plugins/_security_analytics/threat_intel/sources/{source_id}
 | `source_config.source.s3.object_key`  | String   | The key for the object in the S3 bucket, such `alltypess3object`. Applicable to the `S3_CUSTOM` type.   |
 | `source_config.source.s3.region`  | String | The AWS Region in which the S3 bucket is located. Example: `us-west-2`. Applicable to the `S3_CUSTOM` type.  |
 | `source_config.source.s3.role_arn`    | String   | The Amazon Resource Name (ARN) of the role used to access the S3 bucket, such as `arn:aws:iam::248279774929:role/threat_intel_s3_test_role`. Applicable to the `S3_CUSTOM` type. |
+| `source_config.source.url_download`  | Object   | Information about the URL from which IOCs are downloaded. Applicable to the `URL_DOWNLOAD` type. |
+| `source_config.source.url_download.url` | String | The URL from which IOCs are downloaded. Only the `http` and `https` protocols are supported. Applicable to the `URL_DOWNLOAD` type. |
+| `source_config.source.url_download.feed_format` | String | The format of the downloaded feed. The only supported value is `csv`. Applicable to the `URL_DOWNLOAD` type. |
+| `source_config.source.url_download.has_csv_header_field` | Boolean | Whether the first row of the CSV file is a header row. Default is `false`. Applicable to the `URL_DOWNLOAD` type. |
+| `source_config.source.url_download.csv_ioc_value_colum_num` | Integer | The zero-based index of the CSV column containing the IOC value. Applicable to the `URL_DOWNLOAD` type. |
 
 #### IOC fields (STIX2)  
 
@@ -283,6 +290,103 @@ The following example responses show what OpenSearch returns after a successful 
 
 ---
 
+## URL_DOWNLOAD type sources
+
+A `URL_DOWNLOAD` source downloads IOCs from an HTTP or HTTPS URL. OpenSearch creates these sources automatically for built-in threat intelligence feeds, so you cannot create one using the Source API. A request that specifies `URL_DOWNLOAD` in a `POST` request returns the following error:
+
+```
+URL_DOWNLOAD source type cannot be created via the REST API. It is reserved for internal use only.
+```
+
+To list the `URL_DOWNLOAD` sources in your cluster, search for them by type:
+
+```json
+POST _plugins/_security_analytics/threat_intel/sources/_search
+{
+  "query": {
+    "match": {
+      "source_config.type": "URL_DOWNLOAD"
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+The `source.url_download` object in the response describes the feed:
+
+```json
+{
+  "_id": "alienvault_reputation_ip_database",
+  "_version": 2,
+  "source_config": {
+    "name": "Alienvault IP Reputation",
+    "format": "STIX2",
+    "type": "URL_DOWNLOAD",
+    "description": "Alienvault IP Reputation threat intelligence feed managed by AlienVault",
+    "created_by_user": null,
+    "source": {
+      "url_download": {
+        "url": "https://reputation.alienvault.com/reputation.generic",
+        "feed_format": "csv",
+        "has_csv_header_field": false,
+        "csv_ioc_value_colum_num": 0
+      }
+    },
+    "enabled": true,
+    "enabled_for_scan": true,
+    "ioc_types": [
+      "ipv4-addr"
+    ]
+  }
+}
+```
+
+Only the `csv` feed format is supported for `URL_DOWNLOAD` sources. A source configured with any other format fails to refresh with an `unsupported feed format for url download` error.
+{: .note}
+
+### Activating or deactivating a URL_DOWNLOAD source
+
+Because `URL_DOWNLOAD` sources are built in, the only field you can change is `enabled_for_scan`, which activates or deactivates the feed. Update requests that change any other field return an `Unsupported Threat intel Source Config Type passed` error. You must include the `schedule` field in the request, otherwise the request fails validation.
+
+The following request deactivates a built-in feed:
+
+```json
+PUT _plugins/_security_analytics/threat_intel/sources/alienvault_reputation_ip_database
+{
+  "type": "URL_DOWNLOAD",
+  "name": "Alienvault IP Reputation",
+  "format": "STIX2",
+  "description": "Alienvault IP Reputation threat intelligence feed managed by AlienVault",
+  "schedule": {
+    "interval": {
+      "start_time": 1786030387187,
+      "period": 1,
+      "unit": "DAYS"
+    }
+  },
+  "source": {
+    "url_download": {
+      "url": "https://reputation.alienvault.com/reputation.generic",
+      "feed_format": "csv",
+      "has_csv_header_field": false,
+      "csv_ioc_value_colum_num": 0
+    }
+  },
+  "ioc_types": [
+    "ipv4-addr"
+  ],
+  "enabled_for_scan": false
+}
+```
+{% include copy-curl.html %}
+
+To activate the feed again, send the same request with `enabled_for_scan` set to `true`.
+
+You cannot delete a `URL_DOWNLOAD` source. A delete request returns a `Cannot delete built-in tif source config` error.
+{: .note}
+
+---
+
 ## Get threat intelligence source configuration details
 
 Retrieves the threat intelligence source configuration details.
@@ -468,7 +572,7 @@ DELETE /_plugins/_security_analytics/threat_intel/sources/2c0u7JAB9IJUg27gcjUp
 
 ## Refresh the source 
 
-Downloads any IOCs from the threat intelligence source. Only supports the `S3_CUSTOM` type source.
+Downloads any IOCs from the threat intelligence source. Supports the `S3_CUSTOM` and `URL_DOWNLOAD` type sources. Refreshing an `IOC_UPLOAD` source is not supported because its IOCs are supplied directly in the create request.
 
 ### Endpoints
 


### PR DESCRIPTION
### Description

Addresses user feedback submitted through the documentation feedback widget on July 29, 2026:

> URL_DOWNLOAD, possible formats, and the source "url_download" are all undocumented

The Source API page documented only the `S3_CUSTOM` and `IOC_UPLOAD` source types. The strings `URL_DOWNLOAD` and `url_download` appeared nowhere in the threat intelligence documentation.

Importantly, `URL_DOWNLOAD` is **not** a third source type users can create — it is reserved for built-in feeds, and a create request returns a 400. This PR documents the type and its restrictions rather than adding a create example that would fail for every reader.

Changes:
* Added `URL_DOWNLOAD` to the `type` parameter description and documented the `source_config.source.url_download.*` parameters.
* Added a "URL_DOWNLOAD type sources" section covering how to list built-in feeds, the supported feed format, how to activate or deactivate a feed, and the delete restriction.
* Corrected an existing error in the Refresh section, which claimed it "Only supports the `S3_CUSTOM` type source." Refresh actually excludes only `IOC_UPLOAD`.

### Testing

Parameter names came from `UrlDownloadSource.java` field constants and were confirmed against live API responses on a local 3.8.0 cluster. Verified empirically:

* Creating a `URL_DOWNLOAD` source returns `URL_DOWNLOAD source type cannot be created via the REST API. It is reserved for internal use only.`
* One built-in source ships by default: `alienvault_reputation_ip_database`.
* Update permits only toggling `enabled_for_scan`; other field changes are rejected, and `schedule` is required.
* Delete returns `Cannot delete built-in tif source config`.
* Refresh succeeds on the `URL_DOWNLOAD` feed and fails on `IOC_UPLOAD`, confirming the Refresh correction.
* `csv` is the only supported `feed_format`.

Two spellings look like typos but are genuine upstream field names, preserved verbatim so copy-paste works: `has_csv_header_field` and `csv_ioc_value_colum_num`.

### Note for reviewers

The page is written against current behavior without version qualifiers. The REST-API restriction is present in `main`, `3.7`, and `3.8` but absent from `2.19`, `3.0`, `3.5`, and `3.6`, and the backport PRs (opensearch-project/security-analytics#1671–#1680) are still open. If version callouts are wanted, that depends on whether those backports land.

The version that introduced the type is not claimed on the page because it could not be confirmed. Separately, `CUSTOM_SCHEMA_IOC_UPLOAD` also exists in `Source.java` and remains undocumented — out of scope here.

### Issues Resolved

N/A — reported through the site feedback widget.

### Check List
- [x] Commit changes are signed off (`git commit -s`)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
