### PR TITLE
[GRPC] Update protobuf reference links to 1.7.0

### DIFF
--- a/_api-reference/grpc-apis/bulk.md
+++ b/_api-reference/grpc-apis/bulk.md
@@ -17,9 +17,9 @@ To submit gRPC requests, you must have a set of protobufs on the client side. Fo
 
 ## gRPC service and method
 
-gRPC Document APIs reside in the [DocumentService](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/services/document_service.proto#L22).
+gRPC Document APIs reside in the [DocumentService](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/services/document_service.proto#L22).
 
-You can submit bulk requests by invoking the [`Bulk`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/services/document_service.proto#L24) gRPC method within the `DocumentService`. The method takes a [`BulkRequest`](#bulkrequest-fields) and returns a [`BulkResponse`](#bulkresponse-fields).
+You can submit bulk requests by invoking the [`Bulk`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/services/document_service.proto#L24) gRPC method within the `DocumentService`. The method takes a [`BulkRequest`](#bulkrequest-fields) and returns a [`BulkResponse`](#bulkresponse-fields).
 
 ## Document format
 
@@ -40,28 +40,28 @@ For a gRPC Bulk API request, provide the same document in Base64 encoding:
 
 ## BulkRequest fields
 
-The [`BulkRequest`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L852) message is the top-level container for a gRPC bulk operation. It accepts the following fields.
+The [`BulkRequest`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L851) message is the top-level container for a gRPC bulk operation. It accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `bulk_request_body` | `repeated `[`BulkRequestBody`](#bulkrequestbody-fields) | The list of bulk operations, each containing one of the operation types (`index`/`create`/`update`/`delete`). Required. |
 | `index` | `string` | The default index for all operations unless overridden in `bulk_request_body`. Specifying the `index` in the `BulkRequest` means that you don't need to include it in the [BulkRequestBody](#bulkrequestbody-fields). Optional. |
-| `x_source` | [`SourceConfigParam`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1252) | Controls whether to return the full `_source`, no `_source`, or only specific fields from `_source` in the response. Optional. |
+| `x_source` | [`SourceConfigParam`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1251) | Controls whether to return the full `_source`, no `_source`, or only specific fields from `_source` in the response. Optional. |
 | `x_source_excludes` | `repeated string` | Fields to exclude from `source`. Optional. |
 | `x_source_includes` | `repeated string` | Fields to include from `source`. Optional. |
 | `pipeline` | `string` | The preprocessing ingest pipeline ID. Optional. |
-| `refresh` | [`Refresh`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3250) | Whether to refresh shards after indexing. Optional. |
+| `refresh` | [`Refresh`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3552) | Whether to refresh shards after indexing. Optional. |
 | `require_alias` | `bool` | If `true`, actions must target an alias. Optional. |
 | `routing` | `string` | The routing value for shard assignment. Optional. |
 | `timeout` | `string` | The timeout duration (for example, `1m`). Optional. |
 | `type` (Deprecated) | `string` | The document type (always `_doc`). Optional. |
-| `wait_for_active_shards` | [`WaitForActiveShards`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1163) | The minimum number of active shards to wait for. Optional. |
-| `global_params` | [`GlobalParams`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1151) | Global parameters for the request. Optional. |
+| `wait_for_active_shards` | [`WaitForActiveShards`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1162) | The minimum number of active shards to wait for. Optional. |
+| `global_params` | [`GlobalParams`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1150) | Global parameters for the request. Optional. |
 
 
 ## BulkRequestBody fields
 
-The [`BulkRequestBody`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L895) message represents a single document-level operation within a `BulkRequest`. It accepts the following fields.
+The [`BulkRequestBody`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L894) message represents a single document-level operation within a `BulkRequest`. It accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -71,7 +71,7 @@ The [`BulkRequestBody`](https://github.com/opensearch-project/opensearch-protobu
 
 ## OperationContainer fields
 
-The [`OperationContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L919) message contains exactly one operation type. It accepts the following fields.
+The [`OperationContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L918) message contains exactly one operation type. It accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -82,17 +82,17 @@ The [`OperationContainer`](https://github.com/opensearch-project/opensearch-prot
 
 ## UpdateAction fields
 
-The [`UpdateAction`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L937) message provides additional options for update operations. It accepts the following fields.
+The [`UpdateAction`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L936) message provides additional options for update operations. It accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `detect_noop` | `bool` | If `true`, skips the update if the document content hasn't changed. Optional. Default is `true`. |
 | `doc` | `bytes` | Partial or full document data for `update` operations. Optional. |
 | `doc_as_upsert` | `bool` | If `true`, treats the document as the full upsert document if the target document doesn't exist. Only valid for the `update` operation. Optional. |
-| `script` | [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1172) | A script to apply to the document (used with `update`). Optional. |
+| `script` | [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1171) | A script to apply to the document (used with `update`). Optional. |
 | `scripted_upsert` | `bool` | If `true`, executes the script whether or not the document exists. Optional. |
 | `upsert` | `bytes` | The full document to use if the target does not exist. Used with `script`. Optional. |
-| `x_source` | [`SourceConfig`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1268) | Controls how the document source is fetched or filtered. Optional. |
+| `x_source` | [`SourceConfig`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1267) | Controls how the document source is fetched or filtered. Optional. |
 
 
 ### Create
@@ -144,7 +144,7 @@ The `DeleteOperation` removes a document by ID. It accepts the following fields.
 | `if_primary_term` | `int64` | Used for concurrency control. The operation only runs if the document's primary term matches this value. Optional. |
 | `if_seq_no` | `int64` | Used for concurrency control. The operation only runs if the document's sequence number matches this value. Optional. |
 | `version` | `int64` | The explicit document version for concurrency control. Optional. |
-| `version_type` | [`VersionType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3242) | Controls version matching behavior. Optional. |
+| `version_type` | [`VersionType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3544) | Controls version matching behavior. Optional. |
 
 #### Example request
 
@@ -182,9 +182,9 @@ The following optional fields can also be provided.
 | `routing` | `string` | A custom routing value used to control shard placement. Optional. |
 | `if_primary_term` | `int64` | Used for concurrency control. The operation only runs if the document's primary term matches this value. Optional. |
 | `if_seq_no` | `int64` | Used for concurrency control. The operation only runs if the document's sequence number matches this value. Optional. |
-| `op_type` | [`OpType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3236) | The operation type. Controls the overwriting behavior. Valid values are `index` (default) and `create`. Optional. |
+| `op_type` | [`OpType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3538) | The operation type. Controls the overwriting behavior. Valid values are `index` (default) and `create`. Optional. |
 | `version` | `int64` | The explicit document version for concurrency control. Optional. |
-| `version_type` | [`VersionType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3242) | Controls version matching behavior. Optional. |
+| `version_type` | [`VersionType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3544) | Controls version matching behavior. Optional. |
 | `pipeline` | `string` | The preprocessing ingest pipeline ID. Optional. |
 | `require_alias` | `bool` | If `true`, requires that all actions target an index alias rather than an index. Default is `false`. Optional. |
 
@@ -330,7 +330,7 @@ The gRPC Bulk API provides the following response fields.
 
 ### BulkResponse fields
 
-The [`BulkResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1060) message is returned directly from the `Bulk` gRPC method and provides a summary and per-item result of a bulk operation. It contains the following fields.
+The [`BulkResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1059) message is returned directly from the `Bulk` gRPC method and provides a summary and per-item result of a bulk operation. It contains the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -362,23 +362,23 @@ Each `ResponseItem` corresponds to a single operation in the request. It contain
 | `id` | `string` | The document ID associated with the operation. |
 | `index` | `string` | The name of the index associated with the operation. If a data stream was targeted, this is the backing index. |
 | `status` | `int32` | The HTTP status code returned for the operation. *(Note: This field may be replaced with a gRPC code in the future.)* |
-| `error` | [`ErrorCause`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1288) | Contains additional information about a failed operation. |
+| `error` | [`ErrorCause`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1287) | Contains additional information about a failed operation. |
 | `primary_term` | `int64` | The primary term assigned to the document. |
 | `result` | `string` | The operation result. Valid values are `created`, `deleted`, and `updated`. |
 | `seq_no` | `int64` | A sequence number assigned to the document to maintain version order. |
-| `shards` | [`ShardInfo`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1333) | Shard information for the operation (only returned for successful actions). |
+| `shards` | [`ShardInfo`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1332) | Shard information for the operation (only returned for successful actions). |
 | `version` | `int64` | The document version (only returned for successful actions). |
 | `forced_refresh` | `bool` | If `true`, forces the document to become visible immediately after the operation. |
 | `get` | [`InlineGetDictUserDefined`](#inlinegetdictuserdefined-fields) | Contains the document `source` returned from an inline get, if requested. |
 
 ### InlineGetDictUserDefined fields
 
-The [`InlineGetDictUserDefined`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1127) message contains the document source returned from an inline get operation.
+The [`InlineGetDictUserDefined`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1126) message contains the document source returned from an inline get operation.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `metadata_fields` | `optional` [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | The document's metadata fields. |
-| `fields` | `optional` [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | The document's stored fields. |
+| `metadata_fields` | `optional` [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | The document's metadata fields. |
+| `fields` | `optional` [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | The document's stored fields. |
 | `found` | `bool` | Whether the document exists. |
 | `x_seq_no` | `optional int64` | The document's sequence number. |
 | `x_primary_term` | `optional int64` | The document's primary term. |

--- a/_api-reference/grpc-apis/knn.md
+++ b/_api-reference/grpc-apis/knn.md
@@ -22,15 +22,15 @@ To submit gRPC requests, you must have a set of protobufs on the client side. Fo
 
 ## gRPC service and method
 
-gRPC k-NN APIs reside in the [`SearchService`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/services/search_service.proto#L22), the same service used for general search operations.
+gRPC k-NN APIs reside in the [`SearchService`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/services/search_service.proto#L22), the same service used for general search operations.
 
-You can submit k-NN search requests by invoking the [`Search`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/services/search_service.proto#L23) gRPC method within the `SearchService`, using a [`KnnQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2022) within the search request. The method takes a [`SearchRequest`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L20) and returns a [`SearchResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L262).
+You can submit k-NN search requests by invoking the [`Search`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/services/search_service.proto#L23) gRPC method within the `SearchService`, using a [`KnnQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2023) within the search request. The method takes a [`SearchRequest`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L20) and returns a [`SearchResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L262).
 
 The gRPC implementation uses the same underlying k-NN functionality as the HTTP API while providing improved performance through protocol buffer serialization.
 
 ## KnnQuery fields
 
-The gRPC k-NN API uses the [`KnnQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2022) message within a [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1369) for k-NN searches. The `KnnQuery` message accepts the following fields.
+The gRPC k-NN API uses the [`KnnQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2023) message within a [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1368) for k-NN searches. The `KnnQuery` message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -39,11 +39,11 @@ The gRPC k-NN API uses the [`KnnQuery`](https://github.com/opensearch-project/op
 | `k` | `int32` | The number of nearest neighbors to return as top hits. Optional. |
 | `min_score` | `float` | The minimum similarity score required for a neighbor to be considered a hit. Optional. |
 | `max_distance` | `float` | The maximum physical distance in vector space required for a neighbor to be considered a hit. Optional. |
-| `filter` | [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1369) | Filters for the k-NN search query. See [Filter limitations](#filter-limitations). Optional. |
+| `filter` | [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1368) | Filters for the k-NN search query. See [Filter limitations](#filter-limitations). Optional. |
 | `boost` | `float` | A boost value used to increase or decrease relevance scores. Default is 1.0. Optional. |
 | `underscore_name` | `string` | A query name for query tagging (JSON key: `_name`). Optional. |
-| `method_parameters` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | Algorithm-specific parameters (for example, `ef_search` or `nprobes`). Optional. |
-| `rescore` | [`KnnQueryRescore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2072) | A rescoring configuration for improved accuracy. Available in versions later than 2.17. Optional. |
+| `method_parameters` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | Algorithm-specific parameters (for example, `ef_search` or `nprobes`). Optional. |
+| `rescore` | [`KnnQueryRescore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2073) | A rescoring configuration for improved accuracy. Available in versions later than 2.17. Optional. |
 | `expand_nested_docs` | `bool` | When `true`, retrieves scores for all nested field documents within each parent document. Used with nested queries. Optional. |
 
 ## Example request
@@ -136,7 +136,7 @@ public class KnnGrpcClient {
 
 ## Response fields
 
-k-NN search requests return the same [`SearchResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L262) structure as regular search operations. For information about response fields, see [Search (gRPC) response fields]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/search/#response-fields).
+k-NN search requests return the same [`SearchResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L262) structure as regular search operations. For information about response fields, see [Search (gRPC) response fields]({{site.url}}{{site.baseurl}}/api-reference/grpc-apis/search/#response-fields).
 
 The response includes the standard search metadata (`took`, `timed_out`, and `shards`) and a `hits` array containing the k-NN documents with their similarity scores.
 

--- a/_api-reference/grpc-apis/search.md
+++ b/_api-reference/grpc-apis/search.md
@@ -503,18 +503,18 @@ The [`ConstantScoreQuery`](https://github.com/opensearch-project/opensearch-prot
 
 #### FunctionScoreQuery fields
 
-The [`FunctionScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2154) message accepts the following fields.
+The [`FunctionScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2183) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `boost_mode` | `optional` [`FunctionBoostMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2947) | Determines how the computed function score is combined with the query score. |
-| `functions` | `repeated` [`FunctionScoreContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2181) | The score functions. Each entry may set `filter`, `weight`, and one of `exp`, `gauss`, `linear`, `field_value_factor`, `random_score`, or `script_score`. |
+| `boost_mode` | `optional` [`FunctionBoostMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3626) | Determines how the computed function score is combined with the query score. |
+| `functions` | `repeated` [`FunctionScoreContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2210) | The score functions. Each entry may set `filter`, `weight`, and one of `exp`, `gauss`, `linear`, `field_value_factor`, `random_score`, or `script_score`. |
 | `max_boost` | `optional float` | The maximum boost value that a function can apply to a document score. |
 | `min_score` | `optional float` | Excludes documents with a score below this threshold from the results. |
-| `query` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L1341) | The query used to select documents before applying score functions. |
-| `score_mode` | `optional` [`FunctionScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.2.0/protos/schemas/common.proto#L2957) | Determines how scores from multiple functions are combined into a single score. |
+| `query` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1368) | The query used to select documents before applying score functions. |
+| `score_mode` | `optional` [`FunctionScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3636) | Determines how scores from multiple functions are combined into a single score. |
 
 For more information, see [Function score query]({{site.url}}{{site.baseurl}}/query-dsl/compound/function-score/).
 

--- a/_api-reference/grpc-apis/search.md
+++ b/_api-reference/grpc-apis/search.md
@@ -21,9 +21,9 @@ To submit gRPC requests, you must have a set of protobufs on the client side. Fo
 
 ## gRPC service and method
 
-gRPC Document APIs reside in the [`SearchService`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/services/search_service.proto#L22).
+gRPC Document APIs reside in the [`SearchService`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/services/search_service.proto#L22).
 
-You can submit search requests by invoking the [`Search`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/services/search_service.proto#L23) gRPC method within the `SearchService`. The method takes a [`SearchRequest`](#searchrequest-fields) and returns a [`SearchResponse`](#searchresponse-fields).
+You can submit search requests by invoking the [`Search`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/services/search_service.proto#L23) gRPC method within the `SearchService`. The method takes a [`SearchRequest`](#searchrequest-fields) and returns a [`SearchResponse`](#searchresponse-fields).
 
 See [Supported Queries](#supported-queries) for currently supported search queries. Additional query types will be supported in future versions.
 {: .note}
@@ -34,12 +34,12 @@ The gRPC Search API supports the following request fields.
 
 ### SearchRequest fields
 
-The [`SearchRequest`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L20) message accepts the following fields. All fields are optional.
+The [`SearchRequest`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L20) message accepts the following fields. All fields are optional.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `index` | `repeated string` | A list of indexes to search. If not provided, defaults to all indexes. |
-| `x_source` | [`SourceConfigParam`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1252) | Controls whether to return the full `_source`, no `_source`, or only specific fields from `_source` in the response. |
+| `x_source` | [`SourceConfigParam`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1251) | Controls whether to return the full `_source`, no `_source`, or only specific fields from `_source` in the response. |
 | `x_source_excludes` | `repeated string` | Fields to exclude from `_source`. Ignored if `source` is `false`. |
 | `x_source_includes` | `repeated string` | Fields to include in `_source`. Ignored if `source` is `false`.  |
 | `allow_no_indices` | `bool` | Whether to ignore wildcards that match no indexes. Default is `true`. |
@@ -48,10 +48,10 @@ The [`SearchRequest`](https://github.com/opensearch-project/opensearch-protobufs
 | `batched_reduce_size` | `int32` | The number of shards to reduce on a node. Default is `512`.  |
 | `cancel_after_time_interval` | `string` | The time after which the request will be canceled. Default is `-1`. |
 | `ccs_minimize_roundtrips` | `bool` | Whether to minimize round trips between the node and remote clusters. Default is `true`.  |
-| `default_operator` | [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3344) | The default operator for query strings. Valid values are `AND` or `OR`. Default is `OR`.  |
+| `default_operator` | [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3646) | The default operator for query strings. Valid values are `AND` or `OR`. Default is `OR`.  |
 | `df` | `string` | The default field for query strings without field prefixes.  |
 | `docvalue_fields` | `repeated string` | The fields to return as doc values. |
-| `expand_wildcards` | `repeated` [`ExpandWildcard`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3265) | The type of index that wildcard expressions can match. Valid values are `all` (match any index), `open` (match open, non-hidden indexes), `closed` (match closed, non-hidden indexes), `hidden` (match hidden indexes), and `none` (deny wildcard expressions). Default is `open`.|
+| `expand_wildcards` | `repeated` [`ExpandWildcard`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3567) | The type of index that wildcard expressions can match. Valid values are `all` (match any index), `open` (match open, non-hidden indexes), `closed` (match closed, non-hidden indexes), `hidden` (match hidden indexes), and `none` (deny wildcard expressions). Default is `open`.|
 | `ignore_throttled` | `bool` | Whether to ignore frozen indexes when resolving aliases. Default is `true`. |
 | `ignore_unavailable` | `bool` | Whether to ignore unavailable indexes or shards. Default is `false`. |
 | `max_concurrent_shard_requests` | `int32` | The number of concurrent shard requests per node. Default is `5`. |
@@ -63,43 +63,43 @@ The [`SearchRequest`](https://github.com/opensearch-project/opensearch-protobufs
 | `total_hits_as_int` | `bool` | Whether to return the number of total hits as an integer. Default is `false`. |
 | `routing` | `repeated string` | The routing values used to direct requests to specific shards. |
 | `scroll` | `string` | The amount of time to keep the search context alive for scrolling. |
-| `search_type` | [`SearchType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3274) | The method for calculating relevance scores. Valid values are `QUERY_THEN_FETCH` and `DFS_QUERY_THEN_FETCH`. Default is `QUERY_THEN_FETCH`. |
+| `search_type` | [`SearchType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3576) | The method for calculating relevance scores. Valid values are `QUERY_THEN_FETCH` and `DFS_QUERY_THEN_FETCH`. Default is `QUERY_THEN_FETCH`. |
 | `suggest_field` | `string` | The field on which to base suggestions. |
-| `suggest_mode` | [`SuggestMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3280) | The suggestion mode (for example, `always`, `missing`, `popular`). |
+| `suggest_mode` | [`SuggestMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3582) | The suggestion mode (for example, `always`, `missing`, `popular`). |
 | `suggest_size` | `int32` | The number of suggestions to return. |
 | `suggest_text` | `string` | The input text for generating suggestions. |
 | `typed_keys` | `bool` | Whether to include type information in aggregation and suggestion keys. Default is `true`. |
 | `search_request_body` | [`SearchRequestBody`](#searchrequestbody-fields) | The main search request payload, including the query and filters. |
-| `global_params` | [`GlobalParams`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1151) | Global parameters for the request. Optional. |
+| `global_params` | [`GlobalParams`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1150) | Global parameters for the request. Optional. |
 
 ### SearchRequestBody fields
 
-The [`SearchRequestBody`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L123) message accepts the following fields. All fields are optional.
+The [`SearchRequestBody`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L123) message accepts the following fields. All fields are optional.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `collapse` | [`FieldCollapse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1973) | Groups the results by a field. Returns only the top document per group. |
+| `collapse` | [`FieldCollapse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1974) | Groups the results by a field. Returns only the top document per group. |
 | `explain` | `bool` | Returns scoring explanations for matched documents. |
-| `ext` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | Plugin-specific metadata, for example, for extensions like RAG. |
+| `ext` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | Plugin-specific metadata, for example, for extensions like RAG. |
 | `from` | `int32` | The starting index for paginated results. Default is `0`. |
-| `highlight` | [`Highlight`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1727) | Highlights matched terms in the result snippets. |
-| `track_total_hits` | [`TrackHits`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L252) | Whether to return the total hit count. |
+| `highlight` | [`Highlight`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1728) | Highlights matched terms in the result snippets. |
+| `track_total_hits` | [`TrackHits`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L252) | Whether to return the total hit count. |
 | `indices_boost` | `map<string, float>` | **Deprecated.** Use `indices_boost_2` instead. |
-| `docvalue_fields` | `repeated` [`FieldAndFormat`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1964) | The fields to return in their `doc_values` form. You can include a format for the returned values (for example, a date format). For `knn_vector` fields, supported formats are `binary` (default, Base64-encoded) and `array` (JSON numeric arrays). For more information, see [Retrieving vector fields using `docvalue_fields`]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#retrieving-vector-fields-using-docvalue_fields). |
+| `docvalue_fields` | `repeated` [`FieldAndFormat`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1965) | The fields to return in their `doc_values` form. You can include a format for the returned values (for example, a date format). For `knn_vector` fields, supported formats are `binary` (default, Base64-encoded) and `array` (JSON numeric arrays). For more information, see [Retrieving vector fields using `docvalue_fields`]({{site.url}}{{site.baseurl}}/search-plugins/searching-data/retrieve-specific-fields/#retrieving-vector-fields-using-docvalue_fields). |
 | `min_score` | `float` | The minimum score required in order for a document to be included in the results. |
 | `post_filter` | [`QueryContainer`](#querycontainer-fields) | Filters hits after aggregations are applied. |
 | `profile` | `bool` | Enables profiling to analyze query performance. |
 | `search_pipeline` | `string` | The name of the search pipeline to apply. |
 | `verbose_pipeline` | `bool` | Enables verbose logging in the search pipeline. |
 | `query` | [`QueryContainer`](#querycontainer-fields) | The query domain-specific language (DSL) for the search. |
-| `rescore` | `repeated` [`Rescore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L505) | Reranks the top N hits to improve precision. |
-| `script_fields` | `map<string, `[`ScriptField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1676)`>` | Custom fields whose values are computed by scripts. |
-| `search_after` | `repeated` [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2629) | Cursor-based pagination using values from the previous page. |
+| `rescore` | `repeated` [`Rescore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L504) | Reranks the top N hits to improve precision. |
+| `script_fields` | `map<string, `[`ScriptField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1677)`>` | Custom fields whose values are computed by scripts. |
+| `search_after` | `repeated` [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2637) | Cursor-based pagination using values from the previous page. |
 | `size` | `int32` | The number of results to return. Default is `10`. |
-| `slice` | [`SlicedScroll`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L514) | Splits scroll context into slices for parallel processing. |
-| `sort` | `repeated` [`SortCombinations`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1692) | The sorting rules (for example, by field, score, or custom order). |
-| `x_source` | [`SourceConfig`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1268) | Controls whether to return the full `_source`, no `_source`, or only specific fields from `_source` in the response. |
-| `fields` | `repeated` [`FieldAndFormat`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1964) | Additional fields to return, with formatting options. |
+| `slice` | [`SlicedScroll`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L513) | Splits scroll context into slices for parallel processing. |
+| `sort` | `repeated` [`SortCombinations`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1693) | The sorting rules (for example, by field, score, or custom order). |
+| `x_source` | [`SourceConfig`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1267) | Controls whether to return the full `_source`, no `_source`, or only specific fields from `_source` in the response. |
+| `fields` | `repeated` [`FieldAndFormat`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1965) | Additional fields to return, with formatting options. |
 | `terminate_after` | `int32` | The maximum number of matching documents (hits) to process before early termination. Default is `0`. |
 | `timeout` | `string` | The maximum amount of time to wait for query execution. |
 | `track_scores` | `bool` | Whether to return document scores in the results. |
@@ -107,23 +107,23 @@ The [`SearchRequestBody`](https://github.com/opensearch-project/opensearch-proto
 | `version` | `bool` | Whether to include the document version in the response. |
 | `seq_no_primary_term` | `bool` | Whether to include the sequence number and primary term for each hit. |
 | `stored_fields` | `repeated string` | The stored fields to return (excludes `_source` unless re-enabled). |
-| `pit` | [`PointInTimeReference`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L613) | The Point in Time reference used to search a fixed snapshot. |
+| `pit` | [`PointInTimeReference`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L612) | The Point in Time reference used to search a fixed snapshot. |
 | `stats` | `repeated string` | The tagging or logging fields to associate with the request. |
 | `derived` | `map<string, `[`DerivedField`](#derivedfield-fields)`>` | Dynamically computed fields returned in the response. |
-| `indices_boost_2` | `repeated` [`FloatMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2909) | The current protobuf representation for per-index boost multipliers. Each entry contains an index-to-boost mapping. |
-| `aggregations` | `map<string, `[`AggregationContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2931)`>` | Aggregations to compute as part of the search request. |
+| `indices_boost_2` | `repeated` [`FloatMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3004) | The current protobuf representation for per-index boost multipliers. Each entry contains an index-to-boost mapping. |
+| `aggregations` | `map<string, `[`AggregationContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3026)`>` | Aggregations to compute as part of the search request. |
 
 ### DerivedField fields
 
-The [`DerivedField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L228) message is used for dynamically computed fields that are calculated during search execution. It accepts the following fields.
+The [`DerivedField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L228) message is used for dynamically computed fields that are calculated during search execution. It accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `name` | `string` | The name of the derived field. Required. |
 | `type` | `string` | The data type of the derived field. Required. |
-| `script` | [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1172) | The script that computes the field value. Required. |
+| `script` | [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1171) | The script that computes the field value. Required. |
 | `prefilter_field` | `string` | The field to use for prefiltering to optimize script execution. Optional. |
-| `properties` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | Additional properties for the derived field. Optional. |
+| `properties` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | Additional properties for the derived field. Optional. |
 | `ignore_malformed` | `bool` | Whether to ignore malformed values during field computation. Optional. |
 | `format` | `string` | The format to apply to the field value (for example, date formatting). Optional. |
 
@@ -138,32 +138,32 @@ Note that some query types are currently unsupported. See [Supported queries](#s
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `bool` | [`BoolQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2132) | A Boolean query that combines multiple clauses using `AND`, `OR`, or `NOT` logic. Must be the only field set. |
-| `constant_score` | [`ConstantScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2170) | Wraps a filter and assigns a constant relevance score to all matching documents. Must be the only field set. |
-| `function_score` | [`FunctionScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2182) | Adjusts the scores of the results using custom functions. Must be the only field set. |
-| `exists` | [`ExistsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1985) | Matches documents that contain a specific field. Must be the only field set. |
-| `fuzzy` | [`FuzzyQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2585) | Matches terms similar to the search term (fuzzy matching). Must be the only field set. |
-| `ids` | [`IdsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2640) | Matches documents by `_id` values. Must be the only field set. |
-| `prefix` | [`PrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2308) | Matches terms with a specific prefix. Must be the only field set. |
-| `range` | [`RangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2452) | Matches terms within a specified range. Must be the only field set. |
-| `regexp` | [`RegexpQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2383) | Matches terms using regular expressions. Must be the only field set. |
-| `term` | [`TermQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2413) | Matches exact terms (no analysis). Must be the only field set. |
-| `terms` | [`TermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1586) | Matches any document containing one or more specified terms in a field. Must be the only field set. |
-| `terms_set` | [`TermsSetQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2362) | Matches documents containing a minimum number of exact terms in a field. Must be the only field set. |
-| `wildcard` | [`WildcardQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1997) | Matches terms using a wildcard pattern. Must be the only field set. |
-| `match` | [`MatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2081) | Performs a full-text match on text or exact-value fields. Must be the only field set. |
-| `match_bool_prefix` | [`MatchBoolPrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2660) | Matches full words and prefixes in a Boolean-style query. Must be the only field set. |
-| `match_phrase` | [`MatchPhraseQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2738) | Matches an exact phrase in order. Must be the only field set. |
-| `match_phrase_prefix` | [`MatchPhrasePrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2711) | Matches a phrase in which the last term is treated as a prefix. Must be the only field set. |
-| `multi_match` | [`MultiMatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2762) | Searches multiple fields using a single query string. Must be the only field set. |
-| `knn` | [`KnnQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2022) | A k-NN query across vector fields. Must be the only field set. |
-| `match_all` | [`MatchAllQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2651) | Matches all documents in the index. Must be the only field set. |
-| `match_none` | [`MatchNoneQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2702) | Matches no documents. Must be the only field set. |
-| `nested` | [`NestedQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1601) | Wraps a query targeting nested fields. Must be the only field set. |
-| `geo_distance` | [`GeoDistanceQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1559) | Returns documents containing geopoints within a specified distance from a provided geopoint. Must be the only field set. |
-| `geo_bounding_box` | [`GeoBoundingBoxQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1482) | Returns documents containing geopoints within a specified bounding box. Must be the only field set. |
-| `script` | [`ScriptQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1470) | Filters documents based on a custom condition written in Painless scripting language. Must be the only field set. |
-| `hybrid` | [`HybridQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1452) | Combines relevance scores from multiple queries into one score. Must be the only field set. |
+| `bool` | [`BoolQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2133) | A Boolean query that combines multiple clauses using `AND`, `OR`, or `NOT` logic. Must be the only field set. |
+| `constant_score` | [`ConstantScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2171) | Wraps a filter and assigns a constant relevance score to all matching documents. Must be the only field set. |
+| `function_score` | [`FunctionScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2183) | Adjusts the scores of the results using custom functions. Must be the only field set. |
+| `exists` | [`ExistsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1986) | Matches documents that contain a specific field. Must be the only field set. |
+| `fuzzy` | [`FuzzyQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2593) | Matches terms similar to the search term (fuzzy matching). Must be the only field set. |
+| `ids` | [`IdsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2648) | Matches documents by `_id` values. Must be the only field set. |
+| `prefix` | [`PrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2309) | Matches terms with a specific prefix. Must be the only field set. |
+| `range` | [`RangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2460) | Matches terms within a specified range. Must be the only field set. |
+| `regexp` | [`RegexpQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2391) | Matches terms using regular expressions. Must be the only field set. |
+| `term` | [`TermQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2421) | Matches exact terms (no analysis). Must be the only field set. |
+| `terms` | [`TermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1587) | Matches any document containing one or more specified terms in a field. Must be the only field set. |
+| `terms_set` | [`TermsSetQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2370) | Matches documents containing a minimum number of exact terms in a field. Must be the only field set. |
+| `wildcard` | [`WildcardQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1998) | Matches terms using a wildcard pattern. Must be the only field set. |
+| `match` | [`MatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2082) | Performs a full-text match on text or exact-value fields. Must be the only field set. |
+| `match_bool_prefix` | [`MatchBoolPrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2668) | Matches full words and prefixes in a Boolean-style query. Must be the only field set. |
+| `match_phrase` | [`MatchPhraseQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2746) | Matches an exact phrase in order. Must be the only field set. |
+| `match_phrase_prefix` | [`MatchPhrasePrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2719) | Matches a phrase in which the last term is treated as a prefix. Must be the only field set. |
+| `multi_match` | [`MultiMatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2770) | Searches multiple fields using a single query string. Must be the only field set. |
+| `knn` | [`KnnQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2023) | A k-NN query across vector fields. Must be the only field set. |
+| `match_all` | [`MatchAllQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2659) | Matches all documents in the index. Must be the only field set. |
+| `match_none` | [`MatchNoneQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2710) | Matches no documents. Must be the only field set. |
+| `nested` | [`NestedQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1602) | Wraps a query targeting nested fields. Must be the only field set. |
+| `geo_distance` | [`GeoDistanceQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1560) | Returns documents containing geopoints within a specified distance from a provided geopoint. Must be the only field set. |
+| `geo_bounding_box` | [`GeoBoundingBoxQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1483) | Returns documents containing geopoints within a specified bounding box. Must be the only field set. |
+| `script` | [`ScriptQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1471) | Filters documents based on a custom condition written in Painless scripting language. Must be the only field set. |
+| `hybrid` | [`HybridQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1453) | Combines relevance scores from multiple queries into one score. Must be the only field set. |
 
 ## Supported queries
 
@@ -184,7 +184,7 @@ The following sections describe the fields for each term-level query message.
 
 #### ExistsQuery fields
 
-The [`ExistsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1985) message accepts the following fields.
+The [`ExistsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1986) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -194,24 +194,24 @@ The [`ExistsQuery`](https://github.com/opensearch-project/opensearch-protobufs/b
 
 #### FuzzyQuery fields
 
-The [`FuzzyQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2585) message accepts the following fields.
+The [`FuzzyQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2593) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `field` | `string` | Required. The field against which to run a search query. |
-| `value` | [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2629) | Required. The term to search for in the specified field. |
+| `value` | [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2637) | Required. The term to search for in the specified field. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 | `max_expansions` | `optional int32` | The maximum number of terms to which the query can expand. Default is `50`. |
 | `prefix_length` | `optional int32` | The number of leading characters that are not considered in fuzziness. Default is `0`. |
-| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3350) | **Deprecated.** Use `rewrite` instead. |
+| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3652) | **Deprecated.** Use `rewrite` instead. |
 | `transpositions` | `optional bool` | Specifies whether to allow transpositions of two adjacent characters as edits. Default is `true`. |
-| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2618) | The number of character edits (insert, delete, or substitute) that it takes to change one word to another when determining whether a term matched a value.|
+| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2626) | The number of character edits (insert, delete, or substitute) that it takes to change one word to another when determining whether a term matched a value.|
 | `rewrite` | `optional string` | Determines how OpenSearch rewrites the query. See [Rewrite parameter values](#rewrite-parameter-values). Default is `constant_score`. |
 
 #### IdsQuery fields
 
-The [`IdsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2640) message accepts the following fields.
+The [`IdsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2648) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -221,7 +221,7 @@ The [`IdsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob
 
 #### PrefixQuery fields
 
-The [`PrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2308) message accepts the following fields.
+The [`PrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2309) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -229,13 +229,13 @@ The [`PrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/b
 | `value` | `string` | Required. The term to search for in the specified field. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3350) | **Deprecated.** Use `rewrite` instead. |
+| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3652) | **Deprecated.** Use `rewrite` instead. |
 | `case_insensitive` | `optional bool` | Allows ASCII case-insensitive matching. Default is `false`. |
 | `rewrite` | `optional string` | Determines how OpenSearch rewrites the query. See [Rewrite parameter values](#rewrite-parameter-values). Default is `constant_score`. |
 
 #### RangeQuery fields
 
-The [`RangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2452) message is a `oneof` type that can contain either a [`NumberRangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2461) or a [`DateRangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2522).
+The [`RangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2460) message is a `oneof` type that can contain either a [`NumberRangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2469) or a [`DateRangeQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2530).
 
 ##### NumberRangeQuery fields
 
@@ -248,13 +248,13 @@ he `NumberRangeQuery` message accepts the following fields.
 | `field` | `string` | Required. The field against which to run a search query. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `relation` | `optional` [`RangeRelation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3287) | Indicates how the range query matches values for range fields. |
+| `relation` | `optional` [`RangeRelation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3589) | Indicates how the range query matches values for range fields. |
 | `gt` | `optional double` | Greater than. |
 | `gte` | `optional double` | Greater than or equal to. |
 | `lt` | `optional double` | Less than. |
 | `lte` | `optional double` | Less than or equal to. |
-| `from` | `optional` [`NumberRangeQueryAllOfFrom`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2500) | The starting value for the range. |
-| `to` | `optional` [`NumberRangeQueryAllOfTo`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2511) | The ending value for the range. |
+| `from` | `optional` [`NumberRangeQueryAllOfFrom`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2508) | The starting value for the range. |
+| `to` | `optional` [`NumberRangeQueryAllOfTo`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2519) | The ending value for the range. |
 | `include_lower` | `optional bool` | Whether to include the lower bound. |
 | `include_upper` | `optional bool` | Whether to include the upper bound. |
 
@@ -269,13 +269,13 @@ The `DateRangeQuery` message accepts the following fields.
 | `field` | `string` | Required. The field against which to run a search query. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `relation` | `optional` [`RangeRelation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3287) | Indicates how the range query matches values for range fields. |
+| `relation` | `optional` [`RangeRelation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3589) | Indicates how the range query matches values for range fields. |
 | `gt` | `optional string` | Greater than. |
 | `gte` | `optional string` | Greater than or equal to. |
 | `lt` | `optional string` | Less than. |
 | `lte` | `optional string` | Less than or equal to. |
-| `from` | `optional` [`DateRangeQueryAllOfFrom`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2567) | The starting value for the range. |
-| `to` | `optional` [`DateRangeQueryAllOfTo`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2576) | The ending value for the range. |
+| `from` | `optional` [`DateRangeQueryAllOfFrom`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2575) | The starting value for the range. |
+| `to` | `optional` [`DateRangeQueryAllOfTo`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2584) | The ending value for the range. |
 | `format` | `optional string` | The date format pattern. |
 | `time_zone` | `optional string` | The time zone identifier. |
 | `include_lower` | `optional bool` | Whether to include the lower bound. |
@@ -283,7 +283,7 @@ The `DateRangeQuery` message accepts the following fields.
 
 #### RegexpQuery fields
 
-The [`RegexpQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2383) message accepts the following fields.
+The [`RegexpQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2391) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -294,35 +294,35 @@ The [`RegexpQuery`](https://github.com/opensearch-project/opensearch-protobufs/b
 | `case_insensitive` | `optional bool` | Allows case-insensitive matching of the regular expression. Default is `false`. |
 | `flags` | `optional string` | Enables optional operators for the regular expression. |
 | `max_determinized_states` | `optional int32` | The maximum number of automaton states the query requires. Default is `10000`. |
-| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3350) | **Deprecated.** Use `rewrite` instead. |
+| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3652) | **Deprecated.** Use `rewrite` instead. |
 | `rewrite` | `optional string` | Determines how OpenSearch rewrites and scores multi-term queries. See [Rewrite parameter values](#rewrite-parameter-values). Default is `constant_score`. |
 
 #### TermQuery fields
 
-The [`TermQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2413) message accepts the following fields.
+The [`TermQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2421) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `field` | `string` | Required. The field against which to run a search query. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `value` | [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2629) | Required. The term to search for in the provided field. Must exactly match the field value. |
+| `value` | [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2637) | Required. The term to search for in the provided field. Must exactly match the field value. |
 | `case_insensitive` | `optional bool` | Allows ASCII case-insensitive matching. Default is `false`. |
 
 #### TermsQuery fields
 
-The [`TermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1586) message accepts the following fields.
+The [`TermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1587) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `value_type` | `optional` [`TermsQueryValueType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3310) | The types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`. |
-| `terms` | `map<string, `[`TermsQueryField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2332)`>` | A map of field names to term values or term lookups. |
+| `value_type` | `optional` [`TermsQueryValueType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3612) | The types of values used for filtering. Valid values are `default` and `bitmap`. Default is `default`. |
+| `terms` | `map<string, `[`TermsQueryField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2333)`>` | A map of field names to term values or term lookups. |
 
 #### TermsSetQuery fields
 
-The [`TermsSetQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2362) message accepts the following fields.
+The [`TermsSetQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2370) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -331,11 +331,11 @@ The [`TermsSetQuery`](https://github.com/opensearch-project/opensearch-protobufs
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 | `minimum_should_match_field` | `optional string` | The name of the numeric field that specifies the number of matching terms required. |
-| `minimum_should_match_script` | `optional` [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1172) | A script that returns the number of matching terms required. |
+| `minimum_should_match_script` | `optional` [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1171) | A script that returns the number of matching terms required. |
 
 #### WildcardQuery fields
 
-The [`WildcardQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1997) message accepts the following fields.
+The [`WildcardQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1998) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -343,7 +343,7 @@ The [`WildcardQuery`](https://github.com/opensearch-project/opensearch-protobufs
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 | `case_insensitive` | `optional bool` | Allows case-insensitive matching. Default is `false`. |
-| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3350) | **Deprecated.** Use `rewrite` instead. |
+| `rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3652) | **Deprecated.** Use `rewrite` instead. |
 | `value` | `optional string` | A wildcard pattern used for matching terms in the specified field. Required when `wildcard` is not set. |
 | `wildcard` | `optional string` | A wildcard pattern used for matching terms in the specified field. Required when `value` is not set. |
 | `rewrite` | `optional string` | Determines how OpenSearch rewrites the query. See [Rewrite parameter values](#rewrite-parameter-values). Default is `constant_score`. |
@@ -356,30 +356,30 @@ The following sections describe the fields for each full-text query message.
 
 #### MatchQuery fields
 
-The [`MatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2081) message accepts the following fields.
+The [`MatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2082) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `field` | `string` | Required. The field against which to run a search query. |
-| `query` | [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2629) | Required. The query string to use for search. |
+| `query` | [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2637) | Required. The query string to use for search. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 | `analyzer` | `optional string` | The analyzer used to tokenize the query string text. |
 | `auto_generate_synonyms_phrase_query` | `optional bool` | Specifies whether to create a match phrase query automatically for multi-term synonyms. |
-| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2618) | The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value. |
-| `fuzzy_rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3350) | **Deprecated.** Use `fuzzy_rewrite` instead. |
+| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2626) | The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value. |
+| `fuzzy_rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3652) | **Deprecated.** Use `fuzzy_rewrite` instead. |
 | `fuzzy_transpositions` | `optional bool` | Adds swaps of adjacent characters to the fuzziness operations. Default is `true`. |
 | `lenient` | `optional bool` | Ignores data type mismatches between the query and the document field. Default is `false`. |
 | `max_expansions` | `optional int32` | The maximum number of terms to which the query can expand. Default is `50`. |
-| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2159) | The number of terms that need to match for the document to be considered a match. |
-| `operator` | `optional` [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3344) | Whether all terms need to match (`AND`) or only one term needs to match (`OR`). Default is `OR`. |
+| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2160) | The number of terms that need to match for the document to be considered a match. |
+| `operator` | `optional` [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3646) | Whether all terms need to match (`AND`) or only one term needs to match (`OR`). Default is `OR`. |
 | `prefix_length` | `optional int32` | The number of leading characters that are not considered in fuzziness. Default is `0`. |
-| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3304) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
+| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3606) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
 | `fuzzy_rewrite` | `optional string` | Determines how OpenSearch rewrites the query. See [Rewrite parameter values](#rewrite-parameter-values). Default is `constant_score`. |
 
 #### MatchBoolPrefixQuery fields
 
-The [`MatchBoolPrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2660) message accepts the following fields.
+The [`MatchBoolPrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2668) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -388,18 +388,18 @@ The [`MatchBoolPrefixQuery`](https://github.com/opensearch-project/opensearch-pr
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 | `analyzer` | `optional string` | The analyzer used to tokenize the query string text. |
-| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2618) | The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value. |
-| `fuzzy_rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3350) | **Deprecated.** Use `fuzzy_rewrite` instead. |
+| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2626) | The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value. |
+| `fuzzy_rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3652) | **Deprecated.** Use `fuzzy_rewrite` instead. |
 | `fuzzy_transpositions` | `optional bool` | Adds swaps of adjacent characters to the fuzziness operations. Default is `true`. |
 | `max_expansions` | `optional int32` | The maximum number of terms to which the query can expand. Default is `50`. |
-| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2159) | The number of terms that need to match for the document to be considered a match. |
-| `operator` | `optional` [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3344) | Whether all terms need to match (`AND`) or only one term needs to match (`OR`). Default is `OR`. |
+| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2160) | The number of terms that need to match for the document to be considered a match. |
+| `operator` | `optional` [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3646) | Whether all terms need to match (`AND`) or only one term needs to match (`OR`). Default is `OR`. |
 | `prefix_length` | `optional int32` | The number of leading characters that are not considered in fuzziness. Default is `0`. |
 | `fuzzy_rewrite` | `optional string` | Determines how OpenSearch rewrites the query. See [Rewrite parameter values](#rewrite-parameter-values). Default is `constant_score`. |
 
 #### MatchPhraseQuery fields
 
-The [`MatchPhraseQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2738) message accepts the following fields.
+The [`MatchPhraseQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2746) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -409,11 +409,11 @@ The [`MatchPhraseQuery`](https://github.com/opensearch-project/opensearch-protob
 | `x_name` | `optional string` | A query name for query tagging. |
 | `analyzer` | `optional string` | The analyzer used to tokenize the query string text. |
 | `slop` | `optional int32` | The number of other words permitted between words in the query phrase. Default is `0` (exact match). |
-| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3304) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
+| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3606) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
 
 #### MatchPhrasePrefixQuery fields
 
-The [`MatchPhrasePrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2711) message accepts the following fields.
+The [`MatchPhrasePrefixQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2719) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -424,11 +424,11 @@ The [`MatchPhrasePrefixQuery`](https://github.com/opensearch-project/opensearch-
 | `analyzer` | `optional string` | The analyzer used to tokenize the query string text. |
 | `max_expansions` | `optional int32` | The maximum number of terms to which the query can expand. Default is `50`. |
 | `slop` | `optional int32` | The number of other words permitted between words in the query phrase. Default is `0` (exact match). |
-| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3304) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
+| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3606) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
 
 #### MultiMatchQuery fields
 
-The [`MultiMatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2762) message accepts the following fields.
+The [`MultiMatchQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2770) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -438,23 +438,23 @@ The [`MultiMatchQuery`](https://github.com/opensearch-project/opensearch-protobu
 | `analyzer` | `optional string` | The analyzer used to tokenize the query string text. |
 | `auto_generate_synonyms_phrase_query` | `optional bool` | Specifies whether to create a match phrase query automatically for multi-term synonyms. Default is `true`. |
 | `fields` | `repeated string` | The list of fields in which to search. |
-| `fuzzy_rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3350) | **Deprecated.** Use `fuzzy_rewrite` instead. |
-| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2618) | The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value. |
+| `fuzzy_rewrite_deprecated` | `optional` [`MultiTermQueryRewrite`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3652) | **Deprecated.** Use `fuzzy_rewrite` instead. |
+| `fuzziness` | `optional` [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2626) | The number of character edits (insertions, deletions, substitutions, or transpositions) that it takes to change one word to another when determining whether a term matched a value. |
 | `fuzzy_transpositions` | `optional bool` | Adds swaps of adjacent characters to the fuzziness operations. Default is `true`. |
 | `lenient` | `optional bool` | Ignores data type mismatches between the query and the document field. Default is `false`. |
 | `max_expansions` | `optional int32` | The maximum number of terms to which the query can expand. Default is `50`. |
-| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2159) | The number of terms that need to match for the document to be considered a match. |
-| `operator` | `optional` [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3344) | Whether all terms need to match (`AND`) or only one term needs to match (`OR`). Default is `OR`. |
+| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2160) | The number of terms that need to match for the document to be considered a match. |
+| `operator` | `optional` [`Operator`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3646) | Whether all terms need to match (`AND`) or only one term needs to match (`OR`). Default is `OR`. |
 | `prefix_length` | `optional int32` | The number of leading characters that are not considered in fuzziness. Default is `0`. |
 | `slop` | `optional int32` | The number of other words permitted between words in the query phrase. Supported for `phrase` and `phrase_prefix` query types. |
 | `tie_breaker` | `optional float` | A factor between `0` and `1.0` used to assign more weight to documents matching multiple query clauses. |
-| `type` | `optional` [`TextQueryType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3294) | The multi-match query type. Valid values are `best_fields`, `most_fields`, `cross_fields`, `phrase`, `phrase_prefix`, `bool_prefix`. Default is `best_fields`. |
-| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3304) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
+| `type` | `optional` [`TextQueryType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3596) | The multi-match query type. Valid values are `best_fields`, `most_fields`, `cross_fields`, `phrase`, `phrase_prefix`, `bool_prefix`. Default is `best_fields`. |
+| `zero_terms_query` | `optional` [`ZeroTermsQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3606) | Specifies whether to match no documents (`none`) or all documents (`all`) when the analyzer removes all terms. Default is `none`. |
 | `fuzzy_rewrite` | `optional string` | Determines how OpenSearch rewrites the query. See [Rewrite parameter values](#rewrite-parameter-values). Default is `constant_score`. |
 
 #### MatchAllQuery fields
 
-The [`MatchAllQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2651) message accepts the following fields.
+The [`MatchAllQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2659) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -463,7 +463,7 @@ The [`MatchAllQuery`](https://github.com/opensearch-project/opensearch-protobufs
 
 #### MatchNoneQuery fields
 
-The [`MatchNoneQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2702) message accepts the following fields.
+The [`MatchNoneQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2710) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -478,26 +478,26 @@ The following sections describe the fields for each compound query message.
 
 #### BoolQuery fields
 
-The [`BoolQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2132) message accepts the following fields.
+The [`BoolQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2133) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `filter` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2141) | The clause (query) that must appear in matching documents. The query score is ignored. |
-| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2144) | The minimum number of `should` clauses that must match. |
-| `must` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2147) | The clause (query) must appear in matching documents and contributes to the score. |
-| `must_not` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2150) | The clause (query) that must not appear in matching documents. A score of `0` is returned for all documents. |
-| `should` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2153) | The clause (query) that should appear in the matching document. |
+| `filter` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2142) | The clause (query) that must appear in matching documents. The query score is ignored. |
+| `minimum_should_match` | `optional` [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2145) | The minimum number of `should` clauses that must match. |
+| `must` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2148) | The clause (query) must appear in matching documents and contributes to the score. |
+| `must_not` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2151) | The clause (query) that must not appear in matching documents. A score of `0` is returned for all documents. |
+| `should` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2154) | The clause (query) that should appear in the matching document. |
 | `adjust_pure_negative` | `optional bool` | Ensures correct behavior when a query contains only `must_not` clauses. Default is `true`. |
 
 #### ConstantScoreQuery fields
 
-The [`ConstantScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2170) message accepts the following fields.
+The [`ConstantScoreQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2171) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `filter` | [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1369) | Required. The filter query that a document must match to be returned in the results. |
+| `filter` | [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1368) | Required. The filter query that a document must match to be returned in the results. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 
@@ -526,17 +526,17 @@ The following sections describe the fields for each joining query message.
 
 #### NestedQuery fields
 
-The [`NestedQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1601) message accepts the following fields.
+The [`NestedQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1602) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `path` | `string` | Required. The path to a field or an array of paths to fields in which to search. |
-| `query` | [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1369) | Required. The query to run on the nested objects within the specified path. |
+| `query` | [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1368) | Required. The query to run on the nested objects within the specified path. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 | `ignore_unmapped` | `optional bool` | Set to `true` to ignore an unmapped field and not match any documents. Default is `false`. |
 | `inner_hits` | `optional` [`InnerHits`](#innerhits-fields) | If provided, returns the underlying hits that matched the query. |
-| `score_mode` | `optional` [`ChildScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3498) | Defines how scores of matching inner documents influence the parent document's score. |
+| `score_mode` | `optional` [`ChildScoreMode`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3800) | Defines how scores of matching inner documents influence the parent document's score. |
 
 ### Geographic query fields
 
@@ -546,31 +546,31 @@ The following sections describe the fields for each geographic query message.
 
 #### GeoBoundingBoxQuery fields
 
-A geo-bounding box query returns documents whose geopoints are within the bounding box specified in the query. The [`GeoBoundingBoxQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1482) message accepts the following fields.
+A geo-bounding box query returns documents whose geopoints are within the bounding box specified in the query. The [`GeoBoundingBoxQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1483) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `type` | `optional` [`GeoExecution`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3513) | The execution type for the geographic query. |
-| `validation_method` | `optional` [`GeoValidationMethod`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3360) | The validation method. Valid values are `IGNORE_MALFORMED`, `COERCE`, and `STRICT`. Default is `STRICT`. |
+| `type` | `optional` [`GeoExecution`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3815) | The execution type for the geographic query. |
+| `validation_method` | `optional` [`GeoValidationMethod`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3662) | The validation method. Valid values are `IGNORE_MALFORMED`, `COERCE`, and `STRICT`. Default is `STRICT`. |
 | `ignore_unmapped` | `optional bool` | Specifies whether to ignore an unmapped field. Default is `false`. |
-| `bounding_box` | `map<string, `[`GeoBounds`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1503)`>` | A map of field names to geobounds defining the bounding box. |
+| `bounding_box` | `map<string, `[`GeoBounds`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1504)`>` | A map of field names to geobounds defining the bounding box. |
 
 #### GeoDistanceQuery fields
 
-A geodistance query returns documents with geopoints that are within a specified distance from the provided geopoint. The [`GeoDistanceQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1559) message accepts the following fields.
+A geodistance query returns documents with geopoints that are within a specified distance from the provided geopoint. The [`GeoDistanceQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1560) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `distance` | `string` | Required. The distance within which to match the points. This distance is the radius of a circle centered at the specified point. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `distance_type` | `optional` [`GeoDistanceType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3448) | Specifies how to calculate the distance. Valid values are `arc` and `plane`. Default is `arc`. |
-| `validation_method` | `optional` [`GeoValidationMethod`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3360) | The validation method. Valid values are `IGNORE_MALFORMED`, `COERCE`, and `STRICT`. Default is `STRICT`. |
+| `distance_type` | `optional` [`GeoDistanceType`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3750) | Specifies how to calculate the distance. Valid values are `arc` and `plane`. Default is `arc`. |
+| `validation_method` | `optional` [`GeoValidationMethod`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3662) | The validation method. Valid values are `IGNORE_MALFORMED`, `COERCE`, and `STRICT`. Default is `STRICT`. |
 | `ignore_unmapped` | `optional bool` | Set to `true` to ignore an unmapped field and not match any documents. Default is `false`. |
-| `unit` | `optional` [`DistanceUnit`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3485) | The unit of distance measurement. |
-| `location` | `map<string, `[`GeoLocation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1215)`>` | A map of field names to `geolocations` specifying the center point. |
+| `unit` | `optional` [`DistanceUnit`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3787) | The unit of distance measurement. |
+| `location` | `map<string, `[`GeoLocation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1214)`>` | A map of field names to `geolocations` specifying the center point. |
 
 ### Specialized query fields
 
@@ -580,25 +580,25 @@ For `knn` query fields, see [k-NN (gRPC)]({{site.url}}{{site.baseurl}}/api-refer
 
 #### ScriptQuery fields
 
-A script query filters documents based on a custom condition written in the Painless scripting language. The [`ScriptQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1470) message accepts the following fields.
+A script query filters documents based on a custom condition written in the Painless scripting language. The [`ScriptQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1471) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `script` | [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1172) | Required. The script to execute for filtering documents. |
+| `script` | [`Script`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1171) | Required. The script to execute for filtering documents. |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
 
 #### HybridQuery fields
 
-A hybrid query combines relevance scores from multiple queries into one score for a given document. The [`HybridQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1452) message accepts the following fields.
+A hybrid query combines relevance scores from multiple queries into one score for a given document. The [`HybridQuery`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1453) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `boost` | `optional float` | A floating-point number used to decrease or increase the relevance scores of the query. Default is `1.0`. |
 | `x_name` | `optional string` | A query name for query tagging. |
-| `queries` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1369) | An array of one or more query clauses that are used to match documents. A document must match at least one query clause in order to be returned in the results. The documents' relevance scores from all query clauses are combined into one score by applying a search pipeline. The maximum number of query clauses is 5. |
+| `queries` | `repeated` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1368) | An array of one or more query clauses that are used to match documents. A document must match at least one query clause in order to be returned in the results. The documents' relevance scores from all query clauses are combined into one score by applying a search pipeline. The maximum number of query clauses is 5. |
 | `pagination_depth` | `optional int32` | The pagination depth for the hybrid query. |
-| `filter` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1369) | A filter to apply to all subqueries of the hybrid query. |
+| `filter` | `optional` [`QueryContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1368) | A filter to apply to all subqueries of the hybrid query. |
 
 ### AggregationContainer fields
 
@@ -607,14 +607,14 @@ A hybrid query combines relevance scores from multiple queries into one score fo
 Currently, the gRPC Search API supports only the following aggregation types: `max`, `min`, and `terms`.
 {: .note}
 
-The [`AggregationContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2931) message wraps a single aggregation definition and accepts the following fields.
+The [`AggregationContainer`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3026) message wraps a single aggregation definition and accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `meta` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | Optional custom metadata attached to the aggregation. |
-| `max` | [`MaxAggregation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3006) | A [`max`]({{site.url}}{{site.baseurl}}/aggregations/metric/maximum/) metric aggregation. Must be the only aggregation type set. |
-| `min` | [`MinAggregation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3020) | A [`min`]({{site.url}}{{site.baseurl}}/aggregations/metric/minimum/) metric aggregation. Must be the only aggregation type set. |
-| `terms_aggregation` | [`TermsAggregation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3084) | A [`terms`]({{site.url}}{{site.baseurl}}/aggregations/bucket/terms/) bucket aggregation that groups documents by term values. Must be the only aggregation type set. |
+| `meta` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | Optional custom metadata attached to the aggregation. |
+| `max` | [`MaxAggregation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3101) | A [`max`]({{site.url}}{{site.baseurl}}/aggregations/metric/maximum/) metric aggregation. Must be the only aggregation type set. |
+| `min` | [`MinAggregation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3115) | A [`min`]({{site.url}}{{site.baseurl}}/aggregations/metric/minimum/) metric aggregation. Must be the only aggregation type set. |
+| `terms_aggregation` | [`TermsAggregation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3179) | A [`terms`]({{site.url}}{{site.baseurl}}/aggregations/bucket/terms/) bucket aggregation that groups documents by term values. Must be the only aggregation type set. |
 
 ### Common message values
 
@@ -622,7 +622,7 @@ The following sections describe the values used by common message types.
 
 #### Fuzziness
 
-The [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2618) message is a `oneof` type that accepts the following values.
+The [`Fuzziness`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2626) message is a `oneof` type that accepts the following values.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -648,7 +648,7 @@ The rewrite parameter gives you control over how multi-term queries behave inter
 
 #### MinimumShouldMatch
 
-The [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2159) message is a `oneof` type that accepts the following values.
+The [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2160) message is a `oneof` type that accepts the following values.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
@@ -657,30 +657,30 @@ The [`MinimumShouldMatch`](https://github.com/opensearch-project/opensearch-prot
 
 #### FieldValue
 
-The [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2629) message represents a field value and accepts the following values.
+The [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2637) message represents a field value and accepts the following values.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `bool` | `optional bool` | A Boolean value. |
-| `general_number` | `optional` [`GeneralNumber`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3575) | A numeric value. |
+| `general_number` | `optional` [`GeneralNumber`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3915) | A numeric value. |
 | `string` | `optional string` | A string value. |
-| `null_value` | `optional` [`NullValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3585) | A null value. |
+| `null_value` | `optional` [`NullValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3925) | A null value. |
 
 #### InnerHits fields
 
-The [`InnerHits`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1625) message accepts the following fields.
+The [`InnerHits`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1626) message accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
 | `name` | `optional string` | The name to be used for the particular inner hit definition in the response. |
 | `size` | `optional int32` | The maximum number of hits to return in `inner_hits`. |
 | `from` | `optional int32` | The starting document offset for an inner hit. |
-| `collapse` | `optional` [`FieldCollapse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1973) | Groups search results by a particular field value. |
-| `docvalue_fields` | `repeated` [`FieldAndFormat`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1964) | The fields that OpenSearch should return using their `doc_values`. |
+| `collapse` | `optional` [`FieldCollapse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1974) | Groups search results by a particular field value. |
+| `docvalue_fields` | `repeated` [`FieldAndFormat`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1965) | The fields that OpenSearch should return using their `doc_values`. |
 | `explain` | `optional bool` | Whether to return details about how OpenSearch computed the document's score. Default is `false`. |
-| `highlight` | `optional` [`Highlight`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1727) | Highlighting emphasizes the search term(s) in the results. |
+| `highlight` | `optional` [`Highlight`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1728) | Highlighting emphasizes the search term(s) in the results. |
 | `ignore_unmapped` | `optional bool` | Specifies how to treat an unmapped field. Default is `false`. |
-| `script_fields` | `map<string, `[`ScriptField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1676)`>` | Custom fields whose values are computed using scripts. |
+| `script_fields` | `map<string, `[`ScriptField`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1677)`>` | Custom fields whose values are computed using scripts. |
 | `seq_no_primary_term` | `optional bool` | Whether to return sequence number and primary term of the last operation of each document hit. |
 
 
@@ -795,7 +795,7 @@ The gRPC Search API returns the following response fields.
 
 ### SearchResponse fields
 
-The following table lists the supported fields for the [`SearchResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L262) message.
+The following table lists the supported fields for the [`SearchResponse`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L262) message.
 
 The source documents are returned as bytes. Use Base64 decoding to read the `_source` field in the gRPC response.
 {: .note}
@@ -804,32 +804,32 @@ The source documents are returned as bytes. Use Base64 decoding to read the `_so
 | :---- | :---- | :---- |
 | `took` | `int64` | The amount of time taken to process the search request, in milliseconds. |
 | `timed_out` | `bool` | Whether the search timed out. |
-| `x_shards` | [`ShardStatistics`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1312) | The shard-level success/failure/total metadata. |
-| `phase_took` | [`PhaseTook`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L330) | The phase-level `took` time values in the response. |
+| `x_shards` | [`ShardStatistics`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1311) | The shard-level success/failure/total metadata. |
+| `phase_took` | [`PhaseTook`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L330) | The phase-level `took` time values in the response. |
 | `hits` | [`HitsMetadata`](#hitsmetadata-fields) | The main document results and metadata. |
-| `processor_results` | `repeated` [`ProcessorExecutionDetail`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L306) | Processor execution details. |
-| `x_clusters` | [`ClusterStatistics`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L472) | Information about the search on each cluster when searching remote clusters. |
-| `fields` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | **Deprecated.** Retrieved specific fields in the search response. |
+| `processor_results` | `repeated` [`ProcessorExecutionDetail`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L306) | Processor execution details. |
+| `x_clusters` | [`ClusterStatistics`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L471) | Information about the search on each cluster when searching remote clusters. |
+| `fields` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | **Deprecated.** Retrieved specific fields in the search response. |
 | `num_reduce_phases` | `int32` | The number of times that the coordinating node aggregates results from batches of shard responses. |
-| `profile` | [`Profile`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L484) | Profiling data for query execution (debugging/performance insights). |
+| `profile` | [`Profile`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L483) | Profiling data for query execution (debugging/performance insights). |
 | `pit_id` | `string` | The Point in Time ID. |
 | `x_scroll_id` | `string` | The identifier for the search and its search context. |
 | `terminated_early` | `bool` | Whether the query was terminated early. |
-| `aggregations` | `map<string, `[`Aggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2914)`>` | Aggregation results returned with the search response. |
+| `aggregations` | `map<string, `[`Aggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3009)`>` | Aggregation results returned with the search response. |
 
 ### Aggregate fields
 
-The [`Aggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2914) message represents a single aggregation result and accepts the following fields.
+The [`Aggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3009) message represents a single aggregation result and accepts the following fields.
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `dterms` | [`DoubleTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2945) | A `terms` aggregation with double-valued bucket keys. |
-| `lterms` | [`LongTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2971) | A `terms` aggregation with signed-long bucket keys. |
-| `max` | [`SingleMetricAggregateBase`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3034) | The result of a `max` aggregation. |
-| `min` | [`SingleMetricAggregateBase`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3034) | The result of a `min` aggregation. |
-| `sterms` | [`StringTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3060) | A `terms` aggregation with string bucket keys. |
-| `ulterms` | [`UnsignedLongTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3173) | A `terms` aggregation with unsigned-long bucket keys. |
-| `umterms` | [`UnmappedTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3161) | A `terms` aggregation result for unmapped fields. |
+| `dterms` | [`DoubleTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3040) | A `terms` aggregation with double-valued bucket keys. |
+| `lterms` | [`LongTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3066) | A `terms` aggregation with signed-long bucket keys. |
+| `max` | [`SingleMetricAggregateBase`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3129) | The result of a `max` aggregation. |
+| `min` | [`SingleMetricAggregateBase`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3129) | The result of a `min` aggregation. |
+| `sterms` | [`StringTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3155) | A `terms` aggregation with string bucket keys. |
+| `ulterms` | [`UnsignedLongTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3268) | A `terms` aggregation with unsigned-long bucket keys. |
+| `umterms` | [`UnmappedTermsAggregate`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3256) | A `terms` aggregation result for unmapped fields. |
 
 ### HitsMetadata fields
 
@@ -837,8 +837,8 @@ The `HitsMetadata` object contains information about the search results, includi
 
 | Field | Protobuf type | Description |
 | :---- | :---- | :---- |
-| `total` | [`HitsMetadataTotal`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L351) | Metadata about the total number of matching documents (value \+ relation). |
-| `max_score` | [`HitsMetadataMaxScore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L360) | The highest relevance score of the returned hits (may be `null`). |
+| `total` | [`HitsMetadataTotal`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L351) | Metadata about the total number of matching documents (value \+ relation). |
+| `max_score` | [`HitsMetadataMaxScore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L360) | The highest relevance score of the returned hits (may be `null`). |
 | `hits` | `repeated` [`HitsMetadataHitsInner`](#hitsmetadatahitsinner-fields) | The actual list of matched documents. Each hit includes core fields like `index`, `id`, `score`, and `source`, along with additional optional fields. |
 
 ### HitsMetadataHitsInner fields
@@ -850,15 +850,15 @@ Each `HitsMetadataHitsInner` represents a single document matched by the query a
 | `x_type` | `string` | The document type. |
 | `x_index` | `string` | The name of the index containing the returned document. |
 | `x_id` | `string` | The unique ID for the document within the index. |
-| `x_score` | [`HitXScore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L396) | The relevance score of the hit. |
-| `x_explanation` | [`Explanation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L827) | A text explanation of how the `_score` was calculated. |
-| `fields` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | The document field values. |
-| `highlight` | `map<string, `[`StringArray`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1263)`>` | The highlighted fields and fragments per hit. |
-| `inner_hits` | `map<string, `[`InnerHitsResult`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L390)`>` | The matching nested documents from a different scope that contributed to the overall query result. |
+| `x_score` | [`HitXScore`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L395) | The relevance score of the hit. |
+| `x_explanation` | [`Explanation`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L826) | A text explanation of how the `_score` was calculated. |
+| `fields` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | The document field values. |
+| `highlight` | `map<string, `[`StringArray`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1262)`>` | The highlighted fields and fragments per hit. |
+| `inner_hits` | `map<string, `[`InnerHitsResult`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L389)`>` | The matching nested documents from a different scope that contributed to the overall query result. |
 | `matched_queries` | `repeated string` | **Deprecated.** A list of query names matching the document. |
-| `x_nested` | [`NestedIdentity`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L839) | The path to the inner nested object from which the hit originated. |
+| `x_nested` | [`NestedIdentity`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L838) | The path to the inner nested object from which the hit originated. |
 | `x_ignored` | `repeated string` | A list of ignored fields. |
-| `ignored_field_values` | `map<string, `[`StringArray`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L1263)`>` | Raw, unprocessed values from the document's original JSON. |
+| `ignored_field_values` | `map<string, `[`StringArray`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L1262)`>` | Raw, unprocessed values from the document's original JSON. |
 | `x_shard` | `string` | The shard ID from which the hit was retrieved. |
 | `x_node` | `string` | The node ID from which the hit was retrieved. |
 | `x_routing` | `string` | The routing value used for custom shard routing. |
@@ -866,9 +866,9 @@ Each `HitsMetadataHitsInner` represents a single document matched by the query a
 | `x_seq_no` | `int64` | The sequence number (used for indexing history and versioning). |
 | `x_primary_term` | `int64` | The primary term number (used for optimistic concurrency control). |
 | `x_version` | `int64` | The document version number. |
-| `sort` | `repeated` [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2629) | The sort values used for result sorting. |
-| `meta_fields` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L3550) | The metadata values for the document. |
-| `matched_queries_2` | [`HitMatchedQueries`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.4.0/protos/schemas/common.proto#L2843) | The current protobuf representation of matched query names for the document. |
+| `sort` | `repeated` [`FieldValue`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2637) | The sort values used for result sorting. |
+| `meta_fields` | [`ObjectMap`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L3890) | The metadata values for the document. |
+| `matched_queries_2` | [`HitMatchedQueries`](https://github.com/opensearch-project/opensearch-protobufs/blob/1.7.0/protos/schemas/common.proto#L2851) | The current protobuf representation of matched query names for the document. |
 
 `source` is Base64 encoded and must be decoded to obtain the JSON document.
 {: .note}


### PR DESCRIPTION
### Description

Bumps the remaining `opensearch-protobufs` `1.4.0` reference links in the gRPC API docs (`search.md`, `bulk.md`, `knn.md`) to `1.7.0`. #12968 already added new `1.7.0`-tagged links for the `TermsQueryField`/`TermsLookup` additions in `search.md`, but left the ~173 pre-existing links in that file (plus 21 in `bulk.md` and 11 in `knn.md`) still pointing at `1.4.0`. This follows the same full-sweep approach used in #11614 for the 3.4 release (0.19.0 -> 0.24.0).

Both the version segment and the `#L<n>` line anchor were updated for every link, since `common.proto` (+343/-3 lines) and `search_service.proto` (+4 lines) shifted between `1.4.0` and `1.7.0`; `document.proto`, `document_service.proto`, and `search.proto` are byte-identical between the two tags, so those links only needed the version bump. Every remapped link was validated by confirming the referenced identifier (message/field name) actually appears on the target line at the `1.7.0` tag.

`index.md`'s references to "protobuf version 1.2.0" (the GA package/release version) were intentionally left untouched -- that's a different concept from the per-symbol schema line anchors this PR updates.

Note: this branches off current `main`, before #12968 has merged. Will rebase once #12968 lands.

### Issues Resolved

Follow-up to #12968; companion to opensearch-project/OpenSearch#22759 (protobufs 1.7.0 bump).

### Version

3.9

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).