### PR TITLE
Redirect the home page and single-edition sections to latest and update canonical links in 2.18

### DIFF
--- a/_aggregations/pipeline-agg.md
+++ b/_aggregations/pipeline-agg.md
@@ -8,7 +8,7 @@ redirect_from:
   - /query-dsl/aggregations/pipeline-agg/
   - /aggregations/pipeline/
   - /aggregations/pipeline/index/
-canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline-agg/
+canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline/index/
 ---
 
 # Pipeline aggregations

--- a/_api-reference/analyze-apis/terminology.md
+++ b/_api-reference/analyze-apis/terminology.md
@@ -4,7 +4,7 @@ title: Analysis API Terminology
 parent: Analyze API
 
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/api-reference/analyze-apis/terminology/
+canonical_url: https://docs.opensearch.org/latest/api-reference/analyze-apis/
 ---
 
 # Terminology

--- a/_api-reference/count.md
+++ b/_api-reference/count.md
@@ -5,7 +5,7 @@ nav_order: 21
 redirect_from:
   - /opensearch/rest-api/count/
   - /api-reference/search-apis/count/
-canonical_url: https://docs.opensearch.org/latest/api-reference/count/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/count/
 ---
 
 # Count

--- a/_api-reference/explain.md
+++ b/_api-reference/explain.md
@@ -5,7 +5,7 @@ nav_order: 30
 redirect_from: 
   - /opensearch/rest-api/explain/
   - /api-reference/search-apis/explain/
-canonical_url: https://docs.opensearch.org/latest/api-reference/explain/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/explain/
 ---
 
 # Explain

--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -7,7 +7,7 @@ redirect_from:
   - /opensearch/rest-api/alias/
   - /api-reference/alias/
   - /api-reference/alias/aliases-api/
-canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
+canonical_url: https://docs.opensearch.org/latest/api-reference/alias/aliases-api/
 ---
 
 # Alias

--- a/_api-reference/index-apis/update-alias.md
+++ b/_api-reference/index-apis/update-alias.md
@@ -3,7 +3,7 @@ layout: default
 title: Create or update alias
 parent: Index APIs
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/update-alias/
+canonical_url: https://docs.opensearch.org/latest/api-reference/alias/create-alias/
 redirect_from:
   - /api-reference/alias/create-alias/
 ---

--- a/_api-reference/msearch-template.md
+++ b/_api-reference/msearch-template.md
@@ -2,7 +2,7 @@
 layout: default
 title: Multi-search Template 
 nav_order: 47
-canonical_url: https://docs.opensearch.org/latest/api-reference/msearch-template/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/msearch-template/
 redirect_from:
   - /api-reference/search-apis/msearch-template/
   - /api-reference/search-apis/search-template/msearch-template/

--- a/_api-reference/multi-search.md
+++ b/_api-reference/multi-search.md
@@ -5,7 +5,7 @@ nav_order: 45
 redirect_from: 
   - /opensearch/rest-api/multi-search/
   - /api-reference/search-apis/multi-search/
-canonical_url: https://docs.opensearch.org/latest/api-reference/multi-search/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/multi-search/
 ---
 
 # Multi-search 

--- a/_api-reference/profile.md
+++ b/_api-reference/profile.md
@@ -2,7 +2,7 @@
 layout: default
 title: Profile
 nav_order: 55
-canonical_url: https://docs.opensearch.org/latest/api-reference/profile/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/profile/
 redirect_from:
   - /api-reference/search-apis/profile/
 ---

--- a/_api-reference/rank-eval.md
+++ b/_api-reference/rank-eval.md
@@ -2,7 +2,7 @@
 layout: default
 title: Ranking evaluation
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/api-reference/rank-eval/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/rank-eval/
 redirect_from:
   - /api-reference/search-apis/rank-eval/
 ---

--- a/_api-reference/remote-info.md
+++ b/_api-reference/remote-info.md
@@ -5,7 +5,7 @@ nav_order: 67
 redirect_from: 
   - /opensearch/rest-api/remote-info/
   - /api-reference/cluster-api/remote-info/
-canonical_url: https://docs.opensearch.org/latest/api-reference/remote-info/
+canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/remote-info/
 ---
 
 # Remote cluster information

--- a/_api-reference/render-template.md
+++ b/_api-reference/render-template.md
@@ -2,7 +2,7 @@
 layout: default
 title: Render Template
 nav_order: 82
-canonical_url: https://docs.opensearch.org/latest/api-reference/render-template/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/render-template/
 redirect_from:
   - /api-reference/search-apis/render-template/
   - /api-reference/search-apis/search-template/render-template/

--- a/_api-reference/scroll.md
+++ b/_api-reference/scroll.md
@@ -5,7 +5,7 @@ nav_order: 71
 redirect_from:
   - /opensearch/rest-api/scroll/
   - /api-reference/search-apis/scroll/
-canonical_url: https://docs.opensearch.org/latest/api-reference/scroll/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/scroll/
 ---
 
 # Scroll

--- a/_api-reference/search-template.md
+++ b/_api-reference/search-template.md
@@ -7,7 +7,7 @@ redirect_from:
   - /search-plugins/search-template/
   - /api-reference/search-apis/search-template/
   - /api-reference/search-apis/search-template/index/
-canonical_url: https://docs.opensearch.org/latest/api-reference/search-template/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/index/
 ---
 
 # Search templates

--- a/_api-reference/search.md
+++ b/_api-reference/search.md
@@ -5,7 +5,7 @@ nav_order: 75
 redirect_from:
   - /opensearch/rest-api/search/
   - /api-reference/search-apis/search/
-canonical_url: https://docs.opensearch.org/latest/api-reference/search/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search/
 ---
 
 # Search

--- a/_api-reference/security-apis.md
+++ b/_api-reference/security-apis.md
@@ -2,7 +2,7 @@
 layout: default
 title: Security APIs
 nav_order: 84
-canonical_url: https://docs.opensearch.org/latest/api-reference/security-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/security/index/
 ---
 
 # Security APIs

--- a/_api-reference/tasks.md
+++ b/_api-reference/tasks.md
@@ -5,7 +5,7 @@ nav_order: 85
 redirect_from:
   - /opensearch/rest-api/tasks/
   - /api-reference/tasks/tasks/
-canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/
+canonical_url: https://docs.opensearch.org/latest/api-reference/tasks/tasks/
 ---
 
 # Tasks

--- a/_api-reference/validate.md
+++ b/_api-reference/validate.md
@@ -2,7 +2,7 @@
 layout: default
 title: Validate Query
 nav_order: 87
-canonical_url: https://docs.opensearch.org/latest/api-reference/validate/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/validate/
 redirect_from:
   - /api-reference/search-apis/validate/
 ---

--- a/_benchmark/glossary.md
+++ b/_benchmark/glossary.md
@@ -3,6 +3,7 @@ layout: default
 title: Glossary
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/benchmark/glossary/
+redirect_to: https://docs.opensearch.org/latest/benchmark/glossary/
 ---
 
 # OpenSearch Benchmark glossary

--- a/_benchmark/index.md
+++ b/_benchmark/index.md
@@ -9,6 +9,7 @@ permalink: /benchmark/
 redirect_from:
   - /benchmark/index/
 canonical_url: https://docs.opensearch.org/latest/benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 
 # OpenSearch Benchmark

--- a/_benchmark/quickstart.md
+++ b/_benchmark/quickstart.md
@@ -3,6 +3,7 @@ layout: default
 title: Quickstart
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/benchmark/quickstart/
+redirect_to: https://docs.opensearch.org/latest/benchmark/quickstart/
 ---
 
 # OpenSearch Benchmark quickstart

--- a/_benchmark/reference/commands/aggregate.md
+++ b/_benchmark/reference/commands/aggregate.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from: 
   - /benchmark/commands/aggregate/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/aggregate/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/aggregate/
 ---
 
 # aggregate

--- a/_benchmark/reference/commands/command-flags.md
+++ b/_benchmark/reference/commands/command-flags.md
@@ -7,6 +7,7 @@ redirect_from:
   - /benchmark/commands/command-flags/
 grand_parent: OpenSearch Benchmark Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/command-flags/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/command-flags/
 ---
 
 # Command flags

--- a/_benchmark/reference/commands/compare.md
+++ b/_benchmark/reference/commands/compare.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from: 
   - /benchmark/commands/compare/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/compare/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/compare/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/download.md
+++ b/_benchmark/reference/commands/download.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/download/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/download/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/download/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/execute-test.md
+++ b/_benchmark/reference/commands/execute-test.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/execute-test/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/execute-test/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/execute-test.md
+++ b/_benchmark/reference/commands/execute-test.md
@@ -6,7 +6,7 @@ parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/execute-test/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/execute-test/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
 ---
 

--- a/_benchmark/reference/commands/index.md
+++ b/_benchmark/reference/commands/index.md
@@ -8,6 +8,7 @@ redirect_from: /benchmark/commands/index/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
 redirect_from:
   - /benchmark/reference/commands/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
 ---
 
 # OpenSearch Benchmark command reference

--- a/_benchmark/reference/commands/info.md
+++ b/_benchmark/reference/commands/info.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/info/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/info/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/info/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/list.md
+++ b/_benchmark/reference/commands/list.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/list/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/list/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/list/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /benchmark/reference/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/index/
 ---
 
 # OpenSearch Benchmark Reference

--- a/_benchmark/reference/metrics/index.md
+++ b/_benchmark/reference/metrics/index.md
@@ -10,6 +10,7 @@ redirect_from:
   - /benchmark/metrics/
   - /benchmark/metrics/index/
   - /benchmark/reference/metrics/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
 ---
 
 # Metrics

--- a/_benchmark/reference/metrics/metric-keys.md
+++ b/_benchmark/reference/metrics/metric-keys.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/metrics/metric-keys/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-keys/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-keys/
 ---
 
 # Metric keys

--- a/_benchmark/reference/metrics/metric-records.md
+++ b/_benchmark/reference/metrics/metric-records.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/metrics/metric-records/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-records/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-records/
 ---
 
 # Metric records

--- a/_benchmark/reference/summary-report.md
+++ b/_benchmark/reference/summary-report.md
@@ -4,6 +4,7 @@ title: Summary report
 nav_order: 40
 parent: Metrics
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 # Summary report

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -4,6 +4,7 @@ title: Telemetry devices
 nav_order: 45
 parent: OpenSearch Benchmark Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 
 # Telemetry devices

--- a/_benchmark/reference/workloads/corpora.md
+++ b/_benchmark/reference/workloads/corpora.md
@@ -7,6 +7,7 @@ nav_order: 70
 redirect_from:
   - /benchmark/workloads/corpora/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/corpora/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/corpora/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -10,6 +10,7 @@ redirect_from:
   - /benchmark/reference/workloads/
   - /benchmark/workloads/
   - /benchmark/workloads/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # OpenSearch Benchmark workload reference

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -5,7 +5,7 @@ nav_order: 60
 parent: OpenSearch Benchmark Reference
 has_children: true
 redirect_from: /benchmark/workloads/index/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_from:
   - /benchmark/reference/workloads/
   - /benchmark/workloads/

--- a/_benchmark/reference/workloads/indices.md
+++ b/_benchmark/reference/workloads/indices.md
@@ -7,6 +7,7 @@ nav_order: 65
 redirect_from:
   - /benchmark/workloads/indices/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/indices/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/indices/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: OpenSearch Benchmark Reference
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/operations/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/operations/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/test-procedures.md
+++ b/_benchmark/reference/workloads/test-procedures.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: OpenSearch Benchmark Reference
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/test-procedures/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/test-procedures/
 ---
 
 <!-- vale off -->

--- a/_benchmark/tutorials/index.md
+++ b/_benchmark/tutorials/index.md
@@ -3,7 +3,7 @@ layout: default
 title: Tutorials
 nav_order: 10
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/tutorials/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/
 redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 

--- a/_benchmark/tutorials/index.md
+++ b/_benchmark/tutorials/index.md
@@ -4,6 +4,7 @@ title: Tutorials
 nav_order: 10
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/tutorials/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 
 # Tutorial

--- a/_benchmark/tutorials/sigv4.md
+++ b/_benchmark/tutorials/sigv4.md
@@ -3,7 +3,7 @@ layout: default
 title: AWS Signature Version 4 support
 nav_order: 70
 parent: Tutorials
-canonical_url: https://docs.opensearch.org/latest/benchmark/tutorials/sigv4/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 ---
 

--- a/_benchmark/tutorials/sigv4.md
+++ b/_benchmark/tutorials/sigv4.md
@@ -4,6 +4,7 @@ title: AWS Signature Version 4 support
 nav_order: 70
 parent: Tutorials
 canonical_url: https://docs.opensearch.org/latest/benchmark/tutorials/sigv4/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 ---
 
 # Running OpenSearch Benchmark with AWS Signature Version 4

--- a/_benchmark/user-guide/concepts.md
+++ b/_benchmark/user-guide/concepts.md
@@ -6,6 +6,7 @@ parent: User guide
 redirect_from: 
   - /benchmark/user-guide/concepts/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/concepts/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/concepts/
 ---
 
 # Concepts

--- a/_benchmark/user-guide/index.md
+++ b/_benchmark/user-guide/index.md
@@ -6,6 +6,7 @@ has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/index/
 redirect_from:
   - /benchmark/user-guide/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/index/
 ---
 
 # OpenSearch Benchmark User Guide

--- a/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
+++ b/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
@@ -8,6 +8,7 @@ redirect_from:
   - /benchmark/configuring-benchmark/
   - /benchmark/user-guide/configuring-benchmark/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 ---
 
 # Configuring OpenSearch Benchmark

--- a/_benchmark/user-guide/install-and-configure/index.md
+++ b/_benchmark/user-guide/install-and-configure/index.md
@@ -7,6 +7,7 @@ has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/index/
 redirect_from:
   - /benchmark/user-guide/install-and-configure/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/index/
 ---
 
 # Installing and configuring OpenSearch Benchmark 

