### PR TITLE
Redirect the home page and single-edition sections to latest and update canonical links in 3.2

### DIFF
--- a/_api-reference/cluster-api/shard-stores.md
+++ b/_api-reference/cluster-api/shard-stores.md
@@ -3,7 +3,7 @@ layout: default
 title: Shard stores 
 parent: Cluster APIs 
 nav_order: 70
-canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/shard-stores/
+canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/shard-stores/
 redirect_from:
   - /api-reference/index-apis/shard-stores/
 ---

--- a/_api-reference/index-apis/alias.md
+++ b/_api-reference/index-apis/alias.md
@@ -7,7 +7,7 @@ redirect_from:
   - /opensearch/rest-api/alias/
   - /api-reference/alias/
   - /api-reference/alias/aliases-api/
-canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/alias/
+canonical_url: https://docs.opensearch.org/latest/api-reference/alias/aliases-api/
 ---
 
 # Alias API

--- a/_api-reference/index-apis/update-alias.md
+++ b/_api-reference/index-apis/update-alias.md
@@ -3,7 +3,7 @@ layout: default
 title: Create or update alias
 parent: Index APIs
 nav_order: 160
-canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/update-alias/
+canonical_url: https://docs.opensearch.org/latest/api-reference/alias/create-alias/
 redirect_from:
   - /api-reference/alias/create-alias/
 ---

--- a/_benchmark/glossary.md
+++ b/_benchmark/glossary.md
@@ -3,6 +3,7 @@ layout: default
 title: Glossary
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/benchmark/glossary/
+redirect_to: https://docs.opensearch.org/latest/benchmark/glossary/
 ---
 
 # OpenSearch Benchmark glossary

--- a/_benchmark/index.md
+++ b/_benchmark/index.md
@@ -34,6 +34,7 @@ items:
     description: "View your benchmark report and analyze your metrics"
     link: "/benchmark/user-guide/understanding-results/summary-reports/"
 canonical_url: https://docs.opensearch.org/latest/benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 
 # OpenSearch Benchmark

--- a/_benchmark/migration-assistance.md
+++ b/_benchmark/migration-assistance.md
@@ -3,6 +3,7 @@ layout: default
 title: Migration assistance
 nav_order: 102
 canonical_url: https://docs.opensearch.org/latest/benchmark/migration-assistance/
+redirect_to: https://docs.opensearch.org/latest/benchmark/migration-assistance/
 ---
 
 # Migrating from 1.X to 2.X

--- a/_benchmark/quickstart.md
+++ b/_benchmark/quickstart.md
@@ -3,6 +3,7 @@ layout: default
 title: Quickstart
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/benchmark/quickstart/
+redirect_to: https://docs.opensearch.org/latest/benchmark/quickstart/
 ---
 
 # OpenSearch Benchmark quickstart

--- a/_benchmark/reference/commands/aggregate.md
+++ b/_benchmark/reference/commands/aggregate.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/aggregate/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/aggregate/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/aggregate/
 ---
 
 # aggregate

--- a/_benchmark/reference/commands/command-flags.md
+++ b/_benchmark/reference/commands/command-flags.md
@@ -7,6 +7,7 @@ redirect_from:
   - /benchmark/commands/command-flags/
 grand_parent: OpenSearch Benchmark Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/command-flags/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/command-flags/
 ---
 
 # Command flags

--- a/_benchmark/reference/commands/compare.md
+++ b/_benchmark/reference/commands/compare.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/compare/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/compare/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/compare/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/download.md
+++ b/_benchmark/reference/commands/download.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/download/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/download/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/download/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/index.md
+++ b/_benchmark/reference/commands/index.md
@@ -7,6 +7,7 @@ parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/reference/commands/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
 ---
 
 # OpenSearch Benchmark command reference

--- a/_benchmark/reference/commands/info.md
+++ b/_benchmark/reference/commands/info.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/info/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/info/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/info/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/list.md
+++ b/_benchmark/reference/commands/list.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/commands/list/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/list/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/list/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/redline-test.md
+++ b/_benchmark/reference/commands/redline-test.md
@@ -5,6 +5,7 @@ nav_order: 85
 parent: Command reference
 grand_parent: OpenSearch Benchmark Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/redline-test/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/redline-test/
 ---
 
 # Redline testing

--- a/_benchmark/reference/commands/run.md
+++ b/_benchmark/reference/commands/run.md
@@ -8,6 +8,7 @@ redirect_from:
   - /benchmark/commands/run/
   - /benchmark/commands/execute-test/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /benchmark/reference/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/index/
 ---
 
 # Reference

--- a/_benchmark/reference/metrics/index.md
+++ b/_benchmark/reference/metrics/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/reference/metrics/
   - /benchmark/metrics/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
 ---
 
 # Metrics

--- a/_benchmark/reference/metrics/metric-keys.md
+++ b/_benchmark/reference/metrics/metric-keys.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/metrics/metric-keys/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-keys/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-keys/
 ---
 
 # Metric keys

--- a/_benchmark/reference/metrics/metric-records.md
+++ b/_benchmark/reference/metrics/metric-records.md
@@ -7,6 +7,7 @@ grand_parent: OpenSearch Benchmark Reference
 redirect_from:
   - /benchmark/metrics/metric-records/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-records/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-records/
 ---
 
 # Metric records

--- a/_benchmark/reference/summary-report.md
+++ b/_benchmark/reference/summary-report.md
@@ -4,6 +4,7 @@ title: Summary report
 nav_order: 40
 parent: Metrics
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 # Summary report

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -4,6 +4,7 @@ title: Telemetry devices
 nav_order: 45
 parent: OpenSearch Benchmark Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 
 # Telemetry devices

--- a/_benchmark/reference/workloads/corpora.md
+++ b/_benchmark/reference/workloads/corpora.md
@@ -7,6 +7,7 @@ nav_order: 70
 redirect_from:
   - /benchmark/workloads/corpora/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/corpora/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/corpora/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/reference/workloads/
   - /benchmark/workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # OpenSearch Benchmark workload reference

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /benchmark/workloads/index/
   - /benchmark/reference/workloads/
   - /benchmark/workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 

--- a/_benchmark/reference/workloads/indices.md
+++ b/_benchmark/reference/workloads/indices.md
@@ -7,6 +7,7 @@ nav_order: 65
 redirect_from:
   - /benchmark/workloads/indices/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/indices/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/indices/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: OpenSearch Benchmark Reference
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/operations/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/operations/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/test-procedures.md
+++ b/_benchmark/reference/workloads/test-procedures.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: OpenSearch Benchmark Reference
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/test-procedures/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/test-procedures/
 ---
 
 <!-- vale off -->

--- a/_benchmark/user-guide/concepts.md
+++ b/_benchmark/user-guide/concepts.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from: 
   - /benchmark/user-guide/concepts/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/concepts/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/concepts/
 ---
 
 # Concepts

--- a/_benchmark/user-guide/index.md
+++ b/_benchmark/user-guide/index.md
@@ -26,6 +26,7 @@ more_cards:
 redirect_from:
   - /benchmark/user-guide/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/index/
 ---
 
 # OpenSearch Benchmark User Guide

--- a/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
+++ b/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/user-guide/configuring-benchmark/
   - /benchmark/tutorials/sigv4/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 ---
 
 # Configuring OpenSearch Benchmark

--- a/_benchmark/user-guide/install-and-configure/index.md
+++ b/_benchmark/user-guide/install-and-configure/index.md
@@ -7,6 +7,7 @@ has_children: true
 redirect_from:
   - /benchmark/user-guide/install-and-configure/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/index/
 ---
 
 # Installing and configuring OpenSearch Benchmark 

--- a/_benchmark/user-guide/install-and-configure/installing-benchmark.md
+++ b/_benchmark/user-guide/install-and-configure/installing-benchmark.md
@@ -8,6 +8,7 @@ redirect_from:
   - /benchmark/installing-benchmark/
   - /benchmark/user-guide/installing-benchmark/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/installing-benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/installing-benchmark/
 ---
 
 # Installing OpenSearch Benchmark

--- a/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
@@ -5,6 +5,7 @@ nav_order: 15
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/distributed-load/
+redirect_to: https://docs.opensearch.org/latest/benchmark/distributed-load/
 ---
 
 # Running distributed loads

--- a/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
@@ -4,7 +4,7 @@ title: Running distributed loads
 nav_order: 15
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/distributed-load/
+canonical_url: https://docs.opensearch.org/latest/benchmark/distributed-load/
 redirect_to: https://docs.opensearch.org/latest/benchmark/distributed-load/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
@@ -4,7 +4,7 @@ title: Expanding a workload's data corpus
 nav_order: 20
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/expand-data-corpus/
+canonical_url: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 redirect_to: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
@@ -5,6 +5,7 @@ nav_order: 20
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/expand-data-corpus/
+redirect_to: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 ---
 
 # Expanding a workload's data corpus

--- a/_benchmark/user-guide/optimizing-benchmarks/index.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/index.md
@@ -23,7 +23,7 @@ more_cards:
     link: "/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/"
 redirect_from:
   - /benchmark/user-guide/optimizing-benchmarks/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/index.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/index.md
@@ -24,6 +24,7 @@ more_cards:
 redirect_from:
   - /benchmark/user-guide/optimizing-benchmarks/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 
 # Optimizing benchmarks

--- a/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
@@ -5,6 +5,7 @@ nav_order: 160
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices/
+redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 
 # Performance testing best practices

--- a/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
@@ -4,7 +4,7 @@ title: Performance testing best practices
 nav_order: 160
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices/
+canonical_url: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
@@ -5,7 +5,7 @@ nav_order: 160
 parent: Optimizing benchmarks
 grand_parent: User guide
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/
+canonical_url: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 redirect_to: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
@@ -6,6 +6,7 @@ parent: Optimizing benchmarks
 grand_parent: User guide
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/
+redirect_to: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 ---
 
 # Randomizing queries

--- a/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
@@ -6,7 +6,7 @@ parent: Optimizing benchmarks
 grand_parent: User guide
 redirect_from: 
   - /benchmark/user-guide/target-throughput/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/target-throughput/
+canonical_url: https://docs.opensearch.org/latest/benchmark/target-throughput/
 redirect_to: https://docs.opensearch.org/latest/benchmark/target-throughput/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
@@ -7,6 +7,7 @@ grand_parent: User guide
 redirect_from: 
   - /benchmark/user-guide/target-throughput/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/target-throughput/
+redirect_to: https://docs.opensearch.org/latest/benchmark/target-throughput/
 ---
 
 # Target throughput

--- a/_benchmark/user-guide/understanding-results/index.md
+++ b/_benchmark/user-guide/understanding-results/index.md
@@ -6,7 +6,7 @@ parent: User guide
 has_children: true
 redirect_from:
   - /benchmark/user-guide/understanding-results/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 

--- a/_benchmark/user-guide/understanding-results/index.md
+++ b/_benchmark/user-guide/understanding-results/index.md
@@ -7,6 +7,7 @@ has_children: true
 redirect_from:
   - /benchmark/user-guide/understanding-results/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 After a [running a workload]({{site.url}}{{site.baseurl}}/benchmark/user-guide/working-with-workloads/running-workloads/), OpenSearch Benchmark produces a series of metrics. The following pages details:

--- a/_benchmark/user-guide/understanding-results/summary-reports.md
+++ b/_benchmark/user-guide/understanding-results/summary-reports.md
@@ -4,7 +4,7 @@ title: Summary reports
 nav_order: 22
 grand_parent: User guide
 parent: Understanding results
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/summary-reports/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 

--- a/_benchmark/user-guide/understanding-results/summary-reports.md
+++ b/_benchmark/user-guide/understanding-results/summary-reports.md
@@ -5,6 +5,7 @@ nav_order: 22
 grand_parent: User guide
 parent: Understanding results
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/summary-reports/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 # Understanding the summary report

--- a/_benchmark/user-guide/understanding-results/telemetry.md
+++ b/_benchmark/user-guide/understanding-results/telemetry.md
@@ -7,6 +7,7 @@ parent: Understanding results
 redirect_from: 
   - /benchmark/user-guide/telemetry
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/telemetry/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 
 # Enabling telemetry devices

--- a/_benchmark/user-guide/understanding-results/telemetry.md
+++ b/_benchmark/user-guide/understanding-results/telemetry.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Understanding results
 redirect_from: 
   - /benchmark/user-guide/telemetry
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/telemetry/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 15
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # Anatomy of a workload

--- a/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/anatomy-of-a-workload.md
@@ -4,7 +4,7 @@ title: Anatomy of a workload
 nav_order: 15
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
@@ -4,7 +4,7 @@ title: Choosing a workload
 nav_order: 20
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
+canonical_url: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
+++ b/_benchmark/user-guide/understanding-workloads/choosing-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 20
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/choosing-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 ---
 
 # Choosing a workload

