### PR TITLE
Redirect the home page and single-edition sections to latest and update canonical links in 3.7

### DIFF
--- a/_about/breaking-changes.md
+++ b/_about/breaking-changes.md
@@ -3,7 +3,7 @@ layout: default
 title: Breaking changes
 nav_order: 5
 permalink: /breaking-changes/
-canonical_url: https://docs.opensearch.org/latest/about/breaking-changes/
+canonical_url: https://docs.opensearch.org/latest/breaking-changes/
 ---
 
 # Breaking changes

--- a/_about/version-history.md
+++ b/_about/version-history.md
@@ -4,7 +4,7 @@ title: Version history
 nav_order: 4
 description: "A history of OpenSearch releases, with release highlights and release dates for each version, linked to the full release notes."
 permalink: /version-history/
-canonical_url: https://docs.opensearch.org/latest/about/version-history/
+canonical_url: https://docs.opensearch.org/latest/version-history/
 ---
 
 # Version history

--- a/_aggregations/bucket/index.md
+++ b/_aggregations/bucket/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /query-dsl/aggregations/bucket/
   - /aggregations/bucket-agg/
   - /aggregations/bucket/
-canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/
+canonical_url: https://docs.opensearch.org/latest/aggregations/bucket/index/
 ---
 
 # Bucket aggregations

--- a/_aggregations/metric/index.md
+++ b/_aggregations/metric/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /aggregations/metric-agg/
   - /query-dsl/aggregations/metric/
   - /aggregations/metric/
-canonical_url: https://docs.opensearch.org/latest/aggregations/metric/
+canonical_url: https://docs.opensearch.org/latest/aggregations/metric/index/
 ---
 
 # Metric aggregations

--- a/_aggregations/pipeline/index.md
+++ b/_aggregations/pipeline/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /query-dsl/aggregations/pipeline-agg/
   - /aggregations/pipeline/
   - /aggregations/pipeline-agg/
-canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline/
+canonical_url: https://docs.opensearch.org/latest/aggregations/pipeline/index/
 ---
 
 # Pipeline aggregations

--- a/_ai-agent-integrations/mcp-server/index.md
+++ b/_ai-agent-integrations/mcp-server/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /ai-agent-integrations/mcp-server/
-canonical_url: https://docs.opensearch.org/latest/ai-agent-integrations/mcp-server/
+canonical_url: https://docs.opensearch.org/latest/ai-agent-integrations/mcp-server/index/
 ---
 
 # OpenSearch MCP Server

--- a/_analyzers/character-filters/index.md
+++ b/_analyzers/character-filters/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /analyzers/character-filters/
-canonical_url: https://docs.opensearch.org/latest/analyzers/character-filters/
+canonical_url: https://docs.opensearch.org/latest/analyzers/character-filters/index/
 ---
 
 # Character filters

--- a/_analyzers/language-analyzers/index.md
+++ b/_analyzers/language-analyzers/index.md
@@ -8,7 +8,7 @@ has_toc: true
 redirect_from:
   - /query-dsl/analyzers/language-analyzers/
   - /analyzers/language-analyzers/
-canonical_url: https://docs.opensearch.org/latest/analyzers/language-analyzers/
+canonical_url: https://docs.opensearch.org/latest/analyzers/language-analyzers/index/
 ---
 
 # Language analyzers

--- a/_analyzers/supported-analyzers/index.md
+++ b/_analyzers/supported-analyzers/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
     - /analyzers/supported-analyzers/
-canonical_url: https://docs.opensearch.org/latest/analyzers/supported-analyzers/
+canonical_url: https://docs.opensearch.org/latest/analyzers/supported-analyzers/index/
 ---
 
 # Analyzers

--- a/_analyzers/token-filters/index.md
+++ b/_analyzers/token-filters/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /analyzers/token-filters/
-canonical_url: https://docs.opensearch.org/latest/analyzers/token-filters/
+canonical_url: https://docs.opensearch.org/latest/analyzers/token-filters/index/
 ---
 
 # Token filters

--- a/_analyzers/tokenizers/index.md
+++ b/_analyzers/tokenizers/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /analyzers/tokenizers/
-canonical_url: https://docs.opensearch.org/latest/analyzers/tokenizers/
+canonical_url: https://docs.opensearch.org/latest/analyzers/tokenizers/index/
 ---
 
 # Tokenizers

--- a/_api-reference/alias/index.md
+++ b/_api-reference/alias/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/rest-api/alias/
   - /api-reference/alias-api/
   - /api-reference/alias/
-canonical_url: https://docs.opensearch.org/latest/api-reference/alias/
+canonical_url: https://docs.opensearch.org/latest/api-reference/alias/index/
 ---
 
 # Alias APIs

--- a/_api-reference/cat/index.md
+++ b/_api-reference/cat/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/catapis/
   - /opensearch/rest-api/cat/index/
   - /api-reference/cat/
-canonical_url: https://docs.opensearch.org/latest/api-reference/cat/
+canonical_url: https://docs.opensearch.org/latest/api-reference/cat/index/
 ---
 
 # CAT APIs

--- a/_api-reference/cluster-api/index.md
+++ b/_api-reference/cluster-api/index.md
@@ -7,7 +7,7 @@ nav_order: 15
 redirect_from:
   - /opensearch/api-reference/cluster-api/
   - /api-reference/cluster-api/
-canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/
+canonical_url: https://docs.opensearch.org/latest/api-reference/cluster-api/index/
 ---
 
 # Cluster APIs

--- a/_api-reference/document-apis/index.md
+++ b/_api-reference/document-apis/index.md
@@ -7,7 +7,7 @@ nav_order: 25
 redirect_from:
   - /opensearch/rest-api/document-apis/index/
   - /api-reference/document-apis/
-canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/document-apis/index/
 ---
 
 # Document APIs

--- a/_api-reference/grpc-apis/index.md
+++ b/_api-reference/grpc-apis/index.md
@@ -7,7 +7,7 @@ nav_order: 25
 description: "Reference for the OpenSearch gRPC APIs, including the bulk and k-NN search operations that use protocol buffers for high-performance communication."
 redirect_from:
   - /api-reference/grpc-apis/
-canonical_url: https://docs.opensearch.org/latest/api-reference/grpc-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/grpc-apis/index/
 ---
 
 # gRPC APIs

--- a/_api-reference/index-apis/index.md
+++ b/_api-reference/index-apis/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/rest-api/index-apis/index/
   - /opensearch/rest-api/index-apis/
   - /api-reference/index-apis/
-canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/index-apis/index/
 ---
 
 # Index APIs

--- a/_api-reference/ingest-apis/index.md
+++ b/_api-reference/ingest-apis/index.md
@@ -6,7 +6,7 @@ nav_order: 40
 redirect_from:
   - /opensearch/rest-api/ingest-apis/index/
   - /api-reference/ingest-apis/
-canonical_url: https://docs.opensearch.org/latest/api-reference/ingest-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/ingest-apis/index/
 ---
 
 # Ingest APIs

--- a/_api-reference/list/index.md
+++ b/_api-reference/list/index.md
@@ -5,7 +5,7 @@ nav_order: 45
 has_children: true
 redirect_from:
   - /api-reference/list/
-canonical_url: https://docs.opensearch.org/latest/api-reference/list/
+canonical_url: https://docs.opensearch.org/latest/api-reference/list/index/
 ---
 
 # List APIs

--- a/_api-reference/nodes-apis/index.md
+++ b/_api-reference/nodes-apis/index.md
@@ -6,7 +6,7 @@ has_toc: false
 nav_order: 50
 redirect_from:
   - /api-reference/nodes-apis/
-canonical_url: https://docs.opensearch.org/latest/api-reference/nodes-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/nodes-apis/index/
 ---
 
 # Nodes APIs

--- a/_api-reference/script-apis/index.md
+++ b/_api-reference/script-apis/index.md
@@ -7,7 +7,7 @@ nav_order: 70
 redirect_from:
   - /opensearch/rest-api/script-apis/
   - /api-reference/script-apis/
-canonical_url: https://docs.opensearch.org/latest/api-reference/script-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/script-apis/index/
 ---
 
 # Script APIs

--- a/_api-reference/search-apis/index.md
+++ b/_api-reference/search-apis/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /api-reference/search-apis/
-canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/index/
 ---
 
 # Search APIs

--- a/_api-reference/search-apis/search-template/index.md
+++ b/_api-reference/search-apis/search-template/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /search-plugins/search-template/
   - /api-reference/search-template/
   - /api-reference/search-apis/search-template/
-canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/
+canonical_url: https://docs.opensearch.org/latest/api-reference/search-apis/search-template/index/
 ---
 
 # Search Templates API

--- a/_api-reference/security/api-keys/index.md
+++ b/_api-reference/security/api-keys/index.md
@@ -8,7 +8,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /api-reference/security/api-keys/
-canonical_url: https://docs.opensearch.org/latest/api-reference/security/api-keys/
+canonical_url: https://docs.opensearch.org/latest/api-reference/security/api-keys/index/
 ---
 
 # API Key APIs

--- a/_api-reference/security/authentication/index.md
+++ b/_api-reference/security/authentication/index.md
@@ -6,7 +6,7 @@ has_children: true
 nav_order: 10
 redirect_from:
   - /api-reference/security/authentication/
-canonical_url: https://docs.opensearch.org/latest/api-reference/security/authentication/
+canonical_url: https://docs.opensearch.org/latest/api-reference/security/authentication/index/
 ---
 
 # Authentication APIs

--- a/_api-reference/security/configuration/index.md
+++ b/_api-reference/security/configuration/index.md
@@ -6,7 +6,7 @@ has_children: true
 nav_order: 20
 redirect_from:
   - /api-reference/security/configuration/
-canonical_url: https://docs.opensearch.org/latest/api-reference/security/configuration/
+canonical_url: https://docs.opensearch.org/latest/api-reference/security/configuration/index/
 ---
 
 # Security configuration APIs

--- a/_api-reference/security/index.md
+++ b/_api-reference/security/index.md
@@ -6,7 +6,7 @@ has_children: true
 redirect_from:
   - /api-reference/security-apis/
   - /api-reference/security/
-canonical_url: https://docs.opensearch.org/latest/api-reference/security/
+canonical_url: https://docs.opensearch.org/latest/api-reference/security/index/
 ---
 
 # Security APIs

--- a/_api-reference/snapshots/index.md
+++ b/_api-reference/snapshots/index.md
@@ -7,7 +7,7 @@ nav_order: 80
 redirect_from:
   - /opensearch/rest-api/snapshots/
   - /api-reference/snapshots/
-canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/
+canonical_url: https://docs.opensearch.org/latest/api-reference/snapshots/index/
 ---
 
 # Snapshot APIs

--- a/_automating-configurations/api/index.md
+++ b/_automating-configurations/api/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /automating-configurations/api/
-canonical_url: https://docs.opensearch.org/latest/automating-configurations/api/
+canonical_url: https://docs.opensearch.org/latest/automating-configurations/api/index/
 ---
 
 # Workflow APIs

--- a/_automating-configurations/index.md
+++ b/_automating-configurations/index.md
@@ -6,7 +6,7 @@ has_children: false
 nav_exclude: true
 redirect_from:
   - /automating-configurations/
-canonical_url: https://docs.opensearch.org/latest/automating-configurations/
+canonical_url: https://docs.opensearch.org/latest/automating-configurations/index/
 ---
 
 # Automating configurations

--- a/_benchmark/FAQs.md
+++ b/_benchmark/FAQs.md
@@ -3,6 +3,7 @@ layout: default
 title: FAQs
 nav_order: 103
 canonical_url: https://docs.opensearch.org/latest/benchmark/FAQs/
+redirect_to: https://docs.opensearch.org/latest/benchmark/FAQs/
 ---
 
 # FAQs

--- a/_benchmark/anatomy-of-a-workload.md
+++ b/_benchmark/anatomy-of-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 10
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/anatomy-of-a-workload/
 canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # Anatomy of a workload

--- a/_benchmark/choosing-a-workload.md
+++ b/_benchmark/choosing-a-workload.md
@@ -5,6 +5,7 @@ nav_order: 20
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/choosing-a-workload/
 canonical_url: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
+redirect_to: https://docs.opensearch.org/latest/benchmark/choosing-a-workload/
 ---
 
 # Choosing a workload

--- a/_benchmark/common-operations.md
+++ b/_benchmark/common-operations.md
@@ -5,6 +5,7 @@ nav_order: 15
 redirect_from:
   - /benchmark/user-guide/understanding-workloads/common-operations/
 canonical_url: https://docs.opensearch.org/latest/benchmark/common-operations/
+redirect_to: https://docs.opensearch.org/latest/benchmark/common-operations/
 ---
 
 # Common operations

--- a/_benchmark/features/index.md
+++ b/_benchmark/features/index.md
@@ -11,6 +11,7 @@ more_cards:
     description: "Create synthetic datasets using index mappings or custom Python logic for comprehensive benchmarking and testing."
     link: "/benchmark/features/synthetic-data-generation/"
 canonical_url: https://docs.opensearch.org/latest/benchmark/features/
+redirect_to: https://docs.opensearch.org/latest/benchmark/features/index/
 ---
 
 # Additional features

--- a/_benchmark/features/index.md
+++ b/_benchmark/features/index.md
@@ -10,7 +10,7 @@ more_cards:
   - heading: "Synthetic data generation"
     description: "Create synthetic datasets using index mappings or custom Python logic for comprehensive benchmarking and testing."
     link: "/benchmark/features/synthetic-data-generation/"
-canonical_url: https://docs.opensearch.org/latest/benchmark/features/
+canonical_url: https://docs.opensearch.org/latest/benchmark/features/index/
 redirect_to: https://docs.opensearch.org/latest/benchmark/features/index/
 ---
 

--- a/_benchmark/features/synthetic-data-generation/custom-logic-sdg.md
+++ b/_benchmark/features/synthetic-data-generation/custom-logic-sdg.md
@@ -5,6 +5,7 @@ nav_order: 35
 parent: Synthetic data generation
 grand_parent: Additional features
 canonical_url: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/custom-logic-sdg/
+redirect_to: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/custom-logic-sdg/
 ---
 
 # Generating data using custom logic

--- a/_benchmark/features/synthetic-data-generation/generating-vectors.md
+++ b/_benchmark/features/synthetic-data-generation/generating-vectors.md
@@ -5,6 +5,7 @@ nav_order: 40
 parent: Synthetic data generation
 grand_parent: Additional features
 canonical_url: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/generating-vectors/
+redirect_to: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/generating-vectors/
 ---
 
 # Generating vectors

--- a/_benchmark/features/synthetic-data-generation/index.md
+++ b/_benchmark/features/synthetic-data-generation/index.md
@@ -22,7 +22,7 @@ tip_cards:
   - heading: "Tips and best practices"
     description: "Learn practical guidance and best practices to optimize your synthetic data generation workflows."
     link: "/benchmark/features/synthetic-data-generation/tips/"
-canonical_url: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/
+canonical_url: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/index/
 redirect_to: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/index/
 ---
 

--- a/_benchmark/features/synthetic-data-generation/index.md
+++ b/_benchmark/features/synthetic-data-generation/index.md
@@ -23,6 +23,7 @@ tip_cards:
     description: "Learn practical guidance and best practices to optimize your synthetic data generation workflows."
     link: "/benchmark/features/synthetic-data-generation/tips/"
 canonical_url: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/
+redirect_to: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/index/
 ---
 
 # Synthetic data generation

--- a/_benchmark/features/synthetic-data-generation/mapping-sdg.md
+++ b/_benchmark/features/synthetic-data-generation/mapping-sdg.md
@@ -5,6 +5,7 @@ nav_order: 15
 parent: Synthetic data generation
 grand_parent: Additional features
 canonical_url: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/mapping-sdg/
+redirect_to: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/mapping-sdg/
 ---
 
 # Generating data using index mappings

--- a/_benchmark/features/synthetic-data-generation/tips.md
+++ b/_benchmark/features/synthetic-data-generation/tips.md
@@ -5,6 +5,7 @@ nav_order: 45
 parent: Synthetic data generation
 grand_parent: Additional features
 canonical_url: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/tips/
+redirect_to: https://docs.opensearch.org/latest/benchmark/features/synthetic-data-generation/tips/
 ---
 
 # Tips and best practices

--- a/_benchmark/glossary.md
+++ b/_benchmark/glossary.md
@@ -3,6 +3,7 @@ layout: default
 title: Glossary
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/benchmark/glossary/
+redirect_to: https://docs.opensearch.org/latest/benchmark/glossary/
 ---
 
 # OpenSearch Benchmark glossary

--- a/_benchmark/index.md
+++ b/_benchmark/index.md
@@ -35,6 +35,7 @@ items:
     link: "/benchmark/reference/summary-report/"
 description: "OpenSearch Benchmark is a macrobenchmark utility provided by the OpenSearch Project. You can use OpenSearch Benchmark to gather performance metrics from an OpenSearch cluster."
 canonical_url: https://docs.opensearch.org/latest/benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/
 ---
 
 # ![Benchmark icon]({{site.url}}{{site.baseurl}}/images/icons/OpenSearch-PerformanceBenchmarks-Icon-1.png){: .heading-icon} OpenSearch Benchmark

--- a/_benchmark/migration-assistance.md
+++ b/_benchmark/migration-assistance.md
@@ -3,6 +3,7 @@ layout: default
 title: Migration assistance
 nav_order: 102
 canonical_url: https://docs.opensearch.org/latest/benchmark/migration-assistance/
+redirect_to: https://docs.opensearch.org/latest/benchmark/migration-assistance/
 ---
 
 # Migrating from 1.X to 2.X

--- a/_benchmark/quickstart.md
+++ b/_benchmark/quickstart.md
@@ -3,6 +3,7 @@ layout: default
 title: Quickstart
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/benchmark/quickstart/
+redirect_to: https://docs.opensearch.org/latest/benchmark/quickstart/
 ---
 
 # OpenSearch Benchmark quickstart

