### PR TITLE
Document the Delete Task API

### DIFF
--- a/_api-reference/document-apis/delete-by-query.md
+++ b/_api-reference/document-apis/delete-by-query.md
@@ -836,7 +836,7 @@ The `total` field represents the total number of operations that the delete by q
 
 ### Changing throttling for a running operation
 
-To change the throttling of a running delete by query operation, use the Rethrottle API with the task ID:
+To change the throttling of a running delete by query operation, use the Rethrottle Task API with the task ID:
 
 ```json
 POST _delete_by_query/{task_id}/_rethrottle?requests_per_second=100

--- a/_api-reference/document-apis/update-by-query.md
+++ b/_api-reference/document-apis/update-by-query.md
@@ -983,7 +983,7 @@ The `total` field represents the total number of operations that the update by q
 
 ### Changing throttling for a running operation
 
-To change the throttling of a running update by query operation, use the Rethrottle API with the task ID:
+To change the throttling of a running update by query operation, use the Rethrottle Task API with the task ID:
 
 ```json
 POST _update_by_query/<task_id>/_rethrottle?requests_per_second=100

--- a/_api-reference/tasks/cancel-tasks.md
+++ b/_api-reference/tasks/cancel-tasks.md
@@ -2,7 +2,7 @@
 layout: default
 title: Cancel tasks
 parent: Tasks APIs
-nav_order: 30
+nav_order: 40
 ---
 
 # Cancel Tasks API

--- a/_api-reference/tasks/delete-task.md
+++ b/_api-reference/tasks/delete-task.md
@@ -1,0 +1,81 @@
+---
+layout: default
+title: Delete task
+parent: Tasks APIs
+nav_order: 30
+---
+
+# Delete Task API
+**Introduced 3.8**
+{: .label .label-purple }
+
+Use the Delete Task API to delete the stored result of a completed task. For example, when you run a supported operation with `wait_for_completion=false`, OpenSearch stores the task result so that you can retrieve it later using the [Get Task API]({{site.url}}{{site.baseurl}}/api-reference/tasks/get-tasks/). After you no longer need the result, you can delete it to free the associated storage.
+
+The Delete Task API does not cancel or delete a running task. To stop a running task, use the [Cancel Tasks API]({{site.url}}{{site.baseurl}}/api-reference/tasks/cancel-tasks/).
+{: .important }
+
+<!-- spec_insert_start
+api: tasks.delete
+component: endpoints
+-->
+## Endpoint
+
+```json
+DELETE /_tasks/{task_id}
+```
+<!-- spec_insert_end -->
+
+<!-- spec_insert_start
+api: tasks.delete
+component: path_parameters
+-->
+## Path parameters
+
+The following table lists the available path parameter.
+
+| Parameter | Required | Data type | Description |
+| :--- | :--- | :--- | :--- |
+| `task_id` | **Required** | String | The task ID in the format `node_id:task_number`. |
+
+<!-- spec_insert_end -->
+
+## Example request
+
+The following request deletes the stored result for task `JzrCxdtFTCO_RaINw8ckNA:54321`:
+
+```json
+DELETE /_tasks/JzrCxdtFTCO_RaINw8ckNA:54321
+```
+{% include copy.html %}
+
+## Example response
+
+OpenSearch responds with an acknowledgment after deleting the stored result:
+
+```json
+{
+  "acknowledged": true
+}
+```
+
+After a successful deletion, the Get Task API returns a `404 Not Found` response for the task.
+
+## Parent and child tasks
+
+You cannot delete a stored task result while it has running child tasks or stored child task results. For a hierarchy of stored task results, delete the results from the leaves toward the root. For example, delete a grandchild result before its parent result, and then delete the root result.
+
+OpenSearch returns a `409 Conflict` response if the task has running children or stored child results.
+
+## Response codes
+
+The following table lists common response codes.
+
+| HTTP status code | Description |
+| :--- | :--- |
+| `200 OK` | The stored completed task result was deleted. |
+| `404 Not Found` | The task is not running and has no stored result. |
+| `409 Conflict` | The task is still running, is not marked as completed, has running child tasks, or has stored child task results. |
+
+## Required permissions
+
+If you use the Security plugin, make sure you have the `cluster:admin/tasks/delete` permission.

--- a/_api-reference/tasks/delete-task.md
+++ b/_api-reference/tasks/delete-task.md
@@ -6,10 +6,10 @@ nav_order: 30
 ---
 
 # Delete Task API
-**Introduced 3.8**
+**Introduced 3.9**
 {: .label .label-purple }
 
