### PR TITLE
Add resource sharing access control docs for alerting, security analytics, and notifications

### DIFF
--- a/_observing-your-data/alerting/alerting-access-control.md
+++ b/_observing-your-data/alerting/alerting-access-control.md
@@ -18,20 +18,18 @@ For the end-to-end framework concepts and APIs, see [Resource sharing and access
 
 ## Resource configuration
 
-Alerting registers two resource types, both stored in the alerting configuration index.
+Alerting registers two resource types, both stored in the same configuration index. The following table describes the alerting resource configuration.
 
-| Field | Value |
-| :--- | :--- |
-| Resource type | `monitor` |
-| Resource type | `alerting-workflow` |
-| System index | `.opendistro-alerting-config` |
-| Onboarded version | OpenSearch 3.8 |
+| Resource type | System index | Onboarded version |
+| :--- | :--- | :--- |
+| `monitor` | `.opendistro-alerting-config` | OpenSearch 3.8 |
+| `alerting-workflow` | `.opendistro-alerting-config` | OpenSearch 3.8 |
 
-The workflow resource type is named `alerting-workflow` (not `workflow`) to avoid colliding with the `workflow` resource type registered by the Flow Framework plugin. Both types share the `.opendistro-alerting-config` index; the framework distinguishes them by the document's own fields.
+The workflow resource type is named `alerting-workflow` in order to avoid a name collision with the `workflow` resource type registered by the Flow Framework plugin. Because both alerting types share the `.opendistro-alerting-config` index, the framework distinguishes them by the fields in each document.
 
 When resource-level authorization is enabled, each monitor's and workflow's visibility is governed by a central sharing record. Resource owners and users with sharing capabilities can grant or revoke access permissions for specific users, roles, or backend roles.
 
-Alerts and comments are subordinate to their monitor: they are not registered resource types, and access to them is derived from access to the monitor that produced them. A user who can access a monitor can read its alerts; adding a comment requires monitor access at the read-write or full-access level.
+Alerts and comments are subordinate to their monitor. They are not registered resource types, so access to them is derived from access to the monitor that produced them. A user who can access a monitor can read its alerts. Adding a comment requires monitor access at the read-write or full-access level.
 
 ## Enable alerting resource sharing
 
@@ -77,7 +75,7 @@ Alerting provides three predefined access levels that apply to both the `monitor
 
 ### alerting_read_only
 
-The `alerting_read_only` read-only access level grants users the ability to view and search shared monitors, workflows, and their alerts, but not modify them. This access level includes the following permissions:
+The `alerting_read_only` read-only access level grants users the ability to view and search shared monitors, workflows, and their alerts but not modify them. This access level includes the following permissions:
 
 ```yaml
 - 'cluster:admin/opendistro/alerting/monitor/get'
@@ -107,7 +105,7 @@ The `alerting_read_write` read-write access level grants users full access to mo
 
 ### alerting_full_access
 
-The `alerting_full_access` full access level grants users complete control over a monitor or workflow, including owner-like permissions such as sharing the resource with other users. This access level includes all alerting operations plus resource sharing permissions:
+The `alerting_full_access` full access level grants users complete control over a monitor or workflow, including owner-like permissions such as sharing the resource with other users. This access level includes all read-write permissions plus remote index and resource sharing permissions:
 
 ```yaml
 - 'cluster:admin/opendistro/alerting/monitor/*'
@@ -132,7 +130,7 @@ After enabling resource sharing and marking the alerting resource types as prote
 Admin-only: The Migrate API can only be executed by cluster administrators with superadmin or REST admin privileges.
 {: .important }
 
-Both alerting resource types are stored in the same index and store owner information under different paths (`monitor.user` and `workflow.user`). Alerting declares these per-type paths on its resource providers, so the framework reads the owner from the correct path for each document. The request-level `username_path` and `backend_roles_path` remain required and are used as a fallback.
+Both alerting resource types are stored in the same index but keep owner information under different paths (`monitor.user` and `workflow.user`). Alerting declares these per-type paths on its resource providers, so the framework reads the owner from the correct path for each document. The request-level `username_path` and `backend_roles_path` parameters are still required and are used as a fallback.
 
 Use the following API call to migrate legacy alerting sharing data to the resource sharing framework:
 
@@ -157,3 +155,5 @@ Replace `<replace-with-existing-user>` with the username of an existing user who
 
 - [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/) -- Backend concepts, configuration, and setup
 - [Resource sharing APIs]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/) -- REST API reference for programmatic management
+- [Resource access management]({{site.url}}{{site.baseurl}}/dashboards/management/resource-sharing/) -- UI workflows and user guidance
+- [Alerting security]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/security/) -- Built-in alerting roles and legacy backend role filtering

--- a/_observing-your-data/alerting/alerting-access-control.md
+++ b/_observing-your-data/alerting/alerting-access-control.md
@@ -1,0 +1,159 @@
+---
+layout: default
+title: Alerting resource access control
+nav_order: 12
+parent: Alerting
+has_children: false
+---
+
+# Alerting resource access control
+
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).
+{: .warning}
+
+Alerting integrates with the Security plugin's resource sharing and access control framework to provide document-level authorization for monitors and workflows. This replaces the legacy `plugins.alerting.filter_by_backend_roles` setting with a more flexible sharing system that allows resource owners to grant specific access levels to users, roles, or backend roles.
+
+For the end-to-end framework concepts and APIs, see [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/).
+{: .note}
+
+## Resource configuration
+
+Alerting registers two resource types, both stored in the alerting configuration index.
+
+| Field | Value |
+| :--- | :--- |
+| Resource type | `monitor` |
+| Resource type | `alerting-workflow` |
+| System index | `.opendistro-alerting-config` |
+| Onboarded version | OpenSearch 3.8 |
+
+The workflow resource type is named `alerting-workflow` (not `workflow`) to avoid colliding with the `workflow` resource type registered by the Flow Framework plugin. Both types share the `.opendistro-alerting-config` index; the framework distinguishes them by the document's own fields.
+
+When resource-level authorization is enabled, each monitor's and workflow's visibility is governed by a central sharing record. Resource owners and users with sharing capabilities can grant or revoke access permissions for specific users, roles, or backend roles.
+
+Alerts and comments are subordinate to their monitor: they are not registered resource types, and access to them is derived from access to the monitor that produced them. A user who can access a monitor can read its alerts; adding a comment requires monitor access at the read-write or full-access level.
+
+## Enable alerting resource sharing
+
+To enable resource sharing for alerting, add the alerting resource types to the protected types list and enable resource sharing cluster-wide.
+
+Admin-only: These settings can be configured only by cluster administrators with superadmin privileges.
+{: .important }
+
+### Configuration using opensearch.yml
+
+Add the following settings to your `opensearch.yml` configuration file to enable resource sharing for alerting:
+
+```yaml
+plugins.security.experimental.resource_sharing.enabled: true
+plugins.security.system_indices.enabled: true
+plugins.security.experimental.resource_sharing.protected_types:
+  - "monitor"
+  - "alerting-workflow"
+```
+{% include copy.html %}
+
+### Configuration using the Cluster Settings API
+
+Alternatively, you can enable resource sharing dynamically using the Cluster Settings API:
+
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "plugins.security.experimental.resource_sharing.enabled": true,
+    "plugins.security.experimental.resource_sharing.protected_types": ["monitor", "alerting-workflow"]
+  }
+}
+```
+{% include copy-curl.html %}
+
+When adding the alerting resource types to an existing configuration, include all previously configured resource types in the `protected_types` array.
+{: .note}
+
+## Alerting access levels
+
+Alerting provides three predefined access levels that apply to both the `monitor` and `alerting-workflow` resource types. These access levels determine the specific permissions granted to users who have been granted access to a monitor or workflow resource.
+
+### alerting_read_only
+
+The `alerting_read_only` read-only access level grants users the ability to view and search shared monitors, workflows, and their alerts, but not modify them. This access level includes the following permissions:
+
+```yaml
+- 'cluster:admin/opendistro/alerting/monitor/get'
+- 'cluster:admin/opendistro/alerting/monitor/search'
+- 'cluster:admin/opendistro/alerting/alerts/get'
+- 'cluster:admin/opensearch/alerting/workflow/get'
+- 'cluster:admin/opensearch/alerting/workflow_alerts/get'
+- 'cluster:admin/opensearch/alerting/findings/get'
+- 'cluster:admin/opendistro/alerting/destination/get'
+```
+{% include copy.html %}
+
+### alerting_read_write
+
+The `alerting_read_write` read-write access level grants users full access to monitor and workflow operations, including alerts and comments, except for sharing capabilities. This access level includes all read permissions plus write operations:
+
+```yaml
+- 'cluster:admin/opendistro/alerting/monitor/*'
+- 'cluster:admin/opensearch/alerting/workflow/*'
+- 'cluster:admin/opendistro/alerting/alerts/*'
+- 'cluster:admin/opensearch/alerting/workflow_alerts/*'
+- 'cluster:admin/opensearch/alerting/findings/*'
+- 'cluster:admin/opendistro/alerting/destination/*'
+- 'cluster:admin/opensearch/alerting/comments/*'
+```
+{% include copy.html %}
+
+### alerting_full_access
+
+The `alerting_full_access` full access level grants users complete control over a monitor or workflow, including owner-like permissions such as sharing the resource with other users. This access level includes all alerting operations plus resource sharing permissions:
+
+```yaml
+- 'cluster:admin/opendistro/alerting/monitor/*'
+- 'cluster:admin/opensearch/alerting/workflow/*'
+- 'cluster:admin/opendistro/alerting/alerts/*'
+- 'cluster:admin/opensearch/alerting/workflow_alerts/*'
+- 'cluster:admin/opensearch/alerting/findings/*'
+- 'cluster:admin/opendistro/alerting/destination/*'
+- 'cluster:admin/opensearch/alerting/comments/*'
+- 'cluster:admin/opensearch/alerting/remote/indexes/get'
+- 'cluster:admin/security/resource/share'
+```
+{% include copy.html %}
+
+These access levels are predefined and cannot be modified. To request additional access levels, create an issue in the [Alerting GitHub repository](https://github.com/opensearch-project/alerting/).
+{: .note}
+
+## Migrating from the legacy framework
+
+After enabling resource sharing and marking the alerting resource types as protected, cluster administrators must run the migration API to transfer existing monitor and workflow sharing information from the legacy framework to the new resource sharing system.
+
+Admin-only: The Migrate API can only be executed by cluster administrators with superadmin or REST admin privileges.
+{: .important }
+
+Both alerting resource types are stored in the same index and store owner information under different paths (`monitor.user` and `workflow.user`). Alerting declares these per-type paths on its resource providers, so the framework reads the owner from the correct path for each document. The request-level `username_path` and `backend_roles_path` remain required and are used as a fallback.
+
+Use the following API call to migrate legacy alerting sharing data to the resource sharing framework:
+
+```json
+POST _plugins/_security/api/resources/migrate
+{
+  "source_index": ".opendistro-alerting-config",
+  "username_path": "/monitor/user/name",
+  "backend_roles_path": "/monitor/user/backend_roles",
+  "default_owner": "<replace-with-existing-user>",
+  "default_access_level": {
+    "monitor": "<select-appropriate-access-level>",
+    "alerting-workflow": "<select-appropriate-access-level>"
+  }
+}
+```
+{% include copy-curl.html %}
+
+Replace `<replace-with-existing-user>` with the username of an existing user who should own monitors and workflows without explicit ownership information. Replace `<select-appropriate-access-level>` with one of the available alerting access levels: `alerting_read_only`, `alerting_read_write`, or `alerting_full_access`.
+
+## Related documentation
+
+- [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/) -- Backend concepts, configuration, and setup
+- [Resource sharing APIs]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/) -- REST API reference for programmatic management

--- a/_observing-your-data/notifications/notification-access-control.md
+++ b/_observing-your-data/notifications/notification-access-control.md
@@ -1,0 +1,143 @@
+---
+layout: default
+title: Notification access control
+nav_order: 30
+parent: Notifications
+has_children: false
+---
+
+# Notification access control
+
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).
+{: .warning}
+
+Notifications integrates with the Security plugin's resource sharing and access control framework to provide document-level authorization for notification configurations (channels). This replaces the legacy `opensearch.notifications.general.filter_by_backend_roles` setting with a more flexible sharing system that allows resource owners to grant specific access levels to users, roles, or backend roles.
+
+For the end-to-end framework concepts and APIs, see [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/).
+{: .note}
+
+## Resource configuration
+
+The following table describes the notification configuration resource.
+
+| Field | Value |
+| :--- | :--- |
+| Resource type | `notification_config` |
+| System index | `.opensearch-notifications-config` |
+| Onboarded version | OpenSearch 3.8 |
+
+When resource-level authorization is enabled, each notification configuration's visibility is governed by a central sharing record. Resource owners and users with sharing capabilities can grant or revoke access permissions for specific users, roles, or backend roles.
+
+## Enable notification resource sharing
+
+To enable resource sharing for notifications, add the notification configuration resource type to the protected types list and enable resource sharing cluster-wide.
+
+Admin-only: These settings can be configured only by cluster administrators with superadmin privileges.
+{: .important }
+
+### Configuration using opensearch.yml
+
+Add the following settings to your `opensearch.yml` configuration file to enable resource sharing for notifications:
+
+```yaml
+plugins.security.experimental.resource_sharing.enabled: true
+plugins.security.system_indices.enabled: true
+plugins.security.experimental.resource_sharing.protected_types:
+  - "notification_config"
+```
+{% include copy.html %}
+
+### Configuration using the Cluster Settings API
+
+Alternatively, you can enable resource sharing dynamically using the Cluster Settings API:
+
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "plugins.security.experimental.resource_sharing.enabled": true,
+    "plugins.security.experimental.resource_sharing.protected_types": ["notification_config"]
+  }
+}
+```
+{% include copy-curl.html %}
+
+When adding the notification configuration resource type to an existing configuration, include all previously configured resource types in the `protected_types` array.
+{: .note}
+
+## Notification access levels
+
+Notifications provides three predefined access levels for notification configuration documents. These access levels determine the specific permissions granted to users who have been granted access to a notification configuration resource.
+
+### notifications_read_only
+
+The `notifications_read_only` read-only access level grants users the ability to view shared notification configurations and channels but not modify them. This access level includes the following permissions:
+
+```yaml
+- 'cluster:admin/opensearch/notifications/configs/get'
+- 'cluster:admin/opensearch/notifications/channels/get'
+- 'cluster:admin/opensearch/notifications/features'
+```
+{% include copy.html %}
+
+### notifications_read_write
+
+The `notifications_read_write` read-write access level grants users full access to notification configuration operations except for sharing capabilities. This access level includes all read permissions plus write and send operations:
+
+```yaml
+- 'cluster:admin/opensearch/notifications/configs/*'
+- 'cluster:admin/opensearch/notifications/channels/get'
+- 'cluster:admin/opensearch/notifications/features'
+- 'cluster:admin/opensearch/notifications/feature/send'
+- 'cluster:admin/opensearch/notifications/test_notification'
+```
+{% include copy.html %}
+
+### notifications_full_access
+
+The `notifications_full_access` full access level grants users complete control over a notification configuration, including owner-like permissions such as sharing the resource with other users. This access level includes all notification operations plus resource sharing permissions:
+
+```yaml
+- 'cluster:admin/opensearch/notifications/configs/*'
+- 'cluster:admin/opensearch/notifications/channels/get'
+- 'cluster:admin/opensearch/notifications/features'
+- 'cluster:admin/opensearch/notifications/feature/send'
+- 'cluster:admin/opensearch/notifications/test_notification'
+- 'cluster:admin/security/resource/share'
+```
+{% include copy.html %}
+
+These access levels are predefined and cannot be modified. To request additional access levels, create an issue in the [Notifications GitHub repository](https://github.com/opensearch-project/notifications/).
+{: .note}
+
+## Migrating from the legacy framework
+
+After enabling resource sharing and marking the notification configuration resource type as protected, cluster administrators must run the migration API to transfer existing notification sharing information from the legacy framework to the new resource sharing system.
+
+Admin-only: The Migrate API can only be executed by cluster administrators with superadmin or REST admin privileges.
+{: .important }
+
+Notification configuration documents track their authorized backend roles under `metadata.access` and do not store a per-user owner. Set `backend_roles_path` to `/metadata/access`. The `username_path` field is required by the API, but because notification documents have no owner name, the path does not resolve to a value and ownership falls back to `default_owner`.
+
+Use the following API call to migrate legacy notification sharing data to the resource sharing framework:
+
+```json
+POST _plugins/_security/api/resources/migrate
+{
+  "source_index": ".opensearch-notifications-config",
+  "username_path": "/metadata/owner",
+  "backend_roles_path": "/metadata/access",
+  "default_owner": "<replace-with-existing-user>",
+  "default_access_level": {
+    "notification_config": "<select-appropriate-access-level>"
+  }
+}
+```
+{% include copy-curl.html %}
+
+Replace `<replace-with-existing-user>` with the username of an existing user who should own notification configurations. Because notification documents do not carry an owner name, every migrated configuration is attributed to this user. Replace `<select-appropriate-access-level>` with one of the available notification access levels: `notifications_read_only`, `notifications_read_write`, or `notifications_full_access`.
+
+## Related documentation
+
+- [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/) -- Backend concepts, configuration, and setup
+- [Resource sharing APIs]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/) -- REST API reference for programmatic management

--- a/_observing-your-data/notifications/notification-access-control.md
+++ b/_observing-your-data/notifications/notification-access-control.md
@@ -117,7 +117,7 @@ After enabling resource sharing and marking the notification configuration resou
 Admin-only: The Migrate API can only be executed by cluster administrators with superadmin or REST admin privileges.
 {: .important }
 
-Notification configuration documents track their authorized backend roles under `metadata.access` and do not store a per-user owner. Set `backend_roles_path` to `/metadata/access`. The `username_path` parameter is required by the API, but because notification documents have no owner name, the path does not resolve to a value, and ownership falls back to `default_owner`.
+Notification configuration documents track their authorized backend roles under `metadata.access` and do not store a per-user owner. Set `backend_roles_path` to `/metadata/access`. The `username_path` parameter is required and must be a non-empty path (an empty value is rejected), so point it at a field that notification documents do not contain, such as `/metadata/owner`. The path resolves to no value, and ownership falls back to `default_owner`.
 
 Use the following API call to migrate legacy notification sharing data to the resource sharing framework:
 

--- a/_observing-your-data/notifications/notification-access-control.md
+++ b/_observing-your-data/notifications/notification-access-control.md
@@ -11,7 +11,7 @@ has_children: false
 This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).
 {: .warning}
 
-Notifications integrates with the Security plugin's resource sharing and access control framework to provide document-level authorization for notification configurations (channels). This replaces the legacy `opensearch.notifications.general.filter_by_backend_roles` setting with a more flexible sharing system that allows resource owners to grant specific access levels to users, roles, or backend roles.
+Notifications integrates with the Security plugin's resource sharing and access control framework to provide document-level authorization for notification configurations. A notification configuration is the underlying document for a channel, so sharing a configuration controls access to the corresponding channel. This replaces the legacy `opensearch.notifications.general.filter_by_backend_roles` setting with a more flexible sharing system that allows resource owners to grant specific access levels to users, roles, or backend roles.
 
 For the end-to-end framework concepts and APIs, see [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/).
 {: .note}
@@ -117,7 +117,7 @@ After enabling resource sharing and marking the notification configuration resou
 Admin-only: The Migrate API can only be executed by cluster administrators with superadmin or REST admin privileges.
 {: .important }
 
-Notification configuration documents track their authorized backend roles under `metadata.access` and do not store a per-user owner. Set `backend_roles_path` to `/metadata/access`. The `username_path` field is required by the API, but because notification documents have no owner name, the path does not resolve to a value and ownership falls back to `default_owner`.
+Notification configuration documents track their authorized backend roles under `metadata.access` and do not store a per-user owner. Set `backend_roles_path` to `/metadata/access`. The `username_path` parameter is required by the API, but because notification documents have no owner name, the path does not resolve to a value, and ownership falls back to `default_owner`.
 
 Use the following API call to migrate legacy notification sharing data to the resource sharing framework:
 
@@ -141,3 +141,4 @@ Replace `<replace-with-existing-user>` with the username of an existing user who
 
 - [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/) -- Backend concepts, configuration, and setup
 - [Resource sharing APIs]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/) -- REST API reference for programmatic management
+- [Resource access management]({{site.url}}{{site.baseurl}}/dashboards/management/resource-sharing/) -- UI workflows and user guidance

--- a/_security-analytics/resource-access-control.md
+++ b/_security-analytics/resource-access-control.md
@@ -17,7 +17,7 @@ For the end-to-end framework concepts and APIs, see [Resource sharing and access
 
 ## Resource configuration
 
-Security Analytics registers two resource types.
+Security Analytics registers two resource types. The following table describes the Security Analytics resource configuration.
 
 | Resource type | System index | Onboarded version |
 | :--- | :--- | :--- |
@@ -82,7 +82,7 @@ The `sa_read_only` read-only access level grants users the ability to view and s
 ```
 {% include copy.html %}
 