--- a/_benchmark/reference/commands/aggregate.md
+++ b/_benchmark/reference/commands/aggregate.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/commands/aggregate/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/aggregate/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/aggregate/
 ---
 
 # aggregate

--- a/_benchmark/reference/commands/command-flags.md
+++ b/_benchmark/reference/commands/command-flags.md
@@ -7,6 +7,7 @@ redirect_from:
   - /benchmark/commands/command-flags/
 grand_parent: Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/command-flags/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/command-flags/
 ---
 
 # Command flags

--- a/_benchmark/reference/commands/compare.md
+++ b/_benchmark/reference/commands/compare.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/commands/compare/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/compare/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/compare/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/download.md
+++ b/_benchmark/reference/commands/download.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/commands/download/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/download/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/download/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/generate-data.md
+++ b/_benchmark/reference/commands/generate-data.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/commands/generate-data/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/generate-data/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/generate-data/
 ---
 
 # generate-data

--- a/_benchmark/reference/commands/index.md
+++ b/_benchmark/reference/commands/index.md
@@ -7,7 +7,7 @@ has_toc: false
 parent: Reference
 redirect_from:
   - /benchmark/reference/commands/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
 ---
 

--- a/_benchmark/reference/commands/index.md
+++ b/_benchmark/reference/commands/index.md
@@ -8,6 +8,7 @@ parent: Reference
 redirect_from:
   - /benchmark/reference/commands/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/index/
 ---
 
 # OpenSearch Benchmark command reference

--- a/_benchmark/reference/commands/info.md
+++ b/_benchmark/reference/commands/info.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/commands/info/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/info/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/info/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/list.md
+++ b/_benchmark/reference/commands/list.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/commands/list/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/list/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/list/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/commands/redline-test.md
+++ b/_benchmark/reference/commands/redline-test.md
@@ -5,6 +5,7 @@ nav_order: 85
 parent: Command reference
 grand_parent: Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/redline-test/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/redline-test/
 ---
 
 # Redline testing

--- a/_benchmark/reference/commands/run.md
+++ b/_benchmark/reference/commands/run.md
@@ -8,6 +8,7 @@ redirect_from:
   - /benchmark/commands/execute-test/
   - /benchmark/reference/commands/execute-test/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/commands/run/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -6,6 +6,7 @@ has_children: true
 redirect_from:
   - /benchmark/reference/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/index/
 ---
 
 # OpenSearch Benchmark reference

--- a/_benchmark/reference/index.md
+++ b/_benchmark/reference/index.md
@@ -5,7 +5,7 @@ nav_order: 25
 has_children: true
 redirect_from:
   - /benchmark/reference/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/index/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/index/
 ---
 

--- a/_benchmark/reference/metrics/index.md
+++ b/_benchmark/reference/metrics/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/metrics/index/
   - /benchmark/reference/metrics/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
 ---
 
 # OpenSearch Benchmark metrics

--- a/_benchmark/reference/metrics/index.md
+++ b/_benchmark/reference/metrics/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /benchmark/metrics/
   - /benchmark/metrics/index/
   - /benchmark/reference/metrics/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/index/
 ---
 

--- a/_benchmark/reference/metrics/metric-keys.md
+++ b/_benchmark/reference/metrics/metric-keys.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/metrics/metric-keys/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-keys/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-keys/
 ---
 
 # Metric keys

--- a/_benchmark/reference/metrics/metric-records.md
+++ b/_benchmark/reference/metrics/metric-records.md
@@ -7,6 +7,7 @@ grand_parent: Reference
 redirect_from:
   - /benchmark/metrics/metric-records/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-records/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/metrics/metric-records/
 ---
 
 # Metric records

--- a/_benchmark/reference/summary-report.md
+++ b/_benchmark/reference/summary-report.md
@@ -6,6 +6,7 @@ parent: Reference
 redirect_from:
   - /benchmark/user-guide/understanding-results/summary-reports/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 # Summary report

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -6,6 +6,7 @@ parent: Reference
 redirect_from:
   - /benchmark/user-guide/understanding-results/telemetry/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/telemetry/
 ---
 
 # Telemetry devices

--- a/_benchmark/reference/workloads/corpora.md
+++ b/_benchmark/reference/workloads/corpora.md
@@ -7,6 +7,7 @@ nav_order: 70
 redirect_from:
   - /benchmark/workloads/corpora/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/corpora/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/corpora/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /benchmark/workloads/
   - /benchmark/workloads/index/
   - /benchmark/reference/workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 

--- a/_benchmark/reference/workloads/index.md
+++ b/_benchmark/reference/workloads/index.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/workloads/index/
   - /benchmark/reference/workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/anatomy-of-a-workload/
 ---
 
 # OpenSearch Benchmark workload reference

--- a/_benchmark/reference/workloads/indices.md
+++ b/_benchmark/reference/workloads/indices.md
@@ -7,6 +7,7 @@ nav_order: 65
 redirect_from:
   - /benchmark/workloads/indices/
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/indices/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/indices/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/operations.md
+++ b/_benchmark/reference/workloads/operations.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: Reference
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/operations/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/operations/
 ---
 
 <!-- vale off -->

--- a/_benchmark/reference/workloads/parameters.md
+++ b/_benchmark/reference/workloads/parameters.md
@@ -5,6 +5,7 @@ nav_order: 150
 parent: Workload reference
 grand_parent: Reference
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/parameters/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/parameters/
 ---
 
 # Workload parameters

--- a/_benchmark/reference/workloads/test-procedures.md
+++ b/_benchmark/reference/workloads/test-procedures.md
@@ -5,6 +5,7 @@ parent: Workload reference
 grand_parent: Reference
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/benchmark/reference/workloads/test-procedures/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/workloads/test-procedures/
 ---
 
 <!-- vale off -->

--- a/_benchmark/user-guide/concepts.md
+++ b/_benchmark/user-guide/concepts.md
@@ -7,6 +7,7 @@ has_toc: false
 redirect_from: 
   - /benchmark/user-guide/concepts/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/concepts/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/concepts/
 ---
 
 # OpenSearch Benchmark concepts

--- a/_benchmark/user-guide/index.md
+++ b/_benchmark/user-guide/index.md
@@ -26,6 +26,7 @@ more_cards:
 redirect_from:
   - /benchmark/user-guide/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/index/
 ---
 
 # OpenSearch Benchmark user guide

--- a/_benchmark/user-guide/index.md
+++ b/_benchmark/user-guide/index.md
@@ -25,7 +25,7 @@ more_cards:
     link: "/benchmark/user-guide/optimizing-benchmarks/index/" 
 redirect_from:
   - /benchmark/user-guide/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/index/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/index/
 ---
 

--- a/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
+++ b/_benchmark/user-guide/install-and-configure/configuring-benchmark.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/user-guide/configuring-benchmark/
   - /benchmark/tutorials/sigv4/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/configuring-benchmark/
 ---
 
 # Configuring OpenSearch Benchmark

--- a/_benchmark/user-guide/install-and-configure/index.md
+++ b/_benchmark/user-guide/install-and-configure/index.md
@@ -6,7 +6,7 @@ parent: User guide
 has_children: true
 redirect_from:
   - /benchmark/user-guide/install-and-configure/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/
+canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/index/
 redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/index/
 ---
 

--- a/_benchmark/user-guide/install-and-configure/index.md
+++ b/_benchmark/user-guide/install-and-configure/index.md
@@ -7,6 +7,7 @@ has_children: true
 redirect_from:
   - /benchmark/user-guide/install-and-configure/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/index/
 ---
 
 # Installing and configuring OpenSearch Benchmark 

--- a/_benchmark/user-guide/install-and-configure/installing-benchmark.md
+++ b/_benchmark/user-guide/install-and-configure/installing-benchmark.md
@@ -8,6 +8,7 @@ redirect_from:
   - /benchmark/installing-benchmark/
   - /benchmark/user-guide/installing-benchmark/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/installing-benchmark/
+redirect_to: https://docs.opensearch.org/latest/benchmark/user-guide/install-and-configure/installing-benchmark/
 ---
 
 # Installing OpenSearch Benchmark

--- a/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
@@ -5,6 +5,7 @@ nav_order: 15
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/distributed-load/
+redirect_to: https://docs.opensearch.org/latest/benchmark/distributed-load/
 ---
 
 # Running distributed loads

--- a/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/distributed-load.md
@@ -4,7 +4,7 @@ title: Running distributed loads
 nav_order: 15
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/distributed-load/
+canonical_url: https://docs.opensearch.org/latest/benchmark/distributed-load/
 redirect_to: https://docs.opensearch.org/latest/benchmark/distributed-load/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
@@ -4,7 +4,7 @@ title: Expanding a workload's data corpus
 nav_order: 20
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/expand-data-corpus/
+canonical_url: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 redirect_to: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/expand-data-corpus.md
@@ -5,6 +5,7 @@ nav_order: 20
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/expand-data-corpus/
+redirect_to: https://docs.opensearch.org/latest/benchmark/expand-data-corpus/
 ---
 
 # Expanding a workload's data corpus

--- a/_benchmark/user-guide/optimizing-benchmarks/index.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/index.md
@@ -23,7 +23,7 @@ more_cards:
     link: "/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/"
 redirect_from:
   - /benchmark/user-guide/optimizing-benchmarks/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/
+canonical_url: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/index.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/index.md
@@ -24,6 +24,7 @@ more_cards:
 redirect_from:
   - /benchmark/user-guide/optimizing-benchmarks/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/
+redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 
 # Optimizing benchmarks

--- a/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
@@ -5,6 +5,7 @@ nav_order: 160
 parent: Optimizing benchmarks
 grand_parent: User guide
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices/
+redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 
 # Performance testing best practices

--- a/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices.md
@@ -4,7 +4,7 @@ title: Performance testing best practices
 nav_order: 160
 parent: Optimizing benchmarks
 grand_parent: User guide
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/performance-testing-best-practices/
+canonical_url: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 redirect_to: https://docs.opensearch.org/latest/benchmark/performance-testing-best-practices/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
@@ -5,7 +5,7 @@ nav_order: 160
 parent: Optimizing benchmarks
 grand_parent: User guide
 has_math: true
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/
+canonical_url: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 redirect_to: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/randomizing-queries.md
@@ -6,6 +6,7 @@ parent: Optimizing benchmarks
 grand_parent: User guide
 has_math: true
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/randomizing-queries/
+redirect_to: https://docs.opensearch.org/latest/benchmark/randomizing-queries/
 ---
 
 # Randomizing queries

--- a/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
@@ -6,7 +6,7 @@ parent: Optimizing benchmarks
 grand_parent: User guide
 redirect_from: 
   - /benchmark/user-guide/target-throughput/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/target-throughput/
+canonical_url: https://docs.opensearch.org/latest/benchmark/target-throughput/
 redirect_to: https://docs.opensearch.org/latest/benchmark/target-throughput/
 ---
 

--- a/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
+++ b/_benchmark/user-guide/optimizing-benchmarks/target-throughput.md
@@ -7,6 +7,7 @@ grand_parent: User guide
 redirect_from: 
   - /benchmark/user-guide/target-throughput/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/optimizing-benchmarks/target-throughput/
+redirect_to: https://docs.opensearch.org/latest/benchmark/target-throughput/
 ---
 
 # Target throughput

--- a/_benchmark/user-guide/understanding-results/index.md
+++ b/_benchmark/user-guide/understanding-results/index.md
@@ -7,6 +7,7 @@ has_children: true
 redirect_from:
   - /benchmark/user-guide/understanding-results/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/
+redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 
 # Understanding OpenSearch Benchmark results

--- a/_benchmark/user-guide/understanding-results/index.md
+++ b/_benchmark/user-guide/understanding-results/index.md
@@ -6,7 +6,7 @@ parent: User guide
 has_children: true
 redirect_from:
   - /benchmark/user-guide/understanding-results/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/understanding-results/
+canonical_url: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 redirect_to: https://docs.opensearch.org/latest/benchmark/reference/summary-report/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/contributing-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/contributing-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/contributing-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/contributing-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/contributing-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/contributing-workloads/
 ---
 
 # Sharing custom workloads

--- a/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
@@ -9,6 +9,7 @@ redirect_from:
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/creating-custom-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 ---
 
 # Creating custom workloads

--- a/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/creating-custom-workloads.md
@@ -8,7 +8,7 @@ redirect_from:
   - /benchmark/user-guide/creating-custom-workloads/
   - /benchmark/creating-custom-workloads/
   - /benchmark/user-guide/creating-osb-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/creating-custom-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/creating-custom-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/finetine-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/finetune-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/finetune-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from: 
   - /benchmark/user-guide/finetine-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/finetune-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/finetune-workloads/
 ---
 
 # Fine-tuning custom workloads

--- a/_benchmark/user-guide/working-with-workloads/index.md
+++ b/_benchmark/user-guide/working-with-workloads/index.md
@@ -8,6 +8,7 @@ has_children: true
 redirect_from:
   - /benchmark/user-guide/working-with-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 
 # Working with workloads

--- a/_benchmark/user-guide/working-with-workloads/index.md
+++ b/_benchmark/user-guide/working-with-workloads/index.md
@@ -7,7 +7,7 @@ has_toc: false
 has_children: true
 redirect_from:
   - /benchmark/user-guide/working-with-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/running-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 

--- a/_benchmark/user-guide/working-with-workloads/running-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/running-workloads.md
@@ -7,6 +7,7 @@ parent: Working with workloads
 redirect_from:
   - /benchmark/user-guide/running-workloads/
 canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/running-workloads/
+redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 
 # Running a workload

--- a/_benchmark/user-guide/working-with-workloads/running-workloads.md
+++ b/_benchmark/user-guide/working-with-workloads/running-workloads.md
@@ -6,7 +6,7 @@ grand_parent: User guide
 parent: Working with workloads
 redirect_from:
   - /benchmark/user-guide/running-workloads/
-canonical_url: https://docs.opensearch.org/latest/benchmark/user-guide/working-with-workloads/running-workloads/
+canonical_url: https://docs.opensearch.org/latest/benchmark/running-workloads/
 redirect_to: https://docs.opensearch.org/latest/benchmark/running-workloads/
 ---
 

--- a/_benchmark/version-history.md
+++ b/_benchmark/version-history.md
@@ -3,6 +3,7 @@ layout: default
 title: Version history
 nav_order: 101
 canonical_url: https://docs.opensearch.org/latest/benchmark/version-history/
+redirect_to: https://docs.opensearch.org/latest/benchmark/version-history/
 ---
 
 # OpenSearch Benchmark version history

--- a/_benchmark/workloads/vectorsearch.md
+++ b/_benchmark/workloads/vectorsearch.md
@@ -3,6 +3,7 @@ layout: default
 title: Vector search
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/benchmark/workloads/vectorsearch/
+redirect_to: https://docs.opensearch.org/latest/benchmark/workloads/vectorsearch/
 ---
 
 # Vector search workload

--- a/_clients/OSC-dot-net.md
+++ b/_clients/OSC-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 10
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OSC-dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/OSC-dot-net/
 ---
 
 # Getting started with the high-level .NET client (OpenSearch.Client)

--- a/_clients/OSC-example.md
+++ b/_clients/OSC-example.md
@@ -5,6 +5,7 @@ nav_order: 12
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OSC-example/
+redirect_to: https://docs.opensearch.org/latest/clients/OSC-example/
 ---
 
 # More advanced features of the high-level .NET client (OpenSearch.Client)

--- a/_clients/OpenSearch-dot-net.md
+++ b/_clients/OpenSearch-dot-net.md
@@ -5,6 +5,7 @@ nav_order: 30
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/OpenSearch-dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/OpenSearch-dot-net/
 ---
 
 # Low-level .NET client (OpenSearch.Net)

--- a/_clients/dot-net-conventions.md
+++ b/_clients/dot-net-conventions.md
@@ -5,6 +5,7 @@ nav_order: 20
 has_children: false
 parent: .NET clients
 canonical_url: https://docs.opensearch.org/latest/clients/dot-net-conventions/
+redirect_to: https://docs.opensearch.org/latest/clients/dot-net-conventions/
 ---
 
 # .NET client considerations and best practices

--- a/_clients/dot-net.md
+++ b/_clients/dot-net.md
@@ -5,6 +5,7 @@ nav_order: 75
 has_children: true
 has_toc: false
 canonical_url: https://docs.opensearch.org/latest/clients/dot-net/
+redirect_to: https://docs.opensearch.org/latest/clients/dot-net/
 ---
 
 # .NET clients

--- a/_clients/go.md
+++ b/_clients/go.md
@@ -3,6 +3,7 @@ layout: default
 title: Go client
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/clients/go/
+redirect_to: https://docs.opensearch.org/latest/clients/go/
 ---
 
 # Go client

--- a/_clients/hadoop.md
+++ b/_clients/hadoop.md
@@ -3,6 +3,7 @@ layout: default
 title: Hadoop connector
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/clients/hadoop/
+redirect_to: https://docs.opensearch.org/latest/clients/hadoop/
 ---
 
 # Hadoop connector

--- a/_clients/index.md
+++ b/_clients/index.md
@@ -8,6 +8,7 @@ permalink: /clients/
 redirect_from:
   - /clients/index/
 canonical_url: https://docs.opensearch.org/latest/clients/
+redirect_to: https://docs.opensearch.org/latest/clients/
 ---
 
 # ![Clients icon]({{site.url}}{{site.baseurl}}/images/icons/OpenSearch-Clients-Icon.avif){: .heading-icon} OpenSearch language clients

--- a/_clients/java-rest-high-level.md
+++ b/_clients/java-rest-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: Java high-level REST client
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/clients/java-rest-high-level/
+redirect_to: https://docs.opensearch.org/latest/clients/java-rest-high-level/
 ---
 
 # Java high-level REST client

