### PR TITLE
Add entry for false_allow_templates parameter in table

### DIFF
--- a/_mappings/mapping-parameters/dynamic.md
+++ b/_mappings/mapping-parameters/dynamic.md
@@ -19,6 +19,7 @@ Parameter | Description
 :--- | :--- 
 `true`  | Specifies that new fields can be added dynamically to the mapping. Default is `true`.
 `false` | Specifies that new fields cannot be added dynamically to the mapping. If a new field is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
+`false_allow_templates` | Adds new fields if the match predefined dynamic templates in the mapping. If a new field which does not match the template is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
 `strict` | Throws an exception. The indexing operation fails when new fields are detected.
 `strict_allow_templates` | Adds new fields if they match predefined dynamic templates in the mapping.
 

--- a/_mappings/mapping-parameters/dynamic.md
+++ b/_mappings/mapping-parameters/dynamic.md
@@ -19,7 +19,7 @@ Parameter | Description
 :--- | :--- 
 `true`  | Specifies that new fields can be added dynamically to the mapping. Default is `true`.
 `false` | Specifies that new fields cannot be added dynamically to the mapping. If a new field is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
-`false_allow_templates` | Adds new fields if the match predefined dynamic templates in the mapping. If a new field which does not match the template is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
+`false_allow_templates` | Adds new fields if they match predefined dynamic templates in the mapping. If a new field which does not match the template is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
 `strict` | Throws an exception. The indexing operation fails when new fields are detected.
 `strict_allow_templates` | Adds new fields if they match predefined dynamic templates in the mapping.
 

--- a/_mappings/mapping-parameters/dynamic.md
+++ b/_mappings/mapping-parameters/dynamic.md
@@ -19,7 +19,7 @@ Parameter | Description
 :--- | :--- 
 `true`  | Specifies that new fields can be added dynamically to the mapping. Default is `true`.
 `false` | Specifies that new fields cannot be added dynamically to the mapping. If a new field is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
-`false_allow_templates` | Adds new fields if they match predefined dynamic templates in the mapping. If a new field which does not match the template is detected, then it is not indexed or searchable but can be retrieved from the `_source` field.
+`false_allow_templates` | Adds new fields to the mapping when they match a predefined dynamic template. New fields that do not match a template are not indexed or searchable but are present in the `_source` field.
 `strict` | Throws an exception. The indexing operation fails when new fields are detected.
 `strict_allow_templates` | Adds new fields if they match predefined dynamic templates in the mapping.
 


### PR DESCRIPTION
Adding the option `false_allow_templates` in the overview table to make it visible easily.

### Description
Completes the table and communicates about all available options for dynamic setting.

### Issues Resolved
Closes #12990 

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._
3.3.0--3.8.0

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
