### PR TITLE
Redirect the home page and single-edition sections to latest and update canonical links in 2.1

### DIFF
--- a/_api-reference/alias.md
+++ b/_api-reference/alias.md
@@ -2,7 +2,7 @@
 layout: default
 title: Alias
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
+canonical_url: https://docs.opensearch.org/latest/api-reference/alias/aliases-api/
 redirect_from:
   - /api-reference/alias-api/
   - /api-reference/alias/index/

--- a/_api-reference/analyze-apis/terminology.md
+++ b/_api-reference/analyze-apis/terminology.md
@@ -4,7 +4,7 @@ title: Analysis API Terminology
 parent: Analyze API
 
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/api-reference/analyze-apis/terminology/
+canonical_url: https://docs.opensearch.org/latest/api-reference/analyze-apis/
 ---
 
 # Terminology

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -2,7 +2,7 @@
 layout: default
 title: Count
 nav_order: 20
-canonical_url: https://docs.opensearch.org/latest/api-reference/count/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/count/
 redirect_from:
   - /api-reference/search-apis/count/
   - /opensearch/rest-api/count/

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -2,7 +2,7 @@
 layout: default
 title: Explain
 nav_order: 30
-canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/explain/
 redirect_from:
   - /api-reference/search-apis/explain/
   - /opensearch/rest-api/explain/

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -2,7 +2,7 @@
 layout: default
 title: Multi-search
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/multi-search/
 redirect_from:
   - /api-reference/search-apis/multi-search/
   - /opensearch/rest-api/multi-search/

--- a/_api-reference/rank-eval.md
+++ b/_api-reference/rank-eval.md
@@ -2,7 +2,7 @@
 layout: default
 title: Ranking evaluation
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/api-reference/rank-eval/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/rank-eval/
 redirect_from:
   - /api-reference/search-apis/rank-eval/
 ---

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -2,7 +2,7 @@
 layout: default
 title: Remote cluster information
 nav_order: 67
-canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
+canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/remote-info/
 redirect_from:
   - /api-reference/cluster-api/remote-info/
   - /opensearch/rest-api/remote-info/

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -2,7 +2,7 @@
 layout: default
 title: Scroll
 nav_order: 71
-canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/scroll/
 redirect_from:
   - /api-reference/search-apis/scroll/
   - /opensearch/rest-api/scroll/

--- a/_api-reference/search.md
+++ b/_api-reference/search.md
@@ -2,7 +2,7 @@
 layout: default
 title: Search
 nav_order: 75
-canonical_url: https://docs.opensearch.org/latest/api-reference/search/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search/
 redirect_from:
   - /api-reference/search-apis/search/
   - /opensearch/rest-api/search/

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -2,7 +2,7 @@
 layout: default
 title: Tasks
 nav_order: 85
-canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
+canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/tasks/
 redirect_from:
   - /api-reference/tasks/tasks/
   - /opensearch/rest-api/tasks/

--- a/_clients/data-prepper/configure-logstash-data-prepper.md
+++ b/_clients/data-prepper/configure-logstash-data-prepper.md
@@ -3,7 +3,7 @@ layout: default
 title: Configure Logstash for Data Prepper
 parent: Data Prepper
 nav_order: 2
-canonical_url: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
 ---
 # Configure Logstash for Data Prepper

--- a/_clients/k8s-operator.md
+++ b/_clients/k8s-operator.md
@@ -2,7 +2,7 @@
 layout: default
 title: OpenSearch Kubernetes Operator
 nav_order: 210
-canonical_url: https://docs.opensearch.org/latest/tools/k8s-operator/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/index/
 redirect_from:
   - /install-and-configure/install-opensearch/operator/
   - /install-and-configure/install-opensearch/operator/index/

--- a/_dashboards/run-queries.md
+++ b/_dashboards/run-queries.md
@@ -2,7 +2,7 @@
 layout: default
 title: Running queries in the Dev Tools Console
 nav_order: 110
-canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/run-queries/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index/
 redirect_from:
   - /dashboards/dev-tools/index-dev/
   - /dashboards/dev-tools/run-queries/

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -3,7 +3,7 @@ layout: default
 title: Using area charts
 parent: Building data visualizations
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/area/
 redirect_from:
   - /dashboards/visualize/visualize-app/area/
 ---

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -8,7 +8,7 @@ redirect_from:
   - /docs/opensearch-dashboards/maptiles/
   - /dashboards/maptiles/
   - /dashboards/visualize/visualize-app/maptiles/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maptiles/
 ---
 
 {%- comment -%}The `/docs/opensearch-dashboards/maptiles/` redirect is specifically to support the UI links in OpenSearch Dashboards 1.0.0.{%- endcomment -%}

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -3,7 +3,7 @@ layout: default
 title: Building data visualizations
 nav_order: 40
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/index/
 redirect_from:
   - /dashboards/visualize/visualize-app/
   - /dashboards/visualize/visualize-app/index/

--- a/_data-prepper/migrating-from-logstash-data-prepper.md
+++ b/_data-prepper/migrating-from-logstash-data-prepper.md
@@ -4,7 +4,7 @@ title: Migrating from Logstash
 nav_order: 25
 redirect_from: 
   - /data-prepper/configure-logstash-data-prepper/
-canonical_url: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
 ---
 

--- a/_data-prepper/pipelines/configuration/processors/mutate-event.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-event.md
@@ -4,7 +4,7 @@ title: Mutate event
 parent: Processors
 grand_parent: Pipelines
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-event/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-event/
 ---
 

--- a/_data-prepper/pipelines/configuration/processors/mutate-string.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-string.md
@@ -4,7 +4,7 @@ title: Mutate string
 parent: Processors
 grand_parent: Pipelines
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-string/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-string/
 ---
 

--- a/_data-prepper/pipelines/configuration/processors/otel-trace-raw.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-trace-raw.md
@@ -4,8 +4,8 @@ title: otel_trace_raw
 parent: Processors
 grand_parent: Pipelines
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-raw/
-redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-raw/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
 ---
 
 # otel_trace_raw

--- a/_data-prepper/pipelines/configuration/processors/routes.md
+++ b/_data-prepper/pipelines/configuration/processors/routes.md
@@ -4,8 +4,8 @@ title: routes
 parent: Processors
 grand_parent: Pipelines
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/routes/
-redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/routes/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
 ---
 
 # Routes

--- a/_data-prepper/pipelines/configuration/processors/service-map-stateful.md
+++ b/_data-prepper/pipelines/configuration/processors/service-map-stateful.md
@@ -4,8 +4,8 @@ title: service_map_stateful
 parent: Processors
 grand_parent: Pipelines
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map-stateful/
-redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map-stateful/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
 ---
 
 # service_map_stateful

--- a/_data-prepper/pipelines/configuration/processors/sinks.md
+++ b/_data-prepper/pipelines/configuration/processors/sinks.md
@@ -5,6 +5,7 @@ parent: sinks
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
 ---
 
 # Sinks

--- a/_data-prepper/pipelines/configuration/sources/http-source.md
+++ b/_data-prepper/pipelines/configuration/sources/http-source.md
@@ -4,7 +4,7 @@ title: http_source
 parent: Sources
 grand_parent: Pipelines
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http-source/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http-source/
 ---
 

--- a/_data-prepper/pipelines/pipelines-configuration-options.md
+++ b/_data-prepper/pipelines/pipelines-configuration-options.md
@@ -3,8 +3,8 @@ layout: default
 title: Pipeline options
 parent: Pipelines
 nav_order: 11
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines-configuration-options/
-redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines-configuration-options/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
 ---
 
 # Pipeline options

--- a/_install-and-configure/upgrade-opensearch/appendix/index.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /migrate-or-upgrade/rolling-upgrade/appendix/rolling-upgrade-lab/
   - /migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
   - /upgrade-opensearch/appendix/rolling-upgrade-lab/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/index/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
 ---
 
 # Upgrades appendix

--- a/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
@@ -6,7 +6,7 @@ grand_parent: Upgrading OpenSearch
 nav_order: 50
 redirect_from:
   - /upgrade-opensearch/appendix/rolling-upgrade-lab/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
 ---
 
 <!--

