### PR TITLE
Redirect the home page to latest and update canonical links in 1.3

### DIFF
--- a/_aggregations/pipeline-agg.md
+++ b/_aggregations/pipeline-agg.md
@@ -8,7 +8,7 @@ redirect_from:
   - /query-dsl/aggregations/pipeline-agg/
   - /aggregations/pipeline/
   - /aggregations/pipeline/index/
-canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline-agg/
+canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline/index/
 ---
 
 # Pipeline aggregations

--- a/_analyzers/language-analyzers.md
+++ b/_analyzers/language-analyzers.md
@@ -5,7 +5,7 @@ nav_order: 10
 redirect_from:
   - /query-dsl/analyzers/language-analyzers/
   - /analyzers/language-analyzers/index/
-canonical_url: https://docs.opensearch.org/latest/analyzers/language-analyzers/
+canonical_url: https://docs.opensearch.org/latest/analyzers/language-analyzers/index/
 ---
 
 # Language analyzer

--- a/_api-reference/alias.md
+++ b/_api-reference/alias.md
@@ -2,7 +2,7 @@
 layout: default
 title: Alias
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
+canonical_url: https://docs.opensearch.org/latest/api-reference/alias/aliases-api/
 redirect_from:
   - /api-reference/alias-api/
   - /api-reference/alias/index/

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -2,7 +2,7 @@
 layout: default
 title: Count
 nav_order: 21
-canonical_url: https://docs.opensearch.org/latest/api-reference/count/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/count/
 redirect_from:
   - /api-reference/search-apis/count/
   - /opensearch/rest-api/count/

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -2,7 +2,7 @@
 layout: default
 title: Explain
 nav_order: 30
-canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/explain/
 redirect_from:
   - /api-reference/search-apis/explain/
   - /opensearch/rest-api/explain/

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -2,7 +2,7 @@
 layout: default
 title: Multi-search
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/multi-search/
 redirect_from:
   - /api-reference/search-apis/multi-search/
   - /opensearch/rest-api/multi-search/

--- a/_api-reference/profile.md
+++ b/_api-reference/profile.md
@@ -2,7 +2,7 @@
 layout: default
 title: Profile
 nav_order: 55
-canonical_url: https://docs.opensearch.org/latest/api-reference/profile/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/profile/
 redirect_from:
   - /api-reference/search-apis/profile/
 ---

--- a/_api-reference/rank-eval.md
+++ b/_api-reference/rank-eval.md
@@ -2,7 +2,7 @@
 layout: default
 title: Ranking evaluation
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/api-reference/rank-eval/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/rank-eval/
 redirect_from:
   - /api-reference/search-apis/rank-eval/
 ---

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -2,7 +2,7 @@
 layout: default
 title: Remote cluster information
 nav_order: 67
-canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
+canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/remote-info/
 redirect_from:
   - /api-reference/cluster-api/remote-info/
   - /opensearch/rest-api/remote-info/

--- a/_api-reference/render-template.md
+++ b/_api-reference/render-template.md
@@ -2,7 +2,7 @@
 layout: default
 title: Render Template
 nav_order: 82
-canonical_url: https://docs.opensearch.org/latest/api-reference/render-template/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/render-template/
 redirect_from:
   - /api-reference/search-apis/render-template/
   - /api-reference/search-apis/search-template/render-template/

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -2,7 +2,7 @@
 layout: default
 title: Scroll
 nav_order: 71
-canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/scroll/
 redirect_from:
   - /api-reference/search-apis/scroll/
   - /opensearch/rest-api/scroll/

--- a/_api-reference/search.md
+++ b/_api-reference/search.md
@@ -2,7 +2,7 @@
 layout: default
 title: Search
 nav_order: 75
-canonical_url: https://docs.opensearch.org/latest/api-reference/search/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search/
 redirect_from:
   - /api-reference/search-apis/search/
   - /opensearch/rest-api/search/

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -2,7 +2,7 @@
 layout: default
 title: Tasks
 nav_order: 85
-canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
+canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/tasks/
 redirect_from:
   - /api-reference/tasks/tasks/
   - /opensearch/rest-api/tasks/

