### PR TITLE
Add documentation for CCS ignore source security roles setting

### DIFF
--- a/_install-and-configure/configuring-opensearch/security-settings.md
+++ b/_install-and-configure/configuring-opensearch/security-settings.md
@@ -73,6 +73,8 @@ The Security plugin supports the following advanced settings:
   These certificates are well known and therefore unsafe for production. Use only in a private network/environment.
   {: .warning}
 
+- `plugins.security.ccs.ignore_source_security_roles` (Dynamic): When set to `true`, a remote cluster ignores the security roles propagated from the coordinating cluster on cross-cluster search requests and evaluates access using only its own `roles_mapping.yml` configuration. Default is `false`. See [Remote cluster role evaluation]({{site.url}}{{site.baseurl}}/search-plugins/cross-cluster-search/#remote-cluster-role-evaluation).
+
 - `plugins.security.system_indices.permission.enabled` (Static): Enables the system index permissions feature. When set to `true`, the feature is enabled and users with permission to modify roles can create roles that include permissions that grant access to system indexes. When set to `false`, the permission is disabled and only admins with an admin certificate can make changes to system indexes. By default, the permission is set to `false` in a new cluster.
 
 ## Expert-level settings

--- a/_search-plugins/cross-cluster-search.md
+++ b/_search-plugins/cross-cluster-search.md
@@ -41,10 +41,12 @@ The following sequence describes the authentication flow when using cross-cluste
 1. The user's permissions are evaluated on the remote cluster.
 
 ## Remote cluster role evaluation
+**Introduced 3.9**
+{: .label .label-purple }
 
-By default, the remote cluster evaluates permissions using a combination of the security roles propagated from the coordinating cluster and its own role mappings. This means a user with broad permissions on the coordinating cluster (for example, `all_access`) automatically receives those same permissions on the remote cluster.
+By default, the remote cluster evaluates permissions using a combination of the security roles propagated from the coordinating cluster and its own role mappings. As a result, a user who has broad permissions on the coordinating cluster (for example, `all_access`) receives those same permissions on the remote cluster.
 
-To give the remote cluster independent control over what permissions CCS users receive, enable the following cluster setting on the remote cluster:
+To give the remote cluster independent control over the permissions that CCS users receive, set the following cluster setting on the remote cluster:
 
 ```json
 PUT /_cluster/settings
@@ -54,14 +56,16 @@ PUT /_cluster/settings
   }
 }
 ```
+{% include copy-curl.html %}
 
-When enabled, the remote cluster strips the security roles propagated from the coordinating cluster and evaluates access exclusively through its own `roles_mapping.yml` configuration. This allows administrators to define CCS user permissions independently on each cluster.
+When `plugins.security.ccs.ignore_source_security_roles` is `true`, the remote cluster strips the security roles propagated from the coordinating cluster and evaluates access exclusively through its own `roles_mapping.yml` configuration. You can then define CCS user permissions independently on each cluster. The setting is `false` by default, so existing CCS deployments are unaffected.
 
 ### Limitations
 
-- **`internal_users.yml` role assignments are not consulted on the CCS path.** The remote cluster does not re-authenticate CCS users. When this setting is enabled, customers must use `roles_mapping.yml` to grant CCS users access on the remote cluster for authorization. Direct role assignments via `opendistro_security_roles` in `internal_users.yml` have no effect for CCS user authorization.
-- **Applies to cross-cluster search (CCS) requests only.** Other cross-cluster operations are not affected.
-- **The setting defaults to `false`** to preserve backward compatibility. Existing CCS deployments continue to work without changes.
+The setting has the following limitations:
+
+- The remote cluster doesn't re-authenticate CCS users, so it doesn't consult the role assignments in `internal_users.yml`. When this setting is enabled, you must use `roles_mapping.yml` to grant CCS users access to the remote cluster. Role assignments made using `opendistro_security_roles` in `internal_users.yml` have no effect on CCS user authorization.
+- The setting applies only to cross-cluster search requests. Other cross-cluster operations aren't affected.
 
 ## Setting permissions
 

--- a/_search-plugins/cross-cluster-search.md
+++ b/_search-plugins/cross-cluster-search.md
@@ -40,6 +40,28 @@ The following sequence describes the authentication flow when using cross-cluste
 1. The call, including the authenticated user, is forwarded to the remote cluster.
 1. The user's permissions are evaluated on the remote cluster.
 
+## Remote cluster role evaluation
+
+By default, the remote cluster evaluates permissions using a combination of the security roles propagated from the coordinating cluster and its own role mappings. This means a user with broad permissions on the coordinating cluster (for example, `all_access`) automatically receives those same permissions on the remote cluster.
+
+To give the remote cluster independent control over what permissions CCS users receive, enable the following cluster setting on the remote cluster:
+
+```json
+PUT /_cluster/settings
+{
+  "persistent": {
+    "plugins.security.ccs.ignore_source_security_roles": true
+  }
+}
+```
+
+When enabled, the remote cluster strips the security roles propagated from the coordinating cluster and evaluates access exclusively through its own `roles_mapping.yml` configuration. This allows administrators to define CCS user permissions independently on each cluster.
+
+### Limitations
+
+- **`internal_users.yml` role assignments are not consulted on the CCS path.** The remote cluster does not re-authenticate CCS users. When this setting is enabled, customers must use `roles_mapping.yml` to grant CCS users access on the remote cluster for authorization. Direct role assignments via `opendistro_security_roles` in `internal_users.yml` have no effect for CCS user authorization.
+- **Applies to cross-cluster search (CCS) requests only.** Other cross-cluster operations are not affected.
+- **The setting defaults to `false`** to preserve backward compatibility. Existing CCS deployments continue to work without changes.
 
 ## Setting permissions
 


### PR DESCRIPTION
### Description

Documents the new `plugins.security.ccs.ignore_source_security_roles` cluster setting introduced in [opensearch-project/security#6402](https://github.com/opensearch-project/security/pull/6402). This setting allows remote cluster administrators to strip source-propagated security roles on cross-cluster search requests, enabling independent role evaluation via the remote cluster's own `roles_mapping.yml`.

### Issues Resolved

Closes [ documentation for opensearch-project/security#6401](https://github.com/opensearch-project/security/issues/6401)

### Version

3.9

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).