--- a/_install-and-configure/upgrade-opensearch/index.md
+++ b/_install-and-configure/upgrade-opensearch/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /migrate-or-upgrade/
   - /migrate-or-upgrade/index/
   - /upgrade-or-migrate/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/index/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Upgrading OpenSearch

--- a/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
+++ b/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
@@ -3,7 +3,7 @@ layout: default
 title: Rolling Upgrade
 parent: Upgrading OpenSearch
 nav_order: 10
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/rolling-upgrade/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/
 redirect_from:
   - /migrate-or-upgrade/rolling-upgrade/
   - /rolling-upgrade/index/

--- a/_opensearch/pipeline-agg.md
+++ b/_opensearch/pipeline-agg.md
@@ -4,7 +4,7 @@ title: Pipeline Aggregations
 parent: Aggregations
 nav_order: 4
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline-agg/
+canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline/index/
 redirect_from:
   - /aggregations/pipeline-agg/
   - /aggregations/pipeline/

--- a/_opensearch/query-dsl/span-query.md
+++ b/_opensearch/query-dsl/span-query.md
@@ -3,7 +3,7 @@ layout: default
 title: Span queries
 parent: Query DSL
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/query-dsl/span-query/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/span/index/
 redirect_from:
   - /query-dsl/query-dsl/span-query/
   - /query-dsl/span-query/

--- a/_opensearch/search-template.md
+++ b/_opensearch/search-template.md
@@ -2,7 +2,7 @@
 layout: default
 title: Search templates
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/api-reference/search-template/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/index/
 redirect_from:
   - /api-reference/search-apis/search-template/
   - /api-reference/search-apis/search-template/index/

--- a/_opensearch/search/autocomplete.md
+++ b/_opensearch/search/autocomplete.md
@@ -3,7 +3,7 @@ layout: default
 title: Autocomplete
 parent: Searching data
 nav_order: 24
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/autocomplete/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/autocomplete/
 redirect_from:
   - /search-plugins/searching-data/autocomplete/
 ---

--- a/_opensearch/supported-field-types/alias.md
+++ b/_opensearch/supported-field-types/alias.md
@@ -4,7 +4,7 @@ title: Alias
 nav_order: 10
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/alias/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/
 redirect_from:
   - /field-types/alias/
   - /field-types/supported-field-types/alias/

--- a/_opensearch/supported-field-types/autocomplete.md
+++ b/_opensearch/supported-field-types/autocomplete.md
@@ -5,7 +5,7 @@ nav_order: 50
 has_children: true
 has_toc: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/autocomplete/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/autocomplete/
 redirect_from:
   - /field-types/autocomplete/
   - /mappings/supported-field-types/autocomplete/

--- a/_opensearch/supported-field-types/binary.md
+++ b/_opensearch/supported-field-types/binary.md
@@ -4,7 +4,7 @@ title: Binary
 parent: Supported field types
 nav_order: 12
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/binary/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/binary/
 redirect_from:
   - /field-types/binary/
   - /field-types/supported-field-types/binary/

--- a/_opensearch/supported-field-types/boolean.md
+++ b/_opensearch/supported-field-types/boolean.md
@@ -4,7 +4,7 @@ title: Boolean
 nav_order: 20
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/boolean/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/boolean/
 redirect_from:
   - /field-types/boolean/
   - /field-types/supported-field-types/boolean/

--- a/_opensearch/supported-field-types/completion.md
+++ b/_opensearch/supported-field-types/completion.md
@@ -5,7 +5,7 @@ nav_order: 51
 has_children: false
 parent: Autocomplete field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/completion/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/completion/
 redirect_from:
   - /field-types/completion/
   - /field-types/supported-field-types/completion/

--- a/_opensearch/supported-field-types/date.md
+++ b/_opensearch/supported-field-types/date.md
@@ -4,7 +4,7 @@ title: Date
 nav_order: 25
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/date/
 redirect_from:
   - /field-types/date/
   - /field-types/supported-field-types/date/