--- a/_clients/java.md
+++ b/_clients/java.md
@@ -3,6 +3,7 @@ layout: default
 title: Java client
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/clients/java/
+redirect_to: https://docs.opensearch.org/latest/clients/java/
 ---
 
 # Java client

--- a/_clients/javascript/helpers.md
+++ b/_clients/javascript/helpers.md
@@ -4,6 +4,7 @@ title: Helper methods
 parent: JavaScript client
 nav_order: 2
 canonical_url: https://docs.opensearch.org/latest/clients/javascript/helpers/
+redirect_to: https://docs.opensearch.org/latest/clients/javascript/helpers/
 ---
 
 # Helper methods

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -6,6 +6,7 @@ nav_order: 40
 redirect_from:
   - /clients/javascript/
 canonical_url: https://docs.opensearch.org/latest/clients/javascript/
+redirect_to: https://docs.opensearch.org/latest/clients/javascript/index/
 ---
 
 # JavaScript client

--- a/_clients/javascript/index.md
+++ b/_clients/javascript/index.md
@@ -5,7 +5,7 @@ has_children: true
 nav_order: 40
 redirect_from:
   - /clients/javascript/
-canonical_url: https://docs.opensearch.org/latest/clients/javascript/
+canonical_url: https://docs.opensearch.org/latest/clients/javascript/index/
 redirect_to: https://docs.opensearch.org/latest/clients/javascript/index/
 ---
 

--- a/_clients/opensearch-py-ml.md
+++ b/_clients/opensearch-py-ml.md
@@ -3,6 +3,7 @@ layout: default
 title: opensearch-py-ml
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/clients/opensearch-py-ml/
+redirect_to: https://docs.opensearch.org/latest/clients/opensearch-py-ml/
 ---
 
 # opensearch-py-ml

--- a/_clients/php.md
+++ b/_clients/php.md
@@ -3,6 +3,7 @@ layout: default
 title: PHP client
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/clients/php/
+redirect_to: https://docs.opensearch.org/latest/clients/php/
 ---
 
 # PHP client

--- a/_clients/python-high-level.md
+++ b/_clients/python-high-level.md
@@ -3,6 +3,7 @@ layout: default
 title: High-level Python client
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/clients/python-high-level/
+redirect_to: https://docs.opensearch.org/latest/clients/python-high-level/
 ---
 
 The OpenSearch high-level Python client (`opensearch-dsl-py`) will be deprecated after version 2.1.0. We recommend switching to the [Python client (`opensearch-py`)]({{site.url}}{{site.baseurl}}/clients/python-low-level/), which now includes the functionality of `opensearch-dsl-py`.

--- a/_clients/python-low-level.md
+++ b/_clients/python-low-level.md
@@ -5,6 +5,7 @@ nav_order: 10
 redirect_from: 
   - /clients/python/
 canonical_url: https://docs.opensearch.org/latest/clients/python-low-level/
+redirect_to: https://docs.opensearch.org/latest/clients/python-low-level/
 ---
 
 # Low-level Python client

--- a/_clients/ruby.md
+++ b/_clients/ruby.md
@@ -4,6 +4,7 @@ title: Ruby client
 nav_order: 60
 has_children: false
 canonical_url: https://docs.opensearch.org/latest/clients/ruby/
+redirect_to: https://docs.opensearch.org/latest/clients/ruby/
 ---
 
 # Ruby client

--- a/_clients/rust.md
+++ b/_clients/rust.md
@@ -3,6 +3,7 @@ layout: default
 title: Rust client
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/clients/rust/
+redirect_to: https://docs.opensearch.org/latest/clients/rust/
 ---
 
 # Rust client

--- a/_dashboards/dashboard/index.md
+++ b/_dashboards/dashboard/index.md
@@ -5,7 +5,7 @@ nav_order: 60
 has_children: true
 redirect_from:
   - /dashboards/dashboard/
-canonical_url: https://docs.opensearch.org/latest/dashboards/dashboard/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dashboard/index/
 ---
 
 # Creating dashboards

--- a/_dashboards/dashboards-assistant/index.md
+++ b/_dashboards/dashboards-assistant/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /dashboards/dashboards-assistant/
-canonical_url: https://docs.opensearch.org/latest/dashboards/dashboards-assistant/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dashboards-assistant/index/
 ---
 
 Note that machine learning models are probabilistic and that some may perform better than others, so the OpenSearch Assistant may occasionally produce inaccurate information. We recommend evaluating outputs for accuracy as appropriate to your use case, including reviewing the output or combining it with other verification factors.

--- a/_dashboards/discover/index.md
+++ b/_dashboards/discover/index.md
@@ -5,7 +5,7 @@ nav_order: 20
 has_children: true
 redirect_from:
   - /dashboards/discover/
-canonical_url: https://docs.opensearch.org/latest/dashboards/discover/
+canonical_url: https://docs.opensearch.org/latest/dashboards/discover/index/
 ---
 
 # Exploring data

--- a/_dashboards/discover/run-queries.md
+++ b/_dashboards/discover/run-queries.md
@@ -8,7 +8,7 @@ redirect_from:
   - /dashboards/dev-tools/run-queries/
   - /dashboards/dev-tools/index-dev/
   - /dashboards/visualize/run-queries/
-canonical_url: https://docs.opensearch.org/latest/dashboards/discover/run-queries/
+canonical_url: https://docs.opensearch.org/latest/dashboards/dev-tools/index/
 ---
 
 # Running queries in the Dev Tools console

--- a/_dashboards/getting-started/index.md
+++ b/_dashboards/getting-started/index.md
@@ -43,7 +43,7 @@ workflow_items:
   - heading: "Assemble dashboards"
     description: "Combine multiple visualizations into a single page for monitoring and analysis."
     link: "/dashboards/dashboard/"
-canonical_url: https://docs.opensearch.org/latest/dashboards/getting-started/
+canonical_url: https://docs.opensearch.org/latest/dashboards/getting-started/index/
 ---
 
 # Getting started with OpenSearch Dashboards

--- a/_dashboards/im-dashboards/index.md
+++ b/_dashboards/im-dashboards/index.md
@@ -6,7 +6,7 @@ has_children: true
 redirect_from:
   - /dashboards/admin-ui-index/
   - /dashboards/im-dashboards/
-canonical_url: https://docs.opensearch.org/latest/dashboards/im-dashboards/
+canonical_url: https://docs.opensearch.org/latest/dashboards/im-dashboards/index/
 ---
 
 # Index management

--- a/_dashboards/integrations/index.md
+++ b/_dashboards/integrations/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /integrations/
   - /integrations/index/
   - /dashboards/integrations/
-canonical_url: https://docs.opensearch.org/latest/dashboards/integrations/
+canonical_url: https://docs.opensearch.org/latest/dashboards/integrations/index/
 ---
 
 # OpenSearch Dashboards integrations

--- a/_dashboards/visualize/index.md
+++ b/_dashboards/visualize/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /dashboards/visualize/
   - /dashboards/visualize/gantt/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/index/
 ---
 
 # Building data visualizations

--- a/_dashboards/visualize/visualization-editor/configuring-visualizations/index.md
+++ b/_dashboards/visualize/visualization-editor/configuring-visualizations/index.md
@@ -8,7 +8,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /dashboards/visualize/visualization-editor/configuring-visualizations/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualization-editor/configuring-visualizations/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualization-editor/configuring-visualizations/index/
 ---
 
 # Configuring visualizations in the visualization editor

--- a/_dashboards/visualize/visualization-editor/dashboard-variables/index.md
+++ b/_dashboards/visualize/visualization-editor/dashboard-variables/index.md
@@ -8,7 +8,7 @@ parent: Creating visualizations using queries
 grand_parent: Building data visualizations
 redirect_from:
   - /dashboards/visualize/visualization-editor/dashboard-variables/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualization-editor/dashboard-variables/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualization-editor/dashboard-variables/index/
 ---
 
 # Dashboard variables

--- a/_dashboards/visualize/visualization-editor/index.md
+++ b/_dashboards/visualize/visualization-editor/index.md
@@ -8,7 +8,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /dashboards/visualize/visualization-editor/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualization-editor/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualization-editor/index/
 ---
 
 # Creating visualizations using queries

--- a/_dashboards/visualize/visualize-app/index.md
+++ b/_dashboards/visualize/visualize-app/index.md
@@ -9,7 +9,7 @@ has_toc: false
 redirect_from:
   - /dashboards/visualize/visualize-app/
   - /dashboards/visualize/viz-index/
-canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/
+canonical_url: https://docs.opensearch.org/latest/dashboards/visualize/visualize-app/index/
 ---
 
 # Creating visualizations in the Visualize application

--- a/_dashboards/workspace/index.md
+++ b/_dashboards/workspace/index.md
@@ -5,7 +5,7 @@ parent: Workspaces
 nav_order: 0
 redirect_from:
   - /dashboards/workspace/
-canonical_url: https://docs.opensearch.org/latest/dashboards/workspace/
+canonical_url: https://docs.opensearch.org/latest/dashboards/workspace/index/
 ---
 
 # Getting started with workspaces

--- a/_data-prepper/common-use-cases/anomaly-detection.md
+++ b/_data-prepper/common-use-cases/anomaly-detection.md
@@ -4,6 +4,7 @@ title: Anomaly detection
 parent: Common use cases
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/anomaly-detection/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/anomaly-detection/
 ---
 
 # Anomaly detection with Data Prepper

--- a/_data-prepper/common-use-cases/codec-processor-combinations.md
+++ b/_data-prepper/common-use-cases/codec-processor-combinations.md
@@ -4,6 +4,7 @@ title: Codec processor combinations
 parent: Common use cases
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/codec-processor-combinations/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/codec-processor-combinations/
 ---
 
 # Codec processor combinations

--- a/_data-prepper/common-use-cases/common-use-cases.md
+++ b/_data-prepper/common-use-cases/common-use-cases.md
@@ -6,6 +6,7 @@ nav_order: 15
 redirect_from: 
   - /data-prepper/common-use-cases/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/common-use-cases/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/common-use-cases/
 ---
 
 # Common use cases

--- a/_data-prepper/common-use-cases/event-aggregation.md
+++ b/_data-prepper/common-use-cases/event-aggregation.md
@@ -4,6 +4,7 @@ title: Event aggregation
 parent: Common use cases
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/event-aggregation/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/event-aggregation/
 ---
 
 # Event aggregation

--- a/_data-prepper/common-use-cases/log-analytics.md
+++ b/_data-prepper/common-use-cases/log-analytics.md
@@ -4,6 +4,7 @@ title: Log analytics
 parent: Common use cases
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-analytics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-analytics/
 ---
 
 # Log analytics

--- a/_data-prepper/common-use-cases/log-enrichment.md
+++ b/_data-prepper/common-use-cases/log-enrichment.md
@@ -4,6 +4,7 @@ title: Log enrichment
 parent: Common use cases
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-enrichment/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/log-enrichment/
 ---
 
 # Log enrichment

--- a/_data-prepper/common-use-cases/metrics-logs.md
+++ b/_data-prepper/common-use-cases/metrics-logs.md
@@ -4,6 +4,7 @@ title: Deriving metrics from logs
 parent: Common use cases
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-logs/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-logs/
 ---
 
 # Deriving metrics from logs

--- a/_data-prepper/common-use-cases/metrics-traces.md
+++ b/_data-prepper/common-use-cases/metrics-traces.md
@@ -4,6 +4,7 @@ title: Deriving metrics from traces
 parent: Common use cases
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-traces/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/metrics-traces/
 ---
 
 # Deriving metrics from traces

--- a/_data-prepper/common-use-cases/s3-logs.md
+++ b/_data-prepper/common-use-cases/s3-logs.md
@@ -4,6 +4,7 @@ title: S3 logs
 parent: Common use cases
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/s3-logs/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/s3-logs/
 ---
 
 # S3 logs

--- a/_data-prepper/common-use-cases/sampling.md
+++ b/_data-prepper/common-use-cases/sampling.md
@@ -4,6 +4,7 @@ title: Sampling
 parent: Common use cases
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/sampling/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/sampling/
 ---
 
 # Sampling

--- a/_data-prepper/common-use-cases/text-processing.md
+++ b/_data-prepper/common-use-cases/text-processing.md
@@ -4,6 +4,7 @@ title: Text processing
 parent: Common use cases
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/text-processing/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/text-processing/
 ---
 
 # Text processing

--- a/_data-prepper/common-use-cases/trace-analytics.md
+++ b/_data-prepper/common-use-cases/trace-analytics.md
@@ -4,6 +4,7 @@ title: Trace analytics
 parent: Common use cases
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/common-use-cases/trace-analytics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/common-use-cases/trace-analytics/
 ---
 
 # Trace analytics with Data Prepper

--- a/_data-prepper/getting-started.md
+++ b/_data-prepper/getting-started.md
@@ -5,6 +5,7 @@ nav_order: 5
 redirect_from:
   - /clients/data-prepper/get-started/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/getting-started/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/getting-started/
 ---
 
 # Getting started with OpenSearch Data Prepper

--- a/_data-prepper/index.md
+++ b/_data-prepper/index.md
@@ -12,6 +12,7 @@ redirect_from:
   - /data-prepper/index/
   - /data-prepper/migrating-from-logstash-data-prepper/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/
 ---
 
 # ![Data Prepper icon]({{site.url}}{{site.baseurl}}/images/icons/OpenSearch-DataPrepper-1.png){: .heading-icon} OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/configuring-data-prepper.md
@@ -7,6 +7,7 @@ redirect_from:
  - /clients/data-prepper/data-prepper-reference/
  - /monitoring-plugins/trace/data-prepper-reference/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-data-prepper/
 ---
 
 # Configuring OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/configuring-log4j.md
+++ b/_data-prepper/managing-data-prepper/configuring-log4j.md
@@ -4,6 +4,7 @@ title: Configuring Log4j
 parent: Managing OpenSearch Data Prepper
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-log4j/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/configuring-log4j/
 ---
 
 # Configuring Log4j

--- a/_data-prepper/managing-data-prepper/core-apis.md
+++ b/_data-prepper/managing-data-prepper/core-apis.md
@@ -4,6 +4,7 @@ title: Core APIs
 parent: Managing OpenSearch Data Prepper
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/core-apis/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/core-apis/
 ---
 
 # Core APIs

--- a/_data-prepper/managing-data-prepper/extensions/extensions.md
+++ b/_data-prepper/managing-data-prepper/extensions/extensions.md
@@ -5,6 +5,7 @@ parent: Managing OpenSearch Data Prepper
 has_children: true
 nav_order: 18
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/extensions/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/extensions/
 ---
 
 # Data Prepper extensions

--- a/_data-prepper/managing-data-prepper/extensions/geoip-service.md
+++ b/_data-prepper/managing-data-prepper/extensions/geoip-service.md
@@ -5,6 +5,7 @@ nav_order: 5
 parent: Extensions
 grand_parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/geoip-service/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/extensions/geoip-service/
 ---
 
 # GeoIP service extension

--- a/_data-prepper/managing-data-prepper/latency.md
+++ b/_data-prepper/managing-data-prepper/latency.md
@@ -4,6 +4,7 @@ title: Pipeline latency tuning guide
 parent: Managing OpenSearch Data Prepper
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/latency/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/latency/
 ---
 
 # Pipeline latency tuning guide

--- a/_data-prepper/managing-data-prepper/managing-data-prepper.md
+++ b/_data-prepper/managing-data-prepper/managing-data-prepper.md
@@ -4,6 +4,7 @@ title: Managing OpenSearch Data Prepper
 has_children: true
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/managing-data-prepper/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/managing-data-prepper/
 ---
 
 # Managing OpenSearch Data Prepper

--- a/_data-prepper/managing-data-prepper/monitoring.md
+++ b/_data-prepper/managing-data-prepper/monitoring.md
@@ -4,6 +4,7 @@ title: Monitoring
 parent: Managing OpenSearch Data Prepper
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/monitoring/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/monitoring/
 ---
  
 # Monitoring OpenSearch Data Prepper with metrics

--- a/_data-prepper/managing-data-prepper/peer-forwarder.md
+++ b/_data-prepper/managing-data-prepper/peer-forwarder.md
@@ -4,6 +4,7 @@ title: Peer forwarder
 nav_order: 12
 parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/peer-forwarder/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/peer-forwarder/
 ---
 
 # Peer forwarder

--- a/_data-prepper/managing-data-prepper/source-coordination.md
+++ b/_data-prepper/managing-data-prepper/source-coordination.md
@@ -4,6 +4,7 @@ title: Source coordination
 nav_order: 35
 parent: Managing OpenSearch Data Prepper
 canonical_url: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/source-coordination/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/managing-data-prepper/source-coordination/
 ---
 
 # Source coordination

--- a/_data-prepper/migrate-open-distro.md
+++ b/_data-prepper/migrate-open-distro.md
@@ -5,6 +5,7 @@ nav_order: 30
 redirect_from:
   - /clients/data-prepper/migrate-open-distro/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/migrate-open-distro/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/migrate-open-distro/
 ---
 
 # Migrating from Open Distro

--- a/_data-prepper/pipelines/cidrcontains.md
+++ b/_data-prepper/pipelines/cidrcontains.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/cidrcontains/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/cidrcontains/
 ---
 
 # cidrContains()

--- a/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
+++ b/_data-prepper/pipelines/configuration/buffers/bounded-blocking.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/bounded-blocking/
 ---
 
 # Bounded blocking buffer

--- a/_data-prepper/pipelines/configuration/buffers/buffers.md
+++ b/_data-prepper/pipelines/configuration/buffers/buffers.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/buffers/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/buffers/
 ---
 
 # Data Prepper buffers

--- a/_data-prepper/pipelines/configuration/buffers/kafka.md
+++ b/_data-prepper/pipelines/configuration/buffers/kafka.md
@@ -5,6 +5,7 @@ parent: Buffers
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/kafka/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/buffers/kafka/
 ---
 
 # Kafka buffer