--- a/_benchmark/user-guide/install-and-configure/installing-benchmark.md
+++ b/_benchmark/user-guide/install-and-configure/installing-benchmark.md
@@ -8,6 +8,7 @@ redirect_from:
   - /benchmark/installing-benchmark/
   - /benchmark/user-guide/installing-benchmark/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/installing-benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/installing-benchmark/
 ---
 
 # Installing OpenSearch Benchmark

--- a/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
@@ -4,7 +4,7 @@ title: Running distributed loads
 nav_order: 15
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/distributed-load/
+canonical_url: https://docs.opensearch.org/latest/benchmark/distributed-load/
 redirect_to: https://docs.opensearch.org/latest/benchmark/distributed-load/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
@@ -5,6 +5,7 @@ nav_order: 15
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/distributed-load/
+redirect_to: https://docs.opensearch.org/latest/benchmark/distributed-load/
 ---
 
 # Running distributed loads 

--- a/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
@@ -4,7 +4,7 @@ title: Expanding a workload's data corpus
 nav_order: 20
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/expand-data-corpus/
+canonical_url: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 redirect_to: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
@@ -5,6 +5,7 @@ nav_order: 20
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/expand-data-corpus/
+redirect_to: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 ---
 
 # Expanding a workload's data corpus

--- a/_benchmark/user-guide/optimizing-benchmarks/index.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/index.md
@@ -4,7 +4,7 @@ title: Optimizing benchmarks
 nav_order: 25
 parent: User guide
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 redirect_from:
   - /benchmark/user-guide/optimizing-benchmarks/
 redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/

--- a/_benchmark/user-guide/optimizing-benchmarks/index.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/index.md
@@ -7,6 +7,7 @@ has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/index/
 redirect_from:
   - /benchmark/user-guide/optimizing-benchmarks/
+redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 
 # Optimizing benchmarks

--- a/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
@@ -5,7 +5,7 @@ nav_order: 160
 parent: Optimizing benchmarks
 grand_parent: User guide
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/
+canonical_url: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 redirect_to: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
@@ -6,6 +6,7 @@ parent: Optimizing benchmarks
 grand_parent: User guide
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/
+redirect_to: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 ---
 
 # Randomizing queries

--- a/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
@@ -6,7 +6,7 @@ parent: Optimizing benchmarks
 grand_parent: User guide
 redirect_from: 
   - /benchmark/user-guide/target-throughput/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/target-throughput/
+canonical_url: https://docs.opensearch.org/latest/benchmark/target-throughput/
 redirect_to: https://docs.opensearch.org/latest/benchmark/target-throughput/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
@@ -7,6 +7,7 @@ grand_parent: User guide
 redirect_from: 
   - /benchmark/user-guide/target-throughput/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/target-throughput/
+redirect_to: https://docs.opensearch.org/latest/benchmark/target-throughput/
 ---
 
 # Target throughput

--- a/_benchmark/user-guide/understanding-results/index.md
+++ b/_benchmark/user-guide/understanding-results/index.md
@@ -7,6 +7,7 @@ has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/index/
 redirect_from:
   - /benchmark/user-guide/understanding-results/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 After a [running a workload]({{site.url}}{{site.baseurl}}/benchmark/user-guide/working-with-workloads/running-workloads/), OpenSearch Benchmark produces a series of metrics. The following pages details:

--- a/_benchmark/user-guide/understanding-results/index.md
+++ b/_benchmark/user-guide/understanding-results/index.md
@@ -4,7 +4,7 @@ title: Understanding results
 nav_order: 20
 parent: User guide
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 redirect_from:
   - /benchmark/user-guide/understanding-results/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/

--- a/_benchmark/user-guide/understanding-results/summary-reports.md
+++ b/_benchmark/user-guide/understanding-results/summary-reports.md
@@ -4,7 +4,7 @@ title: Summary reports
 nav_order: 22
 grand_parent: User guide
 parent: Understanding results
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/summary-reports/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 

--- a/_benchmark/user-guide/understanding-results/summary-reports.md
+++ b/_benchmark/user-guide/understanding-results/summary-reports.md
@@ -5,6 +5,7 @@ nav_order: 22
 grand_parent: User guide
 parent: Understanding results
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/summary-reports/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 # Understanding the summary report

--- a/_benchmark/user-guide/understanding-results/telemetry.md
+++ b/_benchmark/user-guide/understanding-results/telemetry.md
@@ -7,6 +7,7 @@ parent: Understanding results
 redirect_from: 
   - /benchmark/user-guide/telemetry
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/telemetry/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 
 # Enabling telemetry devices

--- a/_benchmark/user-guide/understanding-results/telemetry.md
+++ b/_benchmark/user-guide/understanding-results/telemetry.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Understanding results
 redirect_from: 
   - /benchmark/user-guide/telemetry
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/telemetry/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 15
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # Anatomy of a workload

--- a/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
@@ -4,7 +4,7 @@ title: Anatomy of a workload
 nav_order: 15
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
@@ -4,7 +4,7 @@ title: Choosing a workload
 nav_order: 20
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
+canonical_url: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 20
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 ---
 
 # Choosing a workload

--- a/_benchmark/user-guide/understanding-workloads/common-operations.md
+++ b/_benchmark/user-guide/understanding-workloads/common-operations.md
@@ -5,6 +5,7 @@ nav_order: 16
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/common-operations/
+redirect_to: https://docs.opensearch.org/latest/benchmark/common-operations/
 ---
 
 # Common operations

--- a/_benchmark/user-guide/understanding-workloads/common-operations.md
+++ b/_benchmark/user-guide/understanding-workloads/common-operations.md
@@ -4,7 +4,7 @@ title: Common operations
 nav_order: 16
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/common-operations/
+canonical_url: https://docs.opensearch.org/latest/benchmark/common-operations/
 redirect_to: https://docs.opensearch.org/latest/benchmark/common-operations/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -4,10 +4,10 @@ title: Understanding workloads
 nav_order: 10
 parent: User guide
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/
-redirect_to: https://docs.opensearch.org/latest/benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # Understanding workloads

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -4,7 +4,7 @@ title: Understanding workloads
 nav_order: 10
 parent: User guide
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -7,6 +7,7 @@ has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 
 # Understanding workloads

--- a/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/contributing-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/contributing-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/contributing-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/contributing-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 ---
 
 # Sharing custom workloads

--- a/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/creating-custom-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 ---
 
 # Creating custom workloads

--- a/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
@@ -8,7 +8,7 @@ redirect_from:
   - /benchmark/user-guide/creating-custom-workloads/
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/creating-custom-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/finetine-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/finetune-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/finetine-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/finetune-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 ---
 
 # Fine-tuning custom workloads

--- a/_benchmark/user-guide/working-with-workloads/index.md
+++ b/_benchmark/user-guide/working-with-workloads/index.md
@@ -4,7 +4,7 @@ title: Working with workloads
 nav_order: 15
 parent: User guide
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/running-workloads/
 redirect_from:
   - /benchmark/user-guide/working-with-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/

--- a/_benchmark/user-guide/working-with-workloads/index.md
+++ b/_benchmark/user-guide/working-with-workloads/index.md
@@ -7,6 +7,7 @@ has_children: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/index/
 redirect_from:
   - /benchmark/user-guide/working-with-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 
 # Working with workloads

--- a/_benchmark/user-guide/working-with-workloads/running-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/running-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/running-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/running-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 
 # Running a workload

--- a/_benchmark/user-guide/working-with-workloads/running-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/running-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/running-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/running-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/running-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 

--- a/_clients/OSC-dot-net.md
+++ b/_clients/OSC-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 10
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OSC-dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/OSC-dot-net/
 ---
 
 # Getting started with the high-level .NET client (OpenSearch.Client)

--- a/_clients/OSC-example.md
+++ b/_clients/OSC-example.md
@@ -5,6 +5,7 @@ nav_order: 12
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OSC-example/
+redirect_to: https://docs.opensearch.org/latest/clients/OSC-example/
 ---
 
 # More advanced features of the high-level .NET client (OpenSearch.Client)

--- a/_clients/OpenSearch-dot-net.md
+++ b/_clients/OpenSearch-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 30
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OpenSearch-dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/OpenSearch-dot-net/
 ---
 
 # Low-level .NET client (OpenSearch.Net)

--- a/_clients/dot-net-conventions.md
+++ b/_clients/dot-net-conventions.md
@@ -5,6 +5,7 @@ nav_order: 20
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/dot-net-conventions/
+redirect_to: https://docs.opensearch.org/latest/clients/dot-net-conventions/
 ---
 
 # .NET client considerations and best practices

--- a/_clients/dot-net.md
+++ b/_clients/dot-net.md
@@ -5,6 +5,7 @@ nav_order: 75
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/clients/dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/dot-net/
 ---
 
 # .NET clients

--- a/_clients/go.md
+++ b/_clients/go.md
@@ -3,6 +3,7 @@ layout: default
 title: Go client
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/clients/go/
+redirect_to: https://docs.opensearch.org/latest/clients/go/
 ---
 
 # Go client

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -8,6 +8,7 @@ permalink: /clients/
 redirect_from:
   - /clients/index/
 canonical_url: https://docs.opensearch.org/latest/clients/
+redirect_to: https://docs.opensearch.org/latest/clients/
 ---
 
 # OpenSearch language clients

--- a/_clients/java-rest-high-level.md
+++ b/_clients/java-rest-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: Java high-level REST client
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/clients/java-rest-high-level/
+redirect_to: https://docs.opensearch.org/latest/clients/java-rest-high-level/
 ---
 
 # Java high-level REST client

--- a/_clients/java.md
+++ b/_clients/java.md
@@ -3,6 +3,7 @@ layout: default
 title: Java client
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/clients/java/
+redirect_to: https://docs.opensearch.org/latest/clients/java/
 ---
 
 # Java client

--- a/_clients/javascript/helpers.md
+++ b/_clients/javascript/helpers.md
@@ -4,6 +4,7 @@ title: Helper methods
 parent: JavaScript client
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/clients/javascript/helpers/
+redirect_to: https://docs.opensearch.org/latest/clients/javascript/helpers/
 ---
 
 # Helper methods

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -6,6 +6,7 @@ nav_order: 40
 redirect_from:
   - /clients/javascript/
 canonical_url: https://docs.opensearch.org/latest/clients/javascript/index/
+redirect_to: https://docs.opensearch.org/latest/clients/javascript/index/
 ---
 
 # JavaScript client

--- a/_clients/opensearch-py-ml.md
+++ b/_clients/opensearch-py-ml.md
@@ -3,6 +3,7 @@ layout: default
 title: Opensearch-py-ml
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/clients/opensearch-py-ml/
+redirect_to: https://docs.opensearch.org/latest/clients/opensearch-py-ml/
 ---
 
 # opensearch-py-ml

--- a/_clients/php.md
+++ b/_clients/php.md
@@ -3,6 +3,7 @@ layout: default
 title: PHP client
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/clients/php/
+redirect_to: https://docs.opensearch.org/latest/clients/php/
 ---
 
 # PHP client

--- a/_clients/python-high-level.md
+++ b/_clients/python-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: High-level Python client
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/clients/python-high-level/
+redirect_to: https://docs.opensearch.org/latest/clients/python-high-level/
 ---
 
 The OpenSearch high-level Python client (`opensearch-dsl-py`) will be deprecated after version 2.1.0. We recommend switching to the [Python client (`opensearch-py`)]({{site.url}}{{site.baseurl}}/clients/python-low-level/), which now includes the functionality of `opensearch-dsl-py`.

--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -5,6 +5,7 @@ nav_order: 10
 redirect_from: 
   - /clients/python/
 canonical_url: https://docs.opensearch.org/latest/clients/python-low-level/
+redirect_to: https://docs.opensearch.org/latest/clients/python-low-level/
 ---
 
 # Low-level Python client

--- a/_clients/ruby.md
+++ b/_clients/ruby.md
@@ -4,6 +4,7 @@ title: Ruby client
 nav_order: 60
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/clients/ruby/
+redirect_to: https://docs.opensearch.org/latest/clients/ruby/
 ---
 
 # Ruby client

--- a/_clients/rust.md
+++ b/_clients/rust.md
@@ -3,6 +3,7 @@ layout: default
 title: Rust client
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/clients/rust/
+redirect_to: https://docs.opensearch.org/latest/clients/rust/
 ---
 
 # Rust client

--- a/_dashboards/dev-tools/index-dev.md
+++ b/_dashboards/dev-tools/index-dev.md
@@ -3,7 +3,7 @@ layout: default
 title: Dev Tools
 nav_order: 120
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index-dev/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index/
 redirect_from:
   - /dashboards/discover/run-queries/
   - /dashboards/run-queries/

--- a/_dashboards/dev-tools/run-queries.md
+++ b/_dashboards/dev-tools/run-queries.md
@@ -5,7 +5,7 @@ parent: Dev Tools
 nav_order: 10
 redirect_from:
   - /dashboards/run-queries/
-canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/run-queries/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index/
 ---
 
 # Running queries in the Dev Tools console

--- a/_dashboards/quickstart.md
+++ b/_dashboards/quickstart.md
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/browser-compatibility/
   - /dashboards/getting-started/
   - /dashboards/getting-started/index/
-canonical_url: https://docs.opensearch.org/latest/dashboards/quickstart/
+canonical_url: https://docs.opensearch.org/latest/dashboards/getting-started/index/
 ---
 
 # OpenSearch Dashboards quickstart guide

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -3,7 +3,7 @@ layout: default
 title: Area charts
 parent: Building data visualizations
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/area/
 redirect_from:
   - /dashboards/visualize/visualize-app/area/
 ---

--- a/_dashboards/visualize/gantt.md
+++ b/_dashboards/visualize/gantt.md
@@ -5,7 +5,7 @@ parent: Building data visualizations
 nav_order: 30
 redirect_from:
   - /dashboards/gantt/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/gantt/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/index/
 ---
 
 # Gantt charts

--- a/_dashboards/visualize/geojson-regionmaps.md
+++ b/_dashboards/visualize/geojson-regionmaps.md
@@ -8,7 +8,7 @@ redirect_from:
   - /dashboards/geojson-regionmaps/
   - /dashboards/visualize/region-maps/
   - /dashboards/visualize/visualize-app/region-maps/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/geojson-regionmaps/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/region-maps/
 ---
 
 # Using coordinate and region maps