--- a/_benchmark/user-guide/understanding-workloads/common-operations.md
+++ b/_benchmark/user-guide/understanding-workloads/common-operations.md
@@ -5,6 +5,7 @@ nav_order: 16
 grand_parent: User guide
 parent: Understanding workloads
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/common-operations/
+redirect_to: https://docs.opensearch.org/latest/benchmark/common-operations/
 ---
 
 # Common operations

--- a/_benchmark/user-guide/understanding-workloads/common-operations.md
+++ b/_benchmark/user-guide/understanding-workloads/common-operations.md
@@ -4,7 +4,7 @@ title: Common operations
 nav_order: 16
 grand_parent: User guide
 parent: Understanding workloads
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/common-operations/
+canonical_url: https://docs.opensearch.org/latest/benchmark/common-operations/
 redirect_to: https://docs.opensearch.org/latest/benchmark/common-operations/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -17,7 +17,7 @@ items:
     link: "/benchmark/user-guide/understanding-workloads/common-operations/"
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -17,8 +17,8 @@ items:
     link: "/benchmark/user-guide/understanding-workloads/common-operations/"
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/
-redirect_to: https://docs.opensearch.org/latest/benchmark/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # Understanding workloads

--- a/_benchmark/user-guide/understanding-workloads/index.md
+++ b/_benchmark/user-guide/understanding-workloads/index.md
@@ -18,6 +18,7 @@ items:
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-workloads/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 
 # Understanding workloads

--- a/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/contributing-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/contributing-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/contributing-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/contributing-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 ---
 
 # Sharing custom workloads

--- a/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/creating-custom-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 ---
 
 # Creating custom workloads

--- a/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
@@ -8,7 +8,7 @@ redirect_from:
   - /benchmark/user-guide/creating-custom-workloads/
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/creating-custom-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/finetine-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/finetune-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/finetine-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/finetune-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 ---
 
 # Fine-tuning custom workloads

--- a/_benchmark/user-guide/working-with-workloads/index.md
+++ b/_benchmark/user-guide/working-with-workloads/index.md
@@ -8,6 +8,7 @@ has_children: true
 redirect_from:
   - /benchmark/user-guide/working-with-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/index/
+redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 
 # Working with workloads

--- a/_benchmark/user-guide/working-with-workloads/index.md
+++ b/_benchmark/user-guide/working-with-workloads/index.md
@@ -7,7 +7,7 @@ has_toc: false
 has_children: true
 redirect_from:
   - /benchmark/user-guide/working-with-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/index/
+canonical_url: https://docs.opensearch.org/latest/benchmark/running-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/running-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/running-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from:
   - /benchmark/user-guide/running-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/running-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 
 # Running a workload

--- a/_benchmark/user-guide/working-with-workloads/running-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/running-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from:
   - /benchmark/user-guide/running-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/running-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/running-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 

--- a/_benchmark/version-history.md
+++ b/_benchmark/version-history.md
@@ -3,6 +3,7 @@ layout: default
 title: Version history
 nav_order: 101
 canonical_url: https://docs.opensearch.org/latest/benchmark/version-history/
+redirect_to: https://docs.opensearch.org/latest/benchmark/version-history/
 ---
 
 # Version history

--- a/_benchmark/workloads/vectorsearch.md
+++ b/_benchmark/workloads/vectorsearch.md
@@ -3,6 +3,7 @@ layout: default
 title: Vector search
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/benchmark/workloads/vectorsearch/
+redirect_to: https://docs.opensearch.org/latest/benchmark/workloads/vectorsearch/
 ---
 
 # Vector search workload

--- a/_clients/OSC-dot-net.md
+++ b/_clients/OSC-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 10
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OSC-dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/OSC-dot-net/
 ---
 
 # Getting started with the high-level .NET client (OpenSearch.Client)

--- a/_clients/OSC-example.md
+++ b/_clients/OSC-example.md
@@ -5,6 +5,7 @@ nav_order: 12
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OSC-example/
+redirect_to: https://docs.opensearch.org/latest/clients/OSC-example/
 ---
 
 # More advanced features of the high-level .NET client (OpenSearch.Client)

--- a/_clients/OpenSearch-dot-net.md
+++ b/_clients/OpenSearch-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 30
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OpenSearch-dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/OpenSearch-dot-net/
 ---
 
 # Low-level .NET client (OpenSearch.Net)

--- a/_clients/dot-net-conventions.md
+++ b/_clients/dot-net-conventions.md
@@ -5,6 +5,7 @@ nav_order: 20
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/dot-net-conventions/
+redirect_to: https://docs.opensearch.org/latest/clients/dot-net-conventions/
 ---
 
 # .NET client considerations and best practices

--- a/_clients/dot-net.md
+++ b/_clients/dot-net.md
@@ -5,6 +5,7 @@ nav_order: 75
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/clients/dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/dot-net/
 ---
 
 # .NET clients

--- a/_clients/go.md
+++ b/_clients/go.md
@@ -3,6 +3,7 @@ layout: default
 title: Go client
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/clients/go/
+redirect_to: https://docs.opensearch.org/latest/clients/go/
 ---
 
 # Go client

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -8,6 +8,7 @@ permalink: /clients/
 redirect_from:
   - /clients/index/
 canonical_url: https://docs.opensearch.org/latest/clients/
+redirect_to: https://docs.opensearch.org/latest/clients/
 ---
 
 # OpenSearch language clients

--- a/_clients/java-rest-high-level.md
+++ b/_clients/java-rest-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: Java high-level REST client
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/clients/java-rest-high-level/
+redirect_to: https://docs.opensearch.org/latest/clients/java-rest-high-level/
 ---
 
 # Java high-level REST client

--- a/_clients/java.md
+++ b/_clients/java.md
@@ -3,6 +3,7 @@ layout: default
 title: Java client
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/clients/java/
+redirect_to: https://docs.opensearch.org/latest/clients/java/
 ---
 
 # Java client

--- a/_clients/javascript/helpers.md
+++ b/_clients/javascript/helpers.md
@@ -4,6 +4,7 @@ title: Helper methods
 parent: JavaScript client
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/clients/javascript/helpers/
+redirect_to: https://docs.opensearch.org/latest/clients/javascript/helpers/
 ---
 
 # Helper methods

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -6,6 +6,7 @@ nav_order: 40
 redirect_from:
   - /clients/javascript/
 canonical_url: https://docs.opensearch.org/latest/clients/javascript/index/
+redirect_to: https://docs.opensearch.org/latest/clients/javascript/index/
 ---
 
 # JavaScript client

--- a/_clients/opensearch-py-ml.md
+++ b/_clients/opensearch-py-ml.md
@@ -3,6 +3,7 @@ layout: default
 title: Opensearch-py-ml
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/clients/opensearch-py-ml/
+redirect_to: https://docs.opensearch.org/latest/clients/opensearch-py-ml/
 ---
 
 # opensearch-py-ml

--- a/_clients/php.md
+++ b/_clients/php.md
@@ -3,6 +3,7 @@ layout: default
 title: PHP client
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/clients/php/
+redirect_to: https://docs.opensearch.org/latest/clients/php/
 ---
 
 # PHP client

--- a/_clients/python-high-level.md
+++ b/_clients/python-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: High-level Python client
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/clients/python-high-level/
+redirect_to: https://docs.opensearch.org/latest/clients/python-high-level/
 ---
 
 The OpenSearch high-level Python client (`opensearch-dsl-py`) will be deprecated after version 2.1.0. We recommend switching to the [Python client (`opensearch-py`)]({{site.url}}{{site.baseurl}}/clients/python-low-level/), which now includes the functionality of `opensearch-dsl-py`.

--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -5,6 +5,7 @@ nav_order: 10
 redirect_from: 
   - /clients/python/
 canonical_url: https://docs.opensearch.org/latest/clients/python-low-level/
+redirect_to: https://docs.opensearch.org/latest/clients/python-low-level/
 ---
 
 # Low-level Python client

--- a/_clients/ruby.md
+++ b/_clients/ruby.md
@@ -4,6 +4,7 @@ title: Ruby client
 nav_order: 60
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/clients/ruby/
+redirect_to: https://docs.opensearch.org/latest/clients/ruby/
 ---
 
 # Ruby client

--- a/_clients/rust.md
+++ b/_clients/rust.md
@@ -3,6 +3,7 @@ layout: default
 title: Rust client
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/clients/rust/
+redirect_to: https://docs.opensearch.org/latest/clients/rust/
 ---
 
 # Rust client

--- a/_dashboards/dev-tools/index-dev.md
+++ b/_dashboards/dev-tools/index-dev.md
@@ -7,7 +7,7 @@ redirect_from:
   - /dashboards/dev-tools/run-queries/
   - /dashboards/discover/run-queries/
   - /dashboards/visualize/run-queries/
-canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index-dev/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index/
 ---
 
 # Running queries in the Dev Tools console

--- a/_dashboards/quickstart.md
+++ b/_dashboards/quickstart.md
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/browser-compatibility/
   - /dashboards/getting-started/
   - /dashboards/getting-started/index/
-canonical_url: https://docs.opensearch.org/latest/dashboards/quickstart/
+canonical_url: https://docs.opensearch.org/latest/dashboards/getting-started/index/
 ---
 
 # OpenSearch Dashboards quickstart guide

--- a/_dashboards/visualize/area.md
+++ b/_dashboards/visualize/area.md
@@ -3,7 +3,7 @@ layout: default
 title: Area charts
 parent: Building data visualizations
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/area/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/area/
 redirect_from:
   - /dashboards/visualize/visualize-app/area/
 ---

--- a/_dashboards/visualize/geojson-regionmaps.md
+++ b/_dashboards/visualize/geojson-regionmaps.md
@@ -8,7 +8,7 @@ redirect_from:
   - /dashboards/geojson-regionmaps/
   - /dashboards/visualize/region-maps/
   - /dashboards/visualize/visualize-app/region-maps/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/geojson-regionmaps/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/region-maps/
 ---
 
 # Using coordinate and region maps

--- a/_dashboards/visualize/maps-stats-api.md
+++ b/_dashboards/visualize/maps-stats-api.md
@@ -5,7 +5,7 @@ nav_order: 20
 grand_parent: Building data visualizations
 parent: Coordinate and region maps 
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps-stats-api/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maps-stats-api/
 redirect_from:
   - /dashboards/visualize/visualize-app/maps-stats-api/
 ---

--- a/_dashboards/visualize/maps.md
+++ b/_dashboards/visualize/maps.md
@@ -9,7 +9,7 @@ redirect_from:
   - /dashboards/visualize/maps/
   - /dashboards/maps/
   - /dashboards/visualize/visualize-app/maps/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maps/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maps/
 ---
 
 # Using maps 

--- a/_dashboards/visualize/maptiles.md
+++ b/_dashboards/visualize/maptiles.md
@@ -7,7 +7,7 @@ nav_order: 30
 redirect_from:
   - /dashboards/maptiles/
   - /dashboards/visualize/visualize-app/maptiles/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/maptiles/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/maptiles/
 ---
 
 {%- comment -%}The `/docs/opensearch-dashboards/maptiles/` redirect is specifically to support the UI links in OpenSearch Dashboards 1.0.0.{%- endcomment -%}

--- a/_dashboards/visualize/selfhost-maps-server.md
+++ b/_dashboards/visualize/selfhost-maps-server.md
@@ -7,7 +7,7 @@ nav_order: 40
 redirect_from:
   - /dashboards/selfhost-maps-server/
   - /dashboards/visualize/visualize-app/selfhost-maps-server/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/selfhost-maps-server/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/selfhost-maps-server/
 ---
 
 # Using self-hosted map servers

--- a/_dashboards/visualize/tsvb.md
+++ b/_dashboards/visualize/tsvb.md
@@ -3,7 +3,7 @@ layout: default
 title: TSVB
 parent: Building data visualizations
 nav_order: 45
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/tsvb/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/tsvb/
 redirect_from:
   - /dashboards/visualize/visualize-app/tsvb/
 ---

--- a/_dashboards/visualize/vega.md
+++ b/_dashboards/visualize/vega.md
@@ -3,7 +3,7 @@ layout: default
 title: Vega
 parent: Building data visualizations
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/vega/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/vega/
 redirect_from:
   - /dashboards/visualize/visualize-app/vega/
 ---