--- a/_opensearch/supported-field-types/geo-point.md
+++ b/_opensearch/supported-field-types/geo-point.md
@@ -5,7 +5,7 @@ nav_order: 56
 has_children: false
 parent: Geographic field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-point/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-point/
 redirect_from:
   - /field-types/geo-point/
   - /field-types/supported-field-types/geo-point/

--- a/_opensearch/supported-field-types/geo-shape.md
+++ b/_opensearch/supported-field-types/geo-shape.md
@@ -5,7 +5,7 @@ nav_order: 57
 has_children: false
 parent: Geographic field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-shape/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-shape/
 redirect_from:
   - /field-types/geo-shape/
   - /field-types/supported-field-types/geo-shape/

--- a/_opensearch/supported-field-types/geographic.md
+++ b/_opensearch/supported-field-types/geographic.md
@@ -5,7 +5,7 @@ nav_order: 55
 has_children: true
 has_toc: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geographic/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geographic/
 redirect_from:
   - /field-types/geographic/
   - /field-types/supported-field-types/geographic/

--- a/_opensearch/supported-field-types/index.md
+++ b/_opensearch/supported-field-types/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /field-types/supported-field-types/
   - /mappings/supported-field-types/
   - /mappings/supported-field-types/index/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/index/
 ---
 
 # Supported field types

--- a/_opensearch/supported-field-types/ip.md
+++ b/_opensearch/supported-field-types/ip.md
@@ -4,7 +4,7 @@ title: IP address
 nav_order: 30
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/ip/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/ip/
 redirect_from:
   - /field-types/ip/
   - /field-types/supported-field-types/ip/

--- a/_opensearch/supported-field-types/join.md
+++ b/_opensearch/supported-field-types/join.md
@@ -5,7 +5,7 @@ nav_order: 43
 has_children: false
 parent: Object field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/join/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/join/
 redirect_from:
   - /field-types/join/
   - /field-types/supported-field-types/join/

--- a/_opensearch/supported-field-types/keyword.md
+++ b/_opensearch/supported-field-types/keyword.md
@@ -5,7 +5,7 @@ nav_order: 46
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/keyword/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/keyword/
 redirect_from:
   - /field-types/keyword/
   - /field-types/supported-field-types/keyword/

--- a/_opensearch/supported-field-types/nested.md
+++ b/_opensearch/supported-field-types/nested.md
@@ -5,7 +5,7 @@ nav_order: 42
 has_children: false
 parent: Object field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/nested/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/nested/
 redirect_from:
   - /field-types/nested/
   - /field-types/supported-field-types/nested/

--- a/_opensearch/supported-field-types/numeric.md
+++ b/_opensearch/supported-field-types/numeric.md
@@ -4,7 +4,7 @@ title: Numeric field types
 parent: Supported field types
 nav_order: 15
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/numeric/
 redirect_from:
   - /field-types/numeric/
   - /field-types/supported-field-types/numeric/

--- a/_opensearch/supported-field-types/object-fields.md
+++ b/_opensearch/supported-field-types/object-fields.md
@@ -5,7 +5,7 @@ nav_order: 40
 has_children: true
 has_toc: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object-fields/
 redirect_from:
   - /field-types/object-fields/
   - /field-types/supported-field-types/object-fields/

--- a/_opensearch/supported-field-types/object.md
+++ b/_opensearch/supported-field-types/object.md
@@ -5,7 +5,7 @@ nav_order: 41
 has_children: false
 parent: Object field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object/
 redirect_from:
   - /field-types/object/
   - /field-types/supported-field-types/object/

--- a/_opensearch/supported-field-types/percolator.md
+++ b/_opensearch/supported-field-types/percolator.md
@@ -4,7 +4,7 @@ title: Percolator
 nav_order: 65
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/percolator/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/percolator/
 redirect_from:
   - /field-types/percolator/
   - /field-types/supported-field-types/percolator/

--- a/_opensearch/supported-field-types/range.md
+++ b/_opensearch/supported-field-types/range.md
@@ -4,7 +4,7 @@ title: Range field types
 nav_order: 35
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/range/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/range/
 redirect_from:
   - /field-types/range/
   - /field-types/supported-field-types/range/