--- a/_data-prepper/pipelines/configuration/processors/add-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/add-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/add-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/add-entries/
 ---
 
 # Add entries processor

--- a/_data-prepper/pipelines/configuration/processors/aggregate.md
+++ b/_data-prepper/pipelines/configuration/processors/aggregate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aggregate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aggregate/
 ---
 
 # Aggregate processor

--- a/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
+++ b/_data-prepper/pipelines/configuration/processors/anomaly-detector.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/anomaly-detector/
 ---
 
 # Anomaly detector processor

--- a/_data-prepper/pipelines/configuration/processors/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/processors/aws-lambda.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aws-lambda/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/aws-lambda/
 ---
 
 # AWS Lambda processor

--- a/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
+++ b/_data-prepper/pipelines/configuration/processors/convert-entry-type.md
@@ -7,6 +7,7 @@ nav_order: 50
 redirect_from:
   - /data-prepper/pipelines/configuration/processors/convert_entry_type/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/convert-entry-type/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/convert-entry-type/
 ---
 
 # Convert type processor

--- a/_data-prepper/pipelines/configuration/processors/copy-values.md
+++ b/_data-prepper/pipelines/configuration/processors/copy-values.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/copy-values/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/copy-values/
 ---
 
 # Copy values processor

--- a/_data-prepper/pipelines/configuration/processors/csv.md
+++ b/_data-prepper/pipelines/configuration/processors/csv.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/csv/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/csv/
 ---
 
 # CSV processor

--- a/_data-prepper/pipelines/configuration/processors/date.md
+++ b/_data-prepper/pipelines/configuration/processors/date.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/date/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/date/
 ---
 
 # Date processor

--- a/_data-prepper/pipelines/configuration/processors/decompress.md
+++ b/_data-prepper/pipelines/configuration/processors/decompress.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/decompress/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/decompress/
 ---
 
 # Decompress processor

--- a/_data-prepper/pipelines/configuration/processors/delay.md
+++ b/_data-prepper/pipelines/configuration/processors/delay.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delay/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delay/
 ---
 
 # Delay processor

--- a/_data-prepper/pipelines/configuration/processors/delete-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/delete-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 110
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delete-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/delete-entries/
 ---
 
 # Delete entries processor

--- a/_data-prepper/pipelines/configuration/processors/dissect.md
+++ b/_data-prepper/pipelines/configuration/processors/dissect.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 120
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/dissect/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/dissect/
 ---
 
 # Dissect processor

--- a/_data-prepper/pipelines/configuration/processors/drop-events.md
+++ b/_data-prepper/pipelines/configuration/processors/drop-events.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 130
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/drop-events/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/drop-events/
 ---
 
 # Drop events processor

--- a/_data-prepper/pipelines/configuration/processors/flatten.md
+++ b/_data-prepper/pipelines/configuration/processors/flatten.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 140
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/flatten/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/flatten/
 ---
 
 # Flatten processor

--- a/_data-prepper/pipelines/configuration/processors/geoip.md
+++ b/_data-prepper/pipelines/configuration/processors/geoip.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 150
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/geoip/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/geoip/
 ---
 
 # Geo IP processor

--- a/_data-prepper/pipelines/configuration/processors/grok.md
+++ b/_data-prepper/pipelines/configuration/processors/grok.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 160
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/grok/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/grok/
 ---
 
 # Grok processor

--- a/_data-prepper/pipelines/configuration/processors/key-value.md
+++ b/_data-prepper/pipelines/configuration/processors/key-value.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 170
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/key-value/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/key-value/
 ---
 
 # Key-value processor

--- a/_data-prepper/pipelines/configuration/processors/list-to-map.md
+++ b/_data-prepper/pipelines/configuration/processors/list-to-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 180
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/list-to-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/list-to-map/
 ---
 
 # List to map processor

--- a/_data-prepper/pipelines/configuration/processors/lowercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/lowercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 190
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/lowercase-string/
 ---
 
 # Lowercase string processor

--- a/_data-prepper/pipelines/configuration/processors/map-to-list.md
+++ b/_data-prepper/pipelines/configuration/processors/map-to-list.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 200
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/map-to-list/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/map-to-list/
 ---
 
 # Map to list processor

--- a/_data-prepper/pipelines/configuration/processors/ml-inference.md
+++ b/_data-prepper/pipelines/configuration/processors/ml-inference.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 210
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/ml-inference/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/ml-inference/
 ---
 
 # ML inference processor

--- a/_data-prepper/pipelines/configuration/processors/obfuscate.md
+++ b/_data-prepper/pipelines/configuration/processors/obfuscate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 240
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/obfuscate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/obfuscate/
 ---
 
 # Obfuscate processor

--- a/_data-prepper/pipelines/configuration/processors/otel-apm-service-map.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-apm-service-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 245
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-apm-service-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-apm-service-map/
 ---
 
 # OTel APM service map processor

--- a/_data-prepper/pipelines/configuration/processors/otel-metrics.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-metrics.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 250
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-metrics/
 ---
 
 # OTel metrics processor

--- a/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-trace-group.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 270
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-trace-group/
 ---
 
 # OTel trace group processor

--- a/_data-prepper/pipelines/configuration/processors/otel-traces.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-traces.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 260
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/otel-traces/
 ---
 
 # OTel trace processor

--- a/_data-prepper/pipelines/configuration/processors/parse-ion.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-ion.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 280
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-ion/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-ion/
 ---
 
 # Parse Ion processor

--- a/_data-prepper/pipelines/configuration/processors/parse-json.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-json.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 290
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-json/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-json/
 ---
 
 # Parse JSON processor

--- a/_data-prepper/pipelines/configuration/processors/parse-xml.md
+++ b/_data-prepper/pipelines/configuration/processors/parse-xml.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 300
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-xml/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/parse-xml/
 ---
 
 # Parse XML processor

--- a/_data-prepper/pipelines/configuration/processors/processors.md
+++ b/_data-prepper/pipelines/configuration/processors/processors.md
@@ -9,6 +9,7 @@ redirect_from:
   - /data-prepper/pipelines/configuration/processors/mutate-string/
   - /data-prepper/pipelines/configuration/processors/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/processors/
 ---
 
 # Data Prepper processors

--- a/_data-prepper/pipelines/configuration/processors/rename-keys.md
+++ b/_data-prepper/pipelines/configuration/processors/rename-keys.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 310
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/rename-keys/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/rename-keys/
 ---
 
 # Rename keys processor

--- a/_data-prepper/pipelines/configuration/processors/select-entries.md
+++ b/_data-prepper/pipelines/configuration/processors/select-entries.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 320
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/select-entries/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/select-entries/
 ---
 
 # Select entries processor

--- a/_data-prepper/pipelines/configuration/processors/service-map.md
+++ b/_data-prepper/pipelines/configuration/processors/service-map.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 330
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/service-map/
 ---
 
 # Service map processor

--- a/_data-prepper/pipelines/configuration/processors/split-event.md
+++ b/_data-prepper/pipelines/configuration/processors/split-event.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 340
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-event/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-event/
 ---
 
 # Split event processor

--- a/_data-prepper/pipelines/configuration/processors/split-string.md
+++ b/_data-prepper/pipelines/configuration/processors/split-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 350
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/split-string/
 ---
 
 # Split string processor

--- a/_data-prepper/pipelines/configuration/processors/string-converter.md
+++ b/_data-prepper/pipelines/configuration/processors/string-converter.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 360
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/string-converter/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/string-converter/
 ---
 
 # String converter processor

--- a/_data-prepper/pipelines/configuration/processors/substitute-string.md
+++ b/_data-prepper/pipelines/configuration/processors/substitute-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 370
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/substitute-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/substitute-string/
 ---
 
 # Substitute string processor

--- a/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
+++ b/_data-prepper/pipelines/configuration/processors/trace-peer-forwarder.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 380
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trace-peer-forwarder/
 ---
 
 # Trace peer forwarder processor

--- a/_data-prepper/pipelines/configuration/processors/translate.md
+++ b/_data-prepper/pipelines/configuration/processors/translate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 390
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/translate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/translate/
 ---
 
 # Translate processor

--- a/_data-prepper/pipelines/configuration/processors/trim-string.md
+++ b/_data-prepper/pipelines/configuration/processors/trim-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 400
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trim-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/trim-string/
 ---
 
 # Trim string processor

--- a/_data-prepper/pipelines/configuration/processors/truncate.md
+++ b/_data-prepper/pipelines/configuration/processors/truncate.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 410
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/truncate/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/truncate/
 ---
 
 # Truncate processor

--- a/_data-prepper/pipelines/configuration/processors/uppercase-string.md
+++ b/_data-prepper/pipelines/configuration/processors/uppercase-string.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 420
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/uppercase-string/
 ---
 
 # Uppercase string processor

--- a/_data-prepper/pipelines/configuration/processors/user-agent.md
+++ b/_data-prepper/pipelines/configuration/processors/user-agent.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 430
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/user-agent/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/user-agent/
 ---
 
 # User agent processor

--- a/_data-prepper/pipelines/configuration/processors/write-json.md
+++ b/_data-prepper/pipelines/configuration/processors/write-json.md
@@ -5,6 +5,7 @@ parent: Processors
 grand_parent: Pipelines
 nav_order: 440
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/write-json/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/processors/write-json/
 ---
 
 # Write JSON processor

--- a/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
+++ b/_data-prepper/pipelines/configuration/sinks/aws-lambda.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/aws-lambda/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/aws-lambda/
 ---
 
 # AWS Lambda sink

--- a/_data-prepper/pipelines/configuration/sinks/file.md
+++ b/_data-prepper/pipelines/configuration/sinks/file.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/file/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/file/
 ---
 
 # File sink

--- a/_data-prepper/pipelines/configuration/sinks/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sinks/opensearch.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/opensearch/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/opensearch/
 ---
 
 # OpenSearch sink

--- a/_data-prepper/pipelines/configuration/sinks/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sinks/pipeline.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/pipeline/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/pipeline/
 ---
 
 # Pipeline sink

--- a/_data-prepper/pipelines/configuration/sinks/prometheus.md
+++ b/_data-prepper/pipelines/configuration/sinks/prometheus.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 59
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/prometheus/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/prometheus/
 ---
 
 # Prometheus sink

--- a/_data-prepper/pipelines/configuration/sinks/s3.md
+++ b/_data-prepper/pipelines/configuration/sinks/s3.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/s3/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/s3/
 ---
 
 # S3 sink

--- a/_data-prepper/pipelines/configuration/sinks/sinks.md
+++ b/_data-prepper/pipelines/configuration/sinks/sinks.md
@@ -5,6 +5,7 @@ parent: Pipelines
 has_children: true
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/sinks/
 ---
 
 # Data Prepper sinks

--- a/_data-prepper/pipelines/configuration/sinks/stdout.md
+++ b/_data-prepper/pipelines/configuration/sinks/stdout.md
@@ -5,6 +5,7 @@ parent: Sinks
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/stdout/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sinks/stdout/
 ---
 
 # Standard output sink

--- a/_data-prepper/pipelines/configuration/sources/atlassian-confluence.md
+++ b/_data-prepper/pipelines/configuration/sources/atlassian-confluence.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-confluence/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-confluence/
 ---
 
 # Atlassian Confluence source

--- a/_data-prepper/pipelines/configuration/sources/atlassian-jira.md
+++ b/_data-prepper/pipelines/configuration/sources/atlassian-jira.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 7
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-jira/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/atlassian-jira/
 ---
 
 # Atlassian Jira source

--- a/_data-prepper/pipelines/configuration/sources/documentdb.md
+++ b/_data-prepper/pipelines/configuration/sources/documentdb.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/documentdb/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/documentdb/
 ---
 
 # DocumentDB source

--- a/_data-prepper/pipelines/configuration/sources/dynamo-db.md
+++ b/_data-prepper/pipelines/configuration/sources/dynamo-db.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/dynamo-db/
 ---
 
 # DynamoDB source

--- a/_data-prepper/pipelines/configuration/sources/file.md
+++ b/_data-prepper/pipelines/configuration/sources/file.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 24
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/file/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/file/
 ---
 
 # File source

--- a/_data-prepper/pipelines/configuration/sources/http.md
+++ b/_data-prepper/pipelines/configuration/sources/http.md
@@ -7,6 +7,7 @@ nav_order: 30
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/http-source/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/http/
 ---
 
 # HTTP source

--- a/_data-prepper/pipelines/configuration/sources/iceberg.md
+++ b/_data-prepper/pipelines/configuration/sources/iceberg.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 35
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/iceberg/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/iceberg/
 ---
 
 # Iceberg source

--- a/_data-prepper/pipelines/configuration/sources/kafka.md
+++ b/_data-prepper/pipelines/configuration/sources/kafka.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kafka/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kafka/
 ---
 
 # Kafka source

--- a/_data-prepper/pipelines/configuration/sources/kinesis.md
+++ b/_data-prepper/pipelines/configuration/sources/kinesis.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 45
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kinesis/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/kinesis/
 ---
 
 # Kinesis source

--- a/_data-prepper/pipelines/configuration/sources/opensearch-api.md
+++ b/_data-prepper/pipelines/configuration/sources/opensearch-api.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 55
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch-api/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch-api/
 ---
 
 # OpenSearch API source

--- a/_data-prepper/pipelines/configuration/sources/opensearch.md
+++ b/_data-prepper/pipelines/configuration/sources/opensearch.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/opensearch/
 ---
 
 # OpenSearch source

--- a/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-logs-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-logs-source/
 ---
 
 # OTel logs source

--- a/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-metrics-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-metrics-source/
 ---
 
 # OTel metrics source

--- a/_data-prepper/pipelines/configuration/sources/otel-trace-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otel-trace-source.md
@@ -7,6 +7,7 @@ nav_order: 80
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/otel-trace/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otel-trace-source/
 ---
 
 

--- a/_data-prepper/pipelines/configuration/sources/otlp-source.md
+++ b/_data-prepper/pipelines/configuration/sources/otlp-source.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 85
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otlp-source/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/otlp-source/
 ---
 
 # OTLP source

--- a/_data-prepper/pipelines/configuration/sources/pipeline.md
+++ b/_data-prepper/pipelines/configuration/sources/pipeline.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/pipeline/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/pipeline/
 ---
 
 # Pipeline source

--- a/_data-prepper/pipelines/configuration/sources/rds.md
+++ b/_data-prepper/pipelines/configuration/sources/rds.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 95
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/rds/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/rds/
 ---
 
 # RDS source

--- a/_data-prepper/pipelines/configuration/sources/s3.md
+++ b/_data-prepper/pipelines/configuration/sources/s3.md
@@ -5,6 +5,7 @@ parent: Sources
 grand_parent: Pipelines
 nav_order: 100
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/s3/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/s3/
 ---
 
 # S3 source

--- a/_data-prepper/pipelines/configuration/sources/sources.md
+++ b/_data-prepper/pipelines/configuration/sources/sources.md
@@ -7,6 +7,7 @@ nav_order: 110
 redirect_from:
   - /data-prepper/pipelines/configuration/sources/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/sources/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/configuration/sources/sources/
 ---
 
 # Data Prepper sources

--- a/_data-prepper/pipelines/contains.md
+++ b/_data-prepper/pipelines/contains.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 10
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/contains/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/contains/
 ---
 
 # contains()

--- a/_data-prepper/pipelines/dlq.md
+++ b/_data-prepper/pipelines/dlq.md
@@ -4,6 +4,7 @@ title: Dead-letter queues
 parent: Pipelines
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/dlq/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/dlq/
 ---
 
 # Dead-letter queues

--- a/_data-prepper/pipelines/expression-syntax.md
+++ b/_data-prepper/pipelines/expression-syntax.md
@@ -4,6 +4,7 @@ title: Expression syntax
 parent: Pipelines
 nav_order: 5
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/expression-syntax/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/expression-syntax/
 ---
 
 # Expression syntax  

--- a/_data-prepper/pipelines/functions.md
+++ b/_data-prepper/pipelines/functions.md
@@ -5,6 +5,7 @@ parent: Pipelines
 nav_order: 10
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/functions/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/functions/
 ---
 
 # Data Prepper expression functions

--- a/_data-prepper/pipelines/generate-uuid.md
+++ b/_data-prepper/pipelines/generate-uuid.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 11
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/generate-uuid/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/generate-uuid/
 ---
 
 # generateUuid()

--- a/_data-prepper/pipelines/get-eventtype.md
+++ b/_data-prepper/pipelines/get-eventtype.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 12
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/get-eventtype/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/get-eventtype/
 ---
 
 # getEventType()

--- a/_data-prepper/pipelines/get-metadata.md
+++ b/_data-prepper/pipelines/get-metadata.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 15
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/get-metadata/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/get-metadata/
 ---
 
 # getMetadata()

--- a/_data-prepper/pipelines/has-tags.md
+++ b/_data-prepper/pipelines/has-tags.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 20
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/has-tags/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/has-tags/
 ---
 
 # hasTags()

--- a/_data-prepper/pipelines/join.md
+++ b/_data-prepper/pipelines/join.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 25
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/join/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/join/
 ---
 
 # join()

--- a/_data-prepper/pipelines/length.md
+++ b/_data-prepper/pipelines/length.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 30
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/length/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/length/
 ---
 
 # length()

--- a/_data-prepper/pipelines/pipelines.md
+++ b/_data-prepper/pipelines/pipelines.md
@@ -7,6 +7,7 @@ redirect_from:
   - /data-prepper/pipelines/
   - /clients/data-prepper/pipelines/
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/pipelines/
 ---
 
 # Pipelines

--- a/_data-prepper/pipelines/startswith.md
+++ b/_data-prepper/pipelines/startswith.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 40
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/startswith/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/startswith/
 ---
 
 # startsWith()

--- a/_data-prepper/pipelines/sublist.md
+++ b/_data-prepper/pipelines/sublist.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 50
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/sublist/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/sublist/
 ---
 
 <!-- vale off -->