-For correlation rules, it includes the following permissions:
+For correlation rules, this access level includes the following permissions:
 
 ```yaml
 - 'cluster:admin/opensearch/securityanalytics/correlation/rule/search'
@@ -105,7 +105,7 @@ The `sa_read_write` read-write access level grants users full access to resource
 ```
 {% include copy.html %}
 
-For correlation rules, it includes the following permissions:
+For correlation rules, this access level includes the following permissions:
 
 ```yaml
 - 'cluster:admin/index/correlation/rules/*'
@@ -158,3 +158,5 @@ Replace `<replace-with-existing-user>` with the username of an existing user who
 
 - [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/) -- Backend concepts, configuration, and setup
 - [Resource sharing APIs]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/) -- REST API reference for programmatic management
+- [Resource access management]({{site.url}}{{site.baseurl}}/dashboards/management/resource-sharing/) -- UI workflows and user guidance
+- [OpenSearch security for Security Analytics]({{site.url}}{{site.baseurl}}/security-analytics/security/) -- Basic permissions and legacy backend role filtering

--- a/_security-analytics/resource-access-control.md
+++ b/_security-analytics/resource-access-control.md
@@ -1,0 +1,160 @@
+---
+layout: default
+title: Security Analytics resource access control
+nav_order: 3
+has_children: false
+---
+
+# Security Analytics resource access control
+
+This is an experimental feature and is not recommended for use in a production environment. For updates on the progress of the feature or if you want to leave feedback, join the discussion on the [OpenSearch forum](https://forum.opensearch.org/).
+{: .warning}
+
+Security Analytics integrates with the Security plugin's resource sharing and access control framework to provide document-level authorization for detectors and correlation rules. This replaces the legacy `plugins.security_analytics.filter_by_backend_roles` setting with a more flexible sharing system that allows resource owners to grant specific access levels to users, roles, or backend roles.
+
+For the end-to-end framework concepts and APIs, see [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/).
+{: .note}
+
+## Resource configuration
+
+Security Analytics registers two resource types.
+
+| Resource type | System index | Onboarded version |
+| :--- | :--- | :--- |
+| `detector` | `.opensearch-sap-detectors-config` | OpenSearch 3.8 |
+| `correlation-rule` | `.opensearch-sap-correlation-rules-config` | OpenSearch 3.8 |
+
+When resource-level authorization is enabled, each detector's and correlation rule's visibility is governed by a central sharing record. Resource owners and users with sharing capabilities can grant or revoke access permissions for specific users, roles, or backend roles.
+
+## Enable Security Analytics resource sharing
+
+To enable resource sharing for Security Analytics, add the Security Analytics resource types to the protected types list and enable resource sharing cluster-wide.
+
+Admin-only: These settings can be configured only by cluster administrators with superadmin privileges.
+{: .important }
+
+### Configuration using opensearch.yml
+
+Add the following settings to your `opensearch.yml` configuration file to enable resource sharing for Security Analytics:
+
+```yaml
+plugins.security.experimental.resource_sharing.enabled: true
+plugins.security.system_indices.enabled: true
+plugins.security.experimental.resource_sharing.protected_types:
+  - "detector"
+  - "correlation-rule"
+```
+{% include copy.html %}
+
+### Configuration using the Cluster Settings API
+
+Alternatively, you can enable resource sharing dynamically using the Cluster Settings API:
+
+```json
+PUT _cluster/settings
+{
+  "transient": {
+    "plugins.security.experimental.resource_sharing.enabled": true,
+    "plugins.security.experimental.resource_sharing.protected_types": ["detector", "correlation-rule"]
+  }
+}
+```
+{% include copy-curl.html %}
+
+When adding the Security Analytics resource types to an existing configuration, include all previously configured resource types in the `protected_types` array.
+{: .note}
+
+## Security Analytics access levels
+
+Security Analytics provides three predefined access levels that apply to both the `detector` and `correlation-rule` resource types. These access levels determine the specific permissions granted to users who have been granted access to a detector or correlation rule resource.
+
+### sa_read_only
+
+The `sa_read_only` read-only access level grants users the ability to view and search shared resources but not modify them. For detectors, this access level includes the following permissions:
+
+```yaml
+- 'cluster:admin/opensearch/securityanalytics/detector/get'
+- 'cluster:admin/opensearch/securityanalytics/detector/search'
+- 'cluster:admin/opensearch/securityanalytics/alerts/get'
+- 'cluster:admin/opensearch/securityanalytics/findings/get'
+- 'cluster:admin/opensearch/securityanalytics/mapping/get'
+- 'cluster:admin/opensearch/securityanalytics/mapping/view/get'
+```
+{% include copy.html %}
+
+For correlation rules, it includes the following permissions:
+
+```yaml
+- 'cluster:admin/opensearch/securityanalytics/correlation/rule/search'
+- 'cluster:admin/opensearch/securityanalytics/correlations/list'
+- 'cluster:admin/opensearch/securityanalytics/correlations/findings'
+- 'cluster:admin/opensearch/securityanalytics/correlationAlerts/get'
+```
+{% include copy.html %}
+
+### sa_read_write
+
+The `sa_read_write` read-write access level grants users full access to resource operations except for sharing capabilities. For detectors, this access level includes the following permissions:
+
+```yaml
+- 'cluster:admin/opensearch/securityanalytics/detector/*'
+- 'cluster:admin/opensearch/securityanalytics/alerts/*'
+- 'cluster:admin/opensearch/securityanalytics/findings/*'
+- 'cluster:admin/opensearch/securityanalytics/mapping/*'
+- 'cluster:admin/opensearch/securityanalytics/rule/*'
+```
+{% include copy.html %}
+
+For correlation rules, it includes the following permissions:
+
+```yaml
+- 'cluster:admin/index/correlation/rules/*'
+- 'cluster:admin/opensearch/securityanalytics/correlation/rule/search'
+- 'cluster:admin/opensearch/securityanalytics/correlations/*'
+- 'cluster:admin/opensearch/securityanalytics/correlationAlerts/*'
+```
+{% include copy.html %}
+
+### sa_full_access
+
+The `sa_full_access` full access level grants users complete control over a resource, including owner-like permissions such as sharing the resource with other users. This access level includes all read-write permissions for the resource type plus the resource sharing permission:
+
+```yaml
+- 'cluster:admin/security/resource/share'
+```
+{% include copy.html %}
+
+These access levels are predefined and cannot be modified. To request additional access levels, create an issue in the [Security Analytics GitHub repository](https://github.com/opensearch-project/security-analytics/).
+{: .note}
+
+## Migrating from the legacy framework
+
+After enabling resource sharing and marking the Security Analytics resource types as protected, cluster administrators must run the migration API to transfer existing detector and correlation rule sharing information from the legacy framework to the new resource sharing system. Run the migration once per resource index.
+
+Admin-only: The Migrate API can only be executed by cluster administrators with superadmin or REST admin privileges.
+{: .important }
+
+Use the following API call to migrate legacy detector sharing data to the resource sharing framework:
+
+```json
+POST _plugins/_security/api/resources/migrate
+{
+  "source_index": ".opensearch-sap-detectors-config",
+  "username_path": "/user/name",
+  "backend_roles_path": "/user/backend_roles",
+  "default_owner": "<replace-with-existing-user>",
+  "default_access_level": {
+    "detector": "<select-appropriate-access-level>"
+  }
+}
+```
+{% include copy-curl.html %}
+
+Run the migration again for the correlation rule index, using `.opensearch-sap-correlation-rules-config` as the `source_index` and `correlation-rule` as the `default_access_level` key.
+
+Replace `<replace-with-existing-user>` with the username of an existing user who should own resources without explicit ownership information. Replace `<select-appropriate-access-level>` with one of the available Security Analytics access levels: `sa_read_only`, `sa_read_write`, or `sa_full_access`.
+
+## Related documentation
+
+- [Resource sharing and access control]({{site.url}}{{site.baseurl}}/security/access-control/resources/) -- Backend concepts, configuration, and setup
+- [Resource sharing APIs]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/) -- REST API reference for programmatic management

--- a/_security/access-control/resources.md
+++ b/_security/access-control/resources.md
@@ -79,18 +79,27 @@ The resource types you specify must exactly match the resource types supported b
 2. **Use the [List resource types API]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/#list-resource-types)** to discover all available resource types for your installed plugins.
 3. **Update your `protected_types` configuration** with the resource types you want to enable.
 
-## Example resource types
+## Resource types by plugin
 
-The following are example resource types available for resource sharing:
+The following table describes the resource types registered by the plugins that support resource sharing. Each plugin's page describes the access levels for its resource types and the steps for migrating from the legacy backend role filtering settings.
 
-- **ML Commons plugin:**
-  - `ml-model-group` -- Machine learning (ML) model groups
+| Plugin | Resource types | Plugin documentation |
+| :--- | :--- | :--- |
+| Alerting | `monitor`, `alerting-workflow` | [Alerting resource access control]({{site.url}}{{site.baseurl}}/observing-your-data/alerting/alerting-access-control/) |
+| Anomaly Detection | `anomaly-detector` | [Anomaly detector access control]({{site.url}}{{site.baseurl}}/observing-your-data/ad/detector-access-control/) |
+| Anomaly Detection | `forecaster` | [Forecaster access control]({{site.url}}{{site.baseurl}}/observing-your-data/forecast/forecaster-access-control/) |
+| Flow Framework | `workflow` | [Workflow access control]({{site.url}}{{site.baseurl}}/automating-configurations/workflow-access-control/) |
+| Flow Framework | `workflow-state` | [Workflow state access control]({{site.url}}{{site.baseurl}}/automating-configurations/workflow-state-access-control/) |
+| ML Commons | `ml-model-group` | [Model access control through resource sharing]({{site.url}}{{site.baseurl}}/ml-commons-plugin/model-sharing-access-control/) |
+| Notifications | `notification_config` | [Notification access control]({{site.url}}{{site.baseurl}}/observing-your-data/notifications/notification-access-control/) |
+| Reporting | `report-definition` | [Report definition access control]({{site.url}}{{site.baseurl}}/reporting/report-definition-access-control/) |
+| Reporting | `report-instance` | [Report instance access control]({{site.url}}{{site.baseurl}}/reporting/report-instance-access-control/) |
+| Security Analytics | `detector`, `correlation-rule` | [Security Analytics resource access control]({{site.url}}{{site.baseurl}}/security-analytics/resource-access-control/) |
 
-- **Anomaly Detection plugin:**
-  - `anomaly-detector` -- Anomaly detection jobs
-  - `forecaster` -- Time series forecasting jobs
+The Security Analytics `detector` resource type is distinct from the Anomaly Detection `anomaly-detector` resource type, and the Alerting `alerting-workflow` resource type is distinct from the Flow Framework `workflow` resource type.
+{: .note}
 
-The following is an example configuration after discovering available types:
+The following is an example configuration that protects the ML Commons and Anomaly Detection resource types:
 
 ```yaml
 plugins.security.experimental.resource_sharing.protected_types: ["ml-model-group", "anomaly-detector", "forecaster"]