--- a/_api-reference/validate.md
+++ b/_api-reference/validate.md
@@ -2,7 +2,7 @@
 layout: default
 title: Validate Query
 nav_order: 87
-canonical_url: https://docs.opensearch.org/latest/api-reference/validate/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/validate/
 redirect_from:
   - /api-reference/search-apis/validate/
 ---

--- a/_benchmark/reference/commands/execute-test.md
+++ b/_benchmark/reference/commands/execute-test.md
@@ -5,7 +5,7 @@ nav_order: 65
 parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from: /benchmark/commands/execute-test/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/execute-test/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/execute-test/
 ---
 

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -5,7 +5,7 @@ nav_order: 60
 parent: OpenSearch Benchmark Reference
 has_children: true
 redirect_from: /benchmark/workloads/index/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/index/
 ---
 

--- a/_benchmark/tutorials/index.md
+++ b/_benchmark/tutorials/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Tutorials
 nav_order: 10
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/tutorials/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/
 redirect_to: https://docs.opensearch.org/latest/benchmark/tutorials/index/
 ---
 

--- a/_benchmark/tutorials/sigv4.md
+++ b/_benchmark/tutorials/sigv4.md
@@ -3,7 +3,7 @@ layout: default
 title: AWS Signature Version 4 support
 nav_order: 70
 parent: Tutorials
-canonical_url: https://docs.opensearch.org/latest/benchmark/tutorials/sigv4/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 redirect_to: https://docs.opensearch.org/latest/benchmark/tutorials/sigv4/
 ---
 

--- a/_benchmark/user-guide/configuring-benchmark.md
+++ b/_benchmark/user-guide/configuring-benchmark.md
@@ -4,7 +4,7 @@ title: Configuring OpenSearch Benchmark
 nav_order: 7
 parent: User guide
 redirect_from: /benchmark/configuring-benchmark/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/configuring-benchmark/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/configuring-benchmark/
 ---
 

--- a/_benchmark/user-guide/contributing-workloads.md
+++ b/_benchmark/user-guide/contributing-workloads.md
@@ -3,7 +3,7 @@ layout: default
 title: Sharing custom workloads
 nav_order: 11
 parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/contributing-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/contributing-workloads/
 ---
 

--- a/_benchmark/user-guide/creating-custom-workloads.md
+++ b/_benchmark/user-guide/creating-custom-workloads.md
@@ -6,7 +6,7 @@ parent: User guide
 redirect_from: 
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/creating-custom-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/creating-custom-workloads/
 ---
 

--- a/_benchmark/user-guide/distributed-load.md
+++ b/_benchmark/user-guide/distributed-load.md
@@ -3,8 +3,8 @@ layout: default
 title: Running distributed loads
 nav_order: 15
 parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/distributed-load/
-redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/distributed-load/
+canonical_url: https://docs.opensearch.org/latest/benchmark/distributed-load/
+redirect_to: https://docs.opensearch.org/latest/benchmark/distributed-load/
 ---
 
 # Running distributed loads 

--- a/_benchmark/user-guide/installing-benchmark.md
+++ b/_benchmark/user-guide/installing-benchmark.md
@@ -4,7 +4,7 @@ title: Installing OpenSearch Benchmark
 nav_order: 5
 parent: User guide
 redirect_from: /benchmark/installing-benchmark/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/installing-benchmark/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/installing-benchmark/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/installing-benchmark/
 ---
 

--- a/_benchmark/user-guide/running-workloads.md
+++ b/_benchmark/user-guide/running-workloads.md
@@ -3,7 +3,7 @@ layout: default
 title: Running a workload
 nav_order: 9
 parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/running-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/running-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/running-workloads/
 ---
 

--- a/_benchmark/user-guide/target-throughput.md
+++ b/_benchmark/user-guide/target-throughput.md
@@ -2,7 +2,7 @@
 layout: default
 title: Target throughput
 nav_order: 150
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/target-throughput/
+canonical_url: https://docs.opensearch.org/latest/benchmark/target-throughput/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/target-throughput/
 ---
 

--- a/_benchmark/user-guide/telemetry.md
+++ b/_benchmark/user-guide/telemetry.md
@@ -3,8 +3,8 @@ layout: default
 title: Enabling telemetry devices
 nav_order: 30
 parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/telemetry/
-redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/telemetry/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 
 Telemetry results will not appear in the summary report. To visualize telemetry results, ingest the data into OpenSearch and visualize the data in OpenSearch Dashboards. 

--- a/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
@@ -4,7 +4,7 @@ title: Anatomy of a workload
 nav_order: 15
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
@@ -4,7 +4,7 @@ title: Choosing a workload
 nav_order: 20
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
+canonical_url: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -4,7 +4,7 @@ title: Understanding workloads
 nav_order: 7
 parent: User guide
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -4,8 +4,8 @@ title: Understanding workloads
 nav_order: 7
 parent: User guide
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/
-redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # Understanding workloads

--- a/_dashboards/quickstart-dashboards.md
+++ b/_dashboards/quickstart-dashboards.md
@@ -6,7 +6,7 @@ has_children: false
 redirect_from:
   - /dashboards/index/
   - /dashboards/quickstart/
-canonical_url: https://docs.opensearch.org/latest/dashboards/quickstart/
+canonical_url: https://docs.opensearch.org/latest/dashboards/getting-started/index/
 ---
 
 # Quickstart guide for OpenSearch Dashboards

--- a/_dashboards/run-queries.md
+++ b/_dashboards/run-queries.md
@@ -2,7 +2,7 @@
 layout: default
 title: Running queries in the Dev Tools Console
 nav_order: 110
-canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/run-queries/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index/
 redirect_from:
   - /dashboards/dev-tools/index-dev/
   - /dashboards/discover/run-queries/

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -3,7 +3,7 @@ layout: default
 title: Using area charts
 parent: Building data visualizations
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/area/
 redirect_from:
   - /dashboards/visualize/visualize-app/area/
 ---

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -8,7 +8,7 @@ redirect_from:
   - /docs/opensearch-dashboards/maptiles/
   - /dashboards/maptiles/
   - /dashboards/visualize/visualize-app/maptiles/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maptiles/
 ---
 
 {%- comment -%}The `/docs/opensearch-dashboards/maptiles/` redirect is specifically to support the UI links in OpenSearch Dashboards 1.0.0.{%- endcomment -%}

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -3,7 +3,7 @@ layout: default
 title: Building data visualizations
 nav_order: 40
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/index/
 redirect_from:
   - /dashboards/visualize/visualize-app/
   - /dashboards/visualize/visualize-app/index/

--- a/_field-types/index.md
+++ b/_field-types/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /field-types/mappings/
   - /mappings/
   - /mappings/index/
-canonical_url: https://docs.opensearch.org/latest/field-types/
+canonical_url: https://docs.opensearch.org/latest/mappings/
 ---
 
 # Mappings and field types

--- a/_field-types/supported-field-types/alias.md
+++ b/_field-types/supported-field-types/alias.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/alias/
   - /field-types/alias/
   - /mappings/supported-field-types/alias/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/alias/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/
 ---
 
 # Alias field type

--- a/_field-types/supported-field-types/autocomplete.md
+++ b/_field-types/supported-field-types/autocomplete.md
@@ -8,7 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/autocomplete/
   - /field-types/autocomplete/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/autocomplete/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/autocomplete/
 ---
 
 # Autocomplete field types

--- a/_field-types/supported-field-types/binary.md
+++ b/_field-types/supported-field-types/binary.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/binary/
   - /field-types/binary/
   - /mappings/supported-field-types/binary/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/binary/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/binary/
 ---
 
 # Binary field type

--- a/_field-types/supported-field-types/boolean.md
+++ b/_field-types/supported-field-types/boolean.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/boolean/
   - /field-types/boolean/
   - /mappings/supported-field-types/boolean/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/boolean/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/boolean/
 ---
 
 # Boolean field type

--- a/_field-types/supported-field-types/completion.md
+++ b/_field-types/supported-field-types/completion.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/completion/
   - /field-types/completion/
   - /mappings/supported-field-types/completion/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/completion/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/completion/
 ---
 
 # Completion field type

--- a/_field-types/supported-field-types/date-nanos.md
+++ b/_field-types/supported-field-types/date-nanos.md
@@ -5,7 +5,7 @@ nav_order: 35
 has_children: false
 parent: Date field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date-nanos/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/date-nanos/
 redirect_from:
   - /mappings/supported-field-types/date-nanos/
 ---

