### PR TITLE
Add doc for allowing -1 index.search.idle.after

### DIFF
--- a/_install-and-configure/configuring-opensearch/index-settings.md
+++ b/_install-and-configure/configuring-opensearch/index-settings.md
@@ -314,7 +314,7 @@ OpenSearch supports the following dynamic index-level index settings:
 
 - `index.blocks.write` (Boolean): Specifies whether the index is read-only. Setting to `true` blocks all write requests and makes the index read-only. Default is `false`.
 
-- `index.search.idle.after` (Time unit): The amount of time a shard should wait for a search or get request until it goes idle. Default is `30s`.
+- `index.search.idle.after` (Time unit): The amount of time a shard should wait for a search or get request until it goes idle. Can be set to -1 to disable idle. Default is `30s`.
 
 - `index.search.default_pipeline` (String): The name of the search pipeline that is used if no pipeline is explicitly set when searching an index. If a default pipeline is set and the pipeline doesn't exist, then the index requests fail. Use the pipeline name `_none` to specify no default search pipeline. For more information, see [Default search pipeline]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/using-search-pipeline/#default-search-pipeline).
 


### PR DESCRIPTION
### Description
Currently, OpenSearch sets index.search.idle.after to 30s by default. To disable idle time, there is only one way, to set index.refresh_interval explicitly. However, index.refresh_interval is 1s by default, and we did not want to change it. It is not a good convention to set one variable explicitly for a different behavior (disabling idle).

-1 is a standard convention to disable something, so this PR is to allow -1 for index.search.idle.after in order to disable idle time.

Related to https://github.com/opensearch-project/OpenSearch/pull/22873

### Issues Resolved
Closes https://github.com/opensearch-project/OpenSearch/issues/9707#issuecomment-5368306320

### Version
_List the OpenSearch version to which this PR applies, e.g. 2.14, 2.12--2.14, or all._

### Frontend features
_If you're submitting documentation for an OpenSearch Dashboards feature, add a video that shows how a user will interact with the UI step by step. A voiceover is optional._ 

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
