### PR TITLE
Add response body fields to search API

### DIFF
--- a/_aggregations/metric/top-hits.md
+++ b/_aggregations/metric/top-hits.md
@@ -35,7 +35,7 @@ Because the `top_hits` aggregation returns standard search hits, the following p
 - [Explain]({{site.url}}{{site.baseurl}}/api-reference/search-apis/explain/)
 - [Named queries]({{site.url}}{{site.baseurl}}/query-dsl/named-queries/)
 - [Source filtering]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#using-source-filtering)
-- [Stored fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored_fields)
+- [Stored fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored-fields)
 - [Script fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#using-scripted-fields)
 - [Doc value fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#searching-with-doc-value-fields)
 - [Include versions]({{site.url}}{{site.baseurl}}/api-reference/search-apis/search/#query-parameters)

--- a/_api-reference/search-apis/search.md
+++ b/_api-reference/search-apis/search.md
@@ -158,7 +158,7 @@ body: |
 {
   "query": {
     "match": {
-      "text_entry": "I am the night"
+      "director": "Christopher Nolan"
     }
   }
 }
@@ -168,7 +168,7 @@ GET /movies/_search
 {
   "query": {
     "match": {
-      "text_entry": "I am the night"
+      "director": "Christopher Nolan"
     }
   }
 }
@@ -182,7 +182,7 @@ response = client.search(
   body =   {
     "query": {
       "match": {
-        "text_entry": "I am the night"
+        "director": "Christopher Nolan"
       }
     }
   }
@@ -196,11 +196,13 @@ response = client.search(
 <!-- spec_insert_end -->
 
 
-## Response body fields
+## Example response
+
+The following example response shows the structure of a search response:
 
 ```json
 {
-  "took": 3,
+  "took": 14,
   "timed_out": false,
   "_shards": {
     "total": 1,
@@ -210,38 +212,31 @@ response = client.search(
   },
   "hits": {
     "total": {
-      "value": 1,
+      "value": 2,
       "relation": "eq"
     },
-    "max_score": 1.0,
+    "max_score": 0.42727602,
     "hits": [
       {
-        "_index": "superheroes",
+        "_index": "movies",
         "_id": "1",
-        "_score": 1.0,
+        "_score": 0.42727602,
         "_source": {
-          "superheroes": [
-            {
-              "Hero name": "Superman",
-              "Real identity": "Clark Kent",
-              "Age": 28
-            },
-            {
-              "Hero name": "Batman",
-              "Real identity": "Bruce Wayne",
-              "Age": 26
-            },
-            {
-              "Hero name": "Flash",
-              "Real identity": "Barry Allen",
-              "Age": 28
-            },
-            {
-              "Hero name": "Robin",
-              "Real identity": "Dick Grayson",
-              "Age": 15
-            }
-          ]
+          "title": "The Dark Knight",
+          "director": "Christopher Nolan",
+          "year": 2008,
+          "genre": "Action"
+        }
+      },
+      {
+        "_index": "movies",
+        "_id": "2",
+        "_score": 0.42727602,
+        "_source": {
+          "title": "Inception",
+          "director": "Christopher Nolan",
+          "year": 2010,
+          "genre": "Science Fiction"
         }
       }
     ]
@@ -249,9 +244,65 @@ response = client.search(
 }
 ```
 
-## The `ext` object
+## Response body fields
 
-Starting with OpenSearch 2.10, plugin authors can add an `ext` object to both search requests and search responses. The `ext` object contains plugin-specific fields that allow plugins to pass additional parameters in requests or return additional information in responses.
+The following table lists the top-level response body fields.
+
+| Field | Data type | Description |
+| :--- | :--- | :--- |
+| `took` | Integer | The time, in milliseconds, that OpenSearch took to run the search. This is measured from the moment the coordinating node receives the request until it is ready to send the response, so it includes communication between the coordinating node and the data nodes, time spent queued in the `search` thread pool, and the search itself. It does not include the time spent transmitting the request or the response over the network. |
+| `phase_took` | Object | The time, in milliseconds, spent in each search phase (`can_match`, `dfs_pre_query`, `query`, `dfs_query`, `fetch`, and `expand`). Returned only when the `phase_took` query parameter is `true`. |
+| `timed_out` | Boolean | Whether the search timed out before completing. If `true`, the returned results may be partial or empty. |
+| `terminated_early` | Boolean | Whether OpenSearch stopped the search early because it collected the number of documents specified in `terminate_after`. Returned only when `terminate_after` is set. |
+| `_shards` | Object | The number of shards that the search ran on and the outcome for each group of shards. |
+| `hits` | Object | The matching documents and their metadata. |
+| `aggregations` | Object | The aggregation results, keyed by aggregation name. Returned only when the request body contains an `aggs` object. |
+| `suggest` | Object | The suggestion results, keyed by suggester name. Returned only when the request body contains a `suggest` object. |
+| `profile` | Object | Per-shard timing details for the query and fetch phases. Returned only when the request body sets `profile` to `true`. For more information, see [Profile API]({{site.url}}{{site.baseurl}}/api-reference/search-apis/profile/). |
+| `_scroll_id` | String | The scroll ID that identifies the search context. Pass this value to the [Scroll API]({{site.url}}{{site.baseurl}}/api-reference/search-apis/scroll/) to retrieve the next batch of results. Returned only when the request includes the `scroll` query parameter. |
+| `pit_id` | String | The Point in Time (PIT) ID that identifies the search context. Returned only when the request searches a PIT. For more information, see [Point in Time API]({{site.url}}{{site.baseurl}}/api-reference/search-apis/point-in-time-api/). |
+| `_clusters` | Object | The number of clusters that a cross-cluster search ran on and the outcome for each group of clusters. Returned only for cross-cluster searches. |
+| `num_reduce_phases` | Integer | The number of reduce phases that OpenSearch performed in order to combine partial shard results into the final result set. Returned only when the search uses more than one reduce phase. |
+
+The following table lists the fields in the `_shards` object.
+
+| Field | Data type | Description |
+| :--- | :--- | :--- |
+| `total` | Integer | The number of shards that the search needed to query, including unallocated shards. |
+| `successful` | Integer | The number of shards that ran the search successfully. |
+| `skipped` | Integer | The number of shards that skipped the search because a preliminary check determined that no document on the shard could match. This commonly happens when the search contains a range filter and all values on the shard fall outside of that range. |
+| `failed` | Integer | The number of shards that failed to run the search. Unallocated shards count as neither successful nor failed, so if `successful` and `failed` add up to less than `total`, some of the shards were unallocated. |
+
+The following table lists the fields in the `hits` object.
+
+| Field | Data type | Description |
+| :--- | :--- | :--- |
+| `total` | Object | The number of matching documents. Contains a `value` field with the count and a `relation` field that is `eq` when the count is exact or `gte` when the count is a lower bound. Omitted when `track_total_hits` is `false`. |
+| `max_score` | Float | The highest `_score` among the matching documents. Is `null` when the search does not sort by `_score`. |
+| `hits` | Array of objects | The matching documents, ordered by relevance or by the specified sort. |
+
+The following table lists the fields in each object in the `hits.hits` array.
+
+| Field | Data type | Description |
+| :--- | :--- | :--- |
+| `_index` | String | The name of the index that contains the document. |
+| `_id` | String | The document ID. This ID is unique only within the returned index. |
+| `_score` | Float | The relevance score for the document. Is `null` when the search does not sort by `_score`. |
+| `_source` | Object | The original JSON document provided at indexing time. Use the `_source` query parameter to omit this field or to return only specific fields. |
+| `fields` | Object | The field values retrieved by `docvalue_fields` or `stored_fields`. Returned only when the request specifies either of those parameters. |
+| `sort` | Array | The sort values for the document. Returned only when the request body contains a `sort` array. Pass the values from the last hit as `search_after` to retrieve the next page of results. |
+| `highlight` | Object | The highlighted snippets, keyed by field name. Returned only when the request body contains a `highlight` object. |
+| `matched_queries` | Array of strings | The names of the named queries that the document matched. Returned only when the search uses the `_name` parameter. |
+| `inner_hits` | Object | The matching nested, child, or parent documents. Returned only when the request body contains an `inner_hits` object. |
+| `_explanation` | Object | A breakdown of how OpenSearch computed the document's relevance score. Returned only when `explain` is `true`. |
+| `_shard` | String | The shard that returned the document. Returned only when `explain` is `true`. |
+| `_node` | String | The node that returned the document. Returned only when `explain` is `true`. |
+
+## The `ext` object
+**Introduced 2.10**
+{: .label .label-purple }
+
+Plugin authors can add an `ext` object to both search requests and search responses. The `ext` object contains plugin-specific fields that allow plugins to pass additional parameters in requests or return additional information in responses.
 
 ### Using `ext` in search responses
 

--- a/_api-reference/search-apis/search.md
+++ b/_api-reference/search-apis/search.md
@@ -64,15 +64,15 @@ Parameter | Type | Description
 `seq_no_primary_term` | Boolean | Whether to return the sequence number and primary term of the last operation of each document hit. Example: `GET test-index/_search?seq_no_primary_term=true&size=1&q=title:test`. |
 `size` | Integer | The number of results to include in the response. Example: `GET test-index/_search?size=3`. |
 `sort` | List | A comma-separated list of `<field> : <direction>` pairs to sort by. Use `track_scores=true` if you want scores when sorting by a non-score field. Example: `GET test-index/_search?sort=views:desc&track_scores=true&size=3`. |
-`_source` | String or Boolean | Controls the `_source` field provided in the response. Valid values are `true` (return the document source), `false` (do not return the document source) and `<string>` (the field or fields in the source to return, provided as a list or wildcard pattern). Examples: `GET test-index/_search?_source=false&size=1`, `GET test-index/_search?_source=titl*&size=1`, `GET test-index/_search?_source=title,description&size=1`. |
-`_source_excludes` | List | A comma-separated list of source fields to exclude from the response. If the `_source` parameter is `false`, this parameter is ignored. Example: `GET test-index/_search?_source_excludes=title&size=1`. |
-`_source_includes` | List | A comma-separated list of source fields to include in the response. If the `_source` parameter is `false`, this parameter is ignored. Example: `GET test-index/_search?_source_includes=title&size=1`. |
+`_source` | String or Boolean | Controls the `_source` field provided in the response. Valid values are `true` (return the document source), `false` (do not return the document source) and `<string>` (the field or fields in the source to return, provided as a list or wildcard pattern). For more information, see [Source filtering](#source-filtering). Examples: `GET test-index/_search?_source=false&size=1`, `GET test-index/_search?_source=titl*&size=1`, `GET test-index/_search?_source=title,description&size=1`. |
+`_source_excludes` | List | A comma-separated list of source fields to exclude from the response. If the `_source` parameter is `false`, this parameter is ignored. For more information, see [Source filtering](#source-filtering). Example: `GET test-index/_search?_source_excludes=title&size=1`. |
+`_source_includes` | List | A comma-separated list of source fields to include in the response. If the `_source` parameter is `false`, this parameter is ignored. For more information, see [Source filtering](#source-filtering). Example: `GET test-index/_search?_source_includes=title&size=1`. |
 `stats` | String | A comma-separated list of [search stats groups](#search-stats-groups) to associate with the request. Example: `GET test-index/_search?stats=group1`. |
 `stored_fields` | List | Whether the GET operation should retrieve fields stored in the index. Default is `false`. Example: `GET test-index-stored/_search?stored_fields=note&size=1`. |
 `terminate_after` | Integer | The maximum number of matching documents (hits) OpenSearch should process before terminating the request. Default is `0` (no maximum). Example: `GET test-index/_search?terminate_after=1&size=10`. |
 `timeout` | Time | How long the operation should wait for a response from active shards. Default is `1m` (1 minute). Example: `GET test-index/_search?timeout=10ms`. |
 `track_scores` | Boolean | Whether to return document scores. Default is `false`. Use with `sort`. Example: `GET test-index/_search?sort=views:desc&track_scores=true&size=3`. |
-`track_total_hits` | Boolean or Integer | Whether to return the total number of documents that matched the query. Example: `GET test-index/_search?track_total_hits=2`. |
+`track_total_hits` | Boolean or Integer | How many matching documents to count. Default is `10000`. For more information, see [Track total hits](#track-total-hits). Example: `GET test-index/_search?track_total_hits=2`. |
 `typed_keys` | Boolean | Whether returned aggregations and suggested terms should include their types in the response. Default is `true`. Only applicable for aggregations or suggesters. Example: `POST test-index/_search?typed_keys=true {"size":0,"aggs":{"a":{"terms":{"field":"views"}}}}`. |
 `version` | Boolean | Whether to include the document version as a match. Example: `GET test-index/_search?version=true&size=1&q=title:test`. |
 
@@ -108,7 +108,7 @@ Field | Type | Description
 `seq_no_primary_term` | Boolean | Whether to return sequence number and primary term of the last operation of each document hit.
 `size` | Integer | How many results to return. Default is 10.
 `sort` | Array of objects or strings | Specifies how to sort the results. Can be a field name, an object with field and sort options, or an array of these. See [Sorting results]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/sort/).
-`_source` | | Whether to include the `_source` field in the response.
+`_source` | Boolean, String, Array of strings, or Object | The document source fields to return in each hit. Default is `true` (return the full document). For more information, see [Source filtering](#source-filtering).
 `stats` | Array of strings | A list of [search stats groups](#search-stats-groups) to associate with the request.
 `suggest_field` | String | The field used for suggestions. Use with `suggest_text` and, optionally, `suggest_mode` or `suggest_size`. |
 `suggest_mode` | String | The mode to use when searching. Valid values are `always` (provide suggestions based on the terms in `suggest_text`), `popular` (provide suggestions occurring in more documents on the shard than the search term), and `missing` (provide suggestions for terms not on the shard). Requires `suggest_field` and `suggest_text`. |
@@ -288,7 +288,7 @@ The following table lists the fields in each object in the `hits.hits` array.
 | `_index` | String | The name of the index that contains the document. |
 | `_id` | String | The document ID. This ID is unique only within the returned index. |
 | `_score` | Float | The relevance score for the document. Is `null` when the search does not sort by `_score`. |
-| `_source` | Object | The original JSON document provided at indexing time. Use the `_source` query parameter to omit this field or to return only specific fields. |
+| `_source` | Object | The original JSON document provided at indexing time. To omit this field or to return only specific fields, see [Source filtering](#source-filtering). |
 | `fields` | Object | The field values retrieved by `docvalue_fields` or `stored_fields`. Returned only when the request specifies either of those parameters. |
 | `sort` | Array | The sort values for the document. Returned only when the request body contains a `sort` array. Pass the values from the last hit as `search_after` to retrieve the next page of results. |
 | `highlight` | Object | The highlighted snippets, keyed by field name. Returned only when the request body contains a `highlight` object. |
@@ -297,6 +297,101 @@ The following table lists the fields in each object in the `hits.hits` array.
 | `_explanation` | Object | A breakdown of how OpenSearch computed the document's relevance score. Returned only when `explain` is `true`. |
 | `_shard` | String | The shard that returned the document. Returned only when `explain` is `true`. |
 | `_node` | String | The node that returned the document. Returned only when `explain` is `true`. |
+
+## Source filtering
+
+Each hit in the response contains a `_source` object holding the original JSON document. Returning the full document for every hit transfers more data than most applications need. Source filtering limits the fields that OpenSearch returns in `_source`.
+
+The following table lists the accepted values for the `_source` request body parameter.
+
+| Value | Description |
+| :--- | :--- |
+| `true` | Returns the full document. This is the default. |
+| `false` | Omits the `_source` object from each hit. |
+| String | A field name or a wildcard pattern, such as `details.*`. OpenSearch returns only the matching fields. |
+| Array of strings | A list of field names or wildcard patterns, such as `["name", "details.*"]`. |
+| Object | An object containing `includes` and `excludes` lists. A field that matches a pattern in both lists is not returned because `excludes` takes precedence. |
+
+To filter the source in the request URL instead of the request body, use the `_source`, `_source_includes`, and `_source_excludes` query parameters.
+
+For examples and limitations, see [Using source filtering]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#using-source-filtering).
+
+## Track total hits
+
+Counting matching documents exactly requires visiting every match, which is expensive for queries that match many documents. The `track_total_hits` parameter limits how many matches OpenSearch counts. Specify it either as a query parameter or in the request body.
+
+By default, OpenSearch counts matches accurately up to `10000`. When more documents match, `hits.total.value` reports `10000` and `hits.total.relation` is `gte`, indicating that the query matched at least that many documents.
+
+The following table lists the accepted values for `track_total_hits`.
+
+| Value | Description |
+| :--- | :--- |
+| `true` | Counts every matching document. `hits.total.relation` is always `eq`. |
+| `false` | Disables hit counting. The response contains no `hits.total` object. |
+| Integer | Counts matching documents accurately up to the specified number. When more documents match, `hits.total.value` reports the threshold and `hits.total.relation` is `gte`. |
+
+Counting every match slows down searches that match many documents. Increase the threshold only when your application requires an exact count.
+
+### Example: Default hit counting
+
+The following example searches a `logs` index containing 10,500 documents without specifying `track_total_hits`:
+
+```json
+GET /logs/_search
+{
+  "size": 0,
+  "query": {
+    "match_all": {}
+  }
+}
+```
+{% include copy-curl.html %}
+
+Because `relation` is `gte`, the index contains at least 10,000 matching documents:
+
+```json
+{
+  "hits": {
+    "total": {
+      "value": 10000,
+      "relation": "gte"
+    },
+    "max_score": null,
+    "hits": []
+  }
+}
+```
+
+### Example: Counting every matching document
+
+To count every match, set `track_total_hits` to `true`:
+
+```json
+GET /logs/_search
+{
+  "size": 0,
+  "track_total_hits": true,
+  "query": {
+    "match_all": {}
+  }
+}
+```
+{% include copy-curl.html %}
+
+Because `relation` is `eq`, `value` is the exact number of matching documents:
+
+```json
+{
+  "hits": {
+    "total": {
+      "value": 10500,
+      "relation": "eq"
+    },
+    "max_score": null,
+    "hits": []
+  }
+}
+```
 
 ## The `ext` object
 **Introduced 2.10**

--- a/_search-plugins/searching-data/retrieve-specific-fields.md
+++ b/_search-plugins/searching-data/retrieve-specific-fields.md
@@ -62,7 +62,7 @@ The `_source` can also be disabled in index mappings by using the following conf
 ```
 
 <!-- vale off -->
-If `_source` is disabled in the index mappings, [searching with docvalue fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#searching-with-doc-value-fields) and [searching with stored fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored_fields) become extremely useful.
+If `_source` is disabled in the index mappings, [searching with docvalue fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#searching-with-doc-value-fields) and [searching with stored fields]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#searching-with-stored-fields) become extremely useful.
 <!-- vale on -->
 
 ## Specifying the fields to retrieve
@@ -994,7 +994,7 @@ The following is the expected response:
 
 Source filtering matches the field names in the original JSON document, so it cannot return values that OpenSearch derives during indexing. Multi-fields, [field aliases]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/alias/), and fields populated by `copy_to` are not part of the source, and a request for those fields returns an empty `_source` object.
 
-OpenSearch loads and parses the entire source document even when the request asks for only a few fields, so source filtering reduces network transfer but not disk reads. To read individual fields directly from the index, use [`docvalue_fields`](#searching-with-doc-value-fields) or [`stored_fields`](#searching-with-stored_fields).
+OpenSearch loads and parses the entire source document even when the request asks for only a few fields, so source filtering reduces network transfer but not disk reads. To read individual fields directly from the index, use [`docvalue_fields`](#searching-with-doc-value-fields) or [`stored_fields`](#searching-with-stored-fields).
 
 ## Using scripted fields
 

--- a/_search-plugins/searching-data/retrieve-specific-fields.md
+++ b/_search-plugins/searching-data/retrieve-specific-fields.md
@@ -552,9 +552,9 @@ The following is the expected response:
   }
 }
 ```
-<!-- vale off -->
-## Searching with stored_fields
-<!-- vale on -->
+
+## Searching with stored fields
+
 By default, OpenSearch stores the entire document in the `_source` field and uses it to return document contents in search results. However, you might also want to store certain fields separately for more efficient retrieval. You can explicitly store and retrieve specific document fields separately from the `_source` field by using `stored_fields`. 
 
 Unlike `_source`, `stored_fields` must be explicitly defined in the mappings for fields you want to store separately. It can be useful if you frequently need to retrieve only a small subset of fields and want to avoid retrieving the entire `_source` field. The following example demonstrates how to use the `stored_fields` parameter.
@@ -894,7 +894,7 @@ The following is the expected response:
 
 ### Including and excluding fields in the same search
 
-In some cases, both the `include` and `exclude` parameters may be necessary. The following examples demonstrate how to include and exclude fields in the same search.
+In some cases, both the `include` and `exclude` parameters may be necessary. When a field matches a pattern in both lists, OpenSearch omits the field because `excludes` takes precedence over `includes`. The following examples demonstrate how to include and exclude fields in the same search.
 
 Consider a `products` index containing the following document:
 
@@ -989,6 +989,12 @@ The following is the expected response:
   }
 }
 ```
+
+### Source filtering limitations
+
+Source filtering matches the field names in the original JSON document, so it cannot return values that OpenSearch derives during indexing. Multi-fields, [field aliases]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/alias/), and fields populated by `copy_to` are not part of the source, and a request for those fields returns an empty `_source` object.
+
+OpenSearch loads and parses the entire source document even when the request asks for only a few fields, so source filtering reduces network transfer but not disk reads. To read individual fields directly from the index, use [`docvalue_fields`](#searching-with-doc-value-fields) or [`stored_fields`](#searching-with-stored_fields).
 
 ## Using scripted fields
 

--- a/_search-plugins/searching-data/retrieve-specific-fields.md
+++ b/_search-plugins/searching-data/retrieve-specific-fields.md
@@ -660,9 +660,8 @@ The following is the expected response:
 
 The `stored_fields` parameter can be disabled completely by setting `stored_fields` to `_none_`.
 {: .note}
-<!-- vale off -->
-### Searching stored_fields with nested objects
-<!-- vale on -->
+### Searching stored fields with nested objects
+
 In OpenSearch, if you want to retrieve `stored_fields` for nested objects, you cannot directly use the `stored_fields` parameter because no data will be returned. Instead, you should use the `inner_hits` parameter with its own `stored_fields` property, as shown in the following example.
 
 1. Create an index with the following mappings:


### PR DESCRIPTION
Adds the response body fields section to the search API page and unifies the example on the page to use the "movies" index.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