--- a/_field-types/supported-field-types/date.md
+++ b/_field-types/supported-field-types/date.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/date/
   - /field-types/date/
   - /mappings/supported-field-types/date/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/date/
 ---
 
 # Date field type

--- a/_field-types/supported-field-types/dates.md
+++ b/_field-types/supported-field-types/dates.md
@@ -5,7 +5,7 @@ nav_order: 25
 has_children: true
 has_toc: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/dates/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/dates/
 redirect_from:
   - /mappings/supported-field-types/dates/
 ---

--- a/_field-types/supported-field-types/geo-point.md
+++ b/_field-types/supported-field-types/geo-point.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geo-point/
   - /field-types/geo-point/
   - /mappings/supported-field-types/geo-point/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-point/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-point/
 ---
 
 # Geopoint field type

--- a/_field-types/supported-field-types/geo-shape.md
+++ b/_field-types/supported-field-types/geo-shape.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geo-shape/
   - /field-types/geo-shape/
   - /mappings/supported-field-types/geo-shape/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-shape/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-shape/
 ---
 
 # Geoshape field type

--- a/_field-types/supported-field-types/geographic.md
+++ b/_field-types/supported-field-types/geographic.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geographic/
   - /field-types/geographic/
   - /mappings/supported-field-types/geographic/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geographic/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geographic/
 ---
 
 # Geographic field types

--- a/_field-types/supported-field-types/index.md
+++ b/_field-types/supported-field-types/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /field-types/supported-field-types/
   - /mappings/supported-field-types/
   - /mappings/supported-field-types/index/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/index/
 ---
 
 # Supported field types

--- a/_field-types/supported-field-types/ip.md
+++ b/_field-types/supported-field-types/ip.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/ip/
   - /field-types/ip/
   - /mappings/supported-field-types/ip/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/ip/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/ip/
 ---
 
 # IP address field type

--- a/_field-types/supported-field-types/join.md
+++ b/_field-types/supported-field-types/join.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/join/
   - /field-types/join/
   - /mappings/supported-field-types/join/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/join/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/join/
 ---
 
 # Join field type

--- a/_field-types/supported-field-types/keyword.md
+++ b/_field-types/supported-field-types/keyword.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/keyword/
   - /field-types/keyword/
   - /mappings/supported-field-types/keyword/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/keyword/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/keyword/
 ---
 
 # Keyword field type

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/nested/
   - /field-types/nested/
   - /mappings/supported-field-types/nested/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/nested/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/nested/
 ---
 
 # Nested field type

--- a/_field-types/supported-field-types/numeric.md
+++ b/_field-types/supported-field-types/numeric.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/numeric/
   - /field-types/numeric/
   - /mappings/supported-field-types/numeric/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/numeric/
 ---
 
 # Numeric field types

--- a/_field-types/supported-field-types/object-fields.md
+++ b/_field-types/supported-field-types/object-fields.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/object-fields/
   - /field-types/object-fields/
   - /mappings/supported-field-types/object-fields/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object-fields/
 ---
 
 # Object field types

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/object/
   - /field-types/object/
   - /mappings/supported-field-types/object/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object/
 ---
 
 # Object field type

--- a/_field-types/supported-field-types/percolator.md
+++ b/_field-types/supported-field-types/percolator.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/percolator/
   - /field-types/percolator/
   - /mappings/supported-field-types/percolator/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/percolator/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/percolator/
 ---
 
 # Percolator field type

--- a/_field-types/supported-field-types/range.md
+++ b/_field-types/supported-field-types/range.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/range/
   - /field-types/range/
   - /mappings/supported-field-types/range/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/range/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/range/
 ---
 
 # Range field types

--- a/_field-types/supported-field-types/rank.md
+++ b/_field-types/supported-field-types/rank.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/rank/
   - /field-types/rank/
   - /mappings/supported-field-types/rank/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/rank/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/rank/
 ---
 
 # Rank field types