--- a/_data-prepper/pipelines/substring-after-last.md
+++ b/_data-prepper/pipelines/substring-after-last.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 70
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-after-last/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-after-last/
 ---
 
 # substringAfterLast()

--- a/_data-prepper/pipelines/substring-after.md
+++ b/_data-prepper/pipelines/substring-after.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 60
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-after/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-after/
 ---
 
 # substringAfter()

--- a/_data-prepper/pipelines/substring-before-last.md
+++ b/_data-prepper/pipelines/substring-before-last.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 90
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-before-last/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-before-last/
 ---
 
 # substringBeforeLast()

--- a/_data-prepper/pipelines/substring-before.md
+++ b/_data-prepper/pipelines/substring-before.md
@@ -5,6 +5,7 @@ parent: Functions
 grand_parent: Pipelines
 nav_order: 80
 canonical_url: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-before/
+redirect_to: https://docs.opensearch.org/latest/data-prepper/pipelines/substring-before/
 ---
 
 # substringBefore()

--- a/_developer-documentation/plugin-as-a-service/index.md
+++ b/_developer-documentation/plugin-as-a-service/index.md
@@ -6,7 +6,7 @@ has_children: false
 has_toc: false
 redirect_from: 
   - /developer-documentation/plugin-as-a-service/
-canonical_url: https://docs.opensearch.org/latest/developer-documentation/plugin-as-a-service/
+canonical_url: https://docs.opensearch.org/latest/developer-documentation/plugin-as-a-service/index/
 ---
 
 # Plugin as a service 

--- a/_im-plugin/index-rollups/index.md
+++ b/_im-plugin/index-rollups/index.md
@@ -5,7 +5,7 @@ nav_order: 60
 has_children: true
 redirect_from: 
   - /im-plugin/index-rollups/
-canonical_url: https://docs.opensearch.org/latest/im-plugin/index-rollups/
+canonical_url: https://docs.opensearch.org/latest/im-plugin/index-rollups/index/
 ---
 
 # Index rollups

--- a/_im-plugin/index-transforms/index.md
+++ b/_im-plugin/index-transforms/index.md
@@ -6,7 +6,7 @@ has_children: true
 redirect_from:
   - /im-plugin/index-transforms/
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/im-plugin/index-transforms/
+canonical_url: https://docs.opensearch.org/latest/im-plugin/index-transforms/index/
 ---
 
 # Index transforms

--- a/_im-plugin/ism/error-prevention/index.md
+++ b/_im-plugin/ism/error-prevention/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /im-plugin/ism/error-prevention/
-canonical_url: https://docs.opensearch.org/latest/im-plugin/ism/error-prevention/
+canonical_url: https://docs.opensearch.org/latest/im-plugin/ism/error-prevention/index/
 ---
 
 # ISM error prevention

--- a/_im-plugin/ism/index.md
+++ b/_im-plugin/ism/index.md
@@ -6,7 +6,7 @@ has_children: true
 redirect_from:
   - /im-plugin/ism/
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/im-plugin/ism/
+canonical_url: https://docs.opensearch.org/latest/im-plugin/ism/index/
 ---
 
 # Index State Management

--- a/_install-and-configure/additional-plugins/index.md
+++ b/_install-and-configure/additional-plugins/index.md
@@ -5,7 +5,7 @@ parent: Installing plugins
 nav_order: 10
 redirect_from:
   - /install-and-configure/additional-plugins/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/additional-plugins/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/additional-plugins/index/
 ---
 
 # Additional plugins

--- a/_install-and-configure/configuring-opensearch/index.md
+++ b/_install-and-configure/configuring-opensearch/index.md
@@ -6,7 +6,7 @@ has_children: true
 redirect_from:
   - /opensearch/configuration/
   - /install-and-configure/configuring-opensearch/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/configuring-opensearch/index/
 ---
 
 # Configuring OpenSearch

--- a/_install-and-configure/install-dashboards/index.md
+++ b/_install-and-configure/install-dashboards/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /dashboards/install/index/
   - /dashboards/compatibility/
   - /install-and-configure/install-dashboards/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-dashboards/index/
 ---
 
 # Installing OpenSearch Dashboards

--- a/_install-and-configure/install-opensearch/index.md
+++ b/_install-and-configure/install-opensearch/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/install/important-settings/
   - /opensearch/install/index/
   - /install-and-configure/install-opensearch/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/index/
 ---
 
 # Installing OpenSearch

--- a/_install-and-configure/install-opensearch/operator/index.md
+++ b/_install-and-configure/install-opensearch/operator/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /clients/k8s-operator/
   - /tools/k8s-operator/
   - /install-and-configure/install-opensearch/operator/
-canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/
+canonical_url: https://docs.opensearch.org/latest/install-and-configure/install-opensearch/operator/index/
 ---
 
 # OpenSearch Kubernetes Operator

--- a/_mappings/mapping-parameters/index.md
+++ b/_mappings/mapping-parameters/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /field-types/mapping-parameters/
   - /field-types/mapping-parameters/index/
   - /mappings/mapping-parameters/
-canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/
+canonical_url: https://docs.opensearch.org/latest/mappings/mapping-parameters/index/
 ---
 
 # Mapping parameters

--- a/_mappings/metadata-fields/index.md
+++ b/_mappings/metadata-fields/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /field-types/metadata-fields/
   - /field-types/metadata-fields/index/
   - /mappings/metadata-fields/
-canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/
+canonical_url: https://docs.opensearch.org/latest/mappings/metadata-fields/index/
 ---
 
 # Metadata fields

--- a/_mappings/supported-field-types/index.md
+++ b/_mappings/supported-field-types/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /field-types/supported-field-types/
   - /field-types/supported-field-types/index/
   - /mappings/supported-field-types/
-canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/
+canonical_url: https://docs.opensearch.org/latest/mappings/supported-field-types/index/
 ---
 
 # Supported field types

--- a/_migration-assistant-classic/architecture.md
+++ b/_migration-assistant-classic/architecture.md
@@ -3,7 +3,7 @@ layout: default
 title: Architecture
 nav_order: 15
 permalink: /classic/migration-assistant/architecture/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/architecture/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/architecture/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/architecture/
 ---
 

--- a/_migration-assistant-classic/architecture.md
+++ b/_migration-assistant-classic/architecture.md
@@ -4,6 +4,7 @@ title: Architecture
 nav_order: 15
 permalink: /classic/migration-assistant/architecture/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/architecture/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/architecture/
 ---
 
 # Architecture

--- a/_migration-assistant-classic/index.md
+++ b/_migration-assistant-classic/index.md
@@ -20,7 +20,7 @@ items:
   - heading: "Execute your migration in phases"
     description: "A step-by-step guide for performing a migration."
     link: "/classic/migration-assistant/migration-phases/"
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/
 ---
 

--- a/_migration-assistant-classic/index.md
+++ b/_migration-assistant-classic/index.md
@@ -21,6 +21,7 @@ items:
     description: "A step-by-step guide for performing a migration."
     link: "/classic/migration-assistant/migration-phases/"
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/
 ---
 
 # ![Migration Assistant icon]({{site.url}}{{site.baseurl}}/images/icons/MigrationUpgrade_Color_Icon.svg){: .heading-icon} Migration Assistant for OpenSearch (Classic)

--- a/_migration-assistant-classic/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant-classic/is-migration-assistant-right-for-you.md
@@ -3,7 +3,7 @@ layout: default
 title: Is Migration Assistant right for you?
 nav_order: 10
 permalink: /classic/migration-assistant/is-migration-assistant-right-for-you/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/is-migration-assistant-right-for-you/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/is-migration-assistant-right-for-you/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/is-migration-assistant-right-for-you/
 ---
 

--- a/_migration-assistant-classic/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant-classic/is-migration-assistant-right-for-you.md
@@ -4,6 +4,7 @@ title: Is Migration Assistant right for you?
 nav_order: 10
 permalink: /classic/migration-assistant/is-migration-assistant-right-for-you/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/is-migration-assistant-right-for-you/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/is-migration-assistant-right-for-you/
 ---
 
 # Is Migration Assistant right for you

--- a/_migration-assistant-classic/key-components.md
+++ b/_migration-assistant-classic/key-components.md
@@ -3,7 +3,7 @@ layout: default
 title: Key components
 nav_order: 20
 permalink: /classic/migration-assistant/key-components/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/key-components/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/key-components/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/key-components/
 ---
 

--- a/_migration-assistant-classic/key-components.md
+++ b/_migration-assistant-classic/key-components.md
@@ -4,6 +4,7 @@ title: Key components
 nav_order: 20
 permalink: /classic/migration-assistant/key-components/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/key-components/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/key-components/
 ---
 
 # Key components 

--- a/_migration-assistant-classic/migration-console/accessing-the-migration-console.md
+++ b/_migration-assistant-classic/migration-console/accessing-the-migration-console.md
@@ -5,6 +5,7 @@ nav_order: 1
 parent: Migration Console
 permalink: /classic/migration-assistant/migration-console/accessing-the-migration-console/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-console/accessing-the-migration-console/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/accessing-the-migration-console/
 ---
 
 # Accessing the Migration Console

--- a/_migration-assistant-classic/migration-console/accessing-the-migration-console.md
+++ b/_migration-assistant-classic/migration-console/accessing-the-migration-console.md
@@ -4,7 +4,7 @@ title: Accessing the Migration Console
 nav_order: 1
 parent: Migration Console
 permalink: /classic/migration-assistant/migration-console/accessing-the-migration-console/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-console/accessing-the-migration-console/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/accessing-the-migration-console/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/accessing-the-migration-console/
 ---
 

--- a/_migration-assistant-classic/migration-console/index.md
+++ b/_migration-assistant-classic/migration-console/index.md
@@ -7,6 +7,7 @@ has_children: true
 has_toc: false
 permalink: /classic/migration-assistant/migration-console/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-console/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/
 ---
 
 # Migration Console

--- a/_migration-assistant-classic/migration-console/index.md
+++ b/_migration-assistant-classic/migration-console/index.md
@@ -6,7 +6,7 @@ nav_exclude: false
 has_children: true
 has_toc: false
 permalink: /classic/migration-assistant/migration-console/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-console/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/
 ---
 

--- a/_migration-assistant-classic/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant-classic/migration-console/migration-console-commands-references.md
@@ -4,7 +4,7 @@ title: Command reference
 nav_order: 2
 parent: Migration Console
 permalink: /classic/migration-assistant/migration-console/migration-console-command-reference/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-console/migration-console-commands-references/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/migration-console-command-reference/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/migration-console-command-reference/
 ---
 

--- a/_migration-assistant-classic/migration-console/migration-console-commands-references.md
+++ b/_migration-assistant-classic/migration-console/migration-console-commands-references.md
@@ -5,6 +5,7 @@ nav_order: 2
 parent: Migration Console
 permalink: /classic/migration-assistant/migration-console/migration-console-command-reference/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-console/migration-console-commands-references/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-console/migration-console-command-reference/
 ---
 
 # Migration Console command reference

--- a/_migration-assistant-classic/migration-phases/assessment/index.md
+++ b/_migration-assistant-classic/migration-phases/assessment/index.md
@@ -7,6 +7,7 @@ has_children: false
 has_toc: false
 permalink: /classic/migration-assistant/migration-phases/assessment/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/assessment/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/assessment/
 ---
 
 # Assessment

--- a/_migration-assistant-classic/migration-phases/assessment/index.md
+++ b/_migration-assistant-classic/migration-phases/assessment/index.md
@@ -6,7 +6,7 @@ parent: Migration phases
 has_children: false
 has_toc: false
 permalink: /classic/migration-assistant/migration-phases/assessment/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/assessment/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/assessment/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/assessment/
 ---
 

--- a/_migration-assistant-classic/migration-phases/backfill.md
+++ b/_migration-assistant-classic/migration-phases/backfill.md
@@ -4,7 +4,7 @@ title: Backfill
 nav_order: 6
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/backfill/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/backfill/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/backfill/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/backfill/
 ---
 

--- a/_migration-assistant-classic/migration-phases/backfill.md
+++ b/_migration-assistant-classic/migration-phases/backfill.md
@@ -5,6 +5,7 @@ nav_order: 6
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/backfill/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/backfill/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/backfill/
 ---
 
 # Using backfill

--- a/_migration-assistant-classic/migration-phases/create-snapshot.md
+++ b/_migration-assistant-classic/migration-phases/create-snapshot.md
@@ -5,6 +5,7 @@ parent: Migration phases
 nav_order: 4
 permalink: /classic/migration-assistant/migration-phases/create-snapshot/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/create-snapshot/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/create-snapshot/
 ---
 
 # Creating a snapshot

--- a/_migration-assistant-classic/migration-phases/create-snapshot.md
+++ b/_migration-assistant-classic/migration-phases/create-snapshot.md
@@ -4,7 +4,7 @@ title: Creating a snapshot
 parent: Migration phases
 nav_order: 4
 permalink: /classic/migration-assistant/migration-phases/create-snapshot/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/create-snapshot/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/create-snapshot/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/create-snapshot/
 ---
 

--- a/_migration-assistant-classic/migration-phases/deploy/configuration-options.md
+++ b/_migration-assistant-classic/migration-phases/deploy/configuration-options.md
@@ -5,7 +5,7 @@ nav_order: 1
 grand_parent: Migration phases
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/configuration-options/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/configuration-options/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/configuration-options/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/configuration-options/
 ---
 

--- a/_migration-assistant-classic/migration-phases/deploy/configuration-options.md
+++ b/_migration-assistant-classic/migration-phases/deploy/configuration-options.md
@@ -6,6 +6,7 @@ grand_parent: Migration phases
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/configuration-options/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/configuration-options/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/configuration-options/
 ---
 
 # Configuration options

--- a/_migration-assistant-classic/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
+++ b/_migration-assistant-classic/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
@@ -6,6 +6,7 @@ grand_parent: Migration phases
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
 ---
 
 # IAM and security groups for existing clusters

--- a/_migration-assistant-classic/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
+++ b/_migration-assistant-classic/migration-phases/deploy/iam-and-security-groups-for-existing-clusters.md
@@ -5,7 +5,7 @@ nav_order: 2
 grand_parent: Migration phases
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/iam-and-security-groups-for-existing-clusters/
 ---
 

--- a/_migration-assistant-classic/migration-phases/deploy/index.md
+++ b/_migration-assistant-classic/migration-phases/deploy/index.md
@@ -6,7 +6,7 @@ nav_order: 2
 has_children: true
 has_toc: true
 permalink: /classic/migration-assistant/migration-phases/deploy/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/
 ---
 

--- a/_migration-assistant-classic/migration-phases/deploy/index.md
+++ b/_migration-assistant-classic/migration-phases/deploy/index.md
@@ -7,6 +7,7 @@ has_children: true
 has_toc: true
 permalink: /classic/migration-assistant/migration-phases/deploy/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/
 ---
 
 # Deploy

--- a/_migration-assistant-classic/migration-phases/deploy/verifying-backfill-components.md
+++ b/_migration-assistant-classic/migration-phases/deploy/verifying-backfill-components.md
@@ -6,6 +6,7 @@ nav_order: 3
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/verifying-backfill-components/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/verifying-backfill-components/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-backfill-components/
 ---
 
 # Verifying backfill components

--- a/_migration-assistant-classic/migration-phases/deploy/verifying-backfill-components.md
+++ b/_migration-assistant-classic/migration-phases/deploy/verifying-backfill-components.md
@@ -5,7 +5,7 @@ grand_parent: Migration phases
 nav_order: 3
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/verifying-backfill-components/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/verifying-backfill-components/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-backfill-components/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-backfill-components/
 ---
 

--- a/_migration-assistant-classic/migration-phases/deploy/verifying-live-capture-components.md
+++ b/_migration-assistant-classic/migration-phases/deploy/verifying-live-capture-components.md
@@ -5,7 +5,7 @@ grand_parent: Migration phases
 nav_order: 4
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/verifying-live-capture-components/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
 ---
 

--- a/_migration-assistant-classic/migration-phases/deploy/verifying-live-capture-components.md
+++ b/_migration-assistant-classic/migration-phases/deploy/verifying-live-capture-components.md
@@ -6,6 +6,7 @@ nav_order: 4
 parent: Deploy
 permalink: /classic/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/deploy/verifying-live-capture-components/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/deploy/verifying-live-capture-components/
 ---
 
 # Verifying live capture components

--- a/_migration-assistant-classic/migration-phases/index.md
+++ b/_migration-assistant-classic/migration-phases/index.md
@@ -6,7 +6,7 @@ nav_exclude: false
 has_children: true
 has_toc: false
 permalink: /classic/migration-assistant/migration-phases/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/
 ---
 

--- a/_migration-assistant-classic/migration-phases/index.md
+++ b/_migration-assistant-classic/migration-phases/index.md
@@ -7,6 +7,7 @@ has_children: true
 has_toc: false
 permalink: /classic/migration-assistant/migration-phases/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/
 ---
 
 # Migration phases

--- a/_migration-assistant-classic/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant-classic/migration-phases/live-traffic-migration/index.md
@@ -6,7 +6,7 @@ nav_order: 99
 permalink: /classic/migration-assistant/live-traffic-migration/
 has_toc: false
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/live-traffic-migration/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/live-traffic-migration/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/live-traffic-migration/
 ---
 

--- a/_migration-assistant-classic/migration-phases/live-traffic-migration/index.md
+++ b/_migration-assistant-classic/migration-phases/live-traffic-migration/index.md
@@ -7,6 +7,7 @@ permalink: /classic/migration-assistant/live-traffic-migration/
 has_toc: false
 has_children: true
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/live-traffic-migration/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/live-traffic-migration/
 ---
 
 # Live traffic migration

--- a/_migration-assistant-classic/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
+++ b/_migration-assistant-classic/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
@@ -6,6 +6,7 @@ grand_parent: Migration phases
 nav_order: 110
 permalink: /classic/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
 ---
 
 # Switching traffic from the source cluster