--- a/_dashboards/visualize/maps-stats-api.md
+++ b/_dashboards/visualize/maps-stats-api.md
@@ -5,7 +5,7 @@ nav_order: 20
 grand_parent: Building data visualizations
 parent: Coordinate and region maps 
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps-stats-api/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maps-stats-api/
 redirect_from:
   - /dashboards/visualize/visualize-app/maps-stats-api/
 ---

--- a/_dashboards/visualize/maps.md
+++ b/_dashboards/visualize/maps.md
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/maps/
   - /dashboards/maps/
   - /dashboards/visualize/visualize-app/maps/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maps/
 ---
 
 # Using maps 

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -7,7 +7,7 @@ nav_order: 30
 redirect_from:
   - /dashboards/maptiles/
   - /dashboards/visualize/visualize-app/maptiles/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maptiles/
 ---
 
 {%- comment -%}The `/docs/opensearch-dashboards/maptiles/` redirect is specifically to support the UI links in OpenSearch Dashboards 1.0.0.{%- endcomment -%}

--- a/_dashboards/visualize/selfhost-maps-server.md
+++ b/_dashboards/visualize/selfhost-maps-server.md
@@ -7,7 +7,7 @@ nav_order: 40
 redirect_from:
   - /dashboards/selfhost-maps-server/
   - /dashboards/visualize/visualize-app/selfhost-maps-server/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/selfhost-maps-server/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/selfhost-maps-server/
 ---
 
 # Using self-hosted map servers

--- a/_dashboards/visualize/tsvb.md
+++ b/_dashboards/visualize/tsvb.md
@@ -3,7 +3,7 @@ layout: default
 title: TSVB
 parent: Building data visualizations
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/tsvb/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/tsvb/
 redirect_from:
   - /dashboards/visualize/visualize-app/tsvb/
 ---

--- a/_dashboards/visualize/vega.md
+++ b/_dashboards/visualize/vega.md
@@ -3,7 +3,7 @@ layout: default
 title: Vega
 parent: Building data visualizations
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/vega/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/vega/
 redirect_from:
   - /dashboards/visualize/visualize-app/vega/
 ---

--- a/_dashboards/visualize/visbuilder.md
+++ b/_dashboards/visualize/visbuilder.md
@@ -6,7 +6,7 @@ nav_order: 100
 redirect_from:
   - /dashboards/drag-drop-wizard/
   - /dashboards/visualize/visualize-app/visbuilder/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visbuilder/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/visbuilder/
 ---
 
 # VisBuilder

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -3,7 +3,7 @@ layout: default
 title: Building data visualizations
 nav_order: 40
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/index/
 redirect_from:
   - /dashboards/visualize/visualize-app/
   - /dashboards/visualize/visualize-app/index/

--- a/_data-prepper/common-use-cases/anomaly-detection.md
+++ b/_data-prepper/common-use-cases/anomaly-detection.md
@@ -4,6 +4,7 @@ title: Anomaly detection
 parent: Common use cases
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/anomaly-detection/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/anomaly-detection/
 ---
 
 # Anomaly detection

--- a/_data-prepper/common-use-cases/codec-processor-combinations.md
+++ b/_data-prepper/common-use-cases/codec-processor-combinations.md
@@ -4,6 +4,7 @@ title: Codec processor combinations
 parent: Common use cases
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/codec-processor-combinations/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/codec-processor-combinations/
 ---
 
 # Codec processor combinations

--- a/_data-prepper/common-use-cases/common-use-cases.md
+++ b/_data-prepper/common-use-cases/common-use-cases.md
@@ -6,6 +6,7 @@ nav_order: 15
 redirect_from: 
   - /data-prepper/common-use-cases/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/common-use-cases/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/common-use-cases/
 ---
 
 # Common use cases

--- a/_data-prepper/common-use-cases/event-aggregation.md
+++ b/_data-prepper/common-use-cases/event-aggregation.md
@@ -4,6 +4,7 @@ title: Event aggregation
 parent: Common use cases
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/event-aggregation/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/event-aggregation/
 ---
 
 # Event aggregation

--- a/_data-prepper/common-use-cases/log-analytics.md
+++ b/_data-prepper/common-use-cases/log-analytics.md
@@ -4,6 +4,7 @@ title: Log analytics
 parent: Common use cases
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-analytics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-analytics/
 ---
 
 # Log analytics

--- a/_data-prepper/common-use-cases/log-enrichment.md
+++ b/_data-prepper/common-use-cases/log-enrichment.md
@@ -4,6 +4,7 @@ title: Log enrichment
 parent: Common use cases
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-enrichment/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-enrichment/
 ---
 
 # Log enrichment

--- a/_data-prepper/common-use-cases/metrics-logs.md
+++ b/_data-prepper/common-use-cases/metrics-logs.md
@@ -4,6 +4,7 @@ title: Deriving metrics from logs
 parent: Common use cases
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-logs/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-logs/
 ---
 
 # Deriving metrics from logs

--- a/_data-prepper/common-use-cases/metrics-traces.md
+++ b/_data-prepper/common-use-cases/metrics-traces.md
@@ -4,6 +4,7 @@ title: Deriving metrics from traces
 parent: Common use cases
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-traces/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-traces/
 ---
 
 # Deriving metrics from traces

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -4,6 +4,7 @@ title: S3 logs
 parent: Common use cases
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/s3-logs/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/s3-logs/
 ---
 
 # S3 logs

--- a/_data-prepper/common-use-cases/sampling.md
+++ b/_data-prepper/common-use-cases/sampling.md
@@ -4,6 +4,7 @@ title: Sampling
 parent: Common use cases
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/sampling/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/sampling/
 ---
 
 # Sampling

--- a/_data-prepper/common-use-cases/text-processing.md
+++ b/_data-prepper/common-use-cases/text-processing.md
@@ -4,6 +4,7 @@ title: Text processing
 parent: Common use cases
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/text-processing/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/text-processing/
 ---
 
 # Text processing

--- a/_data-prepper/common-use-cases/trace-analytics.md
+++ b/_data-prepper/common-use-cases/trace-analytics.md
@@ -4,6 +4,7 @@ title: Trace analytics
 parent: Common use cases
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/trace-analytics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/trace-analytics/
 ---
 
 # Trace analytics

--- a/_data-prepper/getting-started.md
+++ b/_data-prepper/getting-started.md
@@ -5,6 +5,7 @@ nav_order: 5
 redirect_from:
   - /clients/data-prepper/get-started/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/getting-started/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/getting-started/
 ---
 
 # Getting started with OpenSearch Data Prepper

--- a/_data-prepper/index.md
+++ b/_data-prepper/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /monitoring-plugins/trace/data-prepper/
   - /data-prepper/index/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 
 # OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/configuring-data-prepper.md
@@ -7,6 +7,7 @@ redirect_from:
   - /clients/data-prepper/data-prepper-reference/
   - /monitoring-plugins/trace/data-prepper-reference/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
 ---
 
 # Configuring OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-log4j.md
+++ b/_data-prepper/managing-data-prepper/configuring-log4j.md
@@ -4,6 +4,7 @@ title: Configuring Log4j
 parent: Managing OpenSearch Data Prepper
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-log4j/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-log4j/
 ---
 
 # Configuring Log4j

--- a/_data-prepper/managing-data-prepper/core-apis.md
+++ b/_data-prepper/managing-data-prepper/core-apis.md
@@ -4,6 +4,7 @@ title: Core APIs
 parent: Managing OpenSearch Data Prepper
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/core-apis/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/core-apis/
 ---
 
 # Core APIs

--- a/_data-prepper/managing-data-prepper/extensions/extensions.md
+++ b/_data-prepper/managing-data-prepper/extensions/extensions.md
@@ -5,6 +5,7 @@ parent: Managing OpenSearch Data Prepper
 has_children: true
 nav_order: 18
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/extensions/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/extensions/
 ---
 
 # Extensions

--- a/_data-prepper/managing-data-prepper/extensions/geoip-service.md
+++ b/_data-prepper/managing-data-prepper/extensions/geoip-service.md
@@ -5,6 +5,7 @@ nav_order: 5
 parent: Extensions
 grand_parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/geoip-service/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/geoip-service/
 ---
 
 # geoip_service

--- a/_data-prepper/managing-data-prepper/managing-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/managing-data-prepper.md
@@ -4,6 +4,7 @@ title: Managing OpenSearch Data Prepper
 has_children: true
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/managing-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/managing-data-prepper/
 ---
 
 # Managing OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/monitoring.md
+++ b/_data-prepper/managing-data-prepper/monitoring.md
@@ -4,6 +4,7 @@ title: Monitoring
 parent: Managing OpenSearch Data Prepper
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/monitoring/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/monitoring/
 ---
  
 # Monitoring OpenSearch Data Prepper with metrics

--- a/_data-prepper/managing-data-prepper/peer-forwarder.md
+++ b/_data-prepper/managing-data-prepper/peer-forwarder.md
@@ -4,6 +4,7 @@ title: Peer forwarder
 nav_order: 12
 parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/peer-forwarder/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/peer-forwarder/
 ---
 
 # Peer forwarder

--- a/_data-prepper/managing-data-prepper/source-coordination.md
+++ b/_data-prepper/managing-data-prepper/source-coordination.md
@@ -4,6 +4,7 @@ title: Source coordination
 nav_order: 35
 parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/source-coordination/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/source-coordination/
 ---
 
 # Source coordination

--- a/_data-prepper/migrate-open-distro.md
+++ b/_data-prepper/migrate-open-distro.md
@@ -5,6 +5,7 @@ nav_order: 30
 redirect_from:
   - /clients/data-prepper/migrate-open-distro/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/migrate-open-distro/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/migrate-open-distro/
 ---
 
 # Migrating from Open Distro

--- a/_data-prepper/migrating-from-logstash-data-prepper.md
+++ b/_data-prepper/migrating-from-logstash-data-prepper.md
@@ -5,7 +5,7 @@ nav_order: 25
 redirect_from: 
   - /clients/data-prepper/configure-logstash-data-prepper/
   - /data-prepper/configure-logstash-data-prepper/
-canonical_url: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 

--- a/_data-prepper/migrating-from-logstash-data-prepper.md
+++ b/_data-prepper/migrating-from-logstash-data-prepper.md
@@ -6,6 +6,7 @@ redirect_from:
   - /clients/data-prepper/configure-logstash-data-prepper/
   - /data-prepper/configure-logstash-data-prepper/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 
 # Migrating from Logstash

--- a/_data-prepper/pipelines/cidrcontains.md
+++ b/_data-prepper/pipelines/cidrcontains.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/cidrcontains/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/cidrcontains/
 ---
 
 # cidrContains()

--- a/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
+++ b/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
 ---
 
 # Bounded blocking

--- a/_data-prepper/pipelines/configuration/buffers/buffers.md
+++ b/_data-prepper/pipelines/configuration/buffers/buffers.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/buffers/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/buffers/
 ---
 
 # Buffers

--- a/_data-prepper/pipelines/configuration/buffers/kafka.md
+++ b/_data-prepper/pipelines/configuration/buffers/kafka.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/kafka/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/kafka/
 ---
 
 # kafka

--- a/_data-prepper/pipelines/configuration/processors/add-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/add-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/add-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/add-entries/
 ---
 
 # add_entries

--- a/_data-prepper/pipelines/configuration/processors/aggregate.md
+++ b/_data-prepper/pipelines/configuration/processors/aggregate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 41
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aggregate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aggregate/
 ---
 
 # aggregate

--- a/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
+++ b/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
 ---
 
 # anomaly_detector

--- a/_data-prepper/pipelines/configuration/processors/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/processors/aws-lambda.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aws-lambda/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aws-lambda/
 ---
 
 # aws_lambda integration for OpenSearch Data Prepper

--- a/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
+++ b/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 47
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/convert-entry-type/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/convert-entry-type/
 ---
 
 # convert_entry_type

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 48
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/copy-values/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/copy-values/
 ---
 
 # copy_values

--- a/_data-prepper/pipelines/configuration/processors/csv.md
+++ b/_data-prepper/pipelines/configuration/processors/csv.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 49
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/csv/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/csv/
 ---
 
 # csv

--- a/_data-prepper/pipelines/configuration/processors/date.md
+++ b/_data-prepper/pipelines/configuration/processors/date.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/date/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/date/
 ---
 
 # date

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/decompress/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/decompress/
 ---
 
 # decompress

--- a/_data-prepper/pipelines/configuration/processors/delay.md
+++ b/_data-prepper/pipelines/configuration/processors/delay.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 41
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delay/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delay/
 ---
 
 # delay

--- a/_data-prepper/pipelines/configuration/processors/delete-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/delete-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 43
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delete-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delete-entries/
 ---
 
 # delete_entries

--- a/_data-prepper/pipelines/configuration/processors/dissect.md
+++ b/_data-prepper/pipelines/configuration/processors/dissect.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/dissect/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/dissect/
 ---
 
 # dissect

--- a/_data-prepper/pipelines/configuration/processors/drop-events.md
+++ b/_data-prepper/pipelines/configuration/processors/drop-events.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 46
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/drop-events/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/drop-events/
 ---
 
 # drop_events

--- a/_data-prepper/pipelines/configuration/processors/flatten.md
+++ b/_data-prepper/pipelines/configuration/processors/flatten.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 48
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/flatten/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/flatten/
 ---
 
 # flatten

--- a/_data-prepper/pipelines/configuration/processors/geoip.md
+++ b/_data-prepper/pipelines/configuration/processors/geoip.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 49
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/geoip/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/geoip/
 ---
 
 # geoip

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/grok/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/grok/
 ---
 
 # Grok

--- a/_data-prepper/pipelines/configuration/processors/key-value.md
+++ b/_data-prepper/pipelines/configuration/processors/key-value.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 56
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/key-value/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/key-value/
 ---
 
 # key_value