--- a/_opensearch/supported-field-types/rank.md
+++ b/_opensearch/supported-field-types/rank.md
@@ -4,7 +4,7 @@ title: Rank field types
 nav_order: 60
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/rank/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/rank/
 redirect_from:
   - /field-types/rank/
   - /field-types/supported-field-types/rank/

--- a/_opensearch/supported-field-types/search-as-you-type.md
+++ b/_opensearch/supported-field-types/search-as-you-type.md
@@ -5,7 +5,7 @@ nav_order: 53
 has_children: false
 parent: Autocomplete field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/search-as-you-type/
 redirect_from:
   - /field-types/search-as-you-type/
   - /field-types/supported-field-types/search-as-you-type/

--- a/_opensearch/supported-field-types/string.md
+++ b/_opensearch/supported-field-types/string.md
@@ -5,7 +5,7 @@ nav_order: 45
 has_children: true
 has_toc: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/string/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/string/
 redirect_from:
   - /field-types/string/
   - /field-types/supported-field-types/string/

--- a/_opensearch/supported-field-types/text.md
+++ b/_opensearch/supported-field-types/text.md
@@ -5,7 +5,7 @@ nav_order: 47
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/text/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/text/
 redirect_from:
   - /field-types/supported-field-types/text/
   - /field-types/text/

--- a/_opensearch/supported-field-types/token-count.md
+++ b/_opensearch/supported-field-types/token-count.md
@@ -5,7 +5,7 @@ nav_order: 48
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/token-count/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/token-count/
 redirect_from:
   - /field-types/supported-field-types/token-count/
   - /field-types/token-count/

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -59,10 +59,8 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore
-  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
-  # back to `/`, so check_internal would follow the stub into itself.
-  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark)}.freeze
+  # Pattern of local paths to ignore.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -60,7 +60,9 @@ module Jekyll::LinkChecker
 
   ##
   # Pattern of local paths to ignore
-  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark)}.freeze
+  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
+  # back to `/`, so check_internal would follow the stub into itself.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark)}.freeze
 
   ##
   # Holds the list of failures

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -4,7 +4,7 @@ title: API
 nav_order: 5
 parent: k-NN
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/api/
+canonical_url: https://docs.opensearch.org/latest/vector-search/api/index/
 redirect_from:
   - /vector-search/api/
   - /vector-search/api/index/

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -5,7 +5,7 @@ nav_order: 2
 parent: k-NN
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/approximate-knn/
 redirect_from:
   - /vector-search/vector-search-techniques/approximate-knn/
 ---

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /search-plugins/knn/
   - /vector-search/vector-search-techniques/
   - /vector-search/vector-search-techniques/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/index/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/index/
 ---
 
 # k-NN

--- a/_search-plugins/knn/jni-libraries.md
+++ b/_search-plugins/knn/jni-libraries.md
@@ -4,7 +4,7 @@ title: JNI libraries
 nav_order: 6
 parent: k-NN
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/jni-libraries/
+canonical_url: https://docs.opensearch.org/latest/vector-search/api/knn/
 redirect_from:
   - /vector-search/api/knn/
 ---

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -4,7 +4,7 @@ title: k-NN Index
 nav_order: 1
 parent: k-NN
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-index/
+canonical_url: https://docs.opensearch.org/latest/vector-search/creating-vector-index/
 redirect_from:
   - /vector-search/creating-a-vector-db/
   - /vector-search/creating-vector-index/

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -5,7 +5,7 @@ nav_order: 3
 parent: k-NN
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/knn-score-script/
 redirect_from:
   - /vector-search/vector-search-techniques/knn-score-script/
 ---

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -5,7 +5,7 @@ nav_order: 4
 parent: k-NN
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/painless-functions/
 redirect_from:
   - /vector-search/vector-search-techniques/painless-functions/
 ---

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -3,7 +3,7 @@ layout: default
 title: Performance tuning
 parent: k-NN
 nav_order: 8
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/performance-tuning/
+canonical_url: https://docs.opensearch.org/latest/vector-search/performance-tuning/
 redirect_from:
   - /vector-search/performance-tuning/
 ---

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: k-NN
 nav_order: 7
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/settings/
+canonical_url: https://docs.opensearch.org/latest/vector-search/settings/
 redirect_from:
   - /vector-search/settings/
 ---

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -3,7 +3,7 @@ layout: default
 title: SQL and PPL CLI
 parent: SQL and PPL
 nav_order: 3
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/cli/
 redirect_from:
   - /sql-and-ppl/cli/
 ---

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -3,7 +3,7 @@ layout: default
 title: Data Types
 parent: SQL and PPL
 nav_order: 7
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/datatypes/
 redirect_from:
   - /sql-and-ppl/datatypes/
 ---