--- a/_migration-assistant-classic/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
+++ b/_migration-assistant-classic/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster.md
@@ -5,7 +5,7 @@ parent: Live traffic migration
 grand_parent: Migration phases
 nav_order: 110
 permalink: /classic/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/live-traffic-migration/switching-traffic-from-the-source-cluster/
 ---
 

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
 ---
 
 # Transform field types

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
@@ -5,7 +5,7 @@ nav_order: 2
 parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
 ---
 

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
@@ -5,7 +5,7 @@ nav_order: 1
 parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
 ---
 

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
 ---
 
 # Transform type mappings

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/index.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/index.md
@@ -7,6 +7,7 @@ has_children: true
 has_toc: true
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/
 ---
 
 # Migrate metadata

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/index.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/index.md
@@ -6,7 +6,7 @@ parent: Migration phases
 has_children: true
 has_toc: true
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/
 ---
 

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
@@ -5,7 +5,7 @@ nav_order: 5
 parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 ---
 

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 ---
 
 # Transform dense_vector fields to knn_vector

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/transform-flattened-flat-object.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/transform-flattened-flat-object.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/transform-flattened-flat-object/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 ---
 
 # Transform flattened fields to flat_object

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/transform-flattened-flat-object.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/transform-flattened-flat-object.md
@@ -5,7 +5,7 @@ nav_order: 3
 parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/transform-flattened-flat-object/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 ---
 

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/transform-string-text-keyword.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/transform-string-text-keyword.md
@@ -5,7 +5,7 @@ nav_order: 4
 parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/transform-string-text-keyword/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 ---
 

--- a/_migration-assistant-classic/migration-phases/migrate-metadata/transform-string-text-keyword.md
+++ b/_migration-assistant-classic/migration-phases/migrate-metadata/transform-string-text-keyword.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/migrate-metadata/transform-string-text-keyword/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 ---
 
 # Transform string fields to text/keyword

--- a/_migration-assistant-classic/migration-phases/remove-migration-infrastructure.md
+++ b/_migration-assistant-classic/migration-phases/remove-migration-infrastructure.md
@@ -4,7 +4,7 @@ title: Removing Migration Assistant
 nav_order: 9
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/remove-migration-infrastructure/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/remove-migration-infrastructure/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/remove-migration-infrastructure/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/remove-migration-infrastructure/
 ---
 

--- a/_migration-assistant-classic/migration-phases/remove-migration-infrastructure.md
+++ b/_migration-assistant-classic/migration-phases/remove-migration-infrastructure.md
@@ -5,6 +5,7 @@ nav_order: 9
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/remove-migration-infrastructure/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/remove-migration-infrastructure/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/remove-migration-infrastructure/
 ---
 
 # Removing migration infrastructure

--- a/_migration-assistant-classic/migration-phases/replay-captured-traffic.md
+++ b/_migration-assistant-classic/migration-phases/replay-captured-traffic.md
@@ -5,6 +5,7 @@ nav_order: 7
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/replay-captured-traffic/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/replay-captured-traffic/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/replay-captured-traffic/
 ---
 
 # Using Traffic Replayer

--- a/_migration-assistant-classic/migration-phases/replay-captured-traffic.md
+++ b/_migration-assistant-classic/migration-phases/replay-captured-traffic.md
@@ -4,7 +4,7 @@ title: Using Traffic Replayer
 nav_order: 7
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/replay-captured-traffic/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/replay-captured-traffic/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/replay-captured-traffic/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/replay-captured-traffic/
 ---
 

--- a/_migration-assistant-classic/migration-phases/reroute-source-to-proxy.md
+++ b/_migration-assistant-classic/migration-phases/reroute-source-to-proxy.md
@@ -4,7 +4,7 @@ title: Reroute client traffic
 nav_order: 3
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/reroute-source-to-proxy/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/reroute-source-to-proxy/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/reroute-source-to-proxy/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/reroute-source-to-proxy/
 ---
 

--- a/_migration-assistant-classic/migration-phases/reroute-source-to-proxy.md
+++ b/_migration-assistant-classic/migration-phases/reroute-source-to-proxy.md
@@ -5,6 +5,7 @@ nav_order: 3
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/reroute-source-to-proxy/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/reroute-source-to-proxy/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/reroute-source-to-proxy/
 ---
 
 # Reroute client traffic to the Traffic Capture Proxy

--- a/_migration-assistant-classic/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
+++ b/_migration-assistant-classic/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
@@ -5,6 +5,7 @@ nav_order: 8
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/reroute-traffic-from-capture-proxy-to-target/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 ---
 
 # Switching traffic from the source cluster

--- a/_migration-assistant-classic/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
+++ b/_migration-assistant-classic/migration-phases/reroute-traffic-from-capture-proxy-to-target.md
@@ -4,7 +4,7 @@ title: Reroute traffic to the target
 nav_order: 8
 parent: Migration phases
 permalink: /classic/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/migration-phases/reroute-traffic-from-capture-proxy-to-target/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 ---
 

--- a/_migration-assistant-classic/security-patching-and-updating.md
+++ b/_migration-assistant-classic/security-patching-and-updating.md
@@ -3,7 +3,7 @@ layout: default
 title: Security patching and updating
 nav_order: 30
 permalink: /classic/migration-assistant/security-patching-and-updating/
-canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/security-patching-and-updating/
+canonical_url: https://docs.opensearch.org/latest/classic/migration-assistant/security-patching-and-updating/
 redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/security-patching-and-updating/
 ---
 

--- a/_migration-assistant-classic/security-patching-and-updating.md
+++ b/_migration-assistant-classic/security-patching-and-updating.md
@@ -4,6 +4,7 @@ title: Security patching and updating
 nav_order: 30
 permalink: /classic/migration-assistant/security-patching-and-updating/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant-classic/security-patching-and-updating/
+redirect_to: https://docs.opensearch.org/latest/classic/migration-assistant/security-patching-and-updating/
 ---
 
 # Security patching and updating

--- a/_migration-assistant/amazon-opensearch-serverless.md
+++ b/_migration-assistant/amazon-opensearch-serverless.md
@@ -4,6 +4,7 @@ title: Migrate to OpenSearch Serverless
 nav_order: 55
 permalink: /migration-assistant/amazon-opensearch-serverless/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/amazon-opensearch-serverless/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/amazon-opensearch-serverless/
 ---
 
 # Migrate to OpenSearch Serverless

--- a/_migration-assistant/architecture.md
+++ b/_migration-assistant/architecture.md
@@ -6,6 +6,7 @@ permalink: /migration-assistant/architecture/
 redirect_from:
   - /migration-assistant/overview/architecture/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/architecture/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/architecture/
 ---
 
 # Migration Assistant architecture

--- a/_migration-assistant/index.md
+++ b/_migration-assistant/index.md
@@ -30,6 +30,7 @@ items:
     description: "Follow path-specific guides for common source and target combinations."
     link: "/migration-assistant/playbooks/"
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/
 ---
 
 # ![Migration Assistant icon]({{site.url}}{{site.baseurl}}/images/icons/MigrationUpgrade_Color_Icon.svg){: .heading-icon} Migration Assistant for OpenSearch

--- a/_migration-assistant/is-migration-assistant-right-for-you.md
+++ b/_migration-assistant/is-migration-assistant-right-for-you.md
@@ -7,6 +7,7 @@ redirect_from:
   - /migration-assistant/overview/is-migration-assistant-right-for-you/
   - /migration-assistant/migration-paths/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/is-migration-assistant-right-for-you/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/is-migration-assistant-right-for-you/
 ---
 
 # Is Migration Assistant right for you?

--- a/_migration-assistant/migration-phases/assessment/index.md
+++ b/_migration-assistant/migration-phases/assessment/index.md
@@ -10,6 +10,7 @@ redirect_from:
   - /migration-assistant/migration-phases/planning-your-migration/
   - /migration-assistant/migration-phases/planning-your-migration/assessing-your-cluster-for-migration/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/assessment/
 ---
 
 # Migration assessment

--- a/_migration-assistant/migration-phases/backfill.md
+++ b/_migration-assistant/migration-phases/backfill.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/create-snapshot/
   - /migration-phases/create-snapshot/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/backfill/
 ---
 
 # Backfill

--- a/_migration-assistant/migration-phases/deploy/deploying-to-eks.md
+++ b/_migration-assistant/migration-phases/deploy/deploying-to-eks.md
@@ -6,6 +6,7 @@ grand_parent: Migration workflows
 parent: Choose your deployment
 permalink: /migration-assistant/migration-phases/deploy/deploying-to-eks/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/deploying-to-eks/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/deploying-to-eks/
 ---
 
 # Deploy on Amazon EKS

--- a/_migration-assistant/migration-phases/deploy/deploying-to-kubernetes.md
+++ b/_migration-assistant/migration-phases/deploy/deploying-to-kubernetes.md
@@ -6,6 +6,7 @@ grand_parent: Migration workflows
 parent: Choose your deployment
 permalink: /migration-assistant/migration-phases/deploy/deploying-to-kubernetes/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/deploying-to-kubernetes/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/deploying-to-kubernetes/
 ---
 
 # Deploy on Kubernetes

--- a/_migration-assistant/migration-phases/deploy/index.md
+++ b/_migration-assistant/migration-phases/deploy/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /migration-assistant/getting-started-with-data-migration/
   - /deploying-migration-assistant/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/deploy/
 ---
 
 # Choose your deployment

--- a/_migration-assistant/migration-phases/index.md
+++ b/_migration-assistant/migration-phases/index.md
@@ -10,6 +10,7 @@ redirect_from:
   - /migration-assistant/overview/migration-phases/
   - /migration-phases/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/
 ---
 
 # Migration workflows

--- a/_migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/assessment/handling-field-type-breaking-changes/
   - /migration-assistant/migration-phases/planning-your-migration/handling-field-type-breaking-changes/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-field-type-breaking-changes/
 ---
 
 # Transform field types

--- a/_migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/assessment/handling-type-mapping-deprecation/
   - /migration-assistant/migration-phases/planning-your-migration/handling-type-mapping-deprecation/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/handling-type-mapping-deprecation/
 ---
 
 # Transform type mappings

--- a/_migration-assistant/migration-phases/migrate-metadata/index.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/index.md
@@ -11,6 +11,7 @@ redirect_from:
   - /migration-phases/migrating-metadata/
   - /migration-assistant/deploying-migration-assistant/getting-started-data-migration/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/
 ---
 
 # Migrate metadata

--- a/_migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration workflows
 permalink: /migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-dense-vector-knn-vector/
 ---
 
 # Transform dense_vector fields to knn_vector

--- a/_migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration workflows
 permalink: /migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-flattened-flat-object/
 ---
 
 # Transform flattened fields to flat_object

--- a/_migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword.md
+++ b/_migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword.md
@@ -6,6 +6,7 @@ parent: Migrate metadata
 grand_parent: Migration workflows
 permalink: /migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/migrate-metadata/transform-string-text-keyword/
 ---
 
 # Transform string fields to text/keyword

--- a/_migration-assistant/migration-phases/remove-migration-infrastructure.md
+++ b/_migration-assistant/migration-phases/remove-migration-infrastructure.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-phases/removing-migration-infrastructure/
 
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/remove-migration-infrastructure/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/remove-migration-infrastructure/
 ---
 
 # Removing migration infrastructure

--- a/_migration-assistant/migration-phases/replay-captured-traffic.md
+++ b/_migration-assistant/migration-phases/replay-captured-traffic.md
@@ -9,6 +9,7 @@ redirect_from:
   - /migration-assistant/migration-phases/using-traffic-replayer/
   - /migration-phases/using-traffic-replayer/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/replay-captured-traffic/
 ---
 
 # Replay captured traffic

--- a/_migration-assistant/migration-phases/reroute-source-to-proxy.md
+++ b/_migration-assistant/migration-phases/reroute-source-to-proxy.md
@@ -5,6 +5,7 @@ nav_order: 3
 parent: Migration workflows
 permalink: /migration-assistant/migration-phases/reroute-source-to-proxy/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/reroute-source-to-proxy/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/reroute-source-to-proxy/
 ---
 
 # Reroute client traffic to the capture proxy

--- a/_migration-assistant/migration-phases/switch-traffic-to-target.md
+++ b/_migration-assistant/migration-phases/switch-traffic-to-target.md
@@ -7,6 +7,7 @@ permalink: /migration-assistant/migration-phases/switch-traffic-to-target/
 redirect_from:
   - /migration-assistant/migration-phases/reroute-traffic-from-capture-proxy-to-target/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/migration-phases/switch-traffic-to-target/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/migration-phases/switch-traffic-to-target/
 ---
 
 # Switch traffic to the target

--- a/_migration-assistant/playbook-amazon-opensearch-service-to-serverless.md
+++ b/_migration-assistant/playbook-amazon-opensearch-service-to-serverless.md
@@ -5,6 +5,7 @@ nav_order: 2
 parent: Playbooks
 permalink: /migration-assistant/playbook-amazon-opensearch-service-to-serverless/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/playbook-amazon-opensearch-service-to-serverless/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/playbook-amazon-opensearch-service-to-serverless/
 ---
 
 # Playbook: Amazon OpenSearch Service to Amazon OpenSearch Serverless (vector search)

--- a/_migration-assistant/playbook-elasticsearch-6-8-to-opensearch-3.md
+++ b/_migration-assistant/playbook-elasticsearch-6-8-to-opensearch-3.md
@@ -7,6 +7,7 @@ permalink: /migration-assistant/playbook-elasticsearch-6-8-to-opensearch-3/
 redirect_from:
   - /migration-assistant/playbook-elasticsearch-6-8-to-opensearch-3-Kubernetes/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/playbook-elasticsearch-6-8-to-opensearch-3/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/playbook-elasticsearch-6-8-to-opensearch-3/
 ---
 
 # Playbook: Elasticsearch 6.8 to OpenSearch 3.5 on EKS (existing VPC)

--- a/_migration-assistant/playbook-solr-8.11-to-opensearch-3.md
+++ b/_migration-assistant/playbook-solr-8.11-to-opensearch-3.md
@@ -7,6 +7,7 @@ permalink: /migration-assistant/playbook-solr-8.11-to-opensearch-3/
 redirect_from:
   - /migration-assistant/playbook-solr-8-to-opensearch-3/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/playbook-solr-8.11-to-opensearch-3/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/playbook-solr-8.11-to-opensearch-3/
 ---
 
 # Playbook: Apache Solr 8.x or 9.x → OpenSearch 3.x

--- a/_migration-assistant/playbooks/index.md
+++ b/_migration-assistant/playbooks/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 permalink: /migration-assistant/playbooks/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/playbooks/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/playbooks/
 ---
 
 # Playbooks

--- a/_migration-assistant/solr-migration/index.md
+++ b/_migration-assistant/solr-migration/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: true
 permalink: /migration-assistant/solr-migration/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/solr-migration/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/solr-migration/
 ---
 
 # Solr migration

--- a/_migration-assistant/solr-migration/solr-backfill-guide.md
+++ b/_migration-assistant/solr-migration/solr-backfill-guide.md
@@ -5,6 +5,7 @@ nav_order: 2
 parent: Solr migration
 permalink: /migration-assistant/solr-migration/solr-backfill-guide/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/solr-migration/solr-backfill-guide/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/solr-migration/solr-backfill-guide/
 ---
 
 # Solr backfill guide

--- a/_migration-assistant/troubleshooting.md
+++ b/_migration-assistant/troubleshooting.md
@@ -4,6 +4,7 @@ title: Troubleshooting
 nav_order: 70
 permalink: /migration-assistant/troubleshooting/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/troubleshooting/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/troubleshooting/
 ---
 
 # Migration Assistant troubleshooting

--- a/_migration-assistant/why-kubernetes-and-eks.md
+++ b/_migration-assistant/why-kubernetes-and-eks.md
@@ -4,6 +4,7 @@ title: Why Kubernetes and EKS?
 nav_order: 12
 permalink: /migration-assistant/why-kubernetes-and-eks/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/why-kubernetes-and-eks/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/why-kubernetes-and-eks/
 ---
 
 # Why Kubernetes and EKS

--- a/_migration-assistant/workflow-cli/getting-started.md
+++ b/_migration-assistant/workflow-cli/getting-started.md
@@ -5,6 +5,7 @@ nav_order: 1
 parent: Workflow CLI
 permalink: /migration-assistant/workflow-cli/getting-started/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/workflow-cli/getting-started/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/workflow-cli/getting-started/
 ---
 
 # Using the Workflow CLI

--- a/_migration-assistant/workflow-cli/index.md
+++ b/_migration-assistant/workflow-cli/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 permalink: /migration-assistant/workflow-cli/
 canonical_url: https://docs.opensearch.org/latest/migration-assistant/workflow-cli/
+redirect_to: https://docs.opensearch.org/latest/migration-assistant/workflow-cli/
 ---
 
 # Workflow CLI

--- a/_ml-commons-plugin/agents-tools/agents/index.md
+++ b/_ml-commons-plugin/agents-tools/agents/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 10
 redirect_from: 
   - /ml-commons-plugin/agents-tools/agents/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/agents/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/agents/index/
 ---
 
 # Agents

--- a/_ml-commons-plugin/agents-tools/index.md
+++ b/_ml-commons-plugin/agents-tools/index.md
@@ -6,7 +6,7 @@ has_toc: false
 nav_order: 20
 redirect_from:
   - /ml-commons-plugin/agents-tools/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/index/
 ---
 
 # Agents and tools

--- a/_ml-commons-plugin/agents-tools/mcp/index.md
+++ b/_ml-commons-plugin/agents-tools/mcp/index.md
@@ -6,7 +6,7 @@ has_children: true
 nav_order: 30
 redirect_from:
   - /ml-commons-plugin/agents-tools/mcp/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/mcp/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/mcp/index/
 ---
 
 # Using MCP tools