--- a/_dashboards/visualize/visbuilder.md
+++ b/_dashboards/visualize/visbuilder.md
@@ -6,7 +6,7 @@ nav_order: 100
 redirect_from:
   - /dashboards/drag-drop-wizard/
   - /dashboards/visualize/visualize-app/visbuilder/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visbuilder/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/visbuilder/
 ---
 
 # VisBuilder

--- a/_dashboards/visualize/viz-index.md
+++ b/_dashboards/visualize/viz-index.md
@@ -4,7 +4,7 @@ title: Building data visualizations
 nav_order: 40
 has_children: true
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/viz-index/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/index/
 redirect_from:
   - /dashboards/visualize/visualize-app/
   - /dashboards/visualize/visualize-app/index/

--- a/_data-prepper/common-use-cases/anomaly-detection.md
+++ b/_data-prepper/common-use-cases/anomaly-detection.md
@@ -4,6 +4,7 @@ title: Anomaly detection
 parent: Common use cases
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/anomaly-detection/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/anomaly-detection/
 ---
 
 # Anomaly detection

--- a/_data-prepper/common-use-cases/codec-processor-combinations.md
+++ b/_data-prepper/common-use-cases/codec-processor-combinations.md
@@ -4,6 +4,7 @@ title: Codec processor combinations
 parent: Common use cases
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/codec-processor-combinations/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/codec-processor-combinations/
 ---
 
 # Codec processor combinations

--- a/_data-prepper/common-use-cases/common-use-cases.md
+++ b/_data-prepper/common-use-cases/common-use-cases.md
@@ -6,6 +6,7 @@ nav_order: 15
 redirect_from: 
   - /data-prepper/common-use-cases/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/common-use-cases/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/common-use-cases/
 ---
 
 # Common use cases

--- a/_data-prepper/common-use-cases/event-aggregation.md
+++ b/_data-prepper/common-use-cases/event-aggregation.md
@@ -4,6 +4,7 @@ title: Event aggregation
 parent: Common use cases
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/event-aggregation/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/event-aggregation/
 ---
 
 # Event aggregation

--- a/_data-prepper/common-use-cases/log-analytics.md
+++ b/_data-prepper/common-use-cases/log-analytics.md
@@ -4,6 +4,7 @@ title: Log analytics
 parent: Common use cases
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-analytics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-analytics/
 ---
 
 # Log analytics

--- a/_data-prepper/common-use-cases/log-enrichment.md
+++ b/_data-prepper/common-use-cases/log-enrichment.md
@@ -4,6 +4,7 @@ title: Log enrichment
 parent: Common use cases
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-enrichment/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-enrichment/
 ---
 
 # Log enrichment

--- a/_data-prepper/common-use-cases/metrics-logs.md
+++ b/_data-prepper/common-use-cases/metrics-logs.md
@@ -4,6 +4,7 @@ title: Deriving metrics from logs
 parent: Common use cases
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-logs/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-logs/
 ---
 
 # Deriving metrics from logs

--- a/_data-prepper/common-use-cases/metrics-traces.md
+++ b/_data-prepper/common-use-cases/metrics-traces.md
@@ -4,6 +4,7 @@ title: Deriving metrics from traces
 parent: Common use cases
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-traces/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-traces/
 ---
 
 # Deriving metrics from traces

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -4,6 +4,7 @@ title: S3 logs
 parent: Common use cases
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/s3-logs/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/s3-logs/
 ---
 
 # S3 logs

--- a/_data-prepper/common-use-cases/sampling.md
+++ b/_data-prepper/common-use-cases/sampling.md
@@ -4,6 +4,7 @@ title: Sampling
 parent: Common use cases
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/sampling/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/sampling/
 ---
 
 # Sampling

--- a/_data-prepper/common-use-cases/text-processing.md
+++ b/_data-prepper/common-use-cases/text-processing.md
@@ -4,6 +4,7 @@ title: Text processing
 parent: Common use cases
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/text-processing/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/text-processing/
 ---
 
 # Text processing

--- a/_data-prepper/common-use-cases/trace-analytics.md
+++ b/_data-prepper/common-use-cases/trace-analytics.md
@@ -4,6 +4,7 @@ title: Trace analytics
 parent: Common use cases
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/trace-analytics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/trace-analytics/
 ---
 
 # Trace analytics

--- a/_data-prepper/getting-started.md
+++ b/_data-prepper/getting-started.md
@@ -5,6 +5,7 @@ nav_order: 5
 redirect_from:
   - /clients/data-prepper/get-started/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/getting-started/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/getting-started/
 ---
 
 # Getting started with OpenSearch Data Prepper

--- a/_data-prepper/index.md
+++ b/_data-prepper/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /monitoring-plugins/trace/data-prepper/
   - /data-prepper/index/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 
 # OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/configuring-data-prepper.md
@@ -7,6 +7,7 @@ redirect_from:
   - /clients/data-prepper/data-prepper-reference/
   - /monitoring-plugins/trace/data-prepper-reference/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
 ---
 
 # Configuring OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-log4j.md
+++ b/_data-prepper/managing-data-prepper/configuring-log4j.md
@@ -4,6 +4,7 @@ title: Configuring Log4j
 parent: Managing OpenSearch Data Prepper
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-log4j/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-log4j/
 ---
 
 # Configuring Log4j

--- a/_data-prepper/managing-data-prepper/core-apis.md
+++ b/_data-prepper/managing-data-prepper/core-apis.md
@@ -4,6 +4,7 @@ title: Core APIs
 parent: Managing OpenSearch Data Prepper
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/core-apis/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/core-apis/
 ---
 
 # Core APIs

--- a/_data-prepper/managing-data-prepper/extensions/extensions.md
+++ b/_data-prepper/managing-data-prepper/extensions/extensions.md
@@ -5,6 +5,7 @@ parent: Managing OpenSearch Data Prepper
 has_children: true
 nav_order: 18
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/extensions/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/extensions/
 ---
 
 # Extensions

--- a/_data-prepper/managing-data-prepper/extensions/geoip-service.md
+++ b/_data-prepper/managing-data-prepper/extensions/geoip-service.md
@@ -5,6 +5,7 @@ nav_order: 5
 parent: Extensions
 grand_parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/geoip-service/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/geoip-service/
 ---
 
 # geoip_service

--- a/_data-prepper/managing-data-prepper/managing-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/managing-data-prepper.md
@@ -4,6 +4,7 @@ title: Managing OpenSearch Data Prepper
 has_children: true
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/managing-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/managing-data-prepper/
 ---
 
 # Managing OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/monitoring.md
+++ b/_data-prepper/managing-data-prepper/monitoring.md
@@ -4,6 +4,7 @@ title: Monitoring
 parent: Managing OpenSearch Data Prepper
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/monitoring/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/monitoring/
 ---
  
 # Monitoring OpenSearch Data Prepper with metrics

--- a/_data-prepper/managing-data-prepper/peer-forwarder.md
+++ b/_data-prepper/managing-data-prepper/peer-forwarder.md
@@ -4,6 +4,7 @@ title: Peer forwarder
 nav_order: 12
 parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/peer-forwarder/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/peer-forwarder/
 ---
 
 # Peer forwarder

--- a/_data-prepper/managing-data-prepper/source-coordination.md
+++ b/_data-prepper/managing-data-prepper/source-coordination.md
@@ -4,6 +4,7 @@ title: Source coordination
 nav_order: 35
 parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/source-coordination/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/source-coordination/
 ---
 
 # Source coordination

--- a/_data-prepper/migrate-open-distro.md
+++ b/_data-prepper/migrate-open-distro.md
@@ -5,6 +5,7 @@ nav_order: 30
 redirect_from:
   - /clients/data-prepper/migrate-open-distro/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/migrate-open-distro/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/migrate-open-distro/
 ---
 
 # Migrating from Open Distro

--- a/_data-prepper/migrating-from-logstash-data-prepper.md
+++ b/_data-prepper/migrating-from-logstash-data-prepper.md
@@ -5,7 +5,7 @@ nav_order: 25
 redirect_from: 
   - /clients/data-prepper/configure-logstash-data-prepper/
   - /data-prepper/configure-logstash-data-prepper/
-canonical_url: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
+canonical_url: https://docs.opensearch.org/latest/data-prepper/
 redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 

--- a/_data-prepper/migrating-from-logstash-data-prepper.md
+++ b/_data-prepper/migrating-from-logstash-data-prepper.md
@@ -6,6 +6,7 @@ redirect_from:
   - /clients/data-prepper/configure-logstash-data-prepper/
   - /data-prepper/configure-logstash-data-prepper/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/migrating-from-logstash-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 
 # Migrating from Logstash

--- a/_data-prepper/pipelines/cidrcontains.md
+++ b/_data-prepper/pipelines/cidrcontains.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/cidrcontains/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/cidrcontains/
 ---
 
 # cidrContains()

--- a/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
+++ b/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
 ---
 
 # Bounded blocking

--- a/_data-prepper/pipelines/configuration/buffers/buffers.md
+++ b/_data-prepper/pipelines/configuration/buffers/buffers.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/buffers/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/buffers/
 ---
 
 # Buffers

--- a/_data-prepper/pipelines/configuration/buffers/kafka.md
+++ b/_data-prepper/pipelines/configuration/buffers/kafka.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/kafka/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/kafka/
 ---
 
 # kafka

--- a/_data-prepper/pipelines/configuration/processors/add-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/add-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/add-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/add-entries/
 ---
 
 # Add entries processor

--- a/_data-prepper/pipelines/configuration/processors/aggregate.md
+++ b/_data-prepper/pipelines/configuration/processors/aggregate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aggregate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aggregate/
 ---
 
 # Aggregate processor

--- a/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
+++ b/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
 ---
 
 # Anomaly detector processor

--- a/_data-prepper/pipelines/configuration/processors/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/processors/aws-lambda.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aws-lambda/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aws-lambda/
 ---
 
 # AWS Lambda processor

--- a/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
+++ b/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/convert-entry-type/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/convert-entry-type/
 ---
 
 # Convert entry type processor

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/copy-values/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/copy-values/
 ---
 
 # Copy values processor

--- a/_data-prepper/pipelines/configuration/processors/csv.md
+++ b/_data-prepper/pipelines/configuration/processors/csv.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/csv/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/csv/
 ---
 
 # CSV processor

--- a/_data-prepper/pipelines/configuration/processors/date.md
+++ b/_data-prepper/pipelines/configuration/processors/date.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/date/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/date/
 ---
 
 # Date processor

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/decompress/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/decompress/
 ---
 
 # Decompress processor

--- a/_data-prepper/pipelines/configuration/processors/delay.md
+++ b/_data-prepper/pipelines/configuration/processors/delay.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delay/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delay/
 ---
 
 # Delay processor

--- a/_data-prepper/pipelines/configuration/processors/delete-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/delete-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delete-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delete-entries/
 ---
  
 # Delete entries processor

--- a/_data-prepper/pipelines/configuration/processors/dissect.md
+++ b/_data-prepper/pipelines/configuration/processors/dissect.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 120
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/dissect/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/dissect/
 ---
 
 # Dissect processor

--- a/_data-prepper/pipelines/configuration/processors/drop-events.md
+++ b/_data-prepper/pipelines/configuration/processors/drop-events.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 130
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/drop-events/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/drop-events/
 ---
 
 # Drop events processor

--- a/_data-prepper/pipelines/configuration/processors/flatten.md
+++ b/_data-prepper/pipelines/configuration/processors/flatten.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 140
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/flatten/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/flatten/
 ---
 
 # Flatten processor

--- a/_data-prepper/pipelines/configuration/processors/geoip.md
+++ b/_data-prepper/pipelines/configuration/processors/geoip.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 150
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/geoip/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/geoip/
 ---
 
 # Geo IP processor

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 160
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/grok/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/grok/
 ---
 
 # Grok processor

--- a/_data-prepper/pipelines/configuration/processors/key-value.md
+++ b/_data-prepper/pipelines/configuration/processors/key-value.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 170
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/key-value/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/key-value/
 ---
 
 # Key-value processor

--- a/_data-prepper/pipelines/configuration/processors/list-to-map.md
+++ b/_data-prepper/pipelines/configuration/processors/list-to-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 180
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/list-to-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/list-to-map/
 ---
 
 # List to map processor

--- a/_data-prepper/pipelines/configuration/processors/lowercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/lowercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 190
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
 ---
 
 # Lowercase string processor

--- a/_data-prepper/pipelines/configuration/processors/map-to-list.md
+++ b/_data-prepper/pipelines/configuration/processors/map-to-list.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 200
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/map-to-list/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/map-to-list/
 ---
 
 # Map to list processor

--- a/_data-prepper/pipelines/configuration/processors/ml-inference.md
+++ b/_data-prepper/pipelines/configuration/processors/ml-inference.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 210
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/ml-inference/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/ml-inference/
 ---
 
 # ML inference processor