@@ -214,4 +223,5 @@ When managing resource sharing, administrators should follow these best practice
 
 - [Resource sharing APIs]({{site.url}}{{site.baseurl}}/security/access-control/resource-sharing-api/) -- REST API reference for programmatic management
 - [Resource access management]({{site.url}}{{site.baseurl}}/dashboards/management/resource-sharing/) -- UI workflows and user guidance
+- [Resource types by plugin](#resource-types-by-plugin) -- Per-plugin access levels and migration steps
 - [Developer documentation](https://github.com/opensearch-project/security/blob/main/RESOURCE_SHARING_AND_ACCESS_CONTROL.md) -- Detailed technical documentation for plugin developers, users, and administrators


### PR DESCRIPTION
### Description

Adds resource sharing and access control documentation for the three plugins onboarded to the Security plugin's resource-sharing framework that did not yet have a page: **alerting**, **security analytics**, and **notifications**. The other onboarded plugins (anomaly detection, ml-commons, reporting, flow-framework) already have equivalent pages; these three follow the same structure.

Each page documents:
- Resource types and system indexes
- How to enable resource sharing (`opensearch.yml` and Cluster Settings API)
- The predefined access levels and their permissions
- Migration from the legacy `filter_by_backend_roles` framework via `POST _plugins/_security/api/resources/migrate`

Plugin-specific notes:
- **Alerting** — two types, `monitor` and `alerting-workflow` (named to avoid colliding with Flow Framework's `workflow`), sharing the `.opendistro-alerting-config` index. Alerts and comments are documented as subordinate resources whose access derives from the monitor.
- **Security Analytics** — two types, `detector` and `correlation-rule`, in separate indexes; migration is run once per index.
- **Notifications** — `notification_config`; owner metadata is a backend-role list at `metadata.access` with no per-user owner, so migration uses `default_owner` for attribution.

Targets OpenSearch 3.8 (the onboarding release for these three plugins).

### Issues Resolved

Follow-up documentation for the alerting resource-sharing onboarding: https://github.com/opensearch-project/alerting/pull/2180

### Checklist

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developer Certificate of Origin (DCO)](https://github.com/opensearch-project/documentation-website/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/documentation-website/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