--- a/_ml-commons-plugin/agents-tools/tools/index.md
+++ b/_ml-commons-plugin/agents-tools/tools/index.md
@@ -8,7 +8,7 @@ nav_order: 20
 redirect_from: 
   - /ml-commons-plugin/agents-tools/tools/
   - /ml-commons-plugin/agents-tools/tools/cat-index-tool/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/agents-tools/tools/index/
 ---
 
 # Tools

--- a/_ml-commons-plugin/api/agent-apis/index.md
+++ b/_ml-commons-plugin/api/agent-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 30
 redirect_from:
   - /ml-commons-plugin/api/agent-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/agent-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/agent-apis/index/
 ---
 
 # Agent APIs

--- a/_ml-commons-plugin/api/agentic-memory-apis/index.md
+++ b/_ml-commons-plugin/api/agentic-memory-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 35
 redirect_from: 
   - /ml-commons-plugin/api/agentic-memory-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/agentic-memory-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/agentic-memory-apis/index/
 ---
 
 # Agentic memory APIs

--- a/_ml-commons-plugin/api/connector-apis/index.md
+++ b/_ml-commons-plugin/api/connector-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 25
 redirect_from:
   - /ml-commons-plugin/api/connector-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/connector-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/connector-apis/index/
 ---
 
 # Connector APIs

--- a/_ml-commons-plugin/api/context-management-apis/index.md
+++ b/_ml-commons-plugin/api/context-management-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 45
 redirect_from: 
   - /ml-commons-plugin/api/context-management-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/context-management-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/context-management-apis/index/
 ---
 
 # Context management APIs

--- a/_ml-commons-plugin/api/controller-apis/index.md
+++ b/_ml-commons-plugin/api/controller-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 60
 redirect_from:
   - /ml-commons-plugin/api/controller-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/controller-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/controller-apis/index/
 ---
 
 # Controller APIs

--- a/_ml-commons-plugin/api/index.md
+++ b/_ml-commons-plugin/api/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /ml-commons-plugin/api/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/index/
 ---
 
 # ML APIs 

--- a/_ml-commons-plugin/api/mcp-server-apis/index.md
+++ b/_ml-commons-plugin/api/mcp-server-apis/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /ml-commons-plugin/api/mcp-server-apis/
   - /ml-commons-plugin/api/mcp-server-apis/sse-message/
   - /ml-commons-plugin/api/mcp-server-apis/sse-session/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/mcp-server-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/mcp-server-apis/index/
 ---
 
 # MCP server APIs

--- a/_ml-commons-plugin/api/memory-apis/index.md
+++ b/_ml-commons-plugin/api/memory-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 50
 redirect_from:
   - /ml-commons-plugin/api/memory-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/memory-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/memory-apis/index/
 ---
 
 # Memory APIs

--- a/_ml-commons-plugin/api/model-apis/index.md
+++ b/_ml-commons-plugin/api/model-apis/index.md
@@ -7,7 +7,7 @@ nav_order: 10
 has_toc: false
 redirect_from:
   - /ml-commons-plugin/api/model-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-apis/index/
 ---
 
 # Model APIs

--- a/_ml-commons-plugin/api/model-group-apis/index.md
+++ b/_ml-commons-plugin/api/model-group-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 20
 redirect_from:
   - /ml-commons-plugin/api/model-group-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-group-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/model-group-apis/index/
 ---
 
 # Model group APIs

--- a/_ml-commons-plugin/api/tasks-apis/index.md
+++ b/_ml-commons-plugin/api/tasks-apis/index.md
@@ -7,7 +7,7 @@ has_toc: false
 nav_order: 70
 redirect_from:
   - /ml-commons-plugin/api/tasks-apis/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/tasks-apis/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/api/tasks-apis/index/
 ---
 
 # ML Tasks APIs

--- a/_ml-commons-plugin/remote-models/index.md
+++ b/_ml-commons-plugin/remote-models/index.md
@@ -8,7 +8,7 @@ nav_order: 60
 redirect_from: 
   - /ml-commons-plugin/extensibility/index/
   - /ml-commons-plugin/remote-models/
-canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/remote-models/
+canonical_url: https://docs.opensearch.org/latest/ml-commons-plugin/remote-models/index/
 ---
 
 # Connecting to externally hosted models

--- a/_monitoring-your-cluster/job-scheduler/index.md
+++ b/_monitoring-your-cluster/job-scheduler/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /job-scheduler-plugin/index/
   - /monitoring-your-cluster/job-scheduler/
-canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/job-scheduler/
+canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/job-scheduler/index/
 ---
 
 # Job Scheduler

--- a/_monitoring-your-cluster/pa/index.md
+++ b/_monitoring-your-cluster/pa/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /monitoring-plugins/pa/
   - /monitoring-plugins/pa/index/
   - /monitoring-your-cluster/pa/
-canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/
+canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/index/
 ---
 
 # Performance Analyzer

--- a/_monitoring-your-cluster/pa/rca/index.md
+++ b/_monitoring-your-cluster/pa/rca/index.md
@@ -7,7 +7,7 @@ has_children: true
 redirect_from:
   - /monitoring-plugins/pa/rca/index/
   - /monitoring-your-cluster/pa/rca/
-canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/
+canonical_url: https://docs.opensearch.org/latest/monitoring-your-cluster/pa/rca/index/
 ---
 
 # Root cause analysis

--- a/_observing-your-data/ad/index.md
+++ b/_observing-your-data/ad/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /monitoring-plugins/ad/
   - /monitoring-plugins/ad/index/
   - /observing-your-data/ad/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/ad/index/
 ---
 
 # Anomaly detection

--- a/_observing-your-data/agent-traces/index.md
+++ b/_observing-your-data/agent-traces/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /observing-your-data/agent-traces/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/agent-traces/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/agent-traces/index/
 ---
 
 # Agent traces

--- a/_observing-your-data/alerting/index.md
+++ b/_observing-your-data/alerting/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /monitoring-plugins/alerting/
   - /monitoring-plugins/alerting/index/
   - /observing-your-data/alerting/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/alerting/index/
 ---
 
 # Alerting

--- a/_observing-your-data/apm/index.md
+++ b/_observing-your-data/apm/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
    - /observing-your-data/apm/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/apm/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/apm/index/
 ---
 
 # Application performance monitoring

--- a/_observing-your-data/exploring-observability-data/index.md
+++ b/_observing-your-data/exploring-observability-data/index.md
@@ -7,7 +7,7 @@ has_toc: false
 description: "Learn how to explore your observability data using specialized interfaces for logs, metrics, and traces within observability workspaces. These enhanced data exploration capabilities provide tools for querying, analyzing, and correlating different types of telemetry data."
 redirect_from:
   - /observing-your-data/exploring-observability-data/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/exploring-observability-data/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/exploring-observability-data/index/
 ---
 
 # Using Discover for observability

--- a/_observing-your-data/forecast/index.md
+++ b/_observing-your-data/forecast/index.md
@@ -5,7 +5,7 @@ nav_order: 130
 has_children: true
 redirect_from:
   - /observing-your-data/forecast/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/forecast/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/forecast/index/
 ---
 
 # Forecasting

--- a/_observing-your-data/notifications/index.md
+++ b/_observing-your-data/notifications/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /notifications-plugin/
   - /notifications-plugin/index/
   - /observing-your-data/notifications/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/notifications/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/notifications/index/
 ---
 
 # Notifications

--- a/_observing-your-data/query-insights/index.md
+++ b/_observing-your-data/query-insights/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /query-insights/
   - /observing-your-data/query-insights/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/query-insights/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/query-insights/index/
 ---
 
 # Query insights

--- a/_observing-your-data/slo/index.md
+++ b/_observing-your-data/slo/index.md
@@ -5,7 +5,7 @@ nav_order: 125
 has_children: false
 redirect_from:
   - /observing-your-data/slo/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/slo/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/slo/index/
 ---
 
 # Service-level objectives

--- a/_observing-your-data/trace/index.md
+++ b/_observing-your-data/trace/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /observability-plugin/trace/index/
   - /monitoring-plugins/trace/index/
   - /observing-your-data/trace/
-canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/
+canonical_url: https://docs.opensearch.org/latest/observing-your-data/trace/index/
 ---
 
 # Trace analytics

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -86,11 +86,7 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore. The single-edition sections now redirect to
-  # /latest/, which CI rewrites back to the page's own path, so check_internal
-  # would recurse on its own stub.
-  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
-  # back to `/`, so check_internal would follow the stub into itself.
+  # Pattern of local paths to ignore.
   @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -89,7 +89,9 @@ module Jekyll::LinkChecker
   # Pattern of local paths to ignore. The single-edition sections now redirect to
   # /latest/, which CI rewrites back to the page's own path, so check_internal
   # would recurse on its own stub.