--- a/_data-prepper/pipelines/configuration/processors/obfuscate.md
+++ b/_data-prepper/pipelines/configuration/processors/obfuscate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 240
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/obfuscate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/obfuscate/
 ---
 
 # Obfuscate processor

--- a/_data-prepper/pipelines/configuration/processors/otel-metrics.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-metrics.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 250
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
 ---
 
 # OTel metrics processor

--- a/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 270
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
 ---
 
 # OTel trace group processor

--- a/_data-prepper/pipelines/configuration/processors/otel-traces.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-traces.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 260
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
 ---
 
 # OTel trace processor

--- a/_data-prepper/pipelines/configuration/processors/parse-ion.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-ion.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 280
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-ion/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-ion/
 ---
 
 # Parse Ion processor

--- a/_data-prepper/pipelines/configuration/processors/parse-json.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-json.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 290
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-json/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-json/
 ---
 
 # Parse JSON processor

--- a/_data-prepper/pipelines/configuration/processors/parse-xml.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-xml.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 300
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-xml/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-xml/
 ---
 
 # Parse XML processor

--- a/_data-prepper/pipelines/configuration/processors/processors.md
+++ b/_data-prepper/pipelines/configuration/processors/processors.md
@@ -9,6 +9,7 @@ redirect_from:
   - /data-prepper/pipelines/configuration/processors/mutate-string/
   - /data-prepper/pipelines/configuration/processors/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 ---
 
 # Processors

--- a/_data-prepper/pipelines/configuration/processors/rename-keys.md
+++ b/_data-prepper/pipelines/configuration/processors/rename-keys.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 310
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/rename-keys/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/rename-keys/
 ---
 
 # Rename keys processor

--- a/_data-prepper/pipelines/configuration/processors/select-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/select-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 320
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/select-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/select-entries/
 ---
 
 # Select entries processor

--- a/_data-prepper/pipelines/configuration/processors/service-map.md
+++ b/_data-prepper/pipelines/configuration/processors/service-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 330
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
 ---
 
 # Service map processor

--- a/_data-prepper/pipelines/configuration/processors/split-event.md
+++ b/_data-prepper/pipelines/configuration/processors/split-event.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 340
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-event/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-event/
 ---
 
 # Split event processor

--- a/_data-prepper/pipelines/configuration/processors/split-string.md
+++ b/_data-prepper/pipelines/configuration/processors/split-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 350
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-string/
 ---
 
 # Split string processor

--- a/_data-prepper/pipelines/configuration/processors/string-converter.md
+++ b/_data-prepper/pipelines/configuration/processors/string-converter.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 360
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/string-converter/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/string-converter/
 ---
 
 # String converter processor

--- a/_data-prepper/pipelines/configuration/processors/substitute-string.md
+++ b/_data-prepper/pipelines/configuration/processors/substitute-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 370
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/substitute-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/substitute-string/
 ---
 
 # Substitute string processor

--- a/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
+++ b/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 380
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
 ---
 
 # Trace peer forwarder processor

--- a/_data-prepper/pipelines/configuration/processors/translate.md
+++ b/_data-prepper/pipelines/configuration/processors/translate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 390
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/translate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/translate/
 ---
 
 # Translate processor

--- a/_data-prepper/pipelines/configuration/processors/trim-string.md
+++ b/_data-prepper/pipelines/configuration/processors/trim-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 400
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trim-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trim-string/
 ---
 
 # Trim string processor

--- a/_data-prepper/pipelines/configuration/processors/truncate.md
+++ b/_data-prepper/pipelines/configuration/processors/truncate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 410
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/truncate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/truncate/
 ---
 
 # Truncate processor

--- a/_data-prepper/pipelines/configuration/processors/uppercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/uppercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 420
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
 ---
 
 # Uppercase string processor

--- a/_data-prepper/pipelines/configuration/processors/user-agent.md
+++ b/_data-prepper/pipelines/configuration/processors/user-agent.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 430
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/user-agent/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/user-agent/
 ---
 
 # User agent processor

--- a/_data-prepper/pipelines/configuration/processors/write-json.md
+++ b/_data-prepper/pipelines/configuration/processors/write-json.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 440
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/write-json/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/write-json/
 ---
 
 # Write JSON processor

--- a/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/aws-lambda/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/aws-lambda/
 ---
 
 # AWS Lambda sink

--- a/_data-prepper/pipelines/configuration/sinks/file.md
+++ b/_data-prepper/pipelines/configuration/sinks/file.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/file/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/file/
 ---
 
 # File sink

--- a/_data-prepper/pipelines/configuration/sinks/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sinks/opensearch.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/opensearch/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/opensearch/
 ---
 
 # OpenSearch sink

--- a/_data-prepper/pipelines/configuration/sinks/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sinks/pipeline.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/pipeline/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/pipeline/
 ---
 
 # Pipeline sink

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/s3/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/s3/
 ---
 
 # S3 sink

--- a/_data-prepper/pipelines/configuration/sinks/sinks.md
+++ b/_data-prepper/pipelines/configuration/sinks/sinks.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
 ---
 
 # Sinks

--- a/_data-prepper/pipelines/configuration/sinks/stdout.md
+++ b/_data-prepper/pipelines/configuration/sinks/stdout.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/stdout/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/stdout/
 ---
 
 # Standard output sink

--- a/_data-prepper/pipelines/configuration/sources/atlassian-confluence.md
+++ b/_data-prepper/pipelines/configuration/sources/atlassian-confluence.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-confluence/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-confluence/
 ---
 
 # Atlassian Confluence source

--- a/_data-prepper/pipelines/configuration/sources/atlassian-jira.md
+++ b/_data-prepper/pipelines/configuration/sources/atlassian-jira.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-jira/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-jira/
 ---
 
 # Atlassian Jira source

--- a/_data-prepper/pipelines/configuration/sources/documentdb.md
+++ b/_data-prepper/pipelines/configuration/sources/documentdb.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/documentdb/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/documentdb/
 ---
 
 # DocumentDB source

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
 ---
 
 # DynamoDB source

--- a/_data-prepper/pipelines/configuration/sources/http.md
+++ b/_data-prepper/pipelines/configuration/sources/http.md
@@ -7,6 +7,7 @@ nav_order: 30
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/http-source/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http/
 ---
 
 # HTTP source

--- a/_data-prepper/pipelines/configuration/sources/kafka.md
+++ b/_data-prepper/pipelines/configuration/sources/kafka.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kafka/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kafka/
 ---
 
 # Kafka source

--- a/_data-prepper/pipelines/configuration/sources/kinesis.md
+++ b/_data-prepper/pipelines/configuration/sources/kinesis.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kinesis/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kinesis/
 ---
 
 # Kinesis source

--- a/_data-prepper/pipelines/configuration/sources/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sources/opensearch.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/
 ---
 
 # OpenSearch source

--- a/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
 ---
 
 # OTel logs source

--- a/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
 ---
 
 # OTel metrics source

--- a/_data-prepper/pipelines/configuration/sources/otel-trace-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-trace-source.md
@@ -7,6 +7,7 @@ nav_order: 80
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/otel-trace/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
 ---
 
 

--- a/_data-prepper/pipelines/configuration/sources/otlp-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otlp-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 85
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otlp-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otlp-source/
 ---
 
 # OTLP source

--- a/_data-prepper/pipelines/configuration/sources/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sources/pipeline.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/pipeline/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/pipeline/
 ---
 
 # Pipeline source

--- a/_data-prepper/pipelines/configuration/sources/rds.md
+++ b/_data-prepper/pipelines/configuration/sources/rds.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 95
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/rds/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/rds/
 ---
 
 # rds

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/s3/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/s3/
 ---
 
 # S3 source

--- a/_data-prepper/pipelines/configuration/sources/sources.md
+++ b/_data-prepper/pipelines/configuration/sources/sources.md
@@ -7,6 +7,7 @@ nav_order: 110
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/sources/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/sources/
 ---
 
 # Sources

--- a/_data-prepper/pipelines/contains.md
+++ b/_data-prepper/pipelines/contains.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/contains/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/contains/
 ---
 
 # contains()

--- a/_data-prepper/pipelines/dlq.md
+++ b/_data-prepper/pipelines/dlq.md
@@ -4,6 +4,7 @@ title: Dead-letter queues
 parent: Pipelines
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/dlq/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/dlq/
 ---
 
 # Dead-letter queues

--- a/_data-prepper/pipelines/expression-syntax.md
+++ b/_data-prepper/pipelines/expression-syntax.md
@@ -4,6 +4,7 @@ title: Expression syntax
 parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/expression-syntax/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/expression-syntax/
 ---
 
 # Expression syntax  

--- a/_data-prepper/pipelines/functions.md
+++ b/_data-prepper/pipelines/functions.md
@@ -5,6 +5,7 @@ parent: Pipelines
 nav_order: 10
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/functions/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/functions/
 ---
 
 # Functions

--- a/_data-prepper/pipelines/get-eventtype.md
+++ b/_data-prepper/pipelines/get-eventtype.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 12
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/get-eventtype/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/get-eventtype/
 ---
 
 # getEventType()

--- a/_data-prepper/pipelines/get-metadata.md
+++ b/_data-prepper/pipelines/get-metadata.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/get-metadata/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/get-metadata/
 ---
 
 # getMetadata()

--- a/_data-prepper/pipelines/has-tags.md
+++ b/_data-prepper/pipelines/has-tags.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/has-tags/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/has-tags/
 ---
 
 # hasTags()

--- a/_data-prepper/pipelines/join.md
+++ b/_data-prepper/pipelines/join.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/join/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/join/
 ---
 
 # join()

--- a/_data-prepper/pipelines/length.md
+++ b/_data-prepper/pipelines/length.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/length/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/length/
 ---
 
 # length()

--- a/_data-prepper/pipelines/pipelines.md
+++ b/_data-prepper/pipelines/pipelines.md
@@ -7,6 +7,7 @@ redirect_from:
   - /data-prepper/pipelines/
   - /clients/data-prepper/pipelines/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
 ---
 
 # Pipelines

--- a/_data-prepper/pipelines/startswith.md
+++ b/_data-prepper/pipelines/startswith.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/startswith/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/startswith/
 ---
 
 # startsWith()

--- a/_field-types/mapping-parameters/analyzer.md
+++ b/_field-types/mapping-parameters/analyzer.md
@@ -5,7 +5,7 @@ parent: Mapping parameters
 nav_order: 5
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/analyzer/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/analyzer/
 redirect_from:
   - /mappings/mapping-parameters/analyzer/
 ---

--- a/_field-types/mapping-parameters/boost.md
+++ b/_field-types/mapping-parameters/boost.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 10
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/boost/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/boost/
 redirect_from:
   - /mappings/mapping-parameters/boost/
 ---

--- a/_field-types/mapping-parameters/coerce.md
+++ b/_field-types/mapping-parameters/coerce.md
@@ -5,7 +5,7 @@ parent: Mapping parameters
 nav_order: 15
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/coerce/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/coerce/
 redirect_from:
   - /mappings/mapping-parameters/coerce/
 ---

--- a/_field-types/mapping-parameters/copy-to.md
+++ b/_field-types/mapping-parameters/copy-to.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 20
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/copy-to/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/copy-to/
 redirect_from:
   - /mappings/mapping-parameters/copy-to/
 ---

--- a/_field-types/mapping-parameters/doc-values.md
+++ b/_field-types/mapping-parameters/doc-values.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 25
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/doc-values/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/doc-values/
 redirect_from:
   - /mappings/mapping-parameters/doc-values/
 ---

--- a/_field-types/mapping-parameters/dynamic.md
+++ b/_field-types/mapping-parameters/dynamic.md
@@ -10,7 +10,7 @@ redirect_from:
   - /opensearch/dynamic/
   - /field-types/dynamic/
   - /mappings/mapping-parameters/dynamic/
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/dynamic/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/dynamic/
 ---
 
 # Dynamic

--- a/_field-types/mapping-parameters/eager_global_ordinals.md
+++ b/_field-types/mapping-parameters/eager_global_ordinals.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 35
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/eager_global_ordinals/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/eager_global_ordinals/
 redirect_from:
   - /mappings/mapping-parameters/eager_global_ordinals/
 ---

--- a/_field-types/mapping-parameters/enabled.md
+++ b/_field-types/mapping-parameters/enabled.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 40
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/enabled/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/enabled/
 redirect_from:
   - /mappings/mapping-parameters/enabled/
 ---

--- a/_field-types/mapping-parameters/fields.md
+++ b/_field-types/mapping-parameters/fields.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 100
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/fields/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/fields/
 redirect_from:
   - /mappings/mapping-parameters/fields/
 ---