--- a/_field-types/supported-field-types/search-as-you-type.md
+++ b/_field-types/supported-field-types/search-as-you-type.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/search-as-you-type/
   - /field-types/search-as-you-type/
   - /mappings/supported-field-types/search-as-you-type/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/search-as-you-type/
 ---
 
 # Search-as-you-type field type

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/string/
   - /field-types/string/
   - /mappings/supported-field-types/string/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/string/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/string/
 ---
 
 # String field types

--- a/_field-types/supported-field-types/text.md
+++ b/_field-types/supported-field-types/text.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/text/
   - /field-types/text/
   - /mappings/supported-field-types/text/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/text/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/text/
 ---
 
 # Text field type

--- a/_field-types/supported-field-types/token-count.md
+++ b/_field-types/supported-field-types/token-count.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/token-count/
   - /field-types/token-count/
   - /mappings/supported-field-types/token-count/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/token-count/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/token-count/
 ---
 
 # Token count field type

--- a/_install-and-configure/upgrade-opensearch/appendix/index.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /migrate-or-upgrade/rolling-upgrade/appendix/rolling-upgrade-lab/
   - /migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
   - /upgrade-opensearch/appendix/rolling-upgrade-lab/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/index/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
 ---
 
 # Upgrades appendix

--- a/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
@@ -6,7 +6,7 @@ grand_parent: Upgrading OpenSearch
 nav_order: 50
 redirect_from:
   - /upgrade-opensearch/appendix/rolling-upgrade-lab/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
 ---
 
 <!--

--- a/_install-and-configure/upgrade-opensearch/index.md
+++ b/_install-and-configure/upgrade-opensearch/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /migrate-or-upgrade/
   - /migrate-or-upgrade/index/
   - /upgrade-or-migrate/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/index/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Upgrading OpenSearch

--- a/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
+++ b/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
@@ -3,7 +3,7 @@ layout: default
 title: Rolling Upgrade
 parent: Upgrading OpenSearch
 nav_order: 10
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/rolling-upgrade/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/
 redirect_from:
   - /migrate-or-upgrade/rolling-upgrade/
   - /rolling-upgrade/index/

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -59,10 +59,8 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore
-  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
-  # back to `/`, so check_internal would follow the stub into itself.
-  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark)}.freeze
+  # Pattern of local paths to ignore.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -60,7 +60,9 @@ module Jekyll::LinkChecker
 
   ##
   # Pattern of local paths to ignore
-  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark)}.freeze
+  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
+  # back to `/`, so check_internal would follow the stub into itself.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark)}.freeze
 
   ##
   # Holds the list of failures

--- a/_query-dsl/span-query.md
+++ b/_query-dsl/span-query.md
@@ -7,7 +7,7 @@ redirect_from:
   - /query-dsl/query-dsl/span-query/
   - /query-dsl/span/
   - /query-dsl/span/index/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/span-query/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/span/index/
 ---
 
 # Span queries

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -4,7 +4,7 @@ title: API
 nav_order: 30
 parent: k-NN
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/api/
+canonical_url: https://docs.opensearch.org/latest/vector-search/api/index/
 redirect_from:
   - /vector-search/api/
   - /vector-search/api/index/

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -5,7 +5,7 @@ nav_order: 10
 parent: k-NN
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/approximate-knn/
 redirect_from:
   - /vector-search/vector-search-techniques/approximate-knn/
 ---

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /search-plugins/knn/
   - /vector-search/vector-search-techniques/
   - /vector-search/vector-search-techniques/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/index/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/index/
 ---
 
 # k-NN

