### PR TITLE
Add a deprecation message for RestClietn and RestClientTransport

### DIFF
--- a/_clients/java.md
+++ b/_clients/java.md
@@ -10,6 +10,9 @@ The OpenSearch Java client allows you to interact with your OpenSearch clusters 
 
 This getting started guide illustrates how to connect to OpenSearch, index documents, and run queries. For the client source code, see the [`opensearch-java` repo](https://github.com/opensearch-project/opensearch-java).
 
+The Java client requires a transport in order to communicate with your cluster. `ApacheHttpClient5Transport` is the default transport and the recommended choice for new applications. The `RestClient` transport is deprecated and will be removed in a future release.
+{: .note}
+
 ## Installing the client using Apache HttpClient 5 Transport
 
 To start using the OpenSearch Java client, you need to provide a transport. The default `ApacheHttpClient5TransportBuilder` transport comes with the Java client. To use the OpenSearch Java client with the default transport, add it to your `pom.xml` file as a dependency:
@@ -41,7 +44,10 @@ dependencies {
 
 You can now start your OpenSearch cluster.
 
-## Installing the client using RestClient Transport
+## Installing the client using RestClient Transport (deprecated)
+
+The `RestClientTransport` transport and the `org.opensearch.client.RestClient` class that it wraps are deprecated and will be removed in a future release. Use [Apache HttpClient 5 Transport](#installing-the-client-using-apache-httpclient-5-transport) instead.
+{: .warning}
 
 Alternatively, you can create a Java client by using the `RestClient`-based transport. In this case, make sure that you have the following dependencies in your project's `pom.xml` file:
 
@@ -196,7 +202,10 @@ public class OpenSearchClientExample {
 
 ```
 
-## Initializing the client with SSL and TLS enabled using RestClient Transport
+## Initializing the client with SSL and TLS enabled using RestClient Transport (deprecated)
+
+The `RestClientTransport` transport and the `org.opensearch.client.RestClient` class that it wraps are deprecated and will be removed in a future release. Use [Apache HttpClient 5 Transport](#initializing-the-client-with-ssl-and-tls-enabled-using-apache-httpclient-5-transport) instead.
+{: .warning}
 
 This code example uses basic credentials that come with the default OpenSearch configuration. If you’re using the Java client with your own OpenSearch cluster, be sure to change the code so that it uses your own credentials.
 


### PR DESCRIPTION
Add a deprecation message for RestClietn and RestClientTransport in the Java client documentation.

Closes #12993

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