--- a/_data-prepper/pipelines/configuration/processors/list-to-map.md
+++ b/_data-prepper/pipelines/configuration/processors/list-to-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 58
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/list-to-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/list-to-map/
 ---
 
 # list_to_map

--- a/_data-prepper/pipelines/configuration/processors/lowercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/lowercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
 ---
 
 # lowercase_string

--- a/_data-prepper/pipelines/configuration/processors/map-to-list.md
+++ b/_data-prepper/pipelines/configuration/processors/map-to-list.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 63
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/map-to-list/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/map-to-list/
 ---
 
 # map_to_list

--- a/_data-prepper/pipelines/configuration/processors/mutate-event.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-event.md
@@ -4,7 +4,7 @@ title: Mutate event
 parent: Processors
 grand_parent: Pipelines
 nav_order: 65
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-event/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 redirect_from:
   - /data-prepper/pipelines/configuration/processors/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/

--- a/_data-prepper/pipelines/configuration/processors/mutate-event.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-event.md
@@ -7,6 +7,7 @@ nav_order: 65
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-event/
 redirect_from:
   - /data-prepper/pipelines/configuration/processors/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 ---
 
 # Mutate event processors

--- a/_data-prepper/pipelines/configuration/processors/mutate-string.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-string.md
@@ -4,7 +4,7 @@ title: Mutate string
 parent: Processors
 grand_parent: Pipelines
 nav_order: 70
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-string/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 ---
 

--- a/_data-prepper/pipelines/configuration/processors/mutate-string.md
+++ b/_data-prepper/pipelines/configuration/processors/mutate-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/mutate-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 ---
 
 # Mutate string processors

--- a/_data-prepper/pipelines/configuration/processors/obfuscate.md
+++ b/_data-prepper/pipelines/configuration/processors/obfuscate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 71
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/obfuscate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/obfuscate/
 ---
 
 # obfuscate

--- a/_data-prepper/pipelines/configuration/processors/otel-metrics.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-metrics.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 72
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
 ---
 
 # otel_metrics 

--- a/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 73
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
 ---
 
 # otel_trace_group 

--- a/_data-prepper/pipelines/configuration/processors/otel-traces.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-traces.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 75
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
 ---
 
 # otel_trace

--- a/_data-prepper/pipelines/configuration/processors/parse-ion.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-ion.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 79
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-ion/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-ion/
 ---
 
 # parse_ion

--- a/_data-prepper/pipelines/configuration/processors/parse-json.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-json.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-json/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-json/
 ---
 
 # parse_json

--- a/_data-prepper/pipelines/configuration/processors/parse-xml.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-xml.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 83
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-xml/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-xml/
 ---
 
 # parse_xml

--- a/_data-prepper/pipelines/configuration/processors/processors.md
+++ b/_data-prepper/pipelines/configuration/processors/processors.md
@@ -5,6 +5,7 @@ has_children: true
 parent: Pipelines
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 ---
 
 # Processors

--- a/_data-prepper/pipelines/configuration/processors/rename-keys.md
+++ b/_data-prepper/pipelines/configuration/processors/rename-keys.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 85
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/rename-keys/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/rename-keys/
 ---
 
 # rename_keys

--- a/_data-prepper/pipelines/configuration/processors/routes.md
+++ b/_data-prepper/pipelines/configuration/processors/routes.md
@@ -4,8 +4,8 @@ title: routes
 parent: Processors
 grand_parent: Pipelines
 nav_order: 90
-canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/routes/
-redirect_to: https://docs.opensearch.org/latest/data-prepper/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
 ---
 
 # Routes

--- a/_data-prepper/pipelines/configuration/processors/routes.md
+++ b/_data-prepper/pipelines/configuration/processors/routes.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/routes/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 
 # Routes

--- a/_data-prepper/pipelines/configuration/processors/select-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/select-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 59
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/select-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/select-entries/
 ---
 
 # select_entries

--- a/_data-prepper/pipelines/configuration/processors/service-map.md
+++ b/_data-prepper/pipelines/configuration/processors/service-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 95
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
 ---
 
 # service_map

--- a/_data-prepper/pipelines/configuration/processors/split-event.md
+++ b/_data-prepper/pipelines/configuration/processors/split-event.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 96
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-event/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-event/
 ---
 
 # split-event

--- a/_data-prepper/pipelines/configuration/processors/split-string.md
+++ b/_data-prepper/pipelines/configuration/processors/split-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-string/
 ---
 
 # split_string

--- a/_data-prepper/pipelines/configuration/processors/string-converter.md
+++ b/_data-prepper/pipelines/configuration/processors/string-converter.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 105
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/string-converter/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/string-converter/
 ---
 
 # string_converter

--- a/_data-prepper/pipelines/configuration/processors/substitute-string.md
+++ b/_data-prepper/pipelines/configuration/processors/substitute-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/substitute-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/substitute-string/
 ---
 
 # substitute_string

--- a/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
+++ b/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 115
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
 ---
 
 # trace peer forwarder

--- a/_data-prepper/pipelines/configuration/processors/translate.md
+++ b/_data-prepper/pipelines/configuration/processors/translate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 117
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/translate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/translate/
 ---
 
 # translate

--- a/_data-prepper/pipelines/configuration/processors/trim-string.md
+++ b/_data-prepper/pipelines/configuration/processors/trim-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 120
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trim-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trim-string/
 ---
 
 # trim_string

--- a/_data-prepper/pipelines/configuration/processors/truncate.md
+++ b/_data-prepper/pipelines/configuration/processors/truncate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 121
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/truncate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/truncate/
 ---
 
 # truncate

--- a/_data-prepper/pipelines/configuration/processors/uppercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/uppercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 125
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
 ---
 
 # uppercase_string

--- a/_data-prepper/pipelines/configuration/processors/user-agent.md
+++ b/_data-prepper/pipelines/configuration/processors/user-agent.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 130
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/user-agent/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/user-agent/
 ---
 
 # user_agent

--- a/_data-prepper/pipelines/configuration/processors/write-json.md
+++ b/_data-prepper/pipelines/configuration/processors/write-json.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 56
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/write-json/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/write-json/
 ---
 
 # write_json

--- a/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/aws-lambda/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/aws-lambda/
 ---
 
 ----------------------------------------------------------------------------------------

--- a/_data-prepper/pipelines/configuration/sinks/file.md
+++ b/_data-prepper/pipelines/configuration/sinks/file.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/file/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/file/
 ---
 
 # file

--- a/_data-prepper/pipelines/configuration/sinks/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sinks/opensearch.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/opensearch/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/opensearch/
 ---
 
 # opensearch

--- a/_data-prepper/pipelines/configuration/sinks/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sinks/pipeline.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/pipeline/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/pipeline/
 ---
 
 # pipeline

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/s3/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/s3/
 ---
 
 # s3

--- a/_data-prepper/pipelines/configuration/sinks/sinks.md
+++ b/_data-prepper/pipelines/configuration/sinks/sinks.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
 ---
 
 # Sinks

--- a/_data-prepper/pipelines/configuration/sinks/stdout.md
+++ b/_data-prepper/pipelines/configuration/sinks/stdout.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/stdout/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/stdout/
 ---
 
 # stdout sink

--- a/_data-prepper/pipelines/configuration/sources/documentdb.md
+++ b/_data-prepper/pipelines/configuration/sources/documentdb.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/documentdb/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/documentdb/
 ---
 
 # documentdb

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
 ---
 
 # dynamodb

--- a/_data-prepper/pipelines/configuration/sources/http.md
+++ b/_data-prepper/pipelines/configuration/sources/http.md
@@ -7,6 +7,7 @@ nav_order: 30
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/http-source/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http/
 ---
 
 # http

--- a/_data-prepper/pipelines/configuration/sources/kafka.md
+++ b/_data-prepper/pipelines/configuration/sources/kafka.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kafka/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kafka/
 ---
 
 # kafka

--- a/_data-prepper/pipelines/configuration/sources/kinesis.md
+++ b/_data-prepper/pipelines/configuration/sources/kinesis.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kinesis/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kinesis/
 ---
 
 # kinesis

--- a/_data-prepper/pipelines/configuration/sources/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sources/opensearch.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/
 ---
 
 # opensearch

--- a/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
 ---
 
 # otel_logs_source

--- a/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
 ---
 
 # otel_metrics_source

--- a/_data-prepper/pipelines/configuration/sources/otel-trace-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-trace-source.md
@@ -7,6 +7,7 @@ nav_order: 80
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/otel-trace/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
 ---
 
 

--- a/_data-prepper/pipelines/configuration/sources/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sources/pipeline.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/pipeline/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/pipeline/
 ---
 
 # pipeline

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/s3/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/s3/
 ---
 
 # s3 source

--- a/_data-prepper/pipelines/configuration/sources/sources.md
+++ b/_data-prepper/pipelines/configuration/sources/sources.md
@@ -7,6 +7,7 @@ nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/sources/
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/sources/
 ---
 
 # Sources

--- a/_data-prepper/pipelines/contains.md
+++ b/_data-prepper/pipelines/contains.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/contains/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/contains/
 ---
 
 # contains()

--- a/_data-prepper/pipelines/dlq.md
+++ b/_data-prepper/pipelines/dlq.md
@@ -4,6 +4,7 @@ title: Dead-letter queues
 parent: Pipelines
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/dlq/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/dlq/
 ---
 
 # Dead-letter queues

--- a/_data-prepper/pipelines/expression-syntax.md
+++ b/_data-prepper/pipelines/expression-syntax.md
@@ -4,6 +4,7 @@ title: Expression syntax
 parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/expression-syntax/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/expression-syntax/
 ---
 
 # Expression syntax  

--- a/_data-prepper/pipelines/functions.md
+++ b/_data-prepper/pipelines/functions.md
@@ -5,6 +5,7 @@ parent: Pipelines
 nav_order: 10
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/functions/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/functions/
 ---
 
 # Functions

--- a/_data-prepper/pipelines/get-metadata.md
+++ b/_data-prepper/pipelines/get-metadata.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/get-metadata/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/get-metadata/
 ---
 
 # getMetadata()

--- a/_data-prepper/pipelines/has-tags.md
+++ b/_data-prepper/pipelines/has-tags.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/has-tags/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/has-tags/
 ---
 
 # hasTags()

--- a/_data-prepper/pipelines/join.md
+++ b/_data-prepper/pipelines/join.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/join/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/join/
 ---
 
 # join()

--- a/_data-prepper/pipelines/length.md
+++ b/_data-prepper/pipelines/length.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/length/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/length/
 ---
 
 # length()

--- a/_data-prepper/pipelines/pipelines.md
+++ b/_data-prepper/pipelines/pipelines.md
@@ -7,6 +7,7 @@ redirect_from:
   - /data-prepper/pipelines/
   - /clients/data-prepper/pipelines/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
 ---
 
 # Pipelines

--- a/_field-types/mapping-parameters/analyzer.md
+++ b/_field-types/mapping-parameters/analyzer.md
@@ -6,7 +6,7 @@ grand_parent: Mapping and field types
 nav_order: 5
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/analyzer/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/analyzer/
 redirect_from:
   - /mappings/mapping-parameters/analyzer/
 ---

--- a/_field-types/mapping-parameters/boost.md
+++ b/_field-types/mapping-parameters/boost.md
@@ -6,7 +6,7 @@ grand_parent: Mapping and field types
 nav_order: 10
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/boost/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/boost/
 redirect_from:
   - /mappings/mapping-parameters/boost/
 ---

--- a/_field-types/mapping-parameters/coerce.md
+++ b/_field-types/mapping-parameters/coerce.md
@@ -6,7 +6,7 @@ grand_parent: Mapping and field types
 nav_order: 15
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/coerce/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/coerce/
 redirect_from:
   - /mappings/mapping-parameters/coerce/
 ---

--- a/_field-types/mapping-parameters/copy-to.md
+++ b/_field-types/mapping-parameters/copy-to.md
@@ -6,7 +6,7 @@ grand_parent: Mapping and field types
 nav_order: 20
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/copy-to/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/copy-to/
 redirect_from:
   - /mappings/mapping-parameters/copy-to/
 ---

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -6,7 +6,7 @@ grand_parent: Mapping and field types
 nav_order: 25
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/doc-values/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/doc-values/
 redirect_from:
   - /mappings/mapping-parameters/doc-values/
 ---

--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -10,7 +10,7 @@ redirect_from:
   - /opensearch/dynamic/
   - /field-types/dynamic/
   - /mappings/mapping-parameters/dynamic/
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/dynamic/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/dynamic/
 ---
 
 # Dynamic

--- a/_field-types/mapping-parameters/enabled.md
+++ b/_field-types/mapping-parameters/enabled.md
@@ -6,7 +6,7 @@ grand_parent: Mapping and field types
 nav_order: 40
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/enabled/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/enabled/
 redirect_from:
   - /mappings/mapping-parameters/enabled/
 ---

--- a/_field-types/mapping-parameters/index.md
+++ b/_field-types/mapping-parameters/index.md
@@ -4,7 +4,7 @@ title: Mapping parameters
 nav_order: 75
 has_children: true
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/index/
 redirect_from:
   - /field-types/mapping-parameters/
   - /mappings/mapping-parameters/

--- a/_field-types/mappings-use-cases.md
+++ b/_field-types/mappings-use-cases.md
@@ -4,7 +4,7 @@ title: Mappings use cases
 parent: Mappings and fields types
 nav_order: 5
 nav_exclude: true
-canonical_url: https://docs.opensearch.org/latest/field-types/mappings-use-cases/
+canonical_url: https://docs.opensearch.org/latest/mappings/
 ---
 
 # Mappings use cases

--- a/_field-types/metadata-fields/field-names.md
+++ b/_field-types/metadata-fields/field-names.md
@@ -3,7 +3,7 @@ layout: default
 title: Field names
 nav_order: 10
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/field-names/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/field-names/
 redirect_from:
   - /mappings/metadata-fields/field-names/
 ---