--- a/_search-plugins/knn/jni-libraries.md
+++ b/_search-plugins/knn/jni-libraries.md
@@ -4,7 +4,7 @@ title: JNI libraries
 nav_order: 35
 parent: k-NN
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/jni-libraries/
+canonical_url: https://docs.opensearch.org/latest/vector-search/api/knn/
 redirect_from:
   - /search-plugins/knn/jni-library/
   - /vector-search/api/knn/

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -4,7 +4,7 @@ title: k-NN Index
 nav_order: 5
 parent: k-NN
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-index/
+canonical_url: https://docs.opensearch.org/latest/vector-search/creating-vector-index/
 redirect_from:
   - /vector-search/creating-a-vector-db/
   - /vector-search/creating-vector-index/

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -5,7 +5,7 @@ nav_order: 20
 parent: k-NN
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/knn-score-script/
 redirect_from:
   - /vector-search/vector-search-techniques/knn-score-script/
 ---

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -5,7 +5,7 @@ nav_order: 25
 parent: k-NN
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/painless-functions/
 redirect_from:
   - /vector-search/vector-search-techniques/painless-functions/
 ---

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -3,7 +3,7 @@ layout: default
 title: Performance tuning
 parent: k-NN
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/performance-tuning/
+canonical_url: https://docs.opensearch.org/latest/vector-search/performance-tuning/
 redirect_from:
   - /vector-search/performance-tuning/
 ---

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: k-NN
 nav_order: 40
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/settings/
+canonical_url: https://docs.opensearch.org/latest/vector-search/settings/
 redirect_from:
   - /vector-search/settings/
 ---

--- a/_search-plugins/search-template.md
+++ b/_search-plugins/search-template.md
@@ -7,7 +7,7 @@ redirect_from:
   - /api-reference/search-apis/search-template/
   - /api-reference/search-apis/search-template/index/
   - /api-reference/search-template/
-canonical_url: https://docs.opensearch.org/latest/api-reference/search-template/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/index/
 ---
 
 # Search templates

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -3,7 +3,7 @@ layout: default
 title: SQL and PPL CLI
 parent: SQL and PPL
 nav_order: 3
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/cli/
 redirect_from:
   - /sql-and-ppl/cli/
 ---

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -3,7 +3,7 @@ layout: default
 title: Data Types
 parent: SQL and PPL
 nav_order: 7
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/datatypes/
 redirect_from:
   - /sql-and-ppl/datatypes/
 ---

--- a/_search-plugins/sql/full-text.md
+++ b/_search-plugins/sql/full-text.md
@@ -3,7 +3,7 @@ layout: default
 title: Full-Text Search
 parent: SQL and PPL
 nav_order: 11
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/full-text/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/full-text/
 redirect_from:
   - /search-plugins/sql/sql-full-text/
   - /sql-and-ppl/full-text/

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -3,7 +3,7 @@ layout: default
 title: Functions
 parent: SQL and PPL
 nav_order: 10
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 redirect_from:
   - /sql-and-ppl/sql/functions/
 ---

--- a/_search-plugins/sql/identifiers.md
+++ b/_search-plugins/sql/identifiers.md
@@ -3,7 +3,7 @@ layout: default
 title: Identifiers
 parent: SQL and PPL
 nav_order: 6
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/identifiers/
 redirect_from:
   - /observability-plugin/ppl/identifiers/
   - /search-plugins/ppl/identifiers/

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /search-plugins/sql/
   - /sql-and-ppl/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/
 ---
 
 # SQL and PPL

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -3,7 +3,7 @@ layout: default
 title: Limitations
 parent: SQL and PPL
 nav_order: 99
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/limitation/
 redirect_from:
   - /sql-and-ppl/limitation/
 ---

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -3,7 +3,7 @@ layout: default
 title: Monitoring
 parent: SQL and PPL
 nav_order: 95
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/monitoring/
 redirect_from:
   - /sql-and-ppl/monitoring/
 ---

--- a/_search-plugins/sql/ppl/functions.md
+++ b/_search-plugins/sql/ppl/functions.md
@@ -4,7 +4,7 @@ title: Commands
 parent: PPL &ndash; Piped Processing Language
 grand_parent: SQL and PPL
 nav_order: 2
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/index/
 redirect_from:
   - /observability-plugin/ppl/commands/
   - /search-plugins/ppl/commands/

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -15,7 +15,7 @@ redirect_from:
   - /search-plugins/ppl/protocol/
   - /sql-and-ppl/ppl/
   - /sql-and-ppl/ppl/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/index/
 ---
 
 # PPL &ndash; Piped Processing Language

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -4,7 +4,7 @@ title: Syntax
 parent: PPL &ndash; Piped Processing Language
 grand_parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/syntax/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/syntax/
 redirect_from:
   - /sql-and-ppl/ppl/commands/syntax/
 ---