--- a/_search-plugins/sql/full-text.md
+++ b/_search-plugins/sql/full-text.md
@@ -3,7 +3,7 @@ layout: default
 title: Full-Text Search
 parent: SQL and PPL
 nav_order: 11
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/full-text/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/full-text/
 redirect_from:
   - /sql-and-ppl/full-text/
 ---

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -3,7 +3,7 @@ layout: default
 title: Functions
 parent: SQL and PPL
 nav_order: 10
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 redirect_from:
   - /sql-and-ppl/sql/functions/
 ---

--- a/_search-plugins/sql/identifiers.md
+++ b/_search-plugins/sql/identifiers.md
@@ -3,7 +3,7 @@ layout: default
 title: Identifiers
 parent: SQL and PPL
 nav_order: 6
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/identifiers/
 redirect_from:
   - /observability-plugin/ppl/identifiers/
   - /search-plugins/ppl/identifiers/

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /search-plugins/sql/
   - /sql-and-ppl/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/
 ---
 
 # SQL and PPL

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -3,7 +3,7 @@ layout: default
 title: Limitations
 parent: SQL and PPL
 nav_order: 99
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/limitation/
 redirect_from:
   - /sql-and-ppl/limitation/
 ---

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -3,7 +3,7 @@ layout: default
 title: Monitoring
 parent: SQL and PPL
 nav_order: 95
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/monitoring/
 redirect_from:
   - /sql-and-ppl/monitoring/
 ---

--- a/_search-plugins/sql/ppl/functions.md
+++ b/_search-plugins/sql/ppl/functions.md
@@ -4,7 +4,7 @@ title: Commands
 parent: PPL - Piped Processing Language
 grand_parent: SQL and PPL
 nav_order: 2
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/index/
 redirect_from:
   - /observability-plugin/ppl/commands/
   - /search-plugins/ppl/commands/

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -15,7 +15,7 @@ redirect_from:
   - /search-plugins/ppl/protocol/
   - /sql-and-ppl/ppl/
   - /sql-and-ppl/ppl/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/index/
 ---
 
 # PPL &ndash; Piped Processing Language

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -4,7 +4,7 @@ title: Syntax
 parent: PPL - Piped Processing Language
 grand_parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/syntax/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/syntax/
 redirect_from:
   - /sql-and-ppl/ppl/commands/syntax/
 ---

--- a/_search-plugins/sql/response-formats.md
+++ b/_search-plugins/sql/response-formats.md
@@ -3,7 +3,7 @@ layout: default
 title: Response formats
 parent: SQL and PPL
 nav_order: 2
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/response-formats/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/response-formats/
 redirect_from:
   - /sql-and-ppl/response-formats/
 ---

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: SQL and PPL
 nav_order: 77
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/settings/
 redirect_from:
   - /sql-and-ppl/settings/
 ---

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -3,7 +3,7 @@ layout: default
 title: SQL/PPL API
 parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/index/
 redirect_from:
   - /sql-and-ppl/sql-and-ppl-api/index/
   - /sql-and-ppl/sql-ppl-api/

--- a/_search-plugins/sql/sql/aggregations.md
+++ b/_search-plugins/sql/sql/aggregations.md
@@ -4,7 +4,7 @@ title: Aggregate Functions
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 11
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/aggregations/
 redirect_from:
   - /search-plugins/sql/aggregations/
   - /sql-and-ppl/sql/aggregations/