-Use the Delete Task API to delete the stored result of a completed task. For example, when you run a supported operation with `wait_for_completion=false`, OpenSearch stores the task result so that you can retrieve it later using the [Get Task API]({{site.url}}{{site.baseurl}}/api-reference/tasks/get-tasks/). After you no longer need the result, you can delete it to free the associated storage.
+Use the Delete Task API to delete the stored result of a completed task. For example, when you run a supported operation and set `wait_for_completion=false`, OpenSearch stores the task result so that you can retrieve it later by using the [Get Task API]({{site.url}}{{site.baseurl}}/api-reference/tasks/get-tasks/). When you no longer need the result, delete it to free the associated storage.
 
 The Delete Task API does not cancel or delete a running task. To stop a running task, use the [Cancel Tasks API]({{site.url}}{{site.baseurl}}/api-reference/tasks/cancel-tasks/).
 {: .important }
@@ -46,7 +46,7 @@ The following request deletes the stored result for task `JzrCxdtFTCO_RaINw8ckNA
 ```json
 DELETE /_tasks/JzrCxdtFTCO_RaINw8ckNA:54321
 ```
-{% include copy.html %}
+{% include copy-curl.html %}
 
 ## Example response
 
@@ -62,9 +62,9 @@ After a successful deletion, the Get Task API returns a `404 Not Found` response
 
 ## Parent and child tasks
 
-You cannot delete a stored task result while it has running child tasks or stored child task results. For a hierarchy of stored task results, delete the results from the leaves toward the root. For example, delete a grandchild result before its parent result, and then delete the root result.
+You cannot delete a stored task result while it has running child tasks or stored child task results. In a hierarchy of stored task results, delete the results from the leaves toward the root. For example, delete a grandchild result before its parent result, and then delete the root result.
 
-OpenSearch returns a `409 Conflict` response if the task has running children or stored child results.
+OpenSearch returns a `409 Conflict` response if the task has running child tasks or stored child task results.
 
 ## Response codes
 
@@ -78,4 +78,4 @@ The following table lists common response codes.
 
 ## Required permissions
 
-If you use the Security plugin, make sure you have the `cluster:admin/tasks/delete` permission.
+If you use the Security plugin, make sure you have the appropriate permissions: `cluster:admin/tasks/delete`.

--- a/_api-reference/tasks/delete-task.md
+++ b/_api-reference/tasks/delete-task.md
@@ -18,8 +18,7 @@ The Delete Task API does not cancel or delete a running task. To stop a running 
 api: tasks.delete
 component: endpoints
 -->
-## Endpoint
-
+## Endpoints
 ```json
 DELETE /_tasks/{task_id}
 ```
@@ -31,11 +30,11 @@ component: path_parameters
 -->
 ## Path parameters
 
-The following table lists the available path parameter.
+The following table lists the available path parameters.
 
 | Parameter | Required | Data type | Description |
 | :--- | :--- | :--- | :--- |
-| `task_id` | **Required** | String | The task ID in the format `node_id:task_number`. |
+| `task_id` | **Required** | String | The ID of the stored completed task result to delete (`node_id:task_number`). |
 
 <!-- spec_insert_end -->
 
@@ -43,10 +42,27 @@ The following table lists the available path parameter.
 
 The following request deletes the stored result for task `JzrCxdtFTCO_RaINw8ckNA:54321`:
 
-```json
+<!-- spec_insert_start
+component: example_code
+rest: DELETE /_tasks/JzrCxdtFTCO_RaINw8ckNA:54321
+-->
+{% capture step1_rest %}
 DELETE /_tasks/JzrCxdtFTCO_RaINw8ckNA:54321
-```
-{% include copy-curl.html %}
+{% endcapture %}
+
+{% capture step1_python %}
+
+
+response = client.tasks.delete(
+  task_id = "JzrCxdtFTCO_RaINw8ckNA:54321"
+)
+
+{% endcapture %}
+
+{% include code-block.html
+    rest=step1_rest
+    python=step1_python %}
+<!-- spec_insert_end -->
 
 ## Example response
 

--- a/_api-reference/tasks/rethrottle.md
+++ b/_api-reference/tasks/rethrottle.md
@@ -2,7 +2,7 @@
 layout: default
 title: Rethrottle
 parent: Tasks APIs
-nav_order: 40
+nav_order: 50
 ---
 
 # Rethrottle API

--- a/_api-reference/tasks/rethrottle.md
+++ b/_api-reference/tasks/rethrottle.md
@@ -1,11 +1,11 @@
 ---
 layout: default
-title: Rethrottle
+title: Rethrottle task
 parent: Tasks APIs
 nav_order: 50
 ---
 
-# Rethrottle API
+# Rethrottle Task API
 **Introduced 1.0**
 {: .label .label-purple }
 


### PR DESCRIPTION
### Description

Adds API documentation for the Delete Task API introduced by opensearch-project/OpenSearch#21727.

The new page explains how to delete stored completed task results, distinguishes deletion from task cancellation, documents common response codes, and describes the leaf-first deletion requirement for parent and child task results. It also places the new page in the Tasks APIs navigation.

### Issues Resolved

Documents opensearch-project/OpenSearch#21727.

### Version

3.8

### Frontend features

Not applicable.

### Checklist

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