--- a/_field-types/mapping-parameters/format.md
+++ b/_field-types/mapping-parameters/format.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 50
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/format/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/format/
 redirect_from:
   - /mappings/mapping-parameters/format/
 ---

--- a/_field-types/mapping-parameters/ignore-above.md
+++ b/_field-types/mapping-parameters/ignore-above.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 45
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/ignore-above/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/ignore-above/
 redirect_from:
   - /mappings/mapping-parameters/ignore-above/
 ---

--- a/_field-types/mapping-parameters/ignore-malformed.md
+++ b/_field-types/mapping-parameters/ignore-malformed.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 45
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/ignore-malformed/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/ignore-malformed/
 redirect_from:
   - /mappings/mapping-parameters/ignore-malformed/
 ---

--- a/_field-types/mapping-parameters/index-options.md
+++ b/_field-types/mapping-parameters/index-options.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 70
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/index-options/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/index-options/
 redirect_from:
   - /mappings/mapping-parameters/index-options/
 ---

--- a/_field-types/mapping-parameters/index-parameter.md
+++ b/_field-types/mapping-parameters/index-parameter.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 60
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/index-parameter/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/index-parameter/
 redirect_from:
   - /mappings/mapping-parameters/index-parameter/
 ---

--- a/_field-types/mapping-parameters/index-phrases.md
+++ b/_field-types/mapping-parameters/index-phrases.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 80
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/index-phrases/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/index-phrases/
 redirect_from:
   - /mappings/mapping-parameters/index-phrases/
 ---

--- a/_field-types/mapping-parameters/index-prefixes.md
+++ b/_field-types/mapping-parameters/index-prefixes.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 90
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/index-prefixes/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/index-prefixes/
 redirect_from:
   - /mappings/mapping-parameters/index-prefixes/
 ---

--- a/_field-types/mapping-parameters/index.md
+++ b/_field-types/mapping-parameters/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /field-types/mapping-parameters/
   - /mappings/mapping-parameters/
   - /mappings/mapping-parameters/index/
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/index/
 ---
 
 # Mapping parameters

--- a/_field-types/mapping-parameters/meta.md
+++ b/_field-types/mapping-parameters/meta.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 100
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/meta/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/meta/
 redirect_from:
   - /mappings/mapping-parameters/meta/
 ---

--- a/_field-types/mapping-parameters/normalizer.md
+++ b/_field-types/mapping-parameters/normalizer.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 110
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/normalizer/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/normalizer/
 redirect_from:
   - /mappings/mapping-parameters/normalizer/
 ---

--- a/_field-types/mapping-parameters/norms.md
+++ b/_field-types/mapping-parameters/norms.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 120
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/norms/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/norms/
 redirect_from:
   - /mappings/mapping-parameters/norms/
 ---

--- a/_field-types/mapping-parameters/null-value.md
+++ b/_field-types/mapping-parameters/null-value.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 130
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/null-value/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/null-value/
 redirect_from:
   - /mappings/mapping-parameters/null-value/
 ---

--- a/_field-types/mapping-parameters/position-increment-gap.md
+++ b/_field-types/mapping-parameters/position-increment-gap.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 140
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/position-increment-gap/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/position-increment-gap/
 redirect_from:
   - /mappings/mapping-parameters/position-increment-gap/
 ---

--- a/_field-types/mapping-parameters/properties.md
+++ b/_field-types/mapping-parameters/properties.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 150
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/properties/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/properties/
 redirect_from:
   - /mappings/mapping-parameters/properties/
 ---

--- a/_field-types/mapping-parameters/search-analyzer.md
+++ b/_field-types/mapping-parameters/search-analyzer.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 160
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/search-analyzer/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/search-analyzer/
 redirect_from:
   - /mappings/mapping-parameters/search-analyzer/
 ---

--- a/_field-types/mapping-parameters/similarity.md
+++ b/_field-types/mapping-parameters/similarity.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 170
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/similarity/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/similarity/
 redirect_from:
   - /mappings/mapping-parameters/similarity/
 ---

--- a/_field-types/mapping-parameters/store.md
+++ b/_field-types/mapping-parameters/store.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 180
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/store/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/store/
 redirect_from:
   - /mappings/mapping-parameters/store/
 ---

--- a/_field-types/mapping-parameters/term-vector.md
+++ b/_field-types/mapping-parameters/term-vector.md
@@ -6,7 +6,7 @@ parent: Mapping parameters
 nav_order: 190
 has_children: false
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/field-types/mapping-parameters/term-vector/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/term-vector/
 redirect_from:
   - /mappings/mapping-parameters/term-vector/
 ---

--- a/_field-types/mappings-use-cases.md
+++ b/_field-types/mappings-use-cases.md
@@ -4,7 +4,7 @@ title: Mappings use cases
 parent: Mappings and fields types
 nav_order: 5
 nav_exclude: true
-canonical_url: https://docs.opensearch.org/latest/field-types/mappings-use-cases/
+canonical_url: https://docs.opensearch.org/latest/mappings/
 ---
 
 # Mappings use cases

--- a/_field-types/metadata-fields/field-names.md
+++ b/_field-types/metadata-fields/field-names.md
@@ -3,7 +3,7 @@ layout: default
 title: Field names
 nav_order: 10
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/field-names/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/field-names/
 redirect_from:
   - /mappings/metadata-fields/field-names/
 ---

--- a/_field-types/metadata-fields/id.md
+++ b/_field-types/metadata-fields/id.md
@@ -3,7 +3,7 @@ layout: default
 title: ID
 nav_order: 20
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/id/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/id/
 redirect_from:
   - /mappings/metadata-fields/id/
 ---

--- a/_field-types/metadata-fields/ignored.md
+++ b/_field-types/metadata-fields/ignored.md
@@ -3,7 +3,7 @@ layout: default
 title: Ignored
 nav_order: 25
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/ignored/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/ignored/
 redirect_from:
   - /mappings/metadata-fields/ignored/
 ---

--- a/_field-types/metadata-fields/index-metadata.md
+++ b/_field-types/metadata-fields/index-metadata.md
@@ -3,7 +3,7 @@ layout: default
 title: Index
 nav_order: 25
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/index-metadata/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/index-metadata/
 redirect_from:
   - /mappings/metadata-fields/index-metadata/
 ---

--- a/_field-types/metadata-fields/index.md
+++ b/_field-types/metadata-fields/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /field-types/metadata-fields/
   - /mappings/metadata-fields/
   - /mappings/metadata-fields/index/
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/index/
 ---
 
 # Metadata fields

--- a/_field-types/metadata-fields/meta.md
+++ b/_field-types/metadata-fields/meta.md
@@ -3,7 +3,7 @@ layout: default
 title: Meta
 nav_order: 30
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/meta/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/meta/
 redirect_from:
   - /mappings/metadata-fields/meta/
 ---

--- a/_field-types/metadata-fields/routing.md
+++ b/_field-types/metadata-fields/routing.md
@@ -3,7 +3,7 @@ layout: default
 title: Routing
 nav_order: 35
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/routing/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/routing/
 redirect_from:
   - /mappings/metadata-fields/routing/
 ---

--- a/_field-types/metadata-fields/source.md
+++ b/_field-types/metadata-fields/source.md
@@ -3,7 +3,7 @@ layout: default
 title: Source
 nav_order: 40
 parent: Metadata fields
-canonical_url: https://docs.opensearch.org/latest/field-types/metadata-fields/source/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/source/
 redirect_from:
   - /mappings/metadata-fields/source/
 ---

--- a/_field-types/supported-field-types/alias.md
+++ b/_field-types/supported-field-types/alias.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/alias/
   - /field-types/alias/
   - /mappings/supported-field-types/alias/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/alias/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/alias/
 ---
 
 # Alias field type

--- a/_field-types/supported-field-types/autocomplete.md
+++ b/_field-types/supported-field-types/autocomplete.md
@@ -8,7 +8,7 @@ parent: Supported field types
 redirect_from:
   - /opensearch/supported-field-types/autocomplete/
   - /field-types/autocomplete/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/autocomplete/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/autocomplete/
 ---
 
 # Autocomplete field types

--- a/_field-types/supported-field-types/binary.md
+++ b/_field-types/supported-field-types/binary.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/binary/
   - /field-types/binary/
   - /mappings/supported-field-types/binary/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/binary/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/binary/
 ---
 
 # Binary field type

--- a/_field-types/supported-field-types/boolean.md
+++ b/_field-types/supported-field-types/boolean.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/boolean/
   - /field-types/boolean/
   - /mappings/supported-field-types/boolean/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/boolean/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/boolean/
 ---
 
 # Boolean field type

--- a/_field-types/supported-field-types/completion.md
+++ b/_field-types/supported-field-types/completion.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/completion/
   - /field-types/completion/
   - /mappings/supported-field-types/completion/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/completion/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/completion/
 ---
 
 # Completion field type

--- a/_field-types/supported-field-types/constant-keyword.md
+++ b/_field-types/supported-field-types/constant-keyword.md
@@ -5,7 +5,7 @@ nav_order: 71
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/constant-keyword/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/constant-keyword/
 redirect_from:
   - /mappings/supported-field-types/constant-keyword/
 ---

--- a/_field-types/supported-field-types/date-nanos.md
+++ b/_field-types/supported-field-types/date-nanos.md
@@ -5,7 +5,7 @@ nav_order: 35
 has_children: false
 parent: Date field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date-nanos/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/date-nanos/
 redirect_from:
   - /mappings/supported-field-types/date-nanos/
 ---

--- a/_field-types/supported-field-types/date.md
+++ b/_field-types/supported-field-types/date.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/date/
   - /field-types/date/
   - /mappings/supported-field-types/date/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/date/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/date/
 ---
 
 # Date field type

--- a/_field-types/supported-field-types/dates.md
+++ b/_field-types/supported-field-types/dates.md
@@ -5,7 +5,7 @@ nav_order: 25
 has_children: true
 has_toc: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/dates/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/dates/
 redirect_from:
   - /mappings/supported-field-types/dates/
 ---

--- a/_field-types/supported-field-types/derived.md
+++ b/_field-types/supported-field-types/derived.md
@@ -4,7 +4,7 @@ title: Derived
 nav_order: 62
 has_children: false
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/derived/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/derived/
 redirect_from:
   - /mappings/supported-field-types/derived/
 ---

--- a/_field-types/supported-field-types/flat-object.md
+++ b/_field-types/supported-field-types/flat-object.md
@@ -8,7 +8,7 @@ grand_parent: Supported field types
 redirect_from:
   - /field-types/flat-object/
   - /mappings/supported-field-types/flat-object/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/flat-object/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/flat-object/
 ---
 
 # Flat object field type

--- a/_field-types/supported-field-types/geo-point.md
+++ b/_field-types/supported-field-types/geo-point.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geo-point/
   - /field-types/geo-point/
   - /mappings/supported-field-types/geo-point/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-point/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-point/
 ---
 
 # Geopoint field type

--- a/_field-types/supported-field-types/geo-shape.md
+++ b/_field-types/supported-field-types/geo-shape.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geo-shape/
   - /field-types/geo-shape/
   - /mappings/supported-field-types/geo-shape/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geo-shape/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geo-shape/
 ---
 
 # Geoshape field type

--- a/_field-types/supported-field-types/geographic.md
+++ b/_field-types/supported-field-types/geographic.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/geographic/
   - /field-types/geographic/
   - /mappings/supported-field-types/geographic/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/geographic/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/geographic/
 ---
 
 # Geographic field types

--- a/_field-types/supported-field-types/index.md
+++ b/_field-types/supported-field-types/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /field-types/supported-field-types/
   - /mappings/supported-field-types/
   - /mappings/supported-field-types/index/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/index/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/index/
 ---
 
 # Supported field types

--- a/_field-types/supported-field-types/ip.md
+++ b/_field-types/supported-field-types/ip.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/ip/
   - /field-types/ip/
   - /mappings/supported-field-types/ip/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/ip/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/ip/
 ---
 
 # IP address field type

--- a/_field-types/supported-field-types/join.md
+++ b/_field-types/supported-field-types/join.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/join/
   - /field-types/join/
   - /mappings/supported-field-types/join/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/join/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/join/
 ---
 
 # Join field type

--- a/_field-types/supported-field-types/keyword.md
+++ b/_field-types/supported-field-types/keyword.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/keyword/
   - /field-types/keyword/
   - /mappings/supported-field-types/keyword/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/keyword/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/keyword/
 ---
 
 # Keyword field type

