### PR TITLE
Clarify how the ISM action timeout period behaves

### DIFF
--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -61,7 +61,13 @@ Actions are the steps that the policy sequentially executes on entering a specif
 
 ISM executes actions in the order in which they are defined. For example, if you define actions `[A,B,C,D]`, ISM executes action `A`, and then goes into a sleep period based on the cluster setting `plugins.index_state_management.job_interval`. Once the sleep period ends, ISM continues to execute the remaining actions. However, if ISM cannot successfully execute action `A`, the operation ends, and actions `B`, `C`, and `D` do not get executed.
 
-Optionally, you can define an action's timeout period, which, if exceeded, forcibly fails the action. For example, if timeout is set to `1d`, and ISM has not completed the action within one day, even after retries, the action fails.
+Optionally, you can define an action's timeout period, which, if exceeded, forcibly fails the action. The timeout covers the whole action, not a single attempt: the clock starts when ISM begins the action and keeps running through every step, retry, and retry delay, including any time that the action spends waiting for its conditions to be met.
+
+ISM checks the clock only when the managed index job runs, which is every 5 minutes by default. For example, a [Rollover](#rollover) operation with `min_index_age` set to `1d` evaluates that condition on each job run until the index is one day old, so a `timeout` of `1h` expires long before the index can meet the condition.
+
+When the timeout expires, ISM marks the action as failed and stops managing the index until you call the Retry failed index API, which restarts the action and its clock. A timeout does not stop work that ISM already started or undo changes that the action already made.
+
+Because ISM runs one step per job run, make the timeout longer than the total time that the action needs, plus one job interval for each of its steps. If you omit `timeout`, the action never times out and continues to retry according to its `retry` configuration.
 
 This table lists the parameters that you can define for an action.
 

--- a/_im-plugin/ism/policies.md
+++ b/_im-plugin/ism/policies.md
@@ -61,9 +61,9 @@ Actions are the steps that the policy sequentially executes on entering a specif
 
 ISM executes actions in the order in which they are defined. For example, if you define actions `[A,B,C,D]`, ISM executes action `A`, and then goes into a sleep period based on the cluster setting `plugins.index_state_management.job_interval`. Once the sleep period ends, ISM continues to execute the remaining actions. However, if ISM cannot successfully execute action `A`, the operation ends, and actions `B`, `C`, and `D` do not get executed.
 
-Optionally, you can define an action's timeout period, which, if exceeded, forcibly fails the action. The timeout covers the whole action, not a single attempt: the clock starts when ISM begins the action and keeps running through every step, retry, and retry delay, including any time that the action spends waiting for its conditions to be met.
+Optionally, you can define an action's timeout period. When the timeout expires, ISM fails the action. The timeout covers the whole action, not a single attempt: the clock starts when ISM begins the action and keeps running through every step, retry, and retry delay, including the time between job runs while the action waits for its conditions to be met.
 
-ISM checks the clock only when the managed index job runs, which is every 5 minutes by default. For example, a [Rollover](#rollover) operation with `min_index_age` set to `1d` evaluates that condition on each job run until the index is one day old, so a `timeout` of `1h` expires long before the index can meet the condition.
+ISM checks the clock only when the managed index job runs, which is every 5 minutes by default. For example, a [rollover](#rollover) operation with `min_index_age` set to `1d` evaluates `min_index_age` on each job run until the index is one day old. A `timeout` of `1h` therefore causes the action to fail before the index can meet the condition.
 
 When the timeout expires, ISM marks the action as failed and stops managing the index until you call the Retry failed index API, which restarts the action and its clock. A timeout does not stop work that ISM already started or undo changes that the action already made.
 


### PR DESCRIPTION
### Description

Clarifies the `timeout` parameter for ISM actions. The current text ("Optionally, you can define an action's timeout period, which, if exceeded, forcibly fails the action") leaves out the behavior that users most often get wrong, which leads to policies that fail actions that were working correctly.

The change is confined to the existing "Actions" section and replaces one paragraph. No other content, tables, or examples were modified.

### Issues Resolved

N/A. Opened from repeated user confusion about this parameter rather than a tracked issue.

### Version

All.

### Frontend features

N/A. Documentation only, no OpenSearch Dashboards UI involved.

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
