### PR TITLE
Add documentation for the sparse ANN native engine

### DIFF
--- a/_mappings/supported-field-types/sparse-vector.md
+++ b/_mappings/supported-field-types/sparse-vector.md
@@ -16,20 +16,41 @@ The `sparse_vector` field supports [neural sparse approximate nearest neighbor (
     
 ## Parameters
 
-The `sparse_vector` field type supports the following parameters.
+A `sparse_vector` field requires a `method` object that specifies the algorithm, the engine that implements it, and the algorithm parameters.
+
+### Method parameters
+
+The `method` object supports the following parameters.
+
+| Parameter       | Type   | Required | Description                                                                                                                                                                                                      | Default    | Valid values           | 
+|-----------------|--------|----------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|------------------------|
+| `name`          | String | Yes      | The neural sparse ANN search algorithm.                                                                                                                                                                          | -          | `seismic`              | 
+| `engine`        | String | No       | The engine that builds and searches the index. Introduced in OpenSearch 3.9. For a comparison of the two engines, see [Engines]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#engines).  | `lucene`   | `lucene`, `native`     | 
+| `parameters`    | Object | No       | The algorithm parameters. See [Algorithm parameters](#algorithm-parameters).                                                                                                                                     | -          | -                      | 
+
+The `method` object cannot be updated after the field is created. To change the engine or any algorithm parameter, create a new index with the intended mapping and reindex your data.
+{: .important}
+
+### Algorithm parameters
+
+The `method.parameters` object supports the following parameters. All of them apply to both the Lucene engine and the native engine except for `clustering_batch_size` and `forward_index`, which are supported for the native engine only.
 
 | Parameter               | Type    | Required | Description                                   | Default               | Range       | 
 |-------------------------|---------|----------|-----------------------------------------------|-----------------------|-------------|
-| `name`                  | String  | Yes | The neural sparse ANN search algorithm. Valid value is `seismic`.                              | -                     | -           | 
 | `n_postings`            | Integer | No | The maximum number of documents to retain in each posting list.            | `0.0005 * doc_count`¹ | (0, ∞) | 
 | `cluster_ratio`         | Float   | No | The fraction of documents in each posting list used to determine the cluster count.             | `0.1`                 | (0, 1)      | 
-| `summary_prune_ratio`   | Float   | No | The fraction of total token weight to retain when pruning cluster summary vectors. For example, if `summary_prune_ratio` is set to `0.5`, tokens contributing to the top 50% of the total weight are kept. Thus, for a cluster summary `{"100": 1, "200": 2, "300": 3, "400": 6}`, the pruned summary is `{"400": 6}`. | 0.4 | (0, 1] |     | `0.4`                 | (0, 1]      | 
+| `summary_prune_ratio`   | Float   | No | The fraction of total token weight to retain when pruning cluster summary vectors. For example, if `summary_prune_ratio` is set to `0.5`, tokens contributing to the top 50% of the total weight are kept. Thus, for a cluster summary `{"100": 1, "200": 2, "300": 3, "400": 6}`, the pruned summary is `{"400": 6}`. | `0.4`                 | (0, 1]      | 
 | `approximate_threshold` | Integer | No | The minimum number of documents in a segment required to activate neural sparse ANN search.     | `1000000`           | [0, ∞) | 
 | `quantization_ceiling_search`  | Float   | No | The maximum token weight used for quantization during search. | `16`                  | (0, ∞) | 
 | `quantization_ceiling_ingest` | Float | No | The maximum token weight used for quantization during ingestion. | `3`                   | (0, ∞)     | 
+| `clustering_batch_size` | Integer | No | The number of batches that each inverted list is split into for clustering. Supported for the native engine only. When this parameter is greater than `1`, clustering runs on each batch instead of on the whole corpus, which significantly reduces memory usage during index building at the cost of longer build times. | `1`                   | [1, 10000]     | 
+| `forward_index`         | String  | No | How the forward index is stored. Supported for the native engine only. `shared` stores one contiguous forward index for the field. `per_block` stores each block's vectors inline with the block, which lowers query latency but uses more disk space. Introduced in OpenSearch 3.9. | `shared`              | `shared`, `per_block` | 
+
+The `clustering_batch_size` and `forward_index` parameters are supported only for the native engine. If you set `engine` to `lucene` and specify a `forward_index` value other than `shared`, the request is rejected.
+{: .warning}
 
 
-¹`doc_count` represents the number of documents within the segment.
+¹`doc_count` represents the number of documents within the segment. The derived value is never lower than `160`.
 
 For parameter configuration, see [Neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/).  
 {: .note }
@@ -73,6 +94,40 @@ PUT sparse-vector-index
 ```
 {% include copy-curl.html %}
 
+Because `engine` defaults to `lucene`, this field uses the Lucene engine. To use the native engine, set `engine` to `native` and, optionally, set `forward_index` in `parameters`:
+
+```json
+PUT sparse-vector-native-index
+{
+  "settings": {
+    "index": {
+      "sparse": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "sparse_embedding": {
+        "type": "sparse_vector",
+        "method": {
+          "name": "seismic",
+          "engine": "native",
+          "parameters": {
+            "n_postings": 300,
+            "cluster_ratio": 0.1,
+            "summary_prune_ratio": 0.4,
+            "approximate_threshold": 1000000,
+            "forward_index": "per_block"
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+The native engine is disabled by default. Before creating a field that uses it, enable it on every data node. For more information, see [Enabling the native engine]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#enabling-the-native-engine).
+{: .note}
 
 ### Step 2: Ingest data into the index
 

--- a/_query-dsl/specialized/neural-sparse/index.md
+++ b/_query-dsl/specialized/neural-sparse/index.md
@@ -74,6 +74,8 @@ For more information, see [Generating sparse vector embeddings automatically]({{
 
 Use neural sparse ANN search on `sparse_vector` fields for improved query performance with high recall. For more information, see [Neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/).
 
+Neural sparse ANN search supports two engines: the Lucene engine and the native engine. You select the engine in the field mapping by setting `method.engine`, not in the query. The query syntax and all supported query parameters are the same for both engines. For more information, see [Engines]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#engines).
+
 You can run a neural sparse search either using raw sparse vectors or text. 
 
 ### Using raw sparse vectors
@@ -138,7 +140,10 @@ These fields are supported for both `rank_features` and `sparse_vector` field ty
 | `method_parameters.top_n` | Integer | Optional | Specifies the number of query tokens with the highest weights to retain for approximate sparse queries. |
 | `method_parameters.heap_factor` | Float | Optional | Controls the trade-off between recall and performance. Higher values increase recall but reduce query speed; lower values decrease recall but improve query speed. |
 | `method_parameters.k` | Integer | Optional | Specifies the number of top k nearest results that the approximate neural search algorithm returns. |
-| `method_parameters.filter` | Object | Optional | Applies filters to the query results. See [Filtering in neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/filter-search-knn/filtering-in-sparse-search/). |
+| `method_parameters.filter` | Object | Optional | Applies filters to the query results. The engine configured for the field determines how the filter is applied: the Lucene engine applies post-filtering, in which the filter runs after approximate retrieval, so the results are the intersection of the top matches and the filter. The native engine applies pre-filtering, in which the filter is pushed down into the engine as a candidate set, so retrieval runs within the filtered set. See [Filtering in neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/filter-search-knn/filtering-in-sparse-search/). |
+
+On both engines, if the filter matches fewer documents than `k`, the query runs an exact search over the filtered documents. Above that point, the Lucene engine applies the filter after approximate retrieval, so a selective filter can produce fewer than `k` results, whereas the native engine retrieves within the filtered set and can return up to a full `k` results. This difference is a property of the engine configured in the field mapping---no query parameter controls it.
+{: .note}
 
 ## Examples
 

--- a/_query-dsl/specialized/neural-sparse/neural-sparse-explain.md
+++ b/_query-dsl/specialized/neural-sparse/neural-sparse-explain.md
@@ -15,6 +15,8 @@ You can provide the `explain` parameter to understand how scores are calculated 
 `explain` is an expensive operation in terms of both resources and time. For production clusters, we recommend using it sparingly for the purpose of troubleshooting.
 {: .warning }
 
+The examples and field descriptions on this page describe the explanation output of the Lucene engine, which is the default engine for a `sparse_vector` field. On the native engine, the explanation reports query token pruning and an exact dot product score and doesn't include a quantization rescaling component. Both engines quantize token weights to 8 bits using the `quantization_ceiling_ingest` and `quantization_ceiling_search` mapping parameters, so both parameters are meaningful on either engine---only the explanation breakdown differs. For more information about engines, see [Engines]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#engines).
+
 You can provide the `explain` parameter in a URL when running a neural sparse ANN query using the following syntax:
 
 ```json
@@ -362,12 +364,12 @@ Component | Description
 :--- | :---
 Query token pruning | Shows the number of query tokens retained after pruning based on the `top_n` parameter. If no pruning occurs, indicates that all tokens were kept.
 Raw dot product score | The quantized dot product score before rescaling. Contains nested details showing each token's contribution as `query_weight * doc_weight`.
-Quantization rescaling | Explains how the raw quantized score is converted to the final float score using the formula: `boost * ceiling_ingest * ceiling_search / 255 / 255`. Contains details about each parameter used in the calculation.
+Quantization rescaling | (Lucene engine only) Explains how the raw quantized score is converted to the final float score using the formula: `boost * ceiling_ingest * ceiling_search / 255 / 255`. Contains details about each parameter used in the calculation.
 Filter explanation | (When filters are applied) Shows filter criteria and search mode. Indicates whether exact search mode was used when the number of filtered documents is fewer than or equal to `k`.
 
 ### Quantization parameters
 
-Neural sparse ANN search uses unsigned byte quantization to reduce memory usage and improve search performance. The quantization rescaling section includes the following parameters.
+Neural sparse ANN search uses unsigned byte quantization to reduce memory usage and improve search performance. On the Lucene engine, the quantization rescaling section includes the following parameters. The native engine applies the same quantization but reports an exact dot product score instead of a rescaling component, so this section doesn't appear in its explanations.
 
 Parameter | Description
 :--- | :---

--- a/_vector-search/ai-search/neural-sparse-ann.md
+++ b/_vector-search/ai-search/neural-sparse-ann.md
@@ -17,9 +17,10 @@ Neural sparse ANN search provides the following advantages over traditional neur
 
 - **Query performance improvement**: Achieves significant query speed improvements compared to two-phase queries under ≥90% recall conditions with better than linear performance scaling as dataset size increases.
 - **Scalability**: Maintains consistent query performance as datasets scale to 50 million vectors on a single node.
-- **Memory efficiency**: Uses optimized caching strategies, byte quantization, and circuit breakers to manage memory usage and prevent resource exhaustion.
+- **Memory efficiency**: Uses byte quantization to reduce the size of the index, and, depending on the engine, either JVM heap caches with a circuit breaker or off-heap memory-mapped files to manage memory usage and prevent resource exhaustion.
 - **Hybrid approach**: Automatically selects the optimal indexing strategy based on segment size, with minimal impact on indexing performance.
 - **Search flexibility**: Provides tunable trade-offs between high recall and low latency using query parameters.
+- **Engine choice**: Runs on either the Lucene engine or, starting with OpenSearch 3.9, the native engine, which builds and searches the index in off-heap memory. For more information, see [Engines](#engines).
 
 Consider neural sparse ANN search when you need the efficiency of sparse retrieval but require better performance than traditional neural sparse search methods can provide at scale:
 
@@ -37,7 +38,7 @@ During the indexing phase, neural sparse ANN search implements several key optim
 1. **Posting list clustering**: For each term in the inverted index, the algorithm performs the following actions:
    - Sorts documents by their token weights in descending order.
    - Retains only the top `n_postings` documents with the highest weights.
-   - Applies a clustering algorithm to group similar documents into one cluster.
+   - Applies a clustering algorithm to group similar documents into one cluster. On the native engine, `clustering_batch_size` splits each posting list into that many batches and clusters each batch separately, which reduces the memory needed to build the index at the cost of a longer build time.
    - Generates summary sparse vectors for each cluster, keeping only the highest-weighted tokens.
 
 2. **Forward index maintenance**: Neural sparse ANN search maintains both the clustered inverted index and a forward index that stores complete sparse vectors organized by document ID for efficient access during query processing. 
@@ -58,13 +59,145 @@ This approach dramatically reduces the number of documents that need to be score
 
 Neural sparse ANN search is a hybrid indexing approach that depends on the document count in each segment to balance indexing and query performance:
 
-- Segments with fewer documents than `approximate_threshold`: Indexed as plain neural sparse (`rank_features`) segments and queried using the standard neural sparse query.
+- Segments with fewer documents than `approximate_threshold`: Not clustered, so queries against them score every matching document instead of using the SEISMIC algorithm. On the Lucene engine, these segments are indexed as plain neural sparse (`rank_features`) segments and queried using the standard neural sparse query. On the native engine, they are indexed as an equivalent inverted index built in the engine's native format.
 
 - Segments with more documents than `approximate_threshold`: Indexed as neural sparse ANN segments and queried using the sparse ANN query.
 
 This hybrid approach balances indexing performance with query speed. Small segments avoid the overhead of clustering, while large segments benefit from approximate search optimizations. The system maintains backward compatibility by supporting both traditional neural sparse queries and neural sparse ANN queries within the same index.
 
 For more information about the SEISMIC algorithm, see [Efficient Inverted Indexes for Approximate Retrieval over Learned Sparse Representations](https://arxiv.org/abs/2404.18812).
+
+## Engines
+**Introduced 3.9**
+{: .label .label-purple }
+
+An _engine_ is the implementation that builds the neural sparse ANN index and runs queries against it. Both engines implement the SEISMIC algorithm and accept the same algorithm and query parameters; they differ in where the index lives and how its memory is managed.
+
+OpenSearch supports the following engines:
+
+- [**Lucene**](#lucene-engine): Builds the clustered posting lists and forward index in JVM heap and serves queries from a plugin-managed cache. Available in OpenSearch 3.3 and later. This is the default.
+- [**Native**](#native-engine): Builds the index into a memory-mapped file on disk and serves queries from off-heap memory. Available in OpenSearch 3.9 and later.
+
+Select an engine using the `engine` parameter in the field's `method` object:
+
+```json
+PUT /my-sparse-ann-index
+{
+  "settings": {
+    "index": {
+      "sparse": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "sparse_embedding": {
+        "type": "sparse_vector",
+        "method": {
+          "name": "seismic",
+          "engine": "native",
+          "parameters": {
+            "n_postings": 4000,
+            "cluster_ratio": 0.1,
+            "forward_index": "per_block",
+            "clustering_batch_size": 1
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+The `method` object cannot be updated after the field is created. To change the engine, create a new index with the intended mapping and reindex your data.
+{: .important}
+
+### Comparing the engines
+
+The following table compares the two engines.
+
+| Characteristic | Lucene engine | Native engine |
+|:--- |:--- |:--- |
+| `engine` value | `lucene` | `native` |
+| Available in | OpenSearch 3.3 and later | OpenSearch 3.9 and later |
+| Enabled by default | Yes | No. See [Enabling the native engine](#enabling-the-native-engine). |
+| Query performance | Baseline | Higher search throughput and lower query latency |
+| Index build performance | Baseline | Faster segment and force merge builds |
+| Where the index is held | JVM heap, in a plugin-managed cache | A memory-mapped file on disk, read from off-heap memory |
+| Memory bounded by | The `plugins.neural_search.circuit_breaker.limit` setting, with least recently used cache eviction | Operating system page cache. No configurable limit, and no eviction by OpenSearch. |
+| JVM heap required | Proportional to the working set of sparse segments served by the node | Minimal. The index is not held in heap. |
+| Disk layout | Managed by Lucene | A dedicated engine file, memory mapped at query time. Size depends on the [forward index layout](#choosing-a-forward-index-layout). |
+| Filtering | Post-filtering | Pre-filtering. See [Filtering support](#filtering-support). |
+| Format of segments below `approximate_threshold` | `rank_features`, queried using the standard neural sparse query | An inverted index equivalent to `rank_features`, built in the engine's native format |
+| Warm up and clear cache APIs | Supported | Not applicable |
+| Sparse memory statistics | Reported | Not reported |
+
+For benchmark results and guidance on choosing between the engines, see [Neural sparse ANN search performance tuning]({{site.url}}{{site.baseurl}}/vector-search/performance-tuning-sparse/).
+
+### Lucene engine
+
+The Lucene engine is the default and requires no additional configuration. It stores clustered posting lists and forward index data in JVM heap. Memory usage is bounded by a circuit breaker, and data is evicted from the cache when the limit is reached. For more information, see [Memory and caching settings](#memory-and-caching-settings).
+
+Because the index is held in heap, a node running the Lucene engine at scale needs a JVM heap large enough to hold the working set of every sparse segment it serves.
+
+### Native engine
+
+The native engine writes the SEISMIC index to a file that OpenSearch memory maps at query time and reads in place. The on-disk layout is the runtime layout, so nothing is reconstructed when the index is loaded. This has the following consequences:
+
+- The index does not consume JVM heap and adds no garbage collection pressure, so a node can serve large sparse indexes with a comparatively small heap.
+- Index memory is reclaimable operating system page cache rather than anonymous memory, so the operating system reclaims it under memory pressure. No circuit breaker or eviction policy is involved.
+- The first query against a segment pays a one-time cost to establish the memory mapping. Later queries reuse it. This cost grows with segment size.
+
+Because the native engine relies on page cache rather than a configurable limit, sizing a node means leaving enough RAM for page cache, the same as for any other memory-mapped Lucene data.
+
+#### Enabling the native engine
+
+The native engine is disabled by default. Both of the following cluster settings must be `true` before a field can use the native engine:
+
+| Setting | Static/Dynamic | Default | Description |
+|:--- |:--- |:--- |:--- |
+| `plugins.neural_search.sparse.native_engine_feature_enabled` | Static | `true` | Whether the native engine is available. Because this setting is static, configure it in `opensearch.yml` on each node; changing it requires a node restart. |
+| `plugins.neural_search.sparse.native_engine_enabled` | Dynamic | `false` | Whether the native engine is enabled at runtime. |
+
+To enable the native engine, send the following request:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.neural_search.sparse.native_engine_enabled": true
+  }
+}
+```
+{% include copy-curl.html %}
+
+If either setting is `false`, OpenSearch rejects attempts to create a field with `engine` set to `native`, to index documents into an existing native engine field, and to query one. OpenSearch does not silently fall back to the Lucene engine, because the field's mapping still specifies the native engine.
+
+While the native engine is disabled, OpenSearch skips building the native index during segment flush and merge. Raw vectors are still written to disk, so re-enabling the engine and then force merging the affected indexes rebuilds the native index.
+{: .note}
+
+#### Choosing a forward index layout
+
+The `forward_index` algorithm parameter controls how the native engine stores the forward index. Specify it in the field's `method.parameters` object. Like `clustering_batch_size`, it is supported only for the native engine.
+
+| Value | Description | Trade-off |
+|:--- |:--- |:--- |
+| `shared` (default) | One contiguous forward index for the field. | Lower disk usage. |
+| `per_block` | Each block's vectors are stored inline with the block, so a query reads only the blocks it selects. | Lower query latency, higher disk usage. |
+
+Both layouts are memory mapped and apply the same quantization. The `forward_index` parameter selects where forward index data is placed, not the precision at which it is stored.
+
+If you set `engine` to `lucene` and specify a `forward_index` value other than `shared`, the request is rejected.
+{: .warning}
+
+#### Considerations for the native engine
+
+Before choosing the native engine, note the following:
+
+- The [warm up]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#warm-up) and [clear cache]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#clear-cache) APIs operate on the Lucene engine's cache and do not apply to the native engine.
+- The sparse memory statistics returned by the [Neural Search Stats API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#stats) report Lucene engine cache usage only. They do not account for native engine index memory.
+- The `plugins.neural_search.circuit_breaker.limit` setting has no effect on the native engine.
+- The native engine requires an index whose data is stored on the local filesystem.
 
 ## Step 1: Create an index
 
@@ -106,6 +239,8 @@ PUT /my-sparse-ann-index
 }
 ```
 {% include copy-curl.html %}
+
+This example omits the `engine` parameter, so the field uses the default Lucene engine. To use the native engine instead, see [Engines](#engines).
 
 For parameter information, see [Sparse vector]({{site.url}}{{site.baseurl}}/mappings/supported-field-types/sparse-vector/).
 
@@ -190,9 +325,17 @@ GET /my-sparse-ann-index/_search
 | `heap_factor` | Controls recall compared to performance trade-off |
 | `filter` | Optional Boolean filter for pre-filtering or post-filtering |
 
+The query syntax and these parameters are the same for both engines. The engine is selected in the field mapping, not in the query. For more information, see [Engines](#engines).
+{: .note}
+
 ## Filtering support
 
-Neural sparse ANN search supports both pre-filtering and post-filtering approaches. For more information, see [Filtering in neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/filter-search-knn/filtering-in-sparse-search/).
+Neural sparse ANN search supports filtering. On both engines, if the filter matches fewer documents than `k`, the query runs an exact search over the filtered documents instead of the approximate algorithm. Otherwise, the two engines apply the filter at different points:
+
+- On the **Lucene engine**, the filter is applied after approximate retrieval (post-filtering). The results are the intersection of the top matches and the filter, so a selective filter can return fewer than `k` results.
+- On the **native engine**, the filter is pushed into the engine as a candidate set before retrieval (pre-filtering). Retrieval runs within the filtered set, so the query can return a full `k` results.
+
+For more information, see [Filtering in neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/filter-search-knn/filtering-in-sparse-search/).
 
 ## Cluster settings
 
@@ -200,7 +343,7 @@ Neural sparse ANN search supports the following cluster settings.
 
 ### Thread pool configuration
 
-Building a clustered inverted index structure requires intensive computation. By default, the algorithm uses a single-threaded thread pool to build clusters. You can increase the thread pool size to build clusters in parallel, using more CPU cores and reducing index build time. 
+Building a clustered inverted index structure requires intensive computation. By default, the algorithm uses a single-threaded thread pool to build clusters. You can increase the thread pool size to build clusters in parallel, using more CPU cores and reducing index build time. This setting applies to both engines.
 
 To configure the thread pool size, update the `plugins.neural_search.sparse.algo_param.index_thread_qty` setting:
 
@@ -216,7 +359,7 @@ PUT /_cluster/settings
 
 ### Memory and caching settings
 
-Neural sparse ANN search provides a circuit breaker that prevents the algorithm from using excessive memory and ensures that other OpenSearch operations remain unaffected. The default value of `circuit_breaker.limit` is `10%`. you can adjust this setting to control the total memory allocated to the algorithm. When memory usage reaches the defined limit, a cache eviction occurs, removing the least recently used data. 
+The Lucene engine provides a circuit breaker that prevents the algorithm from using excessive memory and ensures that other OpenSearch operations remain unaffected. The default value of `circuit_breaker.limit` is `10%`. You can adjust this setting to control the total memory allocated to the algorithm. When memory usage reaches the defined limit, a cache eviction occurs, removing the least recently used data. 
 
 A higher circuit breaker limit allows more memory usage and reduces the frequency of cache evictions but may impact other OpenSearch operations. A lower limit provides greater safety but can result in more frequent cache evictions.
 
@@ -232,11 +375,17 @@ PUT _cluster/settings
 ```
 {% include copy-curl.html %}
 
+The circuit breaker bounds the Lucene engine's JVM heap cache. It has no effect on the native engine, which holds its index in a memory-mapped file managed by the operating system. For more information, see [Native engine](#native-engine).
+{: .note}
+
 For more information, see [Neural Search plugin settings]({{site.url}}{{site.baseurl}}/vector-search/settings/#neural-search-plugin-settings).
 
 ### Monitoring
 
 Monitor memory usage and query statistics using the [Neural Search Stats API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#stats).
+
+The sparse memory statistics report Lucene engine cache usage only. Native engine index memory is held in operating system page cache and is not reflected in these statistics.
+{: .note}
 
 ## Performance tuning
 

--- a/_vector-search/ai-search/neural-sparse-search.md
+++ b/_vector-search/ai-search/neural-sparse-search.md
@@ -67,6 +67,8 @@ For information about splitting large documents into smaller passages before gen
 
 You can run neural sparse approximate nearest neighbor (ANN) search to achieve better query performance with high query recall (>0.9). For more information, see [Neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/).
 
+Starting with OpenSearch 3.9, you can choose between two engines for a `sparse_vector` field: the Lucene engine, which is the default, and the native engine. You select the engine in the field mapping, and the query syntax is the same for both. For more information, see [Engines]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#engines).
+
 ## Further reading
 
 - Learn more about how sparse encoding models work and explore OpenSearch neural sparse search benchmarks in [Improving document retrieval with sparse semantic encoders](https://opensearch.org/blog/improving-document-retrieval-with-sparse-semantic-encoders/).

--- a/_vector-search/api/neural.md
+++ b/_vector-search/api/neural.md
@@ -373,6 +373,9 @@ The following table lists the available statistics. For statistics with paths pr
 | `clustered_posting_usage` | `nodes`, `all_nodes` | `memory.sparse.clustered_posting_usage`                         | The amount of JVM heap memory used to store clustered posting on the node, in kilobytes.                     |
 | `forward_index_usage` | `nodes`, `all_nodes` | `memory.sparse.forward_index_usage`                            | The amount of JVM heap memory used to store the forward index on the node, in kilobytes.                         |
 
+These memory statistics report the Lucene engine cache only. The native engine keeps its index in a memory-mapped file on disk rather than in the JVM heap cache, so native engine index memory is not reflected in these statistics. For more information, see [Choosing an engine]({{site.url}}{{site.baseurl}}/vector-search/performance-tuning-sparse/#choosing-an-engine).
+{: .note}
+
 **Node-level statistics: Semantic highlighting**
 
 | Statistic name | Category | Statistic path within category | Description |
@@ -429,7 +432,7 @@ To avoid high latency during initial searches, you can run random queries during
 
 As an alternative, you can use the warm up API operation to avoid latency during initial searches. This operation loads all sparse data for the primary and replica shards of the specified indexes into JVM memory. The warm up API operation is idempotent: if a segment's sparse data is already loaded into memory, this operation has no effect. It only loads files not currently stored in memory.
 
-This API operation only works with sparse indexes (indexes created with `index.sparse` set to `true`).
+This API operation only works with sparse indexes (indexes created with `index.sparse` set to `true`) whose fields use the Lucene engine. The native engine bypasses the JVM heap cache in favor of a memory-mapped index file, so there is nothing to warm up. For more information, see [Choosing an engine]({{site.url}}{{site.baseurl}}/vector-search/performance-tuning-sparse/#choosing-an-engine).
 {: .note}
 
 ### Endpoints
@@ -515,7 +518,7 @@ In contrast, decreasing the [neural search circuit breaker limit]({{site.url}}{{
 
 Similar to the [warm up operation](#warm-up), the clear cache operation is idempotent: if you attempt to clear the cache for an index that has already been evicted, the operation has no additional effect.
 
-This API operation only works with sparse indexes (indexes created with `index.sparse` set to `true`).
+This API operation only works with sparse indexes (indexes created with `index.sparse` set to `true`) whose fields use the Lucene engine. The native engine does not use a plugin-managed cache, so there is nothing to clear. For more information, see [Choosing an engine]({{site.url}}{{site.baseurl}}/vector-search/performance-tuning-sparse/#choosing-an-engine).
 {: .note}
 
 ### Endpoints

--- a/_vector-search/filter-search-knn/filtering-in-sparse-search.md
+++ b/_vector-search/filter-search-knn/filtering-in-sparse-search.md
@@ -7,21 +7,86 @@ nav_order: 40
 
 # Filtering in neural sparse ANN search
 
-You can run neural sparse approximate nearest neighbor (ANN) search queries with filtering: efficient filtering and post-filtering are supported.
+You can run neural sparse approximate nearest neighbor (ANN) search queries with filtering in the following ways:
 
-## Efficient neural sparse ANN search filtering
+- Provide a `filter` in the `method_parameters` of the `neural_sparse` query. The filter is evaluated by the engine that is configured for the `sparse_vector` field, so the filtering behavior depends on that engine.
+- Wrap the `neural_sparse` query in a [Boolean filter](#using-a-boolean-filter-with-neural-sparse-ann-search). The filter is evaluated outside the engine, after the query returns its top `k` results, and behaves the same way on both engines.
 
-When you specify a filter for a neural sparse ANN search, the ANN algorithm decides whether to perform an exact search with pre-filtering or an approximate search with modified post-filtering. The algorithm uses the following variables:
+## Filtering behavior by engine
+**Introduced 3.9**
+{: .label .label-purple }
+
+Neural sparse ANN search supports two engines, selected by the `method.engine` mapping parameter of a `sparse_vector` field. Both engines fall back to exact search when a filter is highly selective, but when they do run approximate search, they differ in whether the filter is applied before or after retrieval. The query syntax is identical for both engines. For more information about engines, see [Engines]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#engines).
+
+The algorithm uses the following variables to decide how to apply a filter:
 
 - N: The number of documents in the index.
 - P: The number of documents in the document subset after the filter is applied (P <= N).
 - k: The maximum number of vectors to return in the response.
 
-First, the filter is applied to N documents, resulting in P matching documents. If P is less than k, an exact search is performed. If P is greater than k, the neural sparse ANN search algorithm runs on the N documents, and the filter is applied to the results.
+When P is less than k, both engines run an exact search over the P filtered documents rather than the approximate algorithm, which would otherwise return substantially fewer than k results. When P is greater than k, the engines behave as follows.
+
+| Engine | Approximate search behavior | Number of results |
+|:--- |:--- |:--- |
+| `lucene` (default) | Post-filtering. The algorithm runs on the N documents, and the filter is applied to the results, so the results are the intersection of the top matches and the filter. | A selective filter can return fewer than `k` results. |
+| `native` | Pre-filtering. The filter is pushed down into the engine as a candidate set, so retrieval runs within the filtered set. | Returns up to a full `k` results. |
+
+### Post-filtering on the Lucene engine
+
+When P is greater than k on the Lucene engine, the neural sparse ANN search algorithm runs on the N documents and the filter is applied to the results. Because the filter is applied to the approximate results, a selective filter can return fewer than k results.
+
+### Pre-filtering on the native engine
+
+When P is greater than k on the native engine, the filter is pushed down into the engine as a candidate set before retrieval begins. Approximate retrieval then runs within the filtered set, so a selective filter doesn't reduce the number of results, and the query returns up to a full `k` results.
+
+To use the native engine for a field, set `method.engine` to `native` in the field mapping. The following request creates an index equivalent to the `hotels-index` index used in the following example, with the `name_embedding` field configured to use the native engine:
+
+```json
+PUT /hotels-index-native
+{
+  "settings": {
+    "index": {
+      "sparse": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "name":{
+        "type": "text"
+      },
+      "rating": {
+        "type": "integer"
+      },
+      "parking": {
+        "type": "boolean"
+      },
+      "name_embedding":{
+        "type": "sparse_vector",
+        "method": {
+          "name": "seismic",
+          "engine": "native",
+          "parameters": {
+            "quantization_ceiling_ingest": 16,
+            "n_postings": 4000,
+            "cluster_ratio": 0.1,
+            "summary_prune_ratio": 0.4,
+            "approximate_threshold": 1000000,
+            "forward_index": "per_block"
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+The native engine is opt-in and requires additional node settings. For more information, see [Enabling the native engine]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#enabling-the-native-engine).
+{: .note}
 
 ## Using a neural sparse ANN search filter
 
-In this example, you will create an index and search for the three hotels with high ratings, parking, and a name matching your search criteria.
+In this example, you will create an index and search for the three hotels with high ratings, parking, and a name matching your search criteria. The index uses the default Lucene engine, so the filter is applied after approximate retrieval. To run the same query with pre-filtering, map the field to the native engine, as described in [Pre-filtering on the native engine](#pre-filtering-on-the-native-engine).
 
 ### Step 1: Create a new index
 
@@ -210,9 +275,9 @@ The response returns the three hotels that are nearest to the search point and m
 }
 ```
 
-## Post-filtering
+## Post-filtering outside the query
 
-You can apply post-filtering using a [Boolean filter](#using-a-boolean-filter-with-neural-sparse-ann-search). Note that because filtering occurs after the neural sparse ANN search retrieves its top k results, the final number of returned results may be significantly smaller than k.
+Instead of providing a filter in `method_parameters`, you can apply post-filtering using a [Boolean filter](#using-a-boolean-filter-with-neural-sparse-ann-search). In this case the filter is evaluated outside the engine, so the behavior is the same on both the Lucene engine and the native engine. Because filtering occurs after the neural sparse ANN search retrieves its top k results, the final number of returned results may be significantly smaller than k.
 
 ### Using a Boolean filter with neural sparse ANN search
 
@@ -305,3 +370,4 @@ The response includes documents containing the matching hotels:
 ## Next steps
 
 - For more information about neural sparse ANN search, see [Neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/).
+- For more information about the Lucene engine and the native engine, see [Engines]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#engines).

--- a/_vector-search/performance-tuning-sparse.md
+++ b/_vector-search/performance-tuning-sparse.md
@@ -8,7 +8,76 @@ has_math: true
 
 # Neural sparse ANN search performance tuning
 
-[Neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/) offers several parameters that allow you to balance the trade-off between query recall (accuracy) and query efficiency (latency). You can change these parameters dynamically, without needing to delete and recreate an index for them to take effect. 
+[Neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/) offers several parameters that allow you to balance the trade-off between query recall (accuracy) and query efficiency (latency). You can change the algorithm parameters described in this section dynamically, without needing to delete and recreate an index for them to take effect. The `method` object of a `sparse_vector` field is an exception: the `engine` parameter and everything in `method.parameters`, including `forward_index`, are fixed when the field is created, so changing them requires reindexing into a new index.
+
+## Choosing an engine
+**Introduced 3.9**
+{: .label .label-purple }
+
+Neural sparse ANN search runs the SEISMIC algorithm on one of two engines, which you select for each `sparse_vector` field using the `method.engine` mapping parameter. Valid values are `lucene` (default) and `native`. For a conceptual overview of the engines, see [Neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/).
+
+The following request creates an index with a field that uses the native engine:
+
+```json
+PUT /sparse-ann-documents
+{
+  "settings": {
+    "index": {
+      "sparse": true
+    }
+  },
+  "mappings": {
+    "properties": {
+      "sparse_embedding": {
+        "type": "sparse_vector",
+        "method": {
+          "name": "seismic",
+          "engine": "native",
+          "parameters": {
+            "n_postings": 4000,
+            "cluster_ratio": 0.1,
+            "forward_index": "per_block"
+          }
+        }
+      }
+    }
+  }
+}
+```
+{% include copy-curl.html %}
+
+Before a field can use the native engine, both `plugins.neural_search.sparse.native_engine_feature_enabled` and `plugins.neural_search.sparse.native_engine_enabled` must be `true`. Because `plugins.neural_search.sparse.native_engine_enabled` defaults to `false`, the native engine is opt-in. For more information, see [Enabling the native engine]({{site.url}}{{site.baseurl}}/vector-search/settings/#enabling-the-native-engine).
+
+Both engines support the same query `method_parameters` values, and they support the same `method.parameters` values except for `clustering_batch_size` and `forward_index`, which apply to the native engine only. The tuning guidance in the rest of this page therefore applies to both engines. The engines differ in where they keep the data structures that the algorithm reads, which changes how you size a node:
+
+Characteristic | Lucene engine | Native engine
+:--- | :--- | :---
+Query performance | Baseline | Higher search throughput and lower query latency
+Index build performance | Baseline | Faster segment and force merge builds
+Storage of clustered posting lists and forward index | JVM heap caches | A memory-mapped file on disk, read off-heap
+Cache management | A plugin-managed cache bounded by `plugins.neural_search.circuit_breaker.limit`, which you can preload using the [Warm up API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#warm-up) and release using the [Clear cache API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#clear-cache) | No plugin-managed cache and no eviction
+Effect on garbage collection | Index memory is retained on the JVM heap | Index memory is reclaimable operating system page cache, so it does not add garbage collection pressure
+First query against a segment | Loads the segment's sparse data into the cache | Pays a one-time memory-mapping cost
+Disk usage | Managed by Lucene | Adds a dedicated engine file, whose size depends on the [forward index layout](#forward-index-layout)
+Memory statistics | Reported by the [Neural Search Stats API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#stats) | Not reported by the Neural Search Stats API
+
+The engine is fixed when the field is created. Switching engines requires reindexing your data into a new index.
+{: .important}
+
+Consider the native engine when you want better query and index build performance, when your sparse indexes are large enough that holding them in JVM heap constrains the node, or when you want to serve a large sparse index from a comparatively small heap. Consider the Lucene engine when you want the default, fully supported path, or when you rely on the warm up and clear cache APIs or the sparse memory statistics.
+
+Benchmark both engines against your own data and query mix before choosing one. Relative throughput, latency, and memory usage depend on your corpus, your parameter settings, and the resources available on the node.
+{: .note}
+
+### Forward index layout
+
+For fields that use the native engine, the `forward_index` algorithm parameter controls how the forward index is laid out on disk. Specify it in the field's `method.parameters` object. Valid values are `shared` (default) and `per_block`:
+
+- `shared`: Stores one contiguous forward index for the field. This layout uses less disk space.
+- `per_block`: Stores each block's vectors inline next to the block, so a query reads only the blocks that it selects. This layout reduces query latency but uses more disk space.
+
+The `forward_index` parameter is supported by the native engine only. Specifying a value other than the default with the Lucene engine is rejected.
+{: .note}
 
 ## Indexing performance tuning
 
@@ -30,6 +99,9 @@ These parameters control index construction and memory usage:
 
     This parameter controls whether to activate the neural sparse ANN algorithm in a segment once the segment's document count reaches the specified threshold. As the total number of documents increases, individual segments contain more documents. In this case, you can set `approximate_threshold` to a higher value in order to avoid rebuilding clusters repeatedly when segments with fewer documents are merged. This parameter is especially important if you do not use force merge operations to combine all segments into one, because segments with fewer documents than the threshold fall back to the `rank_features` (regular neural sparse search) mode. Note that if you set this value too high, neural sparse ANN search may never activate.
 
+- `clustering_batch_size`: The number of batches that each inverted list is split into for clustering. Supported for the native engine only.
+
+    By default, this parameter is `1` and clustering runs over the whole corpus. Setting it to a higher value, up to `10000`, splits each inverted list into that many batches and clusters each batch separately, which significantly reduces the memory required to build the index in exchange for a longer build time. Increase this value if index building is memory constrained.
 
 ## Query performance tuning
 
@@ -50,11 +122,13 @@ In addition to tuning the preceding parameters, you can employ the following opt
 
 ### Building clusters
 
-Index building can benefit from using multiple threads. You can adjust the number of threads used for cluster building by specifying the `neural_search.sparse.algo_param.index_thread_qty` setting (by default, `1`). For information about updating this setting, see [Vector search settings]({{site.url}}{{site.baseurl}}/vector-search/settings/#cluster-settings-2). Using a higher `neural_search.sparse.algo_param.index_thread_qty` can reduce force merge time when neural sparse ANN search is enabled, though it also consumes more system resources.
+Index building can benefit from using multiple threads. You can adjust the number of threads used for cluster building by specifying the `neural_search.sparse.algo_param.index_thread_qty` setting (by default, `1`). For information about updating this setting, see [Vector search settings]({{site.url}}{{site.baseurl}}/vector-search/settings/#cluster-settings-2). Using a higher `neural_search.sparse.algo_param.index_thread_qty` can reduce force merge time when neural sparse ANN search is enabled, though it also consumes more system resources. This setting applies to both the Lucene engine and the native engine.
 
 ### Querying after a cold start
 
-After rebooting OpenSearch, the cache is empty, so the first several hundred queries may experience high latency. To address this "cold start" issue, you can use the [Warmup API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#warm-up). This API loads data from disk into cache, ensuring optimal performance for subsequent queries. You can also use the [Clear Cache API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#clear-cache) to free up memory when needed.
+On the Lucene engine, the cache is empty after rebooting OpenSearch, so the first several hundred queries may experience high latency. To address this "cold start" issue, you can use the [Warmup API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#warm-up). This API loads data from disk into cache, ensuring optimal performance for subsequent queries. You can also use the [Clear Cache API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#clear-cache) to free up memory when needed.
+
+The native engine does not use this cache, so the Warmup and Clear Cache APIs do not apply to it. Instead, the first query against a segment pays a one-time cost to memory map the segment's index file. Later queries reuse the existing mapping.
 
 ### Force merging segments
 
@@ -67,11 +141,18 @@ POST /sparse-ann-documents/_forcemerge?max_num_segments=1
 
 You can also set `approximate_threshold` to a high value so that individual segments do not trigger clustering but the merged segment does. This approach helps avoid repeated cluster building during indexing.
 
+Building the sparse index is substantially faster on the native engine, so force merges complete sooner. For more information, see [Choosing an engine](#choosing-an-engine).
+
 ## Best practices
 
 - Start with default parameters and tune based on your specific dataset.
-- Monitor memory usage and adjust cache settings accordingly.
+- On the Lucene engine, monitor memory usage and adjust cache settings accordingly.
 - Consider the trade-off between indexing time and query performance.
+- Choose an engine before creating the field. `method` is not updatable, so switching engines later requires reindexing into a new index.
+- If you are memory constrained or your JVM heap is under pressure, we recommend the native engine, which keeps its index in a memory-mapped file instead of the JVM heap.
+- When sizing a node for the native engine, leave enough RAM for operating system page cache rather than increasing the JVM heap.
+- Use `forward_index: per_block` when query latency matters more than disk usage, and keep the default `shared` layout when you want to minimize disk usage.
+- On the native engine, if index building is memory constrained, increase `clustering_batch_size` to lower peak build memory in exchange for a longer build time.
 - Do not combine neural sparse ANN search fields with a pipeline that includes a [two-phase processor]({{site.url}}{{site.baseurl}}/search-plugins/search-pipelines/neural-sparse-query-two-phase-processor/).
 
 ## Next steps

--- a/_vector-search/settings.md
+++ b/_vector-search/settings.md
@@ -106,12 +106,33 @@ The Neural Search plugin supports the following settings.
 
 ### Cluster settings
 
-The following Neural Search plugin settings apply at the cluster level:
+The following Neural Search plugin settings apply at the cluster level. Dynamic settings are updated using the [Cluster Settings API]({{site.url}}{{site.baseurl}}/install-and-configure/configuring-opensearch/index/#updating-cluster-settings-using-the-api); static settings must be configured in `opensearch.yml` on each node:
 
 - `plugins.neural_search.stats_enabled` (Dynamic, Boolean): Enables the [Neural Search Stats API]({{site.url}}{{site.baseurl}}/vector-search/api/neural/#stats). Default is `false`.
-- `plugins.neural_search.circuit_breaker.limit` (Dynamic, percentage): Specifies the JVM memory limit for the [neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/) circuit breaker. Default is `10%` of the JVM heap. For more information, see [Memory and caching settings]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#memory-and-caching-settings).
-- `plugins.neural_search.circuit_breaker.overhead` (Dynamic, float): A multiplier used to adjust memory usage estimates for [neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/). Higher values provide more conservative memory estimates. Default is `1.0`. 
-- `plugins.neural_search.sparse.algo_param.index_thread_qty` (Dynamic, integer): The number of threads used for building indexes for [neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/). Increasing this value allocates more CPUs to the index build job and boosts indexing performance. Default is `1`. For more information, see [Thread pool configuration]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#thread-pool-configuration).
+- `plugins.neural_search.circuit_breaker.limit` (Dynamic, percentage): Specifies the JVM memory limit for the [neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/) circuit breaker. This limit bounds the JVM heap caches used by the Lucene engine only and has no effect on the native engine, which relies on operating system page cache instead. Default is `10%` of the JVM heap. For more information, see [Memory and caching settings]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#memory-and-caching-settings).
+- `plugins.neural_search.circuit_breaker.overhead` (Dynamic, Float): A multiplier used to adjust memory usage estimates for [neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/). Higher values provide more conservative memory estimates. Like `plugins.neural_search.circuit_breaker.limit`, this setting applies to the Lucene engine only. Default is `1.0`. 
+- `plugins.neural_search.sparse.algo_param.index_thread_qty` (Dynamic, Integer): The number of threads used for building indexes for [neural sparse ANN search]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/). Increasing this value allocates more CPUs to the index build job and boosts indexing performance. Valid values are in the range `1--1024`. This setting applies to both the Lucene engine and the native engine. Default is `1`. For more information, see [Thread pool configuration]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#thread-pool-configuration).
+- `plugins.neural_search.sparse.native_engine_feature_enabled` (Static, Boolean): Whether the [native engine]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#native-engine) for neural sparse ANN search is available. Because this setting is static, configure it in `opensearch.yml` on each node; changing it requires a node restart. Introduced 3.9. Default is `true`.
+- `plugins.neural_search.sparse.native_engine_enabled` (Dynamic, Boolean): The runtime gate for the [native engine]({{site.url}}{{site.baseurl}}/vector-search/ai-search/neural-sparse-ann/#native-engine) for neural sparse ANN search. Introduced 3.9. Default is `false`.
+
+#### Enabling the native engine
+**Introduced 3.9**
+{: .label .label-purple }
+
+Both `plugins.neural_search.sparse.native_engine_feature_enabled` and `plugins.neural_search.sparse.native_engine_enabled` must be `true` before a field can use the native engine. Because `plugins.neural_search.sparse.native_engine_enabled` defaults to `false`, the native engine is opt-in:
+
+```json
+PUT _cluster/settings
+{
+  "persistent": {
+    "plugins.neural_search.sparse.native_engine_enabled": true
+  }
+}
+```
+{% include copy-curl.html %}
+
+No setting bounds the amount of memory that a native engine index uses. The native engine reads its index from a memory-mapped file, so to size a node for the native engine, leave enough RAM for operating system page cache, the same as for any other memory-mapped Lucene data. For guidance on choosing between the two engines, see [Choosing an engine]({{site.url}}{{site.baseurl}}/vector-search/performance-tuning-sparse/#choosing-an-engine).
+{: .note}
 
 ### Index settings
 


### PR DESCRIPTION
Fixes #12996

### Description

OpenSearch 3.9 adds a second engine for neural sparse ANN search, selected per field with `method.engine`. The Lucene engine keeps the SEISMIC index in JVM heap; the native engine uses a memory-mapped file read off-heap.

Design: opensearch-project/neural-search#1802

New parameters:

| Parameter | Default | Notes |
|---|---|---|
| `method.engine` | `lucene` | `lucene` or `native` |
| `..parameters.forward_index` | `shared` | `shared` or `per_block`; native only |
| `..parameters.clustering_batch_size` | `1` | 1--10000; native only |
| `..native_engine_feature_enabled` | `true` | Static; restart required |
| `..native_engine_enabled` | `false` | Dynamic; native is opt-in |

Also documents per-engine filtering and scopes the circuit breaker, warm up, clear cache, and sparse memory stats to the Lucene engine.

### Version

3.9.0

### Checklist

- [x] Contribution made under Apache 2.0 and the [DCO](https://github.com/opensearch-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).