--- a/_field-types/metadata-fields/id.md
+++ b/_field-types/metadata-fields/id.md
@@ -3,7 +3,7 @@ layout: default
 title: ID
 nav_order: 20
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/id/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/id/
 redirect_from:
   - /mappings/metadata-fields/id/
 ---

--- a/_field-types/metadata-fields/ignored.md
+++ b/_field-types/metadata-fields/ignored.md
@@ -3,7 +3,7 @@ layout: default
 title: Ignored
 nav_order: 25
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/ignored/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/ignored/
 redirect_from:
   - /mappings/metadata-fields/ignored/
 ---

--- a/_field-types/metadata-fields/index-metadata.md
+++ b/_field-types/metadata-fields/index-metadata.md
@@ -3,7 +3,7 @@ layout: default
 title: Index
 nav_order: 25
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/index-metadata/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/index-metadata/
 redirect_from:
   - /mappings/metadata-fields/index-metadata/
 ---

--- a/_field-types/metadata-fields/index.md
+++ b/_field-types/metadata-fields/index.md
@@ -4,7 +4,7 @@ title: Metadata fields
 nav_order: 90
 has_children: true
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/index/
 redirect_from:
   - /field-types/metadata-fields/
   - /mappings/metadata-fields/

--- a/_field-types/metadata-fields/meta.md
+++ b/_field-types/metadata-fields/meta.md
@@ -3,7 +3,7 @@ layout: default
 title: Meta
 nav_order: 30
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/meta/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/meta/
 redirect_from:
   - /mappings/metadata-fields/meta/
 ---

--- a/_field-types/metadata-fields/routing.md
+++ b/_field-types/metadata-fields/routing.md
@@ -3,7 +3,7 @@ layout: default
 title: Routing
 nav_order: 35
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/routing/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/routing/
 redirect_from:
   - /mappings/metadata-fields/routing/
 ---

--- a/_field-types/metadata-fields/source.md
+++ b/_field-types/metadata-fields/source.md
@@ -3,7 +3,7 @@ layout: default
 title: Source
 nav_order: 40
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/source/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/source/
 redirect_from:
   - /mappings/metadata-fields/source/
 ---

--- a/_field-types/supported-field-types/alias.md
+++ b/_field-types/supported-field-types/alias.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/alias/
   - /field-types/alias/
   - /mappings/supported-field-types/alias/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/alias/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/
 ---
 
 # Alias field type

--- a/_field-types/supported-field-types/autocomplete.md
+++ b/_field-types/supported-field-types/autocomplete.md
@@ -8,7 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/autocomplete/
   - /field-types/autocomplete/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/autocomplete/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/autocomplete/
 ---
 
 # Autocomplete field types

--- a/_field-types/supported-field-types/binary.md
+++ b/_field-types/supported-field-types/binary.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/binary/
   - /field-types/binary/
   - /mappings/supported-field-types/binary/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/binary/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/binary/
 ---
 
 # Binary field type

--- a/_field-types/supported-field-types/boolean.md
+++ b/_field-types/supported-field-types/boolean.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/boolean/
   - /field-types/boolean/
   - /mappings/supported-field-types/boolean/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/boolean/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/boolean/
 ---
 
 # Boolean field type

--- a/_field-types/supported-field-types/completion.md
+++ b/_field-types/supported-field-types/completion.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/completion/
   - /field-types/completion/
   - /mappings/supported-field-types/completion/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/completion/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/completion/
 ---
 
 # Completion field type

--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -5,7 +5,7 @@ nav_order: 71
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/constant-keyword/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/constant-keyword/
 redirect_from:
   - /mappings/supported-field-types/constant-keyword/
 ---

--- a/_field-types/supported-field-types/date-nanos.md
+++ b/_field-types/supported-field-types/date-nanos.md
@@ -5,7 +5,7 @@ nav_order: 35
 has_children: false
 parent: Date field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date-nanos/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/date-nanos/
 redirect_from:
   - /mappings/supported-field-types/date-nanos/
 ---

--- a/_field-types/supported-field-types/date.md
+++ b/_field-types/supported-field-types/date.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/date/
   - /field-types/date/
   - /mappings/supported-field-types/date/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/date/
 ---
 
 # Date field type

--- a/_field-types/supported-field-types/dates.md
+++ b/_field-types/supported-field-types/dates.md
@@ -5,7 +5,7 @@ nav_order: 25
 has_children: true
 has_toc: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/dates/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/dates/
 redirect_from:
   - /mappings/supported-field-types/dates/
 ---

--- a/_field-types/supported-field-types/derived.md
+++ b/_field-types/supported-field-types/derived.md
@@ -4,7 +4,7 @@ title: Derived
 nav_order: 62
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/derived/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/derived/
 redirect_from:
   - /mappings/supported-field-types/derived/
 ---

--- a/_field-types/supported-field-types/flat-object.md
+++ b/_field-types/supported-field-types/flat-object.md
@@ -8,7 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /field-types/flat-object/
   - /mappings/supported-field-types/flat-object/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/flat-object/
 ---
 
 # Flat object field type

--- a/_field-types/supported-field-types/geo-point.md
+++ b/_field-types/supported-field-types/geo-point.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geo-point/
   - /field-types/geo-point/
   - /mappings/supported-field-types/geo-point/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-point/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-point/
 ---
 
 # Geopoint field type

--- a/_field-types/supported-field-types/geo-shape.md
+++ b/_field-types/supported-field-types/geo-shape.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geo-shape/
   - /field-types/geo-shape/
   - /mappings/supported-field-types/geo-shape/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-shape/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-shape/
 ---
 
 # Geoshape field type

--- a/_field-types/supported-field-types/geographic.md
+++ b/_field-types/supported-field-types/geographic.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geographic/
   - /field-types/geographic/
   - /mappings/supported-field-types/geographic/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geographic/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geographic/
 ---
 
 # Geographic field types

--- a/_field-types/supported-field-types/index.md
+++ b/_field-types/supported-field-types/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /field-types/supported-field-types/
   - /mappings/supported-field-types/
   - /mappings/supported-field-types/index/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/index/
 ---
 
 # Supported field types

--- a/_field-types/supported-field-types/ip.md
+++ b/_field-types/supported-field-types/ip.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/ip/
   - /field-types/ip/
   - /mappings/supported-field-types/ip/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/ip/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/ip/
 ---
 
 # IP address field type

--- a/_field-types/supported-field-types/join.md
+++ b/_field-types/supported-field-types/join.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/join/
   - /field-types/join/
   - /mappings/supported-field-types/join/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/join/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/join/
 ---
 
 # Join field type

--- a/_field-types/supported-field-types/keyword.md
+++ b/_field-types/supported-field-types/keyword.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/keyword/
   - /field-types/keyword/
   - /mappings/supported-field-types/keyword/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/keyword/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/keyword/
 ---
 
 # Keyword field type

--- a/_field-types/supported-field-types/knn-vector.md
+++ b/_field-types/supported-field-types/knn-vector.md
@@ -5,7 +5,7 @@ nav_order: 58
 has_children: false
 parent: Supported field types
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/knn-vector/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/knn-vector/
 redirect_from:
   - /mappings/supported-field-types/knn-vector/
   - /mappings/supported-field-types/vector-field-types/

--- a/_field-types/supported-field-types/match-only-text.md
+++ b/_field-types/supported-field-types/match-only-text.md
@@ -5,7 +5,7 @@ nav_order: 61
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/match-only-text/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/match-only-text/
 redirect_from:
   - /mappings/supported-field-types/match-only-text/
 ---

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/nested/
   - /field-types/nested/
   - /mappings/supported-field-types/nested/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/nested/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/nested/
 ---
 
 # Nested field type

--- a/_field-types/supported-field-types/numeric.md
+++ b/_field-types/supported-field-types/numeric.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/numeric/
   - /field-types/numeric/
   - /mappings/supported-field-types/numeric/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/numeric/
 ---
 
 # Numeric field types

--- a/_field-types/supported-field-types/object-fields.md
+++ b/_field-types/supported-field-types/object-fields.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/object-fields/
   - /field-types/object-fields/
   - /mappings/supported-field-types/object-fields/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object-fields/
 ---
 
 # Object field types

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/object/
   - /field-types/object/
   - /mappings/supported-field-types/object/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object/
 ---
 
 # Object field type

--- a/_field-types/supported-field-types/percolator.md
+++ b/_field-types/supported-field-types/percolator.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/percolator/
   - /field-types/percolator/
   - /mappings/supported-field-types/percolator/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/percolator/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/percolator/
 ---
 
 # Percolator field type

--- a/_field-types/supported-field-types/range.md
+++ b/_field-types/supported-field-types/range.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/range/
   - /field-types/range/
   - /mappings/supported-field-types/range/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/range/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/range/
 ---
 
 # Range field types

--- a/_field-types/supported-field-types/rank.md
+++ b/_field-types/supported-field-types/rank.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/rank/
   - /field-types/rank/
   - /mappings/supported-field-types/rank/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/rank/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/rank/
 ---
 
 # Rank field types

--- a/_field-types/supported-field-types/search-as-you-type.md
+++ b/_field-types/supported-field-types/search-as-you-type.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/search-as-you-type/
   - /field-types/search-as-you-type/
   - /mappings/supported-field-types/search-as-you-type/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/search-as-you-type/
 ---
 
 # Search-as-you-type field type

--- a/_field-types/supported-field-types/star-tree.md
+++ b/_field-types/supported-field-types/star-tree.md
@@ -3,7 +3,7 @@ layout: default
 title: Star-tree
 nav_order: 61
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/star-tree/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/star-tree/
 redirect_from:
   - /mappings/supported-field-types/star-tree/
 ---

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/string/
   - /field-types/string/
   - /mappings/supported-field-types/string/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/string/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/string/
 ---
 
 # String field types

--- a/_field-types/supported-field-types/text.md
+++ b/_field-types/supported-field-types/text.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/text/
   - /field-types/text/
   - /mappings/supported-field-types/text/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/text/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/text/
 ---
 
 # Text field type

--- a/_field-types/supported-field-types/token-count.md
+++ b/_field-types/supported-field-types/token-count.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/token-count/
   - /field-types/token-count/
   - /mappings/supported-field-types/token-count/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/token-count/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/token-count/
 ---
 
 # Token count field type

--- a/_field-types/supported-field-types/unsigned-long.md
+++ b/_field-types/supported-field-types/unsigned-long.md
@@ -5,7 +5,7 @@ parent: Numeric field types
 grand_parent: Supported field types
 nav_order: 15
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/unsigned-long/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/unsigned-long/
 redirect_from:
   - /mappings/supported-field-types/unsigned-long/
 ---

--- a/_field-types/supported-field-types/wildcard.md
+++ b/_field-types/supported-field-types/wildcard.md
@@ -5,7 +5,7 @@ nav_order: 62
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/wildcard/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/wildcard/
 redirect_from:
   - /mappings/supported-field-types/wildcard/
 ---

--- a/_field-types/supported-field-types/xy-point.md
+++ b/_field-types/supported-field-types/xy-point.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/xy-point/
   - /field-types/xy-point/
   - /mappings/supported-field-types/xy-point/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-point/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/xy-point/
 ---
 
 # xy point field type

--- a/_field-types/supported-field-types/xy-shape.md
+++ b/_field-types/supported-field-types/xy-shape.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/xy-shape/
   - /field-types/xy-shape/
   - /mappings/supported-field-types/xy-shape/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-shape/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/xy-shape/
 ---
 
 # xy shape field type

--- a/_field-types/supported-field-types/xy.md
+++ b/_field-types/supported-field-types/xy.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/xy/
   - /field-types/xy/
   - /mappings/supported-field-types/xy/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/xy/
 ---
 
 # Cartesian field types

--- a/_getting-started/security.md
+++ b/_getting-started/security.md
@@ -2,7 +2,7 @@
 layout: default
 title: Getting started with OpenSearch security
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/getting-started/security/
+canonical_url: https://docs.opensearch.org/latest/security/getting-started/
 redirect_from:
   - /security/getting-started/
 ---

--- a/_ingest-pipelines/processors/remove_by_pattern.md
+++ b/_ingest-pipelines/processors/remove_by_pattern.md
@@ -6,7 +6,7 @@ nav_order: 225
 redirect_from:
   - /api-reference/ingest-apis/processors/remove_by_pattern/
   - /ingest-pipelines/processors/remove-by-pattern/
-canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove_by_pattern/
+canonical_url: https://docs.opensearch.org/latest/ingest-pipelines/processors/remove-by-pattern/
 ---
 
 # Remove_by_pattern processor

--- a/_install-and-configure/upgrade-opensearch/appendix/index.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /migrate-or-upgrade/rolling-upgrade/appendix/rolling-upgrade-lab/
   - /migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
   - /upgrade-opensearch/appendix/rolling-upgrade-lab/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/index/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
 ---
 
 # Upgrades appendix

--- a/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
+++ b/_install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab.md
@@ -6,7 +6,7 @@ grand_parent: Upgrading OpenSearch
 nav_order: 50
 redirect_from:
   - /upgrade-opensearch/appendix/rolling-upgrade-lab/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/appendix/rolling-upgrade-lab/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/rolling-upgrade-lab/
 ---
 
 <!--

--- a/_install-and-configure/upgrade-opensearch/index.md
+++ b/_install-and-configure/upgrade-opensearch/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /migrate-or-upgrade/
   - /migrate-or-upgrade/index/
   - /upgrade-or-migrate/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/index/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Upgrading OpenSearch

--- a/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
+++ b/_install-and-configure/upgrade-opensearch/rolling-upgrade.md
@@ -3,7 +3,7 @@ layout: default
 title: Rolling Upgrade
 parent: Upgrading OpenSearch
 nav_order: 10
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/upgrade-opensearch/rolling-upgrade/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/rolling-upgrade/
 redirect_from:
   - /migrate-or-upgrade/rolling-upgrade/
   - /rolling-upgrade/index/

--- a/_integrations/index.md
+++ b/_integrations/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /integrations/index/
   - /dashboards/integrations/
   - /dashboards/integrations/index/