--- a/_search-plugins/sql/sql/basic.md
+++ b/_search-plugins/sql/sql/basic.md
@@ -4,7 +4,7 @@ title: Basic Queries
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/basic/
 redirect_from:
   - /search-plugins/sql/basic/
   - /sql-and-ppl/sql/basic/

--- a/_search-plugins/sql/sql/complex.md
+++ b/_search-plugins/sql/sql/complex.md
@@ -4,7 +4,7 @@ title: Complex Queries
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 6
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/complex/
 redirect_from:
   - /search-plugins/sql/complex/
   - /sql-and-ppl/sql/complex/

--- a/_search-plugins/sql/sql/delete.md
+++ b/_search-plugins/sql/sql/delete.md
@@ -4,7 +4,7 @@ title: Delete
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 12
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/delete/
 redirect_from:
   - /search-plugins/sql/delete/
   - /sql-and-ppl/sql/delete/

--- a/_search-plugins/sql/sql/functions.md
+++ b/_search-plugins/sql/sql/functions.md
@@ -4,7 +4,7 @@ title: Functions
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 7
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/sql/index.md
+++ b/_search-plugins/sql/sql/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /search-plugins/sql/sql
   - /sql-and-ppl/sql/
   - /sql-and-ppl/sql/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/index/
 ---
 
 # SQL

--- a/_search-plugins/sql/sql/jdbc.md
+++ b/_search-plugins/sql/sql/jdbc.md
@@ -4,7 +4,7 @@ title: JDBC Driver
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 71
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/jdbc/
 redirect_from:
   - /search-plugins/sql/jdbc/
   - /sql-and-ppl/sql/jdbc/

--- a/_search-plugins/sql/sql/metadata.md
+++ b/_search-plugins/sql/sql/metadata.md
@@ -4,7 +4,7 @@ title: Metadata Queries
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 9
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/metadata/
 redirect_from:
   - /search-plugins/sql/metadata/
   - /sql-and-ppl/sql/metadata/

--- a/_search-plugins/sql/sql/odbc.md
+++ b/_search-plugins/sql/sql/odbc.md
@@ -4,7 +4,7 @@ title: ODBC Driver
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 72
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/odbc/
 redirect_from:
   - /search-plugins/sql/odbc/
   - /sql-and-ppl/sql/odbc/

--- a/_search-plugins/sql/sql/partiql.md
+++ b/_search-plugins/sql/sql/partiql.md
@@ -4,7 +4,7 @@ title: JSON Support
 parent: SQL
 grand_parent: SQL and PPL
 nav_order: 8
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/partiql/
 redirect_from:
   - /search-plugins/sql/partiql/
   - /sql-and-ppl/sql/partiql/

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -3,7 +3,7 @@ layout: default
 title: Troubleshooting
 parent: SQL and PPL
 nav_order: 88
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/troubleshoot/
 redirect_from:
   - /sql-and-ppl/troubleshoot/
 ---

--- a/_upgrade-to/dashboards-upgrade-to.md
+++ b/_upgrade-to/dashboards-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Kibana OSS to OpenSearch Dashboards
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/dashboards-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Kibana OSS to OpenSearch Dashboards

--- a/_upgrade-to/docker-upgrade-to.md
+++ b/_upgrade-to/docker-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating Docker clusters to OpenSearch
 nav_order: 25
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/docker-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating Docker clusters to OpenSearch

--- a/_upgrade-to/index.md
+++ b/_upgrade-to/index.md
@@ -4,7 +4,7 @@ title: About the migration process
 nav_order: 1
 redirect_from:
   - /upgrade-to/index/
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # About the migration process

--- a/_upgrade-to/snapshot-migrate.md
+++ b/_upgrade-to/snapshot-migrate.md
@@ -2,7 +2,7 @@
 layout: default
 title: Using snapshots to migrate data
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/snapshot-migrate/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/
 ---
 
 # Using snapshots to migrate data

--- a/_upgrade-to/upgrade-to.md
+++ b/_upgrade-to/upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Elasticsearch OSS to OpenSearch
 nav_order: 15
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Elasticsearch OSS to OpenSearch

