### PR TITLE
Remove outdated note that Profile API does not measure the fetch phase

### DIFF
--- a/_api-reference/search-apis/profile.md
+++ b/_api-reference/search-apis/profile.md
@@ -14,7 +14,6 @@ redirect_from:
 The Profile API provides timing information about the execution of individual components of a search request. Using the Profile API, you can debug slow requests and understand how to improve their performance. The Profile API does not measure the following:
 
 - Network latency
-- Time spent in the search fetch phase
 - Amount of time a request spends in queues
 - Idle time while merging shard responses on the coordinating node
 


### PR DESCRIPTION
The Profile API has reported fetch phase timings under profile.shards[].fetch since OpenSearch 3.2 (opensearch-project/OpenSearch#18664). This removes the outdated limitation note.

### Test on my end

I can see the result for fetch phase on Amazon OpenSearch Service domain with OpenSearch 3.5.

```
GET hotels-index/_search
{
  "profile": true,
  "size": 1,
  "query": {
    "match_all": {}
  }
}
{
  "took": 6,
  "timed_out": false,
  "_shards": {
    "total": 5,
    "successful": 5,
    "skipped": 0,
    "failed": 0
  },
  "hits": {
    "total": {
      "value": 5,
      "relation": "eq"
    },
    "max_score": 1,
    "hits": [
...
    "shards": [
      {
        "id": "[FnFzKgkkQ7-1D8HchkCfTg][hotels-index][0]",
        "inbound_network_time_in_millis": 1,
        "outbound_network_time_in_millis": 1,
        "searches": [
          {
            "query": [
             ...
        ],
        "aggregations": [],
        "fetch": [
          {
            "type": "fetch",
            "description": "fetch",
            "time_in_nanos": 71557,
            "breakdown": {
              "get_next_reader_count": 1,
              "load_stored_fields": 52511,
              "load_source": 720,
              "build_sub_phase_processors": 9336,
              "get_next_reader": 2293,
              "load_stored_fields_count": 1,
              "load_source_count": 1,
              "create_stored_fields_visitor": 3166,
              "build_sub_phase_processors_count": 1,
              "create_stored_fields_visitor_count": 1
            },
            "children": [
              {
                "type": "FetchSourcePhase",
                "description": "FetchSourcePhase",
                "time_in_nanos": 3531,
                "breakdown": {
                  "process_count": 1,
                  "process": 1054,
                  "set_next_reader_count": 1,
                  "set_next_reader": 2477
                }
              }
            ]
          }
        ]
      },
...
```