-  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
+  # `^/$` is the branch home page: it redirects to /latest/, which CI rewrites
+  # back to `/`, so check_internal would follow the stub into itself.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -86,8 +86,10 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore
-  @ignored_paths = %r{(^/javadocs|^mailto:)}.freeze
+  # Pattern of local paths to ignore. The single-edition sections now redirect to
+  # /latest/, which CI rewrites back to the page's own path, so check_internal
+  # would recurse on its own stub.
+  @ignored_paths = %r{(^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures

--- a/_query-dsl/ai-vector-search/index.md
+++ b/_query-dsl/ai-vector-search/index.md
@@ -6,7 +6,7 @@ nav_order: 55
 has_toc: false
 redirect_from:
   - /query-dsl/ai-vector-search/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/ai-vector-search/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/ai-vector-search/index/
 ---
 
 # AI and vector search queries

--- a/_query-dsl/compound/index.md
+++ b/_query-dsl/compound/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/query-dsl/compound/index/
   - /query-dsl/query-dsl/compound/
   - /query-dsl/compound/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/compound/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/compound/index/
 ---
 
 # Compound queries

--- a/_query-dsl/full-text/index.md
+++ b/_query-dsl/full-text/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/query-dsl/full-text/index/
   - /query-dsl/query-dsl/full-text/
   - /query-dsl/full-text/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/full-text/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/full-text/index/
 ---
 
 # Full-text queries

--- a/_query-dsl/geo-and-xy/index.md
+++ b/_query-dsl/geo-and-xy/index.md
@@ -8,7 +8,7 @@ redirect_from:
    - /query-dsl/query-dsl/geo-and-xy/
    - /query-dsl/query-dsl/geo-and-xy/index/
    - /query-dsl/geo-and-xy/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/geo-and-xy/index/
 ---
 
 # Geographic and xy queries

--- a/_query-dsl/joining/index.md
+++ b/_query-dsl/joining/index.md
@@ -6,7 +6,7 @@ nav_order: 70
 has_toc: false
 redirect_from:
   - /query-dsl/joining/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/joining/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/joining/index/
 ---
 
 # Joining queries

--- a/_query-dsl/span/index.md
+++ b/_query-dsl/span/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /query-dsl/query-dsl/span-query/
   - /query-dsl/span-query/
   - /query-dsl/span/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/span/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/span/index/
 ---
 
 # Span queries

--- a/_query-dsl/specialized/index.md
+++ b/_query-dsl/specialized/index.md
@@ -6,7 +6,7 @@ nav_order: 60
 has_toc: false
 redirect_from:
   - /query-dsl/specialized/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/index/
 ---
 
 # Specialized queries

--- a/_query-dsl/specialized/k-nn/index.md
+++ b/_query-dsl/specialized/k-nn/index.md
@@ -6,7 +6,7 @@ has_children: true
 nav_order: 15
 redirect_from:
   - /query-dsl/specialized/k-nn/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/k-nn/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/k-nn/index/
 ---
 
 # k-NN query

--- a/_query-dsl/specialized/neural-sparse/index.md
+++ b/_query-dsl/specialized/neural-sparse/index.md
@@ -6,7 +6,7 @@ has_children: true
 nav_order: 55
 redirect_from:
   - /query-dsl/specialized/neural-sparse/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/specialized/neural-sparse/index/
 ---
 
 # Neural sparse query

--- a/_query-dsl/term/index.md
+++ b/_query-dsl/term/index.md
@@ -7,7 +7,7 @@ nav_order: 40
 redirect_from:
   - /opensearch/query-dsl/term/
   - /query-dsl/term/
-canonical_url: https://docs.opensearch.org/latest/query-dsl/term/
+canonical_url: https://docs.opensearch.org/latest/query-dsl/term/index/
 ---
 
 # Term-level queries

--- a/_search-plugins/async/index.md
+++ b/_search-plugins/async/index.md
@@ -6,7 +6,7 @@ parent: Improving search performance
 has_children: true
 redirect_from:
   - /search-plugins/async/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/async/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/async/index/
 ---
 
 # Asynchronous search

--- a/_search-plugins/caching/index.md
+++ b/_search-plugins/caching/index.md
@@ -6,7 +6,7 @@ has_children: true
 nav_order: 10
 redirect_from:
   - /search-plugins/caching/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/caching/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/caching/index/
 ---
 
 # Caching

--- a/_search-plugins/ltr/index.md
+++ b/_search-plugins/ltr/index.md
@@ -7,7 +7,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/ltr/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/ltr/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/ltr/index/
 ---
 
 # Learning to Rank

--- a/_search-plugins/querqy/index.md
+++ b/_search-plugins/querqy/index.md
@@ -7,7 +7,7 @@ has_children: false
 redirect_from:
   - /search-plugins/querqy/
 nav_order: 60
-canonical_url: https://docs.opensearch.org/latest/search-plugins/querqy/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/querqy/index/
 ---
 
 # Querqy

--- a/_search-plugins/search-pipelines/index.md
+++ b/_search-plugins/search-pipelines/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/search-pipelines/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/search-pipelines/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/search-pipelines/index/
 ---
 
 # Search pipelines

--- a/_search-plugins/search-relevance/index.md
+++ b/_search-plugins/search-relevance/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /search-plugins/search-relevance/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/search-relevance/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/search-relevance/index/
 ---
 
 # Optimizing search quality

--- a/_search-plugins/searching-data/index.md
+++ b/_search-plugins/searching-data/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/ux/
   - /search-plugins/searching-data/
   - /search-plugins/search-options/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/searching-data/index/
 ---
 
 # Customizing search results

--- a/_search-plugins/ubi/index.md
+++ b/_search-plugins/ubi/index.md
@@ -7,7 +7,7 @@ nav_order: 10
 description: "User Behavior Insights (UBI) is a schema for capturing user search behavior, including the queries users submit, the results shown, and the actions they take."
 redirect_from:
   - /search-plugins/ubi/
-canonical_url: https://docs.opensearch.org/latest/search-plugins/ubi/
+canonical_url: https://docs.opensearch.org/latest/search-plugins/ubi/index/
 ---
 # User Behavior Insights
 

--- a/_security-analytics/api-tools/index.md
+++ b/_security-analytics/api-tools/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-analytics/api-tools/
-canonical_url: https://docs.opensearch.org/latest/security-analytics/api-tools/
+canonical_url: https://docs.opensearch.org/latest/security-analytics/api-tools/index/
 ---
 
 # Security Analytics APIs

--- a/_security-analytics/log-types-reference/index.md
+++ b/_security-analytics/log-types-reference/index.md
@@ -6,7 +6,7 @@ nav_order: 16
 redirect_from:
   - /security-analytics/sec-analytics-config/log-types/
   - /security-analytics/log-types-reference/
-canonical_url: https://docs.opensearch.org/latest/security-analytics/log-types-reference/
+canonical_url: https://docs.opensearch.org/latest/security-analytics/log-types-reference/index/
 ---
 
 # Supported log types

--- a/_security-analytics/sec-analytics-config/index.md
+++ b/_security-analytics/sec-analytics-config/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-analytics/sec-analytics-config/
-canonical_url: https://docs.opensearch.org/latest/security-analytics/sec-analytics-config/
+canonical_url: https://docs.opensearch.org/latest/security-analytics/sec-analytics-config/index/
 ---
 
 # Setting up Security Analytics

--- a/_security-analytics/threat-intelligence/index.md
+++ b/_security-analytics/threat-intelligence/index.md
@@ -5,7 +5,7 @@ nav_order: 40
 has_children: true
 redirect_from:
   - /security-analytics/threat-intelligence/
-canonical_url: https://docs.opensearch.org/latest/security-analytics/threat-intelligence/
+canonical_url: https://docs.opensearch.org/latest/security-analytics/threat-intelligence/index/
 ---
 
 # Threat intelligence

--- a/_security-analytics/usage/index.md
+++ b/_security-analytics/usage/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /security-analytics/usage/
-canonical_url: https://docs.opensearch.org/latest/security-analytics/usage/
+canonical_url: https://docs.opensearch.org/latest/security-analytics/usage/index/
 ---
 
 # Using Security Analytics

--- a/_security/access-control/index.md
+++ b/_security/access-control/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /security-plugin/access-control/index/
   - /security/access-control/
-canonical_url: https://docs.opensearch.org/latest/security/access-control/
+canonical_url: https://docs.opensearch.org/latest/security/access-control/index/
 ---
 
 # Access control

--- a/_security/audit-logs/index.md
+++ b/_security/audit-logs/index.md
@@ -7,7 +7,7 @@ has_toc: false
 redirect_from:
   - /security-plugin/audit-logs/index/
   - /security/audit-logs/
-canonical_url: https://docs.opensearch.org/latest/security/audit-logs/
+canonical_url: https://docs.opensearch.org/latest/security/audit-logs/index/
 ---
 
 # Audit logs

--- a/_security/configuration/index.md
+++ b/_security/configuration/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /security-plugin/configuration/
   - /security-plugin/configuration/index/
   - /security/configuration/
-canonical_url: https://docs.opensearch.org/latest/security/configuration/
+canonical_url: https://docs.opensearch.org/latest/security/configuration/index/
 ---
 
 # Security configuration

--- a/_sql-and-ppl/ppl/commands/index.md
+++ b/_sql-and-ppl/ppl/commands/index.md
@@ -11,7 +11,7 @@ redirect_from:
   - /search-plugins/ppl/functions/
   - /sql-and-ppl/ppl/functions/
   - /sql-and-ppl/ppl/commands/
-canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/index/
 ---
 
 # PPL commands

--- a/_sql-and-ppl/ppl/functions/index.md
+++ b/_sql-and-ppl/ppl/functions/index.md
@@ -4,7 +4,7 @@ title: Functions
 parent: PPL
 nav_order: 1
 has_children: true
-canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/functions/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/commands/index/
 ---
 
 # PPL functions

--- a/_sql-and-ppl/ppl/index.md
+++ b/_sql-and-ppl/ppl/index.md
@@ -14,7 +14,7 @@ redirect_from:
   - /search-plugins/ppl/endpoint/
   - /search-plugins/ppl/protocol/
   - /observability-plugin/ppl/index/
-canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/ppl/index/
 ---
 
 # PPL

--- a/_sql-and-ppl/sql-and-ppl-api/data-source-apis/index.md
+++ b/_sql-and-ppl/sql-and-ppl-api/data-source-apis/index.md
@@ -8,7 +8,7 @@ has_toc: false
 redirect_from:
   - /sql-and-ppl/sql-and-ppl-api/data-source-apis/
   - /sql-and-ppl/ppl/admin/datasources/
-canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/data-source-apis/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/data-source-apis/index/
 ---
 
 # Data source APIs

--- a/_sql-and-ppl/sql-and-ppl-api/index.md
+++ b/_sql-and-ppl/sql-and-ppl-api/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /search-plugins/sql/sql-ppl-api/
   - /sql-and-ppl/sql-ppl-api/
   - /sql-and-ppl/sql-and-ppl-api/
-canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql-and-ppl-api/index/
 ---
 
 # SQL and PPL API

--- a/_sql-and-ppl/sql/index.md
+++ b/_sql-and-ppl/sql/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /sql-and-ppl/sql/
   - /search-plugins/sql/sql/
   - /search-plugins/sql/sql/index/
-canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/
+canonical_url: https://docs.opensearch.org/latest/sql-and-ppl/sql/index/
 ---
 
 # SQL

--- a/_tools/logstash/index.md
+++ b/_tools/logstash/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /clients/logstash/
   - /clients/logstash/index/
   - /tools/logstash/
-canonical_url: https://docs.opensearch.org/latest/tools/logstash/
+canonical_url: https://docs.opensearch.org/latest/tools/logstash/index/
 ---
 
 # Logstash

--- a/_tuning-your-cluster/availability-and-recovery/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: true
 redirect_from:
   - /tuning-your-cluster/availability-and-recovery/
-canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/index/
 ---
 
 # Availability and recovery

--- a/_tuning-your-cluster/availability-and-recovery/remote-store/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/remote-store/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /opensearch/remote/
   - /tuning-your-cluster/availability-and-recovery/remote/
   - /tuning-your-cluster/availability-and-recovery/remote-store/
-canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/remote-store/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/remote-store/index/
 ---
 
 # Remote-backed storage

--- a/_tuning-your-cluster/availability-and-recovery/segment-replication/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/segment-replication/index.md
@@ -10,7 +10,7 @@ redirect_from:
   - /opensearch/segment-replication/index/
   - /tuning-your-cluster/segment-replication/
   - /tuning-your-cluster/availability-and-recovery/segment-replication/
-canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/segment-replication/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/segment-replication/index/
 ---
 
 # Segment replication

--- a/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/index.md
@@ -9,7 +9,7 @@ redirect_from:
   - /opensearch/snapshots/index/
   - /tuning-your-cluster/availability-and-recovery/snapshots/
 has_toc: false
-canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/availability-and-recovery/snapshots/index/
 ---
 
 # Snapshots

--- a/_tuning-your-cluster/replication-plugin/index.md
+++ b/_tuning-your-cluster/replication-plugin/index.md
@@ -7,7 +7,7 @@ redirect_from:
   - /replication-plugin/
   - /replication-plugin/index/
   - /tuning-your-cluster/replication-plugin/
-canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/replication-plugin/
+canonical_url: https://docs.opensearch.org/latest/tuning-your-cluster/replication-plugin/index/
 ---
 
 # Cross-cluster replication

--- a/_tutorials/gen-ai/agents/index.md
+++ b/_tutorials/gen-ai/agents/index.md
@@ -22,7 +22,7 @@ flows:
       - "<b>Platform:</b> OpenSearch"
       - "<b>Model:</b> Anthropic Claude 3.7 Sonnet"  
       - "<b>Deployment:</b> Amazon Bedrock"
-canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/agents/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/agents/index/
 ---
 
 # Agentic AI tutorials

--- a/_tutorials/gen-ai/ai-search-flows/index.md
+++ b/_tutorials/gen-ai/ai-search-flows/index.md
@@ -12,7 +12,7 @@ flows:
   - heading: Creating and customizing AI search workflows
     link: /vector-search/ai-search/workflow-builder/
     description: "Learn how to build AI search flows in OpenSearch Dashboards"   
-canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/ai-search-flows/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/ai-search-flows/index/
 ---
 
 # AI search workflows tutorials

--- a/_tutorials/gen-ai/chatbots/index.md
+++ b/_tutorials/gen-ai/chatbots/index.md
@@ -27,7 +27,7 @@ chatbots:
       - "<b>Platform:</b> OpenSearch"
       - "<b>Model:</b> Anthropic Claude"  
       - "<b>Deployment:</b> Amazon Bedrock"
-canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/chatbots/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/chatbots/index/
 ---
 
 # Tutorials: Building chatbots

--- a/_tutorials/gen-ai/index.md
+++ b/_tutorials/gen-ai/index.md
@@ -22,7 +22,7 @@ cards:
   - heading: "Model guardrails"
     description: "Add safety boundaries to your models to ensure controlled responses"
     link: "/tutorials/gen-ai/model-controls/"
-canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/index/
 ---
 
 # Generative AI tutorials

--- a/_tutorials/gen-ai/model-controls/index.md
+++ b/_tutorials/gen-ai/model-controls/index.md
@@ -15,7 +15,7 @@ model_controls:
       - "<b>Platform:</b> OpenSearch"
       - "<b>Model:</b> Anthropic Claude"  
       - "<b>Deployment:</b> Amazon Bedrock"   
-canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/model-controls/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/model-controls/index/
 ---
 
 # Model guardrails tutorials

--- a/_tutorials/gen-ai/rag/index.md
+++ b/_tutorials/gen-ai/rag/index.md
@@ -48,7 +48,7 @@ conversational_search:
     - "<b>Platform:</b> OpenSearch"
     - "<b>Model:</b> Anthropic Claude"  
     - "<b>Deployment:</b> Amazon Bedrock API"  
-canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/rag/
+canonical_url: https://docs.opensearch.org/latest/tutorials/gen-ai/rag/index/
 ---
 
 # RAG tutorials

--- a/_tutorials/reranking/index.md
+++ b/_tutorials/reranking/index.md
@@ -44,7 +44,7 @@ reranking:
       - "<b>Platform:</b> OpenSearch, Amazon OpenSearch Service"
       - "<b>Model:</b> Cohere Rerank"  
       - "<b>Deployment:</b> Provider API" 
-canonical_url: https://docs.opensearch.org/latest/tutorials/reranking/
+canonical_url: https://docs.opensearch.org/latest/tutorials/reranking/index/
 ---
 
 # Reranking search results tutorials

--- a/_tutorials/vector-search/index.md
+++ b/_tutorials/vector-search/index.md
@@ -40,7 +40,7 @@ other:
   - heading: "Using semantic highlighting"
     description: "Learn how to highlight the most semantically relevant sentences in the results"
     link: "/tutorials/vector-search/semantic-highlighting-tutorial/"
-canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/
+canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/index/
 ---
 
 # Vector search tutorials

--- a/_tutorials/vector-search/semantic-search/index.md
+++ b/_tutorials/vector-search/semantic-search/index.md
@@ -69,7 +69,7 @@ semantic_search:
       - "<b>Platform:</b> OpenSearch, Amazon OpenSearch Service"
       - "<b>Model:</b> Amazon Titan Text Embeddings"  
       - "<b>Deployment:</b> Amazon Bedrock"
-canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/semantic-search/
+canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/semantic-search/index/
 ---
 
 # Semantic search tutorials

--- a/_tutorials/vector-search/vector-operations/index.md
+++ b/_tutorials/vector-search/vector-operations/index.md
@@ -27,7 +27,7 @@ vector_operations:
       - "<b>Model:</b> Cohere Embed Multilingual v3"  
       - "<b>Deployment:</b> Amazon Bedrock"  
     link: "/tutorials/vector-search/vector-operations/optimize-compression/"
-canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/vector-operations/
+canonical_url: https://docs.opensearch.org/latest/tutorials/vector-search/vector-operations/index/
 ---
 
 # Vector operation tutorials

--- a/_vector-search/ai-search/agentic-search/index.md
+++ b/_vector-search/ai-search/agentic-search/index.md
@@ -7,7 +7,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /vector-search/ai-search/agentic-search/
-canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/agentic-search/index/
 ---
 
 # Agentic search

--- a/_vector-search/ai-search/hybrid-search/index.md
+++ b/_vector-search/ai-search/hybrid-search/index.md
@@ -7,7 +7,7 @@ nav_order: 40
 redirect_from:
    - /search-plugins/hybrid-search/
    - /vector-search/ai-search/hybrid-search/
-canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/hybrid-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/hybrid-search/index/
 ---
 
 # Hybrid search

--- a/_vector-search/ai-search/index.md
+++ b/_vector-search/ai-search/index.md
@@ -38,7 +38,7 @@ search_method_cards:
   - heading: "Conversational search with RAG"
     description: "Uses retrieval-augmented generation (RAG) and conversational memory to provide context-aware responses."
     link: "/vector-search/ai-search/conversational-search/"
-canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ai-search/index/
 ---
 
 # AI search

--- a/_vector-search/api/index.md
+++ b/_vector-search/api/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /vector-search/api/knn/
   - /vector-search/api/
   - /search-plugins/knn/api/
-canonical_url: https://docs.opensearch.org/latest/vector-search/api/
+canonical_url: https://docs.opensearch.org/latest/vector-search/api/index/
 ---
 
 # Vector search API

--- a/_vector-search/filter-search-knn/index.md
+++ b/_vector-search/filter-search-knn/index.md
@@ -6,7 +6,7 @@ has_children: true
 redirect_from:
   - /search-plugins/knn/filter-search-knn/ 
   - /vector-search/filter-search-knn/
-canonical_url: https://docs.opensearch.org/latest/vector-search/filter-search-knn/
+canonical_url: https://docs.opensearch.org/latest/vector-search/filter-search-knn/index/
 ---
 
 # Filtering vector search results

--- a/_vector-search/getting-started/index.md
+++ b/_vector-search/getting-started/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /vector-search/getting-started/
-canonical_url: https://docs.opensearch.org/latest/vector-search/getting-started/
+canonical_url: https://docs.opensearch.org/latest/vector-search/getting-started/index/
 ---
 
 # Getting started with vector search

--- a/_vector-search/ingesting-data/index.md
+++ b/_vector-search/ingesting-data/index.md
@@ -6,7 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /vector-search/ingesting-data/
-canonical_url: https://docs.opensearch.org/latest/vector-search/ingesting-data/
+canonical_url: https://docs.opensearch.org/latest/vector-search/ingesting-data/index/
 ---
 
 # Ingesting data into a vector index

--- a/_vector-search/optimizing-storage/index.md
+++ b/_vector-search/optimizing-storage/index.md
@@ -13,7 +13,7 @@ storage_cards:
   - heading: "Disk-based vector search"
     description: "Uses binary quantization to reduce the operational costs of vector workloads"
     link: "/vector-search/optimizing-storage/disk-based-vector-search/"
-canonical_url: https://docs.opensearch.org/latest/vector-search/optimizing-storage/
+canonical_url: https://docs.opensearch.org/latest/vector-search/optimizing-storage/index/
 ---
 
 # Optimizing vector storage

--- a/_vector-search/specialized-operations/index.md
+++ b/_vector-search/specialized-operations/index.md
@@ -16,7 +16,7 @@ cards:
   - heading: "Vector search with MMR reranking"
     description: "Improve vector search results by automatically reranking for both relevance and diversity using maximal marginal relevance (MMR)"
     link: "/vector-search/specialized-operations/vector-search-mmr/"
-canonical_url: https://docs.opensearch.org/latest/vector-search/specialized-operations/
+canonical_url: https://docs.opensearch.org/latest/vector-search/specialized-operations/index/
 ---
 
 # Specialized vector search

--- a/_vector-search/vector-search-techniques/index.md
+++ b/_vector-search/vector-search-techniques/index.md
@@ -8,7 +8,7 @@ redirect_from:
   - /search-plugins/knn/
   - /search-plugins/knn/index/ 
   - /vector-search/vector-search-techniques/     
-canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/
+canonical_url: https://docs.opensearch.org/latest/vector-search/vector-search-techniques/index/
 ---
 
 # Vector search techniques

--- a/index.md
+++ b/index.md
@@ -5,6 +5,7 @@ nav_order: 1
 has_children: false
 nav_exclude: true
 permalink: /
+redirect_to: https://docs.opensearch.org/latest/
 seo:
   type: "WebSite" # override the site-wide TechArticle default
 ---

--- a/index.md
+++ b/index.md
@@ -6,6 +6,7 @@ has_children: false
 nav_exclude: true
 permalink: /
 redirect_to: https://docs.opensearch.org/latest/
+canonical_url: https://docs.opensearch.org/latest/
 seo:
   type: "WebSite" # override the site-wide TechArticle default
 ---


### PR DESCRIPTION
### Description

The Clients, Data Prepper, Benchmark, and Migration Assistant sections are published as a single edition under `/latest/`; only the OpenSearch section is versioned. A versioned build still emits a full copy of those collections, so `/3.7/data-prepper/...` serves content that no release ever corresponded to. Readers reach those copies from search engines, bookmarks, and LLM answers, so rewriting on-site links cannot close the gap.

This adds `redirect_to` front matter pointing each of those pages at its equivalent under `/latest/`. It continues the pass done for 1.3 through 2.14 in June 2024 (#7517, #7535 to #7550), which stopped at 2.15.

Every target was resolved against the live site before being written:

- HTTP redirects and meta-refresh stubs are followed, so each target is a final endpoint rather than another redirect.
- A missing page returns HTTP 200 after being rewritten to `/latest/404.html`, so existence is tested by inspecting the effective URL rather than the status code. A target that lands there falls back to the section index.
- Pages whose only equivalent on `/latest/` is inside the versioned OpenSearch section are left alone, because redirecting them would serve content for the wrong release.

Files that already carried a `redirect_to` are untouched, so hand-curated targets from the earlier pass are preserved.

`_plugins/link-checker.rb` also regains the single-edition path exclusions that 1.3 through 2.14 already carry. CI builds every branch with `baseurl: /latest`, so without them the checker rewrites each redirect target back to the page's own path, reads the stub it just generated, and recurses until the build dies with `stack level too deep`. This filters the *target* of a link, so links pointing into these sections are no longer verified. Links written *on* those pages were already unverified, on this branch and on 1.3 through 2.14: `redirect_to` makes jekyll-redirect-from replace a page's content with the redirect stub during the generator phase, before the checker collects links from it.

Target selection for this branch:

```
  exact       236
  collapsed   13
  section     0
  moved       0
  unresolved  0
```

The branch home page is redirected too. `/3.7/` serves a home page frozen at that release. GA shows no versioned root page has a single referrer from `docs.opensearch.org`, against 37% on-site referrals for `/latest/`, so nobody navigates within a version from its home page. The arrivals are external: bookmarks, third-party links, and OpenSearch Dashboards, whose `noDocumentation` block holds 62 version-pinned links that resolve to exactly this root. All of them are better served by the current home page than a stale one. Content pages are out of scope: a reader who lands on `/3.7/dashboards/dql/` stays in 3.7.

`@ignored_paths` also gains `^/$`. CI builds every branch with `baseurl: /latest`, so without it the checker rewrites the home page's redirect target back to `/`, reads the stub it just generated, pulls the same absolute URL out of it, and recurses until the build dies with `stack level too deep`. That was the cause of the CI failures on the first attempt at this pass.

Verified locally with `JEKYLL_FATAL_LINK_CHECKER=internal` on 2.13 and 3.7, one branch of each `@ignored_paths` shape. Both report no broken links, and `_site/index.html` is the redirect stub.

`@ignored_paths` ends up covering the home page and all five single-edition section paths on this branch, so nothing that carries a `redirect_to` is followed:

```ruby
@ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
```

The pattern matches the link target rather than the page the link sits on, so these entries also stop inbound links to those sections from being verified. That costs nothing here: the targets are redirect stubs the checker would skip anyway, and no new content will land on this branch. It would cost real coverage on `main`, where those are live pages, so `main` keeps a shorter list on purpose (#13056) and this line is not meant to be synced to it.

The `Retarget canonical links to their current pages on latest` commit corrects this branch's canonical links. `canonical_url` is what tells search engines to index the `/latest/` copy of a page rather than this one, but pages keep moving on main after a branch is cut, and a canonical aimed at a `jekyll-redirect-from` stub is worth little more than no canonical at all. 162 of them on this branch pointed at a stub and now name the real page, followed through the `redirect_from` entries on main.

31 pages have no equivalent on latest, not even a redirect, so they keep pointing at their own path. Fixing those means adding `redirect_from` to whichever page on main replaced them; nothing on this branch can do it.

Every target was resolved against `upstream/main` and every rewritten line was checked to be a `canonical_url` line and nothing else. Spot checks against the live site confirm each new URL is a real page whose own canonical is exactly the URL written here.

### Issues Resolved

N/A

### Version

3.7

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