-canonical_url: https://docs.opensearch.org/latest/integrations/
+canonical_url: https://docs.opensearch.org/latest/dashboards/integrations/index/
 ---
 
 # Integrations in OpenSearch Dashboards

--- a/_migration-assistant/deploying-migration-assistant/configuration-options.md
+++ b/_migration-assistant/deploying-migration-assistant/configuration-options.md
@@ -3,7 +3,7 @@ layout: default
 title: Configuration options
 nav_order: 15
 parent: Deploying Migration Assistant
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/deploying-migration-assistant/configuration-options/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/deploying-migration-assistant/configuration-options.md
+++ b/_migration-assistant/deploying-migration-assistant/configuration-options.md
@@ -4,6 +4,7 @@ title: Configuration options
 nav_order: 15
 parent: Deploying Migration Assistant
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/deploying-migration-assistant/configuration-options/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Configuration options

--- a/_migration-assistant/deploying-migration-assistant/getting-started-data-migration.md
+++ b/_migration-assistant/deploying-migration-assistant/getting-started-data-migration.md
@@ -10,6 +10,7 @@ redirect_from:
   - /migration-assistant/migration-phases/migrate-metadata/
   - /migration-phases/migrating-metadata/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/deploying-migration-assistant/getting-started-data-migration/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 ---
 
 # Getting started with data migration

--- a/_migration-assistant/deploying-migration-assistant/getting-started-data-migration.md
+++ b/_migration-assistant/deploying-migration-assistant/getting-started-data-migration.md
@@ -9,7 +9,7 @@ redirect_from:
   - /migration-assistant/getting-started-with-data-migration/
   - /migration-assistant/migration-phases/migrate-metadata/
   - /migration-phases/migrating-metadata/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/deploying-migration-assistant/getting-started-data-migration/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 ---
 

--- a/_migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters.md
+++ b/_migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters.md
@@ -3,7 +3,7 @@ layout: default
 title: IAM and security groups for existing clusters
 nav_order: 20
 parent: Deploying Migration Assistant
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters.md
+++ b/_migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters.md
@@ -4,6 +4,7 @@ title: IAM and security groups for existing clusters
 nav_order: 20
 parent: Deploying Migration Assistant
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # IAM and security groups for existing clusters

--- a/_migration-assistant/deploying-migration-assistant/index.md
+++ b/_migration-assistant/deploying-migration-assistant/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /migration-assistant/deploying-migration-assistant/
   - /migration-assistant/getting-started-with-data-migration/
   - /migration-assistant/migration-phases/deploy/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/
 ---
 
 # Deploying Migration Assistant

--- a/_migration-assistant/deploying-migration-assistant/index.md
+++ b/_migration-assistant/deploying-migration-assistant/index.md
@@ -6,7 +6,7 @@ has_children: true
 permalink: /deploying-migration-assistant/
 redirect-from:
   - /deploying-migration-assistant/index/
-canonical_url: https://docs.opensearch.org/latest/deploying-migration-assistant/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/
 redirect_from:
   - /migration-assistant/deploying-migration-assistant/
   - /migration-assistant/getting-started-with-data-migration/

--- a/_migration-assistant/index.md
+++ b/_migration-assistant/index.md
@@ -12,6 +12,7 @@ redirect_from:
   - /upgrade-to/
   - /migration-assistant/overview/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Migration Assistant for OpenSearch

--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -6,6 +6,7 @@ canonical_url: https://docs.opensearch.org/latest/migration-assistant/is-migrati
 redirect_from:
   - /migration-assistant/migration-paths/
   - /migration-assistant/overview/is-migration-assistant-right-for-you/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/is-migration-assistant-right-for-you/
 ---
 
 # Is Migration Assistant right for you?

--- a/_migration-assistant/migration-console/accessing-the-migration-console.md
+++ b/_migration-assistant/migration-console/accessing-the-migration-console.md
@@ -3,7 +3,7 @@ layout: default
 title: Accessing the migration console
 nav_order: 35
 parent: Migration console
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/accessing-the-migration-console/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/accessing-the-migration-console/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-console/accessing-the-migration-console.md
+++ b/_migration-assistant/migration-console/accessing-the-migration-console.md
@@ -4,6 +4,7 @@ title: Accessing the migration console
 nav_order: 35
 parent: Migration console
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/accessing-the-migration-console/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Accessing the migration console

--- a/_migration-assistant/migration-console/index.md
+++ b/_migration-assistant/migration-console/index.md
@@ -8,6 +8,7 @@ has_toc: false
 redirect_from: 
   - /migration-console/index/
 canonical_url: https://docs.opensearch.org/latest/migration-console/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Migration console

--- a/_migration-assistant/migration-console/index.md
+++ b/_migration-assistant/migration-console/index.md
@@ -7,7 +7,7 @@ permalink: /migration-console/
 has_toc: false
 redirect_from: 
   - /migration-console/index/
-canonical_url: https://docs.opensearch.org/latest/migration-console/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant/migration-console/migration-console-commands-references.md
@@ -3,7 +3,7 @@ layout: default
 title: Command reference
 nav_order: 40
 parent: Migration console
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/migration-console-commands-references/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant/migration-console/migration-console-commands-references.md
@@ -4,6 +4,7 @@ title: Command reference
 nav_order: 40
 parent: Migration console
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/migration-console-commands-references/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Migration console command reference

--- a/_migration-assistant/migration-phases/backfill.md
+++ b/_migration-assistant/migration-phases/backfill.md
@@ -8,6 +8,7 @@ redirect_from:
   - /migration-assistant/migration-phases/create-snapshot/
   - /migration-phases/backfill/
   - /migration-phases/create-snapshot/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
 ---
 
 # Backfill

--- a/_migration-assistant/migration-phases/index.md
+++ b/_migration-assistant/migration-phases/index.md
@@ -10,6 +10,7 @@ redirect_from:
   - /migration-assistant/migration-phases/
   - /migration-assistant/overview/migration-phases/
 canonical_url: https://docs.opensearch.org/latest/migration-phases/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/
 ---
 
 # Migration phases

--- a/_migration-assistant/migration-phases/index.md
+++ b/_migration-assistant/migration-phases/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /migration-phases/index/
   - /migration-assistant/migration-phases/
   - /migration-assistant/overview/migration-phases/
-canonical_url: https://docs.opensearch.org/latest/migration-phases/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/
 ---
 

--- a/_migration-assistant/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/index.md
@@ -6,6 +6,7 @@ parent: Migration phases
 has_toc: false
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/index/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Live traffic migration

--- a/_migration-assistant/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/index.md
@@ -5,7 +5,7 @@ nav_order: 99
 parent: Migration phases
 has_toc: false
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/index.md
@@ -5,7 +5,7 @@ nav_order: 99
 parent: Migration phases
 has_toc: false
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/index/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
@@ -7,6 +7,7 @@ parent: Live traffic migration
 redirect_from:
   - /migration-assistant/migration-phases/switching-traffic-from-the-source-cluster/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Switching traffic from the source cluster

--- a/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
@@ -6,7 +6,7 @@ grand_parent: Migration phases
 parent: Live traffic migration
 redirect_from:
   - /migration-assistant/migration-phases/switching-traffic-from-the-source-cluster/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/live-traffic-migration/using-traffic-replayer.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/using-traffic-replayer.md
@@ -10,6 +10,7 @@ redirect_from:
   - /migration-assistant/migration-phases/using-traffic-Replayer/
   - /migration-phases/using-traffic-Replayer/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/using-traffic-replayer/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
 ---
 
 # Using Traffic Replayer

--- a/_migration-assistant/migration-phases/live-traffic-migration/using-traffic-replayer.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/using-traffic-replayer.md
@@ -9,7 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/replay-captured-traffic/
   - /migration-assistant/migration-phases/using-traffic-Replayer/
   - /migration-phases/using-traffic-Replayer/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/using-traffic-replayer/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
 ---
 

--- a/_migration-assistant/migration-phases/migrating-metadata.md
+++ b/_migration-assistant/migration-phases/migrating-metadata.md
@@ -4,6 +4,7 @@ title: Migrating metadata
 nav_order: 85
 parent: Migration phases
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrating-metadata/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 ---
 
 # Migrating metadata

--- a/_migration-assistant/migration-phases/migrating-metadata.md
+++ b/_migration-assistant/migration-phases/migrating-metadata.md
@@ -3,7 +3,7 @@ layout: default
 title: Migrating metadata
 nav_order: 85
 parent: Migration phases
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrating-metadata/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 ---
 

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -7,6 +7,7 @@ grand_parent: Migration phases
 redirect_from:
   - /migration-assistant/migration-phases/assessing-your-cluster-for-migration/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 ---
 
 # Assessing your cluster for migration

--- a/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration.md
@@ -6,7 +6,7 @@ parent: Planning your migration
 grand_parent: Migration phases
 redirect_from:
   - /migration-assistant/migration-phases/assessing-your-cluster-for-migration/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 ---
 

--- a/_migration-assistant/migration-phases/planning-your-migration/index.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/index.md
@@ -9,6 +9,7 @@ canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-
 redirect_from:
   - /migration-assistant/migration-phases/assessment/
   - /migration-assistant/migration-phases/planning-your-migration/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 ---
 
 # Planning your migration

--- a/_migration-assistant/migration-phases/planning-your-migration/index.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/index.md
@@ -5,7 +5,7 @@ nav_order: 59
 parent: Migration phases
 has_toc: false
 has_children: true 
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/planning-your-migration/index/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 redirect_from:
   - /migration-assistant/migration-phases/assessment/
   - /migration-assistant/migration-phases/planning-your-migration/

--- a/_migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools.md
@@ -7,6 +7,7 @@ grand_parent: Migration phases
 redirect_from:
   - /migration-assistant/migration-phases/verifying-migration-tools/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Verifying migration tools

--- a/_migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools.md
+++ b/_migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools.md
@@ -6,7 +6,7 @@ parent: Planning your migration
 grand_parent: Migration phases
 redirect_from:
   - /migration-assistant/migration-phases/verifying-migration-tools/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/removing-migration-infrastructure.md
+++ b/_migration-assistant/migration-phases/removing-migration-infrastructure.md
@@ -7,6 +7,7 @@ canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-
 redirect_from:
   - /migration-assistant/migration-phases/remove-migration-infrastructure/
   - /migration-phases/removing-migration-infrastructure/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/remove-migration-infrastructure/
 ---
 
 # Removing migration infrastructure

--- a/_migration-assistant/migration-phases/removing-migration-infrastructure.md
+++ b/_migration-assistant/migration-phases/removing-migration-infrastructure.md
@@ -3,7 +3,7 @@ layout: default
 title: Removing migration infrastructure
 nav_order: 120
 parent: Migration phases
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/removing-migration-infrastructure/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/remove-migration-infrastructure/
 redirect_from:
   - /migration-assistant/migration-phases/remove-migration-infrastructure/
   - /migration-phases/removing-migration-infrastructure/

--- a/_ml-commons-plugin/agents-tools/tools/cat-index-tool.md
+++ b/_ml-commons-plugin/agents-tools/tools/cat-index-tool.md
@@ -6,7 +6,7 @@ has_toc: false
 nav_order: 20
 parent: Tools
 grand_parent: Agents and tools
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/cat-index-tool/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/
 ---
 
 <!-- vale off -->

--- a/_ml-commons-plugin/tutorials/bedrock-guardrails.md
+++ b/_ml-commons-plugin/tutorials/bedrock-guardrails.md
@@ -3,7 +3,7 @@ layout: default
 title: Using Amazon Bedrock guardrails 
 parent: Tutorials
 nav_order: 25
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/bedrock-guardrails/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/model-controls/bedrock-guardrails/
 redirect_from:
   - /tutorials/gen-ai/model-controls/bedrock-guardrails/
   - /vector-search/tutorials/model-controls/bedrock-guardrails/

--- a/_ml-commons-plugin/tutorials/build-chatbot.md
+++ b/_ml-commons-plugin/tutorials/build-chatbot.md
@@ -3,7 +3,7 @@ layout: default
 title: Build your own chatbot
 parent: Tutorials
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/build-chatbot/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/chatbots/build-chatbot/
 redirect_from:
   - /tutorials/gen-ai/chatbots/build-chatbot/
   - /vector-search/tutorials/chatbots/build-chatbot/

--- a/_ml-commons-plugin/tutorials/conversational-search-cohere.md
+++ b/_ml-commons-plugin/tutorials/conversational-search-cohere.md
@@ -3,7 +3,7 @@ layout: default
 title: Conversational search with Cohere Command
 parent: Tutorials
 nav_order: 20
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/conversational-search-cohere/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/rag/conversational-search-cohere/
 redirect_from:
   - /tutorials/gen-ai/rag/conversational-search-cohere/
   - /tutorials/vector-search/rag/conversational-search/conversational-search-cohere/

--- a/_ml-commons-plugin/tutorials/generate-embeddings.md
+++ b/_ml-commons-plugin/tutorials/generate-embeddings.md
@@ -3,7 +3,7 @@ layout: default
 title: Generating embeddings
 parent: Tutorials
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/generate-embeddings/
+canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/vector-operations/generate-embeddings/
 redirect_from:
   - /tutorials/vector-search/vector-operations/generate-embeddings/
   - /vector-search/tutorials/vector-operations/generate-embeddings/

--- a/_ml-commons-plugin/tutorials/index.md
+++ b/_ml-commons-plugin/tutorials/index.md
@@ -4,7 +4,7 @@ title: Tutorials
 has_children: true
 has_toc: false
 nav_order: 140
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/index/
+canonical_url: https://docs.opensearch.org/latest/tutorials/
 redirect_from:
   - /ml-commons-plugin/tutorials/
   - /tutorials/

--- a/_ml-commons-plugin/tutorials/rag-chatbot.md
+++ b/_ml-commons-plugin/tutorials/rag-chatbot.md
@@ -3,7 +3,7 @@ layout: default
 title: RAG chatbot
 parent: Tutorials
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/rag-chatbot/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/chatbots/rag-chatbot/
 redirect_from:
   - /tutorials/gen-ai/chatbots/rag-chatbot/
   - /vector-search/tutorials/chatbots/rag-chatbot/

