### PR TITLE
Document plugins.security.restapi.max_string_length setting

### DIFF
--- a/_install-and-configure/configuring-opensearch/security-settings.md
+++ b/_install-and-configure/configuring-opensearch/security-settings.md
@@ -45,6 +45,8 @@ The Security plugin supports the following REST management API settings:
 
 - `plugins.security.restapi.endpoints_disabled.<role>.<endpoint>` (Static): Disables specific endpoints and their HTTP methods for roles. Values for this setting compose an array of HTTP methods. For example: `plugins.security.restapi.endpoints_disabled.all_access.ACTIONGROUPS: ["PUT","POST","DELETE"]`. By default, all endpoints and methods are allowed. Existing endpoints include `ACTIONGROUPS`, `CACHE`, `CONFIG`, `ROLES`, `ROLESMAPPING`, `INTERNALUSERS`, `SYSTEMINFO`, `PERMISSIONSINFO`, and `LICENSE`. See [Access control for the API]({{site.url}}{{site.baseurl}}/security/access-control/api/#access-control-for-the-api).
 
+- `plugins.security.restapi.max_string_length` (Static): Sets the maximum number of characters allowed for any individual string value in a Security REST API request body. Valid values are between `1` and `50000000`, inclusive. Default is `4096`. Increase this value if you submit large free-form values, such as document-level security (DLS) queries, through the REST API.
+
 - `plugins.security.restapi.password_validation_regex` (Static): Specifies a regular expression to set the criteria for the login password. For more information, see [Password settings]({{site.url}}{{site.baseurl}}/security/configuration/yaml/#password-settings).
 
 - `plugins.security.restapi.password_validation_error_message` (Static): Specifies an error message that loads when a password doesn’t pass validation. This setting is used in conjunction with `plugins.security.restapi.password_validation_regex`.

--- a/_security/configuration/yaml.md
+++ b/_security/configuration/yaml.md
@@ -415,3 +415,26 @@ The following example shows the response from the [Create user]({{site.url}}{{si
   "reason": "Weak password"
 }
 ```
+
+### REST API request body validation
+
+The Security plugin enforces a maximum length on every string value contained in a Security REST API request body (for example, when creating or updating roles, users, or tenants). This guards against excessively large inputs. The limit is configurable using the `plugins.security.restapi.max_string_length` setting.
+
+| Setting | Description |
+| :--- | :--- |
+| `plugins.security.restapi.max_string_length` | Sets the maximum number of characters allowed for any individual string value in a Security REST API request body. The default is `4096`. Increase this value if you submit large free-form values, such as document-level security (DLS) queries, through the REST API. |
+
+The following example increases the limit to `8192` characters:
+
+```yml
+plugins.security.restapi.max_string_length: 8192
+```
+
+If a request contains a string value that exceeds the configured limit, the API returns an HTTP `400` response similar to the following:
+
+```json
+{
+  "status": "error",
+  "reason": "String value exceeds the maximum allowed length of 4096 characters"
+}
+```

--- a/_security/configuration/yaml.md
+++ b/_security/configuration/yaml.md
@@ -415,26 +415,3 @@ The following example shows the response from the [Create user]({{site.url}}{{si
   "reason": "Weak password"
 }
 ```
-
-### REST API request body validation
-
-The Security plugin enforces a maximum length on every string value contained in a Security REST API request body (for example, when creating or updating roles, users, or tenants). This guards against excessively large inputs. The limit is configurable using the `plugins.security.restapi.max_string_length` setting.
-
-| Setting | Description |
-| :--- | :--- |
-| `plugins.security.restapi.max_string_length` | Sets the maximum number of characters allowed for any individual string value in a Security REST API request body. The default is `4096`. Increase this value if you submit large free-form values, such as document-level security (DLS) queries, through the REST API. |
-
-The following example increases the limit to `8192` characters:
-
-```yml
-plugins.security.restapi.max_string_length: 8192
-```
-
-If a request contains a string value that exceeds the configured limit, the API returns an HTTP `400` response similar to the following:
-
-```json
-{
-  "status": "error",
-  "reason": "String value exceeds the maximum allowed length of 4096 characters"
-}
-```


### PR DESCRIPTION
### Description

Documents the new `plugins.security.restapi.max_string_length` setting, which makes the Security plugin's REST API request body string-length limit configurable (default `4096`).

Background: opensearch-security 3.8.0.0 introduced a hard-coded 256-character limit on every string value in a Security REST API request body, which broke legitimate configurations with large free-form values such as document-level security (DLS) queries (opensearch-project/security#6434). The code change replaces that hard limit with this configurable setting (opensearch-project/security#6437).

Added under `_security/configuration/yaml.md` → **opensearch.yml** as a new "REST API request body validation" subsection, next to the existing REST API password settings.

### Issues Resolved

Documentation follow-up for opensearch-project/security#6434 / opensearch-project/security#6437.

### Version

Targets the release that ships opensearch-project/security#6437 (3.9.0, with a planned backport to a 3.8 patch). Maintainers: please advise if this should be labeled for a specific version branch.

### Checklist

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developer Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

For any changes to documentation, I have reviewed the [OpenSearch Project style guidelines](https://github.com/opensearch-project/documentation-website/blob/main/STYLE_GUIDE.md).