--- a/_field-types/supported-field-types/knn-memory-optimized.md
+++ b/_field-types/supported-field-types/knn-memory-optimized.md
@@ -4,7 +4,7 @@ title: Memory-optimized vectors
 parent: k-NN vector
 grand_parent: Supported field types
 nav_order: 30
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/knn-memory-optimized/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/knn-memory-optimized/
 redirect_from:
   - /mappings/supported-field-types/knn-memory-optimized/
 ---

--- a/_field-types/supported-field-types/knn-methods-engines.md
+++ b/_field-types/supported-field-types/knn-methods-engines.md
@@ -4,7 +4,7 @@ title: Methods and engines
 parent: k-NN vector
 grand_parent: Supported field types
 nav_order: 20
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/knn-methods-engines/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/knn-methods-engines/
 redirect_from:
   - /mappings/supported-field-types/knn-methods-engines/
 ---

--- a/_field-types/supported-field-types/knn-spaces.md
+++ b/_field-types/supported-field-types/knn-spaces.md
@@ -5,7 +5,7 @@ parent: k-NN vector
 grand_parent: Supported field types
 nav_order: 10
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/knn-spaces/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/knn-spaces/
 redirect_from:
   - /mappings/supported-field-types/knn-spaces/
 ---

--- a/_field-types/supported-field-types/knn-vector.md
+++ b/_field-types/supported-field-types/knn-vector.md
@@ -5,7 +5,7 @@ nav_order: 20
 has_children: true
 parent: Supported field types
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/knn-vector/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/knn-vector/
 redirect_from:
   - /mappings/supported-field-types/knn-vector/
   - /mappings/supported-field-types/vector-field-types/

--- a/_field-types/supported-field-types/match-only-text.md
+++ b/_field-types/supported-field-types/match-only-text.md
@@ -5,7 +5,7 @@ nav_order: 61
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/match-only-text/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/match-only-text/
 redirect_from:
   - /mappings/supported-field-types/match-only-text/
 ---

--- a/_field-types/supported-field-types/nested.md
+++ b/_field-types/supported-field-types/nested.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/nested/
   - /field-types/nested/
   - /mappings/supported-field-types/nested/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/nested/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/nested/
 ---
 
 # Nested field type

--- a/_field-types/supported-field-types/numeric.md
+++ b/_field-types/supported-field-types/numeric.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/numeric/
   - /field-types/numeric/
   - /mappings/supported-field-types/numeric/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/numeric/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/numeric/
 ---
 
 # Numeric field types

--- a/_field-types/supported-field-types/object-fields.md
+++ b/_field-types/supported-field-types/object-fields.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/object-fields/
   - /field-types/object-fields/
   - /mappings/supported-field-types/object-fields/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object-fields/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object-fields/
 ---
 
 # Object field types

--- a/_field-types/supported-field-types/object.md
+++ b/_field-types/supported-field-types/object.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/object/
   - /field-types/object/
   - /mappings/supported-field-types/object/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/object/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/object/
 ---
 
 # Object field type

--- a/_field-types/supported-field-types/percolator.md
+++ b/_field-types/supported-field-types/percolator.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/percolator/
   - /field-types/percolator/
   - /mappings/supported-field-types/percolator/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/percolator/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/percolator/
 ---
 
 # Percolator field type

--- a/_field-types/supported-field-types/range.md
+++ b/_field-types/supported-field-types/range.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/range/
   - /field-types/range/
   - /mappings/supported-field-types/range/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/range/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/range/
 ---
 
 # Range field types

--- a/_field-types/supported-field-types/rank.md
+++ b/_field-types/supported-field-types/rank.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/supported-field-types/rank/
   - /field-types/rank/
   - /mappings/supported-field-types/rank/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/rank/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/rank/
 ---
 
 # Rank field types

--- a/_field-types/supported-field-types/search-as-you-type.md
+++ b/_field-types/supported-field-types/search-as-you-type.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/search-as-you-type/
   - /field-types/search-as-you-type/
   - /mappings/supported-field-types/search-as-you-type/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/search-as-you-type/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/search-as-you-type/
 ---
 
 # Search-as-you-type field type

--- a/_field-types/supported-field-types/semantic.md
+++ b/_field-types/supported-field-types/semantic.md
@@ -3,7 +3,7 @@ layout: default
 title: Semantic
 nav_order: 20
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/semantic/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/semantic/
 redirect_from:
   - /mappings/supported-field-types/semantic/
 ---

--- a/_field-types/supported-field-types/star-tree.md
+++ b/_field-types/supported-field-types/star-tree.md
@@ -3,7 +3,7 @@ layout: default
 title: Star-tree
 nav_order: 61
 parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/star-tree/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/star-tree/
 redirect_from:
   - /mappings/supported-field-types/star-tree/
 ---

--- a/_field-types/supported-field-types/string.md
+++ b/_field-types/supported-field-types/string.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/string/
   - /field-types/string/
   - /mappings/supported-field-types/string/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/string/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/string/
 ---
 
 # String field types

--- a/_field-types/supported-field-types/text.md
+++ b/_field-types/supported-field-types/text.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/text/
   - /field-types/text/
   - /mappings/supported-field-types/text/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/text/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/text/
 ---
 
 # Text field type

--- a/_field-types/supported-field-types/token-count.md
+++ b/_field-types/supported-field-types/token-count.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/token-count/
   - /field-types/token-count/
   - /mappings/supported-field-types/token-count/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/token-count/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/token-count/
 ---
 
 # Token count field type

--- a/_field-types/supported-field-types/unsigned-long.md
+++ b/_field-types/supported-field-types/unsigned-long.md
@@ -5,7 +5,7 @@ parent: Numeric field types
 grand_parent: Supported field types
 nav_order: 15
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/unsigned-long/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/unsigned-long/
 redirect_from:
   - /mappings/supported-field-types/unsigned-long/
 ---

--- a/_field-types/supported-field-types/wildcard.md
+++ b/_field-types/supported-field-types/wildcard.md
@@ -5,7 +5,7 @@ nav_order: 62
 has_children: false
 parent: String field types
 grand_parent: Supported field types
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/wildcard/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/wildcard/
 redirect_from:
   - /mappings/supported-field-types/wildcard/
 ---

--- a/_field-types/supported-field-types/xy-point.md
+++ b/_field-types/supported-field-types/xy-point.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/xy-point/
   - /field-types/xy-point/
   - /mappings/supported-field-types/xy-point/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-point/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/xy-point/
 ---
 
 # xy point field type

--- a/_field-types/supported-field-types/xy-shape.md
+++ b/_field-types/supported-field-types/xy-shape.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/xy-shape/
   - /field-types/xy-shape/
   - /mappings/supported-field-types/xy-shape/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy-shape/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/xy-shape/
 ---
 
 # xy shape field type

--- a/_field-types/supported-field-types/xy.md
+++ b/_field-types/supported-field-types/xy.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/supported-field-types/xy/
   - /field-types/xy/
   - /mappings/supported-field-types/xy/
-canonical_url: https://docs.opensearch.org/latest/field-types/supported-field-types/xy/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/xy/
 ---
 
 # Cartesian field types

--- a/_getting-started/security.md
+++ b/_getting-started/security.md
@@ -2,7 +2,7 @@
 layout: default
 title: Getting started with OpenSearch security
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/getting-started/security/
+canonical_url: https://docs.opensearch.org/latest/security/getting-started/
 redirect_from:
   - /security/getting-started/
 ---

--- a/_install-and-configure/install-opensearch/operator.md
+++ b/_install-and-configure/install-opensearch/operator.md
@@ -7,7 +7,7 @@ redirect_from:
   - /clients/k8s-operator/
   - /tools/k8s-operator/
   - /install-and-configure/install-opensearch/operator/index/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/index/
 ---
 
 # OpenSearch Kubernetes Operator

--- a/_migrate-or-upgrade/index.md
+++ b/_migrate-or-upgrade/index.md
@@ -14,7 +14,7 @@ redirect_from:
   - /install-and-configure/upgrade-opensearch/index/
   - /upgrade-to/docker-upgrade-to/
 nav_exclude: true
-canonical_url: https://docs.opensearch.org/latest/upgrade-or-migrate/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 # Migrate or upgrade OpenSearch
 

--- a/_migration-assistant/architecture.md
+++ b/_migration-assistant/architecture.md
@@ -7,6 +7,7 @@ permalink: /migration-assistant/architecture/
 redirect_from:
   - /migration-assistant/overview/architecture/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/architecture/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/architecture/
 ---
 
 # Architecture

--- a/_migration-assistant/index.md
+++ b/_migration-assistant/index.md
@@ -22,6 +22,7 @@ items:
     description: "A step-by-step guide for performing a migration."
     link: "/migration-assistant/migration-phases/"
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Migration Assistant for OpenSearch

--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -7,6 +7,7 @@ redirect_from:
   - /migration-assistant/overview/is-migration-assistant-right-for-you/
   - /migration-assistant/migration-paths/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/is-migration-assistant-right-for-you/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/is-migration-assistant-right-for-you/
 ---
 
 # Is Migration Assistant right for you?

--- a/_migration-assistant/key-components.md
+++ b/_migration-assistant/key-components.md
@@ -7,6 +7,7 @@ permalink: /migration-assistant/key-components/
 redirect_from:
   - /migration-assistant/overview/key-components/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/key-components/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Key components 

--- a/_migration-assistant/key-components.md
+++ b/_migration-assistant/key-components.md
@@ -6,7 +6,7 @@ nav_order: 20
 permalink: /migration-assistant/key-components/
 redirect_from:
   - /migration-assistant/overview/key-components/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/key-components/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/key-components/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-console/accessing-the-migration-console.md
+++ b/_migration-assistant/migration-console/accessing-the-migration-console.md
@@ -7,7 +7,7 @@ grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-console/accessing-the-migration-console/
 redirect_from:
   - /migration-console/accessing-the-migration-console/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/accessing-the-migration-console/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/accessing-the-migration-console/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-console/accessing-the-migration-console.md
+++ b/_migration-assistant/migration-console/accessing-the-migration-console.md
@@ -8,6 +8,7 @@ permalink: /migration-assistant/migration-console/accessing-the-migration-consol
 redirect_from:
   - /migration-console/accessing-the-migration-console/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/accessing-the-migration-console/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Accessing the migration console

--- a/_migration-assistant/migration-console/index.md
+++ b/_migration-assistant/migration-console/index.md
@@ -10,7 +10,7 @@ permalink: /migration-assistant/migration-console/
 redirect_from: 
   - /migration-assistant/migration-console/index/
   - /migration-console/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-console/index.md
+++ b/_migration-assistant/migration-console/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /migration-assistant/migration-console/index/
   - /migration-console/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Migration console

--- a/_migration-assistant/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant/migration-console/migration-console-commands-references.md
@@ -8,7 +8,7 @@ permalink: /migration-assistant/migration-console/migration-console-command-refe
 redirect_from:
   - /migration-console/migration-console-commands-references/
   - /migration-assistant/migration-console/migration-console-commands-references/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/migration-console-command-reference/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant/migration-console/migration-console-commands-references.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-console/migration-console-commands-references/
   - /migration-assistant/migration-console/migration-console-commands-references/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-console/migration-console-command-reference/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Migration console command reference

--- a/_migration-assistant/migration-phases/assessment/index.md
+++ b/_migration-assistant/migration-phases/assessment/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration/
   - /migration-assistant/migration-phases/planning-your-migration/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 ---
 
 # Assessment

--- a/_migration-assistant/migration-phases/backfill.md
+++ b/_migration-assistant/migration-phases/backfill.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-phases/backfill/
   - /migration-phases/create-snapshot/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
 ---
 
 # Using backfill

--- a/_migration-assistant/migration-phases/create-snapshot.md
+++ b/_migration-assistant/migration-phases/create-snapshot.md
@@ -5,7 +5,7 @@ parent: Migration phases
 grand_parent: Migration Assistant for OpenSearch
 nav_order: 4
 permalink: /migration-assistant/migration-phases/create-snapshot/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/create-snapshot/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
 ---
 

--- a/_migration-assistant/migration-phases/create-snapshot.md
+++ b/_migration-assistant/migration-phases/create-snapshot.md
@@ -6,6 +6,7 @@ grand_parent: Migration Assistant for OpenSearch
 nav_order: 4
 permalink: /migration-assistant/migration-phases/create-snapshot/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/create-snapshot/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
 ---
 
 # Creating a snapshot

--- a/_migration-assistant/migration-phases/deploy/configuration-options.md
+++ b/_migration-assistant/migration-phases/deploy/configuration-options.md
@@ -9,7 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/deploying-migration-assistant/configuration-options/
   - /deploying-migration-assistant/configuration-options/
   - /migration-assistant/deploying-migration-assistant/configuration-options/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/configuration-options/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/configuration-options/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/deploy/configuration-options.md