--- a/_ml-commons-plugin/tutorials/rag-conversational-agent.md
+++ b/_ml-commons-plugin/tutorials/rag-conversational-agent.md
@@ -3,7 +3,7 @@ layout: default
 title: RAG chatbot with a conversational flow agent
 parent: Tutorials
 nav_order: 40
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/rag-conversational-agent/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/chatbots/rag-conversational-agent/
 redirect_from:
   - /tutorials/gen-ai/chatbots/rag-conversational-agent/
   - /vector-search/tutorials/chatbots/rag-conversational-agent/

--- a/_ml-commons-plugin/tutorials/reranking-cohere.md
+++ b/_ml-commons-plugin/tutorials/reranking-cohere.md
@@ -3,7 +3,7 @@ layout: default
 title: Reranking with Cohere Rerank
 parent: Tutorials
 nav_order: 30
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/reranking-cohere/
+canonical_url: https://docs.opensearch.org/latest/tutorials/reranking/reranking-cohere/
 redirect_from:
   - /tutorials/reranking/reranking-cohere/
   - /vector-search/tutorials/reranking/reranking-cohere/

--- a/_ml-commons-plugin/tutorials/reranking-cross-encoder.md
+++ b/_ml-commons-plugin/tutorials/reranking-cross-encoder.md
@@ -3,7 +3,7 @@ layout: default
 title: Reranking with the MS MARCO cross-encoder
 parent: Tutorials
 nav_order: 35
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/reranking-cross-encoder/
+canonical_url: https://docs.opensearch.org/latest/tutorials/reranking/reranking-cross-encoder/
 redirect_from:
   - /tutorials/reranking/reranking-cross-encoder/
   - /vector-search/tutorials/reranking/reranking-cross-encoder/

--- a/_ml-commons-plugin/tutorials/semantic-search-byte-vectors.md
+++ b/_ml-commons-plugin/tutorials/semantic-search-byte-vectors.md
@@ -3,7 +3,7 @@ layout: default
 title: Semantic search using byte vectors
 parent: Tutorials
 nav_order: 10
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/tutorials/semantic-search-byte-vectors/
+canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/vector-operations/semantic-search-byte-vectors/
 redirect_from:
   - /tutorials/vector-search/vector-operations/semantic-search-byte-vectors/
   - /vector-search/tutorials/vector-operations/semantic-search-byte-vectors/

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -71,8 +71,10 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore
-  @ignored_paths = %r{(^/javadocs|^mailto:)}.freeze
+  # Pattern of local paths to ignore. The single-edition sections now redirect to
+  # /latest/, which CI rewrites back to the page's own path, so check_internal
+  # would recurse on its own stub.
+  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -74,7 +74,9 @@ module Jekyll::LinkChecker
   # Pattern of local paths to ignore. The single-edition sections now redirect to
   # /latest/, which CI rewrites back to the page's own path, so check_internal
   # would recurse on its own stub.
-  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
+  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
+  # back to `/`, so check_internal would follow the stub into itself.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -71,11 +71,7 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore. The single-edition sections now redirect to
-  # /latest/, which CI rewrites back to the page's own path, so check_internal
-  # would recurse on its own stub.
-  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
-  # back to `/`, so check_internal would follow the stub into itself.
+  # Pattern of local paths to ignore.
   @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##

--- a/_query-dsl/span-query.md
+++ b/_query-dsl/span-query.md
@@ -7,7 +7,7 @@ redirect_from:
   - /query-dsl/query-dsl/span-query/
   - /query-dsl/span/
   - /query-dsl/span/index/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/span-query/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/span/index/
 ---
 
 # Span queries

--- a/_query-dsl/specialized/neural-sparse.md
+++ b/_query-dsl/specialized/neural-sparse.md
@@ -3,7 +3,7 @@ layout: default
 title: Neural sparse
 parent: Specialized queries
 nav_order: 55
-canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/index/
 redirect_from:
   - /query-dsl/specialized/neural-sparse/index/
 ---

--- a/_search-plugins/collapse-search.md
+++ b/_search-plugins/collapse-search.md
@@ -3,7 +3,7 @@ layout: default
 title: Collapse search results
 parent: Searching data
 nav_order: 40
-canonical_url: https://docs.opensearch.org/latest/search-plugins/collapse-search/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/collapse-search/
 redirect_from:
   - /search-plugins/searching-data/collapse-search/
 ---

--- a/_search-plugins/conversational-search.md
+++ b/_search-plugins/conversational-search.md
@@ -6,7 +6,7 @@ nav_order: 70
 redirect_from:
   - /ml-commons-plugin/conversational-search/
   - /vector-search/ai-search/conversational-search/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/conversational-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/conversational-search/
 ---
 
 # Conversational search

--- a/_search-plugins/hybrid-search.md
+++ b/_search-plugins/hybrid-search.md
@@ -3,7 +3,7 @@ layout: default
 title: Hybrid search
 has_children: false
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/search-plugins/hybrid-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/hybrid-search/index/
 redirect_from:
   - /vector-search/ai-search/hybrid-search/
   - /vector-search/ai-search/hybrid-search/index/

--- a/_search-plugins/knn/api.md
+++ b/_search-plugins/knn/api.md
@@ -4,7 +4,7 @@ title: k-NN plugin API
 nav_order: 30
 parent: k-NN search
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/api/
+canonical_url: https://docs.opensearch.org/latest/vector-search/api/index/
 redirect_from:
   - /vector-search/api/
   - /vector-search/api/index/

--- a/_search-plugins/knn/approximate-knn.md
+++ b/_search-plugins/knn/approximate-knn.md
@@ -5,7 +5,7 @@ nav_order: 15
 parent: k-NN search
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/approximate-knn/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/approximate-knn/
 redirect_from:
   - /vector-search/vector-search-techniques/approximate-knn/
 ---

--- a/_search-plugins/knn/disk-based-vector-search.md
+++ b/_search-plugins/knn/disk-based-vector-search.md
@@ -4,7 +4,7 @@ title: Disk-based vector search
 nav_order: 16
 parent: k-NN search
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/disk-based-vector-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/optimizing-storage/disk-based-vector-search/
 redirect_from:
   - /vector-search/optimizing-storage/disk-based-vector-search/
 ---

--- a/_search-plugins/knn/filter-search-knn.md
+++ b/_search-plugins/knn/filter-search-knn.md
@@ -5,7 +5,7 @@ nav_order: 20
 parent: k-NN search
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/filter-search-knn/
+canonical_url: https://docs.opensearch.org/latest/vector-search/filter-search-knn/index/
 redirect_from:
   - /vector-search/filter-search-knn/
   - /vector-search/filter-search-knn/index/

--- a/_search-plugins/knn/index.md
+++ b/_search-plugins/knn/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /search-plugins/knn/
   - /vector-search/vector-search-techniques/
   - /vector-search/vector-search-techniques/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/index/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/index/
 ---
 
 # k-NN search

--- a/_search-plugins/knn/jni-libraries.md
+++ b/_search-plugins/knn/jni-libraries.md
@@ -7,7 +7,7 @@ has_children: false
 redirect_from:
   - /search-plugins/knn/jni-library/
   - /vector-search/api/knn/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/jni-libraries/
+canonical_url: https://docs.opensearch.org/latest/vector-search/api/knn/
 ---
 
 # JNI libraries

--- a/_search-plugins/knn/knn-index.md
+++ b/_search-plugins/knn/knn-index.md
@@ -4,7 +4,7 @@ title: k-NN index
 nav_order: 5
 parent: k-NN search
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-index/
+canonical_url: https://docs.opensearch.org/latest/vector-search/creating-vector-index/
 redirect_from:
   - /vector-search/creating-a-vector-db/
   - /vector-search/creating-vector-index/

--- a/_search-plugins/knn/knn-score-script.md
+++ b/_search-plugins/knn/knn-score-script.md
@@ -5,7 +5,7 @@ nav_order: 10
 parent: k-NN search
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-score-script/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/knn-score-script/
 redirect_from:
   - /vector-search/vector-search-techniques/knn-score-script/
 ---

--- a/_search-plugins/knn/knn-vector-quantization.md
+++ b/_search-plugins/knn/knn-vector-quantization.md
@@ -5,7 +5,7 @@ nav_order: 27
 parent: k-NN search
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/knn-vector-quantization/
+canonical_url: https://docs.opensearch.org/latest/vector-search/optimizing-storage/knn-vector-quantization/
 redirect_from:
   - /vector-search/optimizing-storage/knn-vector-quantization/
 ---

--- a/_search-plugins/knn/nested-search-knn.md
+++ b/_search-plugins/knn/nested-search-knn.md
@@ -5,7 +5,7 @@ nav_order: 21
 parent: k-NN search
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/nested-search-knn/
+canonical_url: https://docs.opensearch.org/latest/vector-search/specialized-operations/nested-search-knn/
 redirect_from:
   - /vector-search/specialized-operations/nested-search-knn/
 ---

--- a/_search-plugins/knn/painless-functions.md
+++ b/_search-plugins/knn/painless-functions.md
@@ -5,7 +5,7 @@ nav_order: 25
 parent: k-NN search
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/painless-functions/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/painless-functions/
 redirect_from:
   - /vector-search/vector-search-techniques/painless-functions/
 ---

--- a/_search-plugins/knn/performance-tuning.md
+++ b/_search-plugins/knn/performance-tuning.md
@@ -3,7 +3,7 @@ layout: default
 title: Performance tuning
 parent: k-NN search
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/performance-tuning/
+canonical_url: https://docs.opensearch.org/latest/vector-search/performance-tuning/
 redirect_from:
   - /vector-search/performance-tuning/
 ---

--- a/_search-plugins/knn/radial-search-knn.md
+++ b/_search-plugins/knn/radial-search-knn.md
@@ -5,7 +5,7 @@ nav_order: 28
 parent: k-NN search
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/radial-search-knn/
+canonical_url: https://docs.opensearch.org/latest/vector-search/specialized-operations/radial-search-knn/
 redirect_from:
   - /vector-search/specialized-operations/radial-search-knn/
 ---

--- a/_search-plugins/knn/settings.md
+++ b/_search-plugins/knn/settings.md
@@ -3,7 +3,7 @@ layout: default
 title: Settings
 parent: k-NN search
 nav_order: 40
-canonical_url: https://docs.opensearch.org/latest/search-plugins/knn/settings/
+canonical_url: https://docs.opensearch.org/latest/vector-search/settings/
 redirect_from:
   - /vector-search/settings/
 ---

--- a/_search-plugins/multimodal-search.md
+++ b/_search-plugins/multimodal-search.md
@@ -6,7 +6,7 @@ has_children: false
 redirect_from:
   - /search-plugins/neural-multimodal-search/
   - /vector-search/ai-search/multimodal-search/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/multimodal-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/multimodal-search/
 ---
 
 # Multimodal search

--- a/_search-plugins/neural-search-tutorial.md
+++ b/_search-plugins/neural-search-tutorial.md
@@ -7,7 +7,7 @@ redirect_from:
   - /ml-commons-plugin/semantic-search/
   - /tutorials/vector-search/neural-search-tutorial/
   - /vector-search/tutorials/neural-search-tutorial/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-search-tutorial/
+canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/neural-search-tutorial/
 ---
 
 # Neural search tutorial

--- a/_search-plugins/neural-search.md
+++ b/_search-plugins/neural-search.md
@@ -8,7 +8,7 @@ redirect_from:
   - /neural-search-plugin/index/
   - /vector-search/ai-search/
   - /vector-search/ai-search/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/index/
 ---
 
 # Neural search

--- a/_search-plugins/neural-sparse-search.md
+++ b/_search-plugins/neural-sparse-search.md
@@ -7,7 +7,7 @@ redirect_from:
   - /search-plugins/neural-sparse-search/
   - /search-plugins/sparse-search/
   - /vector-search/ai-search/neural-sparse-search/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-sparse-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/neural-sparse-search/
 ---
 
 # Neural sparse search

--- a/_search-plugins/neural-sparse-with-pipelines.md
+++ b/_search-plugins/neural-sparse-with-pipelines.md
@@ -4,7 +4,7 @@ title: Configuring ingest pipelines
 parent: Neural sparse search
 nav_order: 10
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-sparse-with-pipelines/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/neural-sparse-with-pipelines/
 redirect_from:
   - /vector-search/ai-search/neural-sparse-with-pipelines/
 ---

--- a/_search-plugins/neural-sparse-with-raw-vectors.md
+++ b/_search-plugins/neural-sparse-with-raw-vectors.md
@@ -4,7 +4,7 @@ title: Using raw vectors
 parent: Neural sparse search
 nav_order: 20
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/neural-sparse-with-raw-vectors/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/neural-sparse-with-raw-vectors/
 redirect_from:
   - /vector-search/ai-search/neural-sparse-with-raw-vectors/
 ---

--- a/_search-plugins/searching-data/point-in-time-api.md
+++ b/_search-plugins/searching-data/point-in-time-api.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/point-in-time-api/
   - /search-plugins/point-in-time-api/
   - /api-reference/search-apis/point-in-time-api/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/point-in-time-api/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/point-in-time-api/
 ---
 
 # Point in Time API

--- a/_search-plugins/semantic-search.md
+++ b/_search-plugins/semantic-search.md
@@ -6,7 +6,7 @@ has_children: false
 redirect_from:
   - /search-plugins/neural-text-search/
   - /vector-search/ai-search/semantic-search/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/semantic-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/semantic-search/
 ---
 
 # Semantic search

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -6,7 +6,7 @@ nav_order: 3
 redirect_from:
   - /search-plugins/sql/cli/
   - /sql-and-ppl/cli/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/cli/
 ---
 
 # SQL and PPL CLI

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -3,7 +3,7 @@ layout: default
 title: Data Types
 parent: SQL and PPL
 nav_order: 7
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/datatypes/
 redirect_from:
   - /sql-and-ppl/datatypes/
 ---