--- a/index.md
+++ b/index.md
@@ -6,6 +6,7 @@ has_children: false
 nav_exclude: true
 permalink: /
 canonical_url: https://docs.opensearch.org/latest/
+redirect_to: https://docs.opensearch.org/latest/
 ---
 
 {% include banner.html %}


### PR DESCRIPTION
### Description

The Clients, Data Prepper, Benchmark, and Migration Assistant sections are published as a single edition under `/latest/`; only the OpenSearch section is versioned. A versioned build still emits a full copy of those collections, so `/2.1/data-prepper/...` serves content that no release ever corresponded to. Readers reach those copies from search engines, bookmarks, and LLM answers, so rewriting on-site links cannot close the gap.

Most pages in those sections on this branch already redirect, from the June 2024 pass (#7517, #7535 to #7550). This adds `redirect_to` to the one page that pass missed. Files that already carry one are untouched, so that pass's hand-curated targets are preserved.

Every target was resolved against the live site before being written:

- HTTP redirects and meta-refresh stubs are followed, so each target is a final endpoint rather than another redirect.
- A missing page returns HTTP 200 after being rewritten to `/latest/404.html`, so existence is tested by inspecting the effective URL rather than the status code. A target that lands there falls back to the section index.
- Pages whose only equivalent on `/latest/` is inside the versioned OpenSearch section are left alone, because redirecting them would serve content for the wrong release. On this branch that covers 10 pages, mostly the CLI, Logstash, and Grafana pages, which moved out of `_clients` into the versioned section.

Target selection for this branch:

```
  exact       0
  collapsed   1
  section     0
  moved       10
  unresolved  0
```

The branch home page is redirected too. `/2.1/` serves a home page frozen at that release. GA shows no versioned root page has a single referrer from `docs.opensearch.org`, against 37% on-site referrals for `/latest/`, so nobody navigates within a version from its home page. The arrivals are external: bookmarks, third-party links, and OpenSearch Dashboards, whose `noDocumentation` block holds 62 version-pinned links that resolve to exactly this root. All of them are better served by the current home page than a stale one. Content pages are out of scope: a reader who lands on `/2.1/dashboards/dql/` stays in 2.1.

`@ignored_paths` also gains `^/$`. CI builds every branch with `baseurl: /latest`, so without it the checker rewrites the home page's redirect target back to `/`, reads the stub it just generated, pulls the same absolute URL out of it, and recurses until the build dies with `stack level too deep`. That was the cause of the CI failures on the first attempt at this pass.

Verified locally with `JEKYLL_FATAL_LINK_CHECKER=internal` on 2.13 and 3.7, one branch of each `@ignored_paths` shape. Both report no broken links, and `_site/index.html` is the redirect stub.

`@ignored_paths` ends up covering the home page and all five single-edition section paths on this branch, so nothing that carries a `redirect_to` is followed:

```ruby
@ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
```

The pattern matches the link target rather than the page the link sits on, so these entries also stop inbound links to those sections from being verified. That costs nothing here: the targets are redirect stubs the checker would skip anyway, and no new content will land on this branch. It would cost real coverage on `main`, where those are live pages, so `main` keeps a shorter list on purpose (#13056) and this line is not meant to be synced to it.

The `Retarget canonical links to their current pages on latest` commit corrects this branch's canonical links. `canonical_url` is what tells search engines to index the `/latest/` copy of a page rather than this one, but pages keep moving on main after a branch is cut, and a canonical aimed at a `jekyll-redirect-from` stub is worth little more than no canonical at all. 91 of them on this branch pointed at a stub and now name the real page, followed through the `redirect_from` entries on main.

4 pages have no equivalent on latest, not even a redirect, so they keep pointing at their own path. Fixing those means adding `redirect_from` to whichever page on main replaced them; nothing on this branch can do it.

Every target was resolved against `upstream/main` and every rewritten line was checked to be a `canonical_url` line and nothing else. Spot checks against the live site confirm each new URL is a real page whose own canonical is exactly the URL written here.

### Issues Resolved

N/A

### Version

2.1

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