+++ b/_migration-assistant/migration-phases/deploy/configuration-options.md
@@ -10,6 +10,7 @@ redirect_from:
   - /deploying-migration-assistant/configuration-options/
   - /migration-assistant/deploying-migration-assistant/configuration-options/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/configuration-options/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Configuration options

--- a/_migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
+++ b/_migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
@@ -8,7 +8,7 @@ permalink: /migration-assistant/migration-phases/deploy/iam-and-security-groups-
 redirect_from:
   - /migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters/
   - /deploying-migration-assistant/iam-and-security-groups-for-existing-clusters/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
+++ b/_migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/deploying-migration-assistant/iam-and-security-groups-for-existing-clusters/
   - /deploying-migration-assistant/iam-and-security-groups-for-existing-clusters/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # IAM and security groups for existing clusters

--- a/_migration-assistant/migration-phases/deploy/index.md
+++ b/_migration-assistant/migration-phases/deploy/index.md
@@ -12,6 +12,7 @@ redirect_from:
   - /deploying-migration-assistant/
   - /migration-assistant/deploying-migration-assistant/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/
 ---
 
 # Deploy

--- a/_migration-assistant/migration-phases/deploy/verifying-backfill-components.md
+++ b/_migration-assistant/migration-phases/deploy/verifying-backfill-components.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/verifying-migration-tools/verifying-backfill-components/
   - /migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/verifying-backfill-components/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Verifying backfill components

--- a/_migration-assistant/migration-phases/deploy/verifying-backfill-components.md
+++ b/_migration-assistant/migration-phases/deploy/verifying-backfill-components.md
@@ -8,7 +8,7 @@ permalink: /migration-assistant/migration-phases/deploy/verifying-backfill-compo
 redirect_from:
   - /migration-assistant/migration-phases/verifying-migration-tools/verifying-backfill-components/
   - /migration-assistant/migration-phases/planning-your-migration/verifying-migration-tools/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/verifying-backfill-components/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-backfill-components/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/deploy/verifying-live-capture-components.md
+++ b/_migration-assistant/migration-phases/deploy/verifying-live-capture-components.md
@@ -6,6 +6,7 @@ nav_order: 4
 parent: Deploy
 permalink: /migration-assistant/migration-phases/deploy/verifying-live-capture-components/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Verifying live capture components

--- a/_migration-assistant/migration-phases/deploy/verifying-live-capture-components.md
+++ b/_migration-assistant/migration-phases/deploy/verifying-live-capture-components.md
@@ -5,7 +5,7 @@ grand_parent: Migration phases
 nav_order: 4
 parent: Deploy
 permalink: /migration-assistant/migration-phases/deploy/verifying-live-capture-components/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/index.md
+++ b/_migration-assistant/migration-phases/index.md
@@ -13,6 +13,7 @@ redirect_from:
   - /migration-assistant/migration-phases/planning-your-migration/index/
   - /migration-assistant/migration-phases/live-traffic-migration/index/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/
 ---
 
 # Migration phases

--- a/_migration-assistant/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/index.md
@@ -6,7 +6,7 @@ nav_exclude: true
 permalink: /migration-assistant/live-traffic-migration/
 has_toc: false
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/live-traffic-migration/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/index.md
@@ -7,6 +7,7 @@ permalink: /migration-assistant/live-traffic-migration/
 has_toc: false
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/live-traffic-migration/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Live traffic migration

--- a/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
@@ -8,6 +8,7 @@ redirect_from:
   - /migration-assistant/migration-phases/switching-traffic-from-the-source-cluster/
   - /migration-phases/switching-traffic-from-the-source-cluster/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Switching traffic from the source cluster

--- a/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
+++ b/_migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
@@ -7,7 +7,7 @@ permalink: /migration-assistant/migration-phases/live-traffic-migration/switchin
 redirect_from:
   - /migration-assistant/migration-phases/switching-traffic-from-the-source-cluster/
   - /migration-phases/switching-traffic-from-the-source-cluster/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/assessment/handling-field-type-breaking-changes/
   - /migration-assistant/migration-phases/planning-your-migration/handling-field-type-breaking-changes/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
 ---
 
 # Transform field types

--- a/_migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/assessment/handling-type-mapping-deprecation/
   - /migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
 ---
 
 # Transform type mappings

--- a/_migration-assistant/migration-phases/migrate-metadata/index.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/index.md
@@ -12,6 +12,7 @@ redirect_from:
   - /migration-phases/migrating-metadata/
   - /migration-assistant/deploying-migration-assistant/getting-started-data-migration/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 ---
 
 # Migrate metadata

--- a/_migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 ---
 
 # Transform dense_vector fields to knn_vector

--- a/_migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 ---
 
 # Transform flattened fields to flat_object

--- a/_migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 ---
 
 # Transform string fields to text/keyword

--- a/_migration-assistant/migration-phases/remove-migration-infrastructure.md
+++ b/_migration-assistant/migration-phases/remove-migration-infrastructure.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/removing-migration-infrastructure/
   - /migration-phases/removing-migration-infrastructure/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/remove-migration-infrastructure/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/remove-migration-infrastructure/
 ---
 
 # Removing migration infrastructure

--- a/_migration-assistant/migration-phases/replay-captured-traffic.md
+++ b/_migration-assistant/migration-phases/replay-captured-traffic.md
@@ -12,6 +12,7 @@ redirect_from:
   - /migration-assistant/migration-phases/using-traffic-Replayer/
   - /migration-phases/using-traffic-Replayer/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
 ---
 
 # Using Traffic Replayer

--- a/_migration-assistant/migration-phases/reroute-source-to-proxy.md
+++ b/_migration-assistant/migration-phases/reroute-source-to-proxy.md
@@ -6,6 +6,7 @@ parent: Migration phases
 grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-phases/reroute-source-to-proxy/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/reroute-source-to-proxy/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/reroute-source-to-proxy/
 ---
 
 # Reroute client traffic to the Traffic Capture Proxy

--- a/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
+++ b/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
@@ -8,6 +8,7 @@ permalink: /migration-assistant/migration-phases/reroute-traffic-from-capture-pr
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 redirect_from:
   - /migration-assistant/migration-phases/switch-traffic-to-target/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/switch-traffic-to-target/
 ---
 
 # Switching traffic from the source cluster

--- a/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
+++ b/_migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
@@ -5,7 +5,7 @@ nav_order: 8
 parent: Migration phases
 grand_parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
+canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/switch-traffic-to-target/
 redirect_from:
   - /migration-assistant/migration-phases/switch-traffic-to-target/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/switch-traffic-to-target/

--- a/_migration-assistant/security-patching-and-updating.md
+++ b/_migration-assistant/security-patching-and-updating.md
@@ -5,6 +5,7 @@ nav_order: 30
 parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/security-patching-and-updating/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/security-patching-and-updating/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # Security patching and updating

--- a/_migration-assistant/security-patching-and-updating.md
+++ b/_migration-assistant/security-patching-and-updating.md
@@ -4,7 +4,7 @@ title: Security patching & updating
 nav_order: 30
 parent: Migration Assistant for OpenSearch
 permalink: /migration-assistant/security-patching-and-updating/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant/security-patching-and-updating/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/security-patching-and-updating/
 redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 

--- a/_ml-commons-plugin/api/mcp-server-apis/sse-message.md
+++ b/_ml-commons-plugin/api/mcp-server-apis/sse-message.md
@@ -4,7 +4,7 @@ title: MCP SSE message
 parent: MCP server APIs
 grand_parent: ML Commons APIs
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/mcp-server-apis/sse-message/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/mcp-server-apis/index/
 ---
 
 # MCP SSE Message API

--- a/_ml-commons-plugin/api/mcp-server-apis/sse-session.md
+++ b/_ml-commons-plugin/api/mcp-server-apis/sse-session.md
@@ -4,7 +4,7 @@ title: MCP SSE session
 parent: MCP server APIs
 grand_parent: ML Commons APIs
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/mcp-server-apis/sse-session/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/mcp-server-apis/index/
 ---
 
 # MCP SSE Session API

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -78,8 +78,10 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore
-  @ignored_paths = %r{(^/javadocs|^mailto:)}.freeze
+  # Pattern of local paths to ignore. The single-edition sections now redirect to
+  # /latest/, which CI rewrites back to the page's own path, so check_internal
+  # would recurse on its own stub.
+  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -81,7 +81,9 @@ module Jekyll::LinkChecker
   # Pattern of local paths to ignore. The single-edition sections now redirect to
   # /latest/, which CI rewrites back to the page's own path, so check_internal
   # would recurse on its own stub.
-  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
+  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
+  # back to `/`, so check_internal would follow the stub into itself.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -78,11 +78,7 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore. The single-edition sections now redirect to
-  # /latest/, which CI rewrites back to the page's own path, so check_internal
-  # would recurse on its own stub.
-  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
-  # back to `/`, so check_internal would follow the stub into itself.
+  # Pattern of local paths to ignore.
   @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##

--- a/_query-dsl/specialized/neural-sparse.md
+++ b/_query-dsl/specialized/neural-sparse.md
@@ -3,7 +3,7 @@ layout: default
 title: Neural sparse
 parent: Specialized queries
 nav_order: 55
-canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/index/
 redirect_from:
   - /query-dsl/specialized/neural-sparse/index/
 ---

--- a/_search-plugins/sql/cli.md
+++ b/_search-plugins/sql/cli.md
@@ -6,7 +6,7 @@ nav_order: 3
 redirect_from:
   - /search-plugins/sql/cli/
   - /sql-and-ppl/cli/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/cli/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/cli/
 ---
 
 # SQL and PPL CLI

--- a/_search-plugins/sql/datatypes.md
+++ b/_search-plugins/sql/datatypes.md
@@ -3,7 +3,7 @@ layout: default
 title: Data types
 parent: SQL and PPL
 nav_order: 7
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/datatypes/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/datatypes/
 redirect_from:
   - /sql-and-ppl/datatypes/
 ---

--- a/_search-plugins/sql/full-text.md
+++ b/_search-plugins/sql/full-text.md
@@ -6,7 +6,7 @@ nav_order: 11
 redirect_from:
   - /search-plugins/sql/sql-full-text/
   - /sql-and-ppl/full-text/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/full-text/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/full-text/
 ---
 
 # Full-text search

--- a/_search-plugins/sql/functions.md
+++ b/_search-plugins/sql/functions.md
@@ -6,7 +6,7 @@ nav_order: 10
 redirect_from:
   - /search-plugins/sql/functions/
   - /sql-and-ppl/sql/functions/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/identifiers.md
+++ b/_search-plugins/sql/identifiers.md
@@ -7,7 +7,7 @@ redirect_from:
   - /observability-plugin/ppl/identifiers/
   - /search-plugins/ppl/identifiers/
   - /sql-and-ppl/identifiers/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/identifiers/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/identifiers/
 ---
 
 

--- a/_search-plugins/sql/index.md
+++ b/_search-plugins/sql/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /search-plugins/sql/
   - /sql-and-ppl/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/
 ---
 
 # SQL and PPL

--- a/_search-plugins/sql/limitation.md
+++ b/_search-plugins/sql/limitation.md
@@ -6,7 +6,7 @@ nav_order: 99
 redirect_from:
   - /search-plugins/sql/limitation/
   - /sql-and-ppl/limitation/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/limitation/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/limitation/
 ---
 
 # Limitations

--- a/_search-plugins/sql/monitoring.md
+++ b/_search-plugins/sql/monitoring.md
@@ -6,7 +6,7 @@ nav_order: 95
 redirect_from:
   - /search-plugins/sql/monitoring/
   - /sql-and-ppl/monitoring/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/monitoring/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/monitoring/
 ---
 
 # Monitoring

--- a/_search-plugins/sql/ppl/functions.md
+++ b/_search-plugins/sql/ppl/functions.md
@@ -10,7 +10,7 @@ redirect_from:
   - /search-plugins/ppl/functions/
   - /sql-and-ppl/ppl/commands/index/
   - /sql-and-ppl/ppl/functions/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/index/
 ---
 
 # Commands

--- a/_search-plugins/sql/ppl/index.md
+++ b/_search-plugins/sql/ppl/index.md
@@ -15,7 +15,7 @@ redirect_from:
   - /observability-plugin/ppl/index/
   - /sql-and-ppl/ppl/
   - /sql-and-ppl/ppl/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/index/
 ---
 
 # PPL