--- a/_search-plugins/sql/full-text.md
+++ b/_search-plugins/sql/full-text.md
@@ -6,7 +6,7 @@ nav_order: 11
 redirect_from:
   - /search-plugins/sql/sql-full-text/
   - /sql-and-ppl/full-text/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/full-text/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/full-text/
 ---
 
 # Full-text search

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -6,7 +6,7 @@ nav_order: 10
 redirect_from:
   - /search-plugins/sql/functions/
   - /sql-and-ppl/sql/functions/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/identifiers.md
+++ b/_search-plugins/sql/identifiers.md
@@ -7,7 +7,7 @@ redirect_from:
   - /observability-plugin/ppl/identifiers/
   - /search-plugins/ppl/identifiers/
   - /sql-and-ppl/identifiers/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/identifiers/
 ---
 
 

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /search-plugins/sql/index/
   - /search-plugins/sql/
   - /sql-and-ppl/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/
 ---
 
 # SQL and PPL

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -6,7 +6,7 @@ nav_order: 99
 redirect_from:
   - /search-plugins/sql/limitation/
   - /sql-and-ppl/limitation/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/limitation/
 ---
 
 # Limitations

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -6,7 +6,7 @@ nav_order: 95
 redirect_from:
   - /search-plugins/sql/monitoring/
   - /sql-and-ppl/monitoring/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/monitoring/
 ---
 
 # Monitoring

--- a/_search-plugins/sql/ppl/functions.md
+++ b/_search-plugins/sql/ppl/functions.md
@@ -10,7 +10,7 @@ redirect_from:
   - /search-plugins/ppl/functions/
   - /sql-and-ppl/ppl/commands/index/
   - /sql-and-ppl/ppl/functions/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/index/
 ---
 
 # Commands

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -16,7 +16,7 @@ redirect_from:
   - /observability-plugin/ppl/index/
   - /sql-and-ppl/ppl/
   - /sql-and-ppl/ppl/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/index/
 ---
 
 # PPL

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -4,7 +4,7 @@ title: Syntax
 parent: PPL
 grand_parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/syntax/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/syntax/
 redirect_from:
   - /sql-and-ppl/ppl/commands/syntax/
 ---

--- a/_search-plugins/sql/response-formats.md
+++ b/_search-plugins/sql/response-formats.md
@@ -3,7 +3,7 @@ layout: default
 title: Response formats
 parent: SQL and PPL
 nav_order: 2
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/response-formats/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/response-formats/
 redirect_from:
   - /sql-and-ppl/response-formats/
 ---

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -6,7 +6,7 @@ nav_order: 77
 redirect_from:
   - /search-plugins/sql/settings/
   - /sql-and-ppl/settings/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/settings/
 ---
 
 # SQL settings

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -3,7 +3,7 @@ layout: default
 title: SQL and PPL API
 parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/index/
 redirect_from:
   - /sql-and-ppl/sql-and-ppl-api/index/
   - /sql-and-ppl/sql-ppl-api/

--- a/_search-plugins/sql/sql/aggregations.md
+++ b/_search-plugins/sql/sql/aggregations.md
@@ -6,7 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 11
 Redirect_from:
   - /search-plugins/sql/aggregations/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/aggregations/
 redirect_from:
   - /search-plugins/sql/aggregations/
   - /sql-and-ppl/sql/aggregations/

--- a/_search-plugins/sql/sql/basic.md
+++ b/_search-plugins/sql/sql/basic.md
@@ -7,7 +7,7 @@ nav_order: 5
 redirect_from:
   - /search-plugins/sql/basic/
   - /sql-and-ppl/sql/basic/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/basic/
 ---
 
 

--- a/_search-plugins/sql/sql/complex.md
+++ b/_search-plugins/sql/sql/complex.md
@@ -7,7 +7,7 @@ nav_order: 6
 redirect_from:
   - /search-plugins/sql/complex/
   - /sql-and-ppl/sql/complex/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/complex/
 ---
 
 # Complex queries

--- a/_search-plugins/sql/sql/delete.md
+++ b/_search-plugins/sql/sql/delete.md
@@ -7,7 +7,7 @@ nav_order: 12
 redirect_from:
   - /search-plugins/sql/delete/
   - /sql-and-ppl/sql/delete/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/delete/
 ---
 
 

--- a/_search-plugins/sql/sql/functions.md
+++ b/_search-plugins/sql/sql/functions.md
@@ -7,7 +7,7 @@ nav_order: 7
 redirect_from:
   - /search-plugins/ppl/commands/
   - /observability-plugin/ppl/commands/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/sql/index.md
+++ b/_search-plugins/sql/sql/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /search-plugins/sql/sql/
   - /sql-and-ppl/sql/
   - /sql-and-ppl/sql/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/index/
 ---
 
 # SQL

--- a/_search-plugins/sql/sql/jdbc.md
+++ b/_search-plugins/sql/sql/jdbc.md
@@ -8,7 +8,7 @@ redirect_from:
   - /search-plugins/sql/jdbc/
 
   - /sql-and-ppl/sql/jdbc/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/jdbc/
 ---
 
 # JDBC driver

--- a/_search-plugins/sql/sql/metadata.md
+++ b/_search-plugins/sql/sql/metadata.md
@@ -7,7 +7,7 @@ nav_order: 9
 redirect_from:
   - /search-plugins/sql/metadata/
   - /sql-and-ppl/sql/metadata/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/metadata/
 ---
 
 # Metadata queries

--- a/_search-plugins/sql/sql/odbc.md
+++ b/_search-plugins/sql/sql/odbc.md
@@ -7,7 +7,7 @@ nav_order: 72
 redirect_from:
   - /search-plugins/sql/odbc/
   - /sql-and-ppl/sql/odbc/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/odbc/
 ---
 
 # ODBC driver

--- a/_search-plugins/sql/sql/partiql.md
+++ b/_search-plugins/sql/sql/partiql.md
@@ -7,7 +7,7 @@ nav_order: 8
 redirect_from:
   - /search-plugins/sql/partiql/
   - /sql-and-ppl/sql/partiql/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/partiql/
 ---
 
 # JSON Support

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -6,7 +6,7 @@ nav_order: 88
 redirect_from:
   - /search-plugins/sql/troubleshoot/
   - /sql-and-ppl/troubleshoot/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/troubleshoot/
 ---
 
 # Troubleshooting

--- a/_search-plugins/text-chunking.md
+++ b/_search-plugins/text-chunking.md
@@ -2,7 +2,7 @@
 layout: default
 title: Text chunking
 nav_order: 65
-canonical_url: https://docs.opensearch.org/latest/search-plugins/text-chunking/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ingesting-data/text-chunking/
 redirect_from:
   - /vector-search/ingesting-data/text-chunking/
 ---

--- a/_search-plugins/ubi/data-structures.md
+++ b/_search-plugins/ubi/data-structures.md
@@ -4,7 +4,7 @@ title: UBI client data structures
 parent: User Behavior Insights
 has_children: false
 nav_order: 10
-canonical_url: https://docs.opensearch.org/latest/search-plugins/ubi/data-structures/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/ubi/schemas/
 ---
 
 # UBI client data structures

--- a/_search-plugins/vector-search.md
+++ b/_search-plugins/vector-search.md
@@ -4,7 +4,7 @@ title: Vector search
 nav_order: 22
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/search-plugins/vector-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/
 redirect_from:
   - /vector-search/
   - /vector-search/index/

--- a/_tools/k8s-operator.md
+++ b/_tools/k8s-operator.md
@@ -7,7 +7,7 @@ redirect_from:
   - /clients/k8s-operator/
   - /install-and-configure/install-opensearch/operator/
   - /install-and-configure/install-opensearch/operator/index/
-canonical_url: https://docs.opensearch.org/latest/tools/k8s-operator/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/index/
 ---
 
 The OpenSearch Kubernetes Operator is an open-source kubernetes operator that helps automate the deployment and provisioning of OpenSearch and OpenSearch Dashboards in a containerized environment. The operator can manage multiple OpenSearch clusters that can be scaled up and down depending on your needs. 

--- a/_tuning-your-cluster/availability-and-recovery/workload-management/query-group-lifecycle-api.md
+++ b/_tuning-your-cluster/availability-and-recovery/workload-management/query-group-lifecycle-api.md
@@ -4,7 +4,7 @@ title: Query Group Lifecycle API
 nav_order: 20
 parent: Workload management
 grand_parent: Availability and recovery
-canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/workload-management/query-group-lifecycle-api/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/workload-management/workload-groups/
 ---
 
 # Query Group Lifecycle API

--- a/_upgrade-to/dashboards-upgrade-to.md
+++ b/_upgrade-to/dashboards-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Kibana OSS to OpenSearch Dashboards
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/dashboards-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Kibana OSS to OpenSearch Dashboards

--- a/_upgrade-to/docker-upgrade-to.md
+++ b/_upgrade-to/docker-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating Docker clusters to OpenSearch
 nav_order: 25
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/docker-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating Docker clusters to OpenSearch

--- a/_upgrade-to/index.md
+++ b/_upgrade-to/index.md
@@ -6,7 +6,7 @@ nav_exclude: true
 permalink: /upgrade-to/
 redirect_from:
   - /upgrade-to/index/
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Upgrading OpenSearch

--- a/_upgrade-to/snapshot-migrate.md
+++ b/_upgrade-to/snapshot-migrate.md
@@ -2,7 +2,7 @@
 layout: default
 title: Using snapshots to migrate data
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/snapshot-migrate/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/
 ---
 
 # Using snapshots to migrate data

--- a/_upgrade-to/upgrade-to.md
+++ b/_upgrade-to/upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Elasticsearch OSS to OpenSearch
 nav_order: 15
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Elasticsearch OSS to OpenSearch

--- a/index.md
+++ b/index.md
@@ -6,6 +6,7 @@ has_children: false
 nav_exclude: true
 permalink: /
 canonical_url: https://docs.opensearch.org/latest/
+redirect_to: https://docs.opensearch.org/latest/
 ---
 
 {% include banner.html %}


### PR DESCRIPTION
### Description

The Clients, Data Prepper, Benchmark, and Migration Assistant sections are published as a single edition under `/latest/`; only the OpenSearch section is versioned. A versioned build still emits a full copy of those collections, so `/2.18/data-prepper/...` serves content that no release ever corresponded to. Readers reach those copies from search engines, bookmarks, and LLM answers, so rewriting on-site links cannot close the gap.

This adds `redirect_to` front matter pointing each of those pages at its equivalent under `/latest/`. It continues the pass done for 1.3 through 2.14 in June 2024 (#7517, #7535 to #7550), which stopped at 2.15.

Every target was resolved against the live site before being written:

- HTTP redirects and meta-refresh stubs are followed, so each target is a final endpoint rather than another redirect.
- A missing page returns HTTP 200 after being rewritten to `/latest/404.html`, so existence is tested by inspecting the effective URL rather than the status code. A target that lands there falls back to the section index.
- Pages whose only equivalent on `/latest/` is inside the versioned OpenSearch section are left alone, because redirecting them would serve content for the wrong release.

Files that already carried a `redirect_to` are untouched, so hand-curated targets from the earlier pass are preserved.

`_plugins/link-checker.rb` also regains the single-edition path exclusions that 1.3 through 2.14 already carry. CI builds every branch with `baseurl: /latest`, so without them the checker rewrites each redirect target back to the page's own path, reads the stub it just generated, and recurses until the build dies with `stack level too deep`. This filters the *target* of a link, so links pointing into these sections are no longer verified. Links written *on* those pages were already unverified, on this branch and on 1.3 through 2.14: `redirect_to` makes jekyll-redirect-from replace a page's content with the redirect stub during the generator phase, before the checker collects links from it.

Target selection for this branch:

```
  exact       143
  collapsed   31
  section     10
  moved       0
  unresolved  0
```

The branch home page is redirected too. `/2.18/` serves a home page frozen at that release. GA shows no versioned root page has a single referrer from `docs.opensearch.org`, against 37% on-site referrals for `/latest/`, so nobody navigates within a version from its home page. The arrivals are external: bookmarks, third-party links, and OpenSearch Dashboards, whose `noDocumentation` block holds 62 version-pinned links that resolve to exactly this root. All of them are better served by the current home page than a stale one. Content pages are out of scope: a reader who lands on `/2.18/dashboards/dql/` stays in 2.18.

`@ignored_paths` also gains `^/$`. CI builds every branch with `baseurl: /latest`, so without it the checker rewrites the home page's redirect target back to `/`, reads the stub it just generated, pulls the same absolute URL out of it, and recurses until the build dies with `stack level too deep`. That was the cause of the CI failures on the first attempt at this pass.

Verified locally with `JEKYLL_FATAL_LINK_CHECKER=internal` on 2.13 and 3.7, one branch of each `@ignored_paths` shape. Both report no broken links, and `_site/index.html` is the redirect stub.

`@ignored_paths` ends up covering the home page and all five single-edition section paths on this branch, so nothing that carries a `redirect_to` is followed:

```ruby
@ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
```

The pattern matches the link target rather than the page the link sits on, so these entries also stop inbound links to those sections from being verified. That costs nothing here: the targets are redirect stubs the checker would skip anyway, and no new content will land on this branch. It would cost real coverage on `main`, where those are live pages, so `main` keeps a shorter list on purpose (#13056) and this line is not meant to be synced to it.

The `Retarget canonical links to their current pages on latest` commit corrects this branch's canonical links. `canonical_url` is what tells search engines to index the `/latest/` copy of a page rather than this one, but pages keep moving on main after a branch is cut, and a canonical aimed at a `jekyll-redirect-from` stub is worth little more than no canonical at all. 193 of them on this branch pointed at a stub and now name the real page, followed through the `redirect_from` entries on main.

14 pages have no equivalent on latest, not even a redirect, so they keep pointing at their own path. Fixing those means adding `redirect_from` to whichever page on main replaced them; nothing on this branch can do it.

Every target was resolved against `upstream/main` and every rewritten line was checked to be a `canonical_url` line and nothing else. Spot checks against the live site confirm each new URL is a real page whose own canonical is exactly the URL written here.

### Issues Resolved

N/A

### Version

2.18

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
