### PR TITLE
Make code font in a header relative font size

### DIFF
--- a/_sass/custom/custom.scss
+++ b/_sass/custom/custom.scss
@@ -115,6 +115,11 @@ nav#site-nav > .nav-list:nth-of-type(1) {
   }
 }
 
+h1 code, h2 code, h3 code {
+  font-size: 0.75em;
+  padding: 0.1em 0.15em;
+}
+
 .site-title {
   @include mq(md) {
     padding-top: 1rem;


### PR DESCRIPTION
Make the code font in a header level 1--3 have a font size relative to the parent's computed size as opposed to the root font size, which makes the code font the same size regardless of the heading font.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