--- a/_search-plugins/sql/response-formats.md
+++ b/_search-plugins/sql/response-formats.md
@@ -3,7 +3,7 @@ layout: default
 title: Response formats
 parent: SQL and PPL
 nav_order: 2
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/response-formats/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/response-formats/
 redirect_from:
   - /sql-and-ppl/response-formats/
 ---

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: SQL and PPL
 nav_order: 77
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/settings/
 redirect_from:
   - /sql-and-ppl/settings/
 ---

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -3,7 +3,7 @@ layout: default
 title: SQL/PPL API
 parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/index/
 redirect_from:
   - /sql-and-ppl/sql-and-ppl-api/index/
   - /sql-and-ppl/sql-ppl-api/

--- a/_search-plugins/sql/sql/aggregations.md
+++ b/_search-plugins/sql/sql/aggregations.md
@@ -4,7 +4,7 @@ title: Aggregate Functions
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 11
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/aggregations/
 redirect_from:
   - /search-plugins/sql/aggregations/
   - /sql-and-ppl/sql/aggregations/

--- a/_search-plugins/sql/sql/basic.md
+++ b/_search-plugins/sql/sql/basic.md
@@ -4,7 +4,7 @@ title: Basic Queries
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/basic/
 redirect_from:
   - /search-plugins/sql/basic/
   - /sql-and-ppl/sql/basic/

--- a/_search-plugins/sql/sql/complex.md
+++ b/_search-plugins/sql/sql/complex.md
@@ -4,7 +4,7 @@ title: Complex Queries
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 6
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/complex/
 redirect_from:
   - /search-plugins/sql/complex/
   - /sql-and-ppl/sql/complex/

--- a/_search-plugins/sql/sql/delete.md
+++ b/_search-plugins/sql/sql/delete.md
@@ -4,7 +4,7 @@ title: Delete
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 12
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/delete/
 redirect_from:
   - /search-plugins/sql/delete/
   - /sql-and-ppl/sql/delete/

--- a/_search-plugins/sql/sql/functions.md
+++ b/_search-plugins/sql/sql/functions.md
@@ -4,7 +4,7 @@ title: Functions
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 7
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/sql/index.md
+++ b/_search-plugins/sql/sql/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /search-plugins/sql/sql
   - /sql-and-ppl/sql/
   - /sql-and-ppl/sql/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/index/
 ---
 
 # SQL

--- a/_search-plugins/sql/sql/jdbc.md
+++ b/_search-plugins/sql/sql/jdbc.md
@@ -4,7 +4,7 @@ title: JDBC Driver
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 71
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/jdbc/
 redirect_from:
   - /search-plugins/sql/jdbc/
   - /sql-and-ppl/sql/jdbc/

--- a/_search-plugins/sql/sql/metadata.md
+++ b/_search-plugins/sql/sql/metadata.md
@@ -4,7 +4,7 @@ title: Metadata Queries
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 9
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/metadata/
 redirect_from:
   - /search-plugins/sql/metadata/
   - /sql-and-ppl/sql/metadata/

--- a/_search-plugins/sql/sql/odbc.md
+++ b/_search-plugins/sql/sql/odbc.md
@@ -4,7 +4,7 @@ title: ODBC Driver
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 72
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/odbc/
 redirect_from:
   - /search-plugins/sql/odbc/
   - /sql-and-ppl/sql/odbc/

--- a/_search-plugins/sql/sql/partiql.md
+++ b/_search-plugins/sql/sql/partiql.md
@@ -4,7 +4,7 @@ title: JSON Support
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 8
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/partiql/
 redirect_from:
   - /search-plugins/sql/partiql/
   - /sql-and-ppl/sql/partiql/

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -3,7 +3,7 @@ layout: default
 title: Troubleshooting
 parent: SQL and PPL
 nav_order: 88
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/troubleshoot/
 redirect_from:
   - /sql-and-ppl/troubleshoot/
 ---

--- a/_tools/k8s-operator.md
+++ b/_tools/k8s-operator.md
@@ -3,7 +3,7 @@ layout: default
 title: OpenSearch Kubernetes Operator
 nav_order: 80
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/tools/k8s-operator/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/index/
 redirect_from:
   - /clients/k8s-operator/
   - /install-and-configure/install-opensearch/operator/