--- a/_search-plugins/sql/ppl/subsearch.md
+++ b/_search-plugins/sql/ppl/subsearch.md
@@ -4,7 +4,7 @@ title: Subsearch
 parent: PPL
 grand_parent: SQL and PPL
 nav_order: 3
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/subsearch/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/subsearch/
 redirect_from:
   - /sql-and-ppl/ppl/subsearch/
 ---

--- a/_search-plugins/sql/ppl/syntax.md
+++ b/_search-plugins/sql/ppl/syntax.md
@@ -4,7 +4,7 @@ title: Syntax
 parent: PPL
 grand_parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/ppl/syntax/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/syntax/
 redirect_from:
   - /sql-and-ppl/ppl/commands/syntax/
 ---

--- a/_search-plugins/sql/response-formats.md
+++ b/_search-plugins/sql/response-formats.md
@@ -3,7 +3,7 @@ layout: default
 title: Response formats
 parent: SQL and PPL
 nav_order: 2
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/response-formats/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/response-formats/
 redirect_from:
   - /sql-and-ppl/response-formats/
 ---

--- a/_search-plugins/sql/settings.md
+++ b/_search-plugins/sql/settings.md
@@ -6,7 +6,7 @@ nav_order: 77
 redirect_from:
   - /search-plugins/sql/settings/
   - /sql-and-ppl/settings/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/settings/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/settings/
 ---
 
 # SQL settings

--- a/_search-plugins/sql/sql-ppl-api.md
+++ b/_search-plugins/sql/sql-ppl-api.md
@@ -3,7 +3,7 @@ layout: default
 title: SQL and PPL API
 parent: SQL and PPL
 nav_order: 1
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql-ppl-api/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/index/
 redirect_from:
   - /sql-and-ppl/sql-and-ppl-api/index/
   - /sql-and-ppl/sql-ppl-api/

--- a/_search-plugins/sql/sql/aggregations.md
+++ b/_search-plugins/sql/sql/aggregations.md
@@ -6,7 +6,7 @@ grand_parent: SQL and PPL
 nav_order: 11
 Redirect_from:
   - /search-plugins/sql/aggregations/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/aggregations/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/aggregations/
 redirect_from:
   - /search-plugins/sql/aggregations/
   - /sql-and-ppl/sql/aggregations/

--- a/_search-plugins/sql/sql/basic.md
+++ b/_search-plugins/sql/sql/basic.md
@@ -7,7 +7,7 @@ nav_order: 5
 redirect_from:
   - /search-plugins/sql/basic/
   - /sql-and-ppl/sql/basic/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/basic/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/basic/
 ---
 
 

--- a/_search-plugins/sql/sql/complex.md
+++ b/_search-plugins/sql/sql/complex.md
@@ -7,7 +7,7 @@ nav_order: 6
 redirect_from:
   - /search-plugins/sql/complex/
   - /sql-and-ppl/sql/complex/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/complex/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/complex/
 ---
 
 # Complex queries

--- a/_search-plugins/sql/sql/delete.md
+++ b/_search-plugins/sql/sql/delete.md
@@ -7,7 +7,7 @@ nav_order: 12
 redirect_from:
   - /search-plugins/sql/delete/
   - /sql-and-ppl/sql/delete/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/delete/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/delete/
 ---
 
 

--- a/_search-plugins/sql/sql/functions.md
+++ b/_search-plugins/sql/sql/functions.md
@@ -7,7 +7,7 @@ nav_order: 7
 redirect_from:
   - /search-plugins/ppl/commands/
   - /observability-plugin/ppl/commands/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/functions/
 ---
 
 # Functions

--- a/_search-plugins/sql/sql/index.md
+++ b/_search-plugins/sql/sql/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /search-plugins/sql/sql/
   - /sql-and-ppl/sql/
   - /sql-and-ppl/sql/index/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/index/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/index/
 ---
 
 # SQL

--- a/_search-plugins/sql/sql/jdbc.md
+++ b/_search-plugins/sql/sql/jdbc.md
@@ -8,7 +8,7 @@ redirect_from:
   - /search-plugins/sql/jdbc/
 
   - /sql-and-ppl/sql/jdbc/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/jdbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/jdbc/
 ---
 
 # JDBC driver

--- a/_search-plugins/sql/sql/metadata.md
+++ b/_search-plugins/sql/sql/metadata.md
@@ -7,7 +7,7 @@ nav_order: 9
 redirect_from:
   - /search-plugins/sql/metadata/
   - /sql-and-ppl/sql/metadata/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/metadata/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/metadata/
 ---
 
 # Metadata queries

--- a/_search-plugins/sql/sql/odbc.md
+++ b/_search-plugins/sql/sql/odbc.md
@@ -7,7 +7,7 @@ nav_order: 72
 redirect_from:
   - /search-plugins/sql/odbc/
   - /sql-and-ppl/sql/odbc/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/odbc/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/odbc/
 ---
 
 # ODBC driver

--- a/_search-plugins/sql/sql/partiql.md
+++ b/_search-plugins/sql/sql/partiql.md
@@ -7,7 +7,7 @@ nav_order: 8
 redirect_from:
   - /search-plugins/sql/partiql/
   - /sql-and-ppl/sql/partiql/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/sql/partiql/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/partiql/
 ---
 
 # JSON Support

--- a/_search-plugins/sql/troubleshoot.md
+++ b/_search-plugins/sql/troubleshoot.md
@@ -6,7 +6,7 @@ nav_order: 88
 redirect_from:
   - /search-plugins/sql/troubleshoot/
   - /sql-and-ppl/troubleshoot/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/sql/troubleshoot/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/troubleshoot/
 ---
 
 # Troubleshooting

--- a/_upgrade-to/dashboards-upgrade-to.md
+++ b/_upgrade-to/dashboards-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Kibana OSS to OpenSearch Dashboards
 nav_order: 50
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/dashboards-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Kibana OSS to OpenSearch Dashboards

--- a/_upgrade-to/docker-upgrade-to.md
+++ b/_upgrade-to/docker-upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating Docker clusters to OpenSearch
 nav_order: 25
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/docker-upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating Docker clusters to OpenSearch

--- a/_upgrade-to/index.md
+++ b/_upgrade-to/index.md
@@ -6,7 +6,7 @@ nav_exclude: true
 permalink: /upgrade-to/
 redirect_from:
   - /upgrade-to/index/
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Upgrading OpenSearch

--- a/_upgrade-to/snapshot-migrate.md
+++ b/_upgrade-to/snapshot-migrate.md
@@ -2,7 +2,7 @@
 layout: default
 title: Using snapshots to migrate data
 nav_order: 5
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/snapshot-migrate/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore/
 ---
 
 # Using snapshots to migrate data

--- a/_upgrade-to/upgrade-to.md
+++ b/_upgrade-to/upgrade-to.md
@@ -2,7 +2,7 @@
 layout: default
 title: Migrating from Elasticsearch OSS to OpenSearch
 nav_order: 15
-canonical_url: https://docs.opensearch.org/latest/upgrade-to/upgrade-to/
+canonical_url: https://docs.opensearch.org/latest/migrate-or-upgrade/
 ---
 
 # Migrating from Elasticsearch OSS to OpenSearch

--- a/_vector-search/ai-search/agentic-search.md
+++ b/_vector-search/ai-search/agentic-search.md
@@ -4,7 +4,7 @@ title: Agentic search
 parent: AI search
 nav_order: 30
 has_children: false
-canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/index/
 redirect_from:
   - /vector-search/ai-search/agentic-search/index/
 ---

--- a/_vector-search/optimizing-storage/faiss-16-bit-quantization.md
+++ b/_vector-search/optimizing-storage/faiss-16-bit-quantization.md
@@ -6,7 +6,7 @@ grand_parent: Optimizing vector storage
 nav_order: 20
 has_children: false
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/vector-search/optimizing-storage/faiss-16-bit-quantization/
+canonical_url: https://docs.opensearch.org/latest/vector-search/optimizing-storage/faiss-scalar-quantization/
 redirect_from:
   - /vector-search/optimizing-storage/faiss-scalar-quantization/
 ---

--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ nav_order: 1
 has_children: false
 nav_exclude: true
 permalink: /
+redirect_to: https://docs.opensearch.org/latest/
 ---
 
 {% include banner.html %}

--- a/index.md
+++ b/index.md
@@ -6,6 +6,7 @@ has_children: false
 nav_exclude: true
 permalink: /
 redirect_to: https://docs.opensearch.org/latest/
+canonical_url: https://docs.opensearch.org/latest/
 ---
 
 {% include banner.html %}


### PR DESCRIPTION
### Description

The Clients, Data Prepper, Benchmark, and Migration Assistant sections are published as a single edition under `/latest/`; only the OpenSearch section is versioned. A versioned build still emits a full copy of those collections, so `/3.2/data-prepper/...` serves content that no release ever corresponded to. Readers reach those copies from search engines, bookmarks, and LLM answers, so rewriting on-site links cannot close the gap.

This adds `redirect_to` front matter pointing each of those pages at its equivalent under `/latest/`. It continues the pass done for 1.3 through 2.14 in June 2024 (#7517, #7535 to #7550), which stopped at 2.15.

Every target was resolved against the live site before being written:

- HTTP redirects and meta-refresh stubs are followed, so each target is a final endpoint rather than another redirect.
- A missing page returns HTTP 200 after being rewritten to `/latest/404.html`, so existence is tested by inspecting the effective URL rather than the status code. A target that lands there falls back to the section index.
- Pages whose only equivalent on `/latest/` is inside the versioned OpenSearch section are left alone, because redirecting them would serve content for the wrong release.

Files that already carried a `redirect_to` are untouched, so hand-curated targets from the earlier pass are preserved.

`_plugins/link-checker.rb` also regains the single-edition path exclusions that 1.3 through 2.14 already carry. CI builds every branch with `baseurl: /latest`, so without them the checker rewrites each redirect target back to the page's own path, reads the stub it just generated, and recurses until the build dies with `stack level too deep`. This filters the *target* of a link, so links pointing into these sections are no longer verified. Links written *on* those pages were already unverified, on this branch and on 1.3 through 2.14: `redirect_to` makes jekyll-redirect-from replace a page's content with the redirect stub during the generator phase, before the checker collects links from it.

Target selection for this branch:

```
  exact       168
  collapsed   21
  section     12
  moved       0
  unresolved  0
```

The branch home page is redirected too. `/3.2/` serves a home page frozen at that release. GA shows no versioned root page has a single referrer from `docs.opensearch.org`, against 37% on-site referrals for `/latest/`, so nobody navigates within a version from its home page. The arrivals are external: bookmarks, third-party links, and OpenSearch Dashboards, whose `noDocumentation` block holds 62 version-pinned links that resolve to exactly this root. All of them are better served by the current home page than a stale one. Content pages are out of scope: a reader who lands on `/3.2/dashboards/dql/` stays in 3.2.

`@ignored_paths` also gains `^/$`. CI builds every branch with `baseurl: /latest`, so without it the checker rewrites the home page's redirect target back to `/`, reads the stub it just generated, pulls the same absolute URL out of it, and recurses until the build dies with `stack level too deep`. That was the cause of the CI failures on the first attempt at this pass.

Verified locally with `JEKYLL_FATAL_LINK_CHECKER=internal` on 2.13 and 3.7, one branch of each `@ignored_paths` shape. Both report no broken links, and `_site/index.html` is the redirect stub.

`@ignored_paths` ends up covering the home page and all five single-edition section paths on this branch, so nothing that carries a `redirect_to` is followed:

```ruby
@ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
```

The pattern matches the link target rather than the page the link sits on, so these entries also stop inbound links to those sections from being verified. That costs nothing here: the targets are redirect stubs the checker would skip anyway, and no new content will land on this branch. It would cost real coverage on `main`, where those are live pages, so `main` keeps a shorter list on purpose (#13056) and this line is not meant to be synced to it.

The `Retarget canonical links to their current pages on latest` commit corrects this branch's canonical links. `canonical_url` is what tells search engines to index the `/latest/` copy of a page rather than this one, but pages keep moving on main after a branch is cut, and a canonical aimed at a `jekyll-redirect-from` stub is worth little more than no canonical at all. 149 of them on this branch pointed at a stub and now name the real page, followed through the `redirect_from` entries on main.

15 pages have no equivalent on latest, not even a redirect, so they keep pointing at their own path. Fixing those means adding `redirect_from` to whichever page on main replaced them; nothing on this branch can do it.

Every target was resolved against `upstream/main` and every rewritten line was checked to be a `canonical_url` line and nothing else. Spot checks against the live site confirm each new URL is a real page whose own canonical is exactly the URL written here.

### Issues Resolved

N/A

### Version

3.2

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