--- a/_upgrade-to/dashboards-upgrade-to.md
+++ b/_upgrade-to/dashboards-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Kibana OSS to OpenSearch Dashboards
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/dashboards-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Kibana OSS to OpenSearch Dashboards

--- a/_upgrade-to/docker-upgrade-to.md
+++ b/_upgrade-to/docker-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating Docker clusters to OpenSearch
 nav_order: 25
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/docker-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating Docker clusters to OpenSearch

--- a/_upgrade-to/index.md
+++ b/_upgrade-to/index.md
@@ -6,7 +6,7 @@ nav_exclude: true
 permalink: /upgrade-to/
 redirect_from:
   - /upgrade-to/index/
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # About the migration process

--- a/_upgrade-to/snapshot-migrate.md
+++ b/_upgrade-to/snapshot-migrate.md
@@ -2,7 +2,7 @@
 layout: default
 title: Using snapshots to migrate data
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/snapshot-migrate/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/
 ---
 
 # Using snapshots to migrate data

--- a/_upgrade-to/upgrade-to.md
+++ b/_upgrade-to/upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Elasticsearch OSS to OpenSearch
 nav_order: 15
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Elasticsearch OSS to OpenSearch

--- a/index.md
+++ b/index.md
@@ -6,6 +6,7 @@ has_children: false
 nav_exclude: true
 permalink: /
 canonical_url: https://docs.opensearch.org/latest/
+redirect_to: https://docs.opensearch.org/latest/
 ---
 
 {% include banner.html %}


### PR DESCRIPTION
### Description

The June 2024 pass (#7517, #7535 to #7550) already redirected every Clients, Data Prepper, Benchmark, and Migration Assistant page on this branch, so nothing is left to do there. What remains is the branch home page.

`/1.3/` serves a home page frozen at that release. GA shows no versioned root page has a single referrer from `docs.opensearch.org`, against 37% on-site referrals for `/latest/`, so nobody navigates within a version from its home page. The arrivals are external: bookmarks, third-party links, and OpenSearch Dashboards, whose `noDocumentation` block holds 62 version-pinned links that resolve to exactly this root. All of them are better served by the current home page than a stale one. Content pages are out of scope: a reader who lands on `/1.3/dashboards/dql/` stays in 1.3.

`_plugins/link-checker.rb` gains `^/$` in `@ignored_paths`. CI builds every branch with `baseurl: /latest`, so without it the checker rewrites the home page's redirect target back to `/`, reads the stub it just generated, pulls the same absolute URL out of it, and recurses until the build dies with `stack level too deep`. That was the cause of the CI failures on the first attempt at this pass.

Verified locally with `JEKYLL_FATAL_LINK_CHECKER=internal` on 2.13 and 3.7, one branch of each `@ignored_paths` shape. Both report no broken links, and `_site/index.html` is the redirect stub.

`@ignored_paths` ends up covering the home page and all five single-edition section paths on this branch, so nothing that carries a `redirect_to` is followed:

```ruby
@ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
```

The pattern matches the link target rather than the page the link sits on, so these entries also stop inbound links to those sections from being verified. That costs nothing here: the targets are redirect stubs the checker would skip anyway, and no new content will land on this branch. It would cost real coverage on `main`, where those are live pages, so `main` keeps a shorter list on purpose (#13056) and this line is not meant to be synced to it.

The `Retarget canonical links to their current pages on latest` commit corrects this branch's canonical links. `canonical_url` is what tells search engines to index the `/latest/` copy of a page rather than this one, but pages keep moving on main after a branch is cut, and a canonical aimed at a `jekyll-redirect-from` stub is worth little more than no canonical at all. 104 of them on this branch pointed at a stub and now name the real page, followed through the `redirect_from` entries on main.

3 pages have no equivalent on latest, not even a redirect, so they keep pointing at their own path. Fixing those means adding `redirect_from` to whichever page on main replaced them; nothing on this branch can do it.

Every target was resolved against `upstream/main` and every rewritten line was checked to be a `canonical_url` line and nothing else. Spot checks against the live site confirm each new URL is a real page whose own canonical is exactly the URL written here.

### Issues Resolved

N/A

### Version

1.3

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
