### PR TITLE
Keep the link checker's ignored paths identical on every branch

### DIFF
--- a/_plugins/link-checker.rb
+++ b/_plugins/link-checker.rb
@@ -91,8 +91,20 @@ module Jekyll::LinkChecker
   ]
 
   ##
-  # Pattern of local paths to ignore
-  @ignored_paths = %r{(^/javadocs|^mailto:)}.freeze
+  # Pattern of local paths to ignore.
+  #
+  # `^/$` is the site home page, and the five section paths are the sections
+  # published as a single edition. On a branch that is no longer the source of
+  # /latest/, every one of those pages carries a `redirect_to` aimed at /latest/.
+  # CI sets `baseurl: /latest`, so the checker rewrites that target back to the
+  # page's own path, reads the stub jekyll-redirect-from just generated, pulls the
+  # same absolute URL out of it, and recurses until the build dies with `stack
+  # level too deep`. `check_internal` has no cycle detection.
+  #
+  # Every entry is a no-op on whichever branch builds /latest/, where these pages
+  # are real content. The list is kept identical on all branches so that one cut
+  # from here already carries the fix.
+  @ignored_paths = %r{(^/$|^/javadocs|^mailto:|^/clients|^/data-prepper|^/benchmark|^/migration-assistant|^/classic/migration-assistant)}.freeze
 
   ##
   # Holds the list of failures


### PR DESCRIPTION
### Description

The redirect passes on 1.3 through 3.7 (#13026 to #13054) point each branch's home page and its Clients, Data Prepper, Benchmark, Migration Assistant, and Migration Assistant (Classic) pages at `/latest/`. Those redirects need matching entries in `@ignored_paths`, because CI builds every branch with `baseurl: /latest`: the checker rewrites the redirect target back to the page's own path, reads the stub `jekyll-redirect-from` just generated, pulls the same absolute URL back out of it, and recurses until the build dies with `stack level too deep`. `check_internal` has no cycle detection.

`main` had none of those entries. This adds all of them, in the same order and with the same comment, so the line is byte-identical on 1.3 through `main`. Two reasons to carry it here rather than only on the version branches:

- A branch cut from `main` already has the fix. Today the release process has to patch it in later, once the branch stops being the source of `/latest/` and the redirects go on.
- One form of the line means a future change to it is one change, not thirty.

Every entry is a no-op on `main`, which is where `/latest/` is built and where all of these pages are real content rather than redirect stubs.

**One tradeoff worth flagging:** internal links pointing *into* those five sections are no longer verified on `main`. On a version branch nothing is lost, since the targets are stubs the checker skips anyway, but on `main` they are live pages, and `main` is where a broken link is most likely to be introduced. A typo like `/clients/javascpirt/` would now pass. The alternative is to keep `main` on a shorter list and accept that every new release branch needs the longer one patched in by hand.

Verified locally with `JEKYLL_FATAL_LINK_CHECKER=internal` on 2.13 and 3.7, one branch of each prior `@ignored_paths` shape. Both report no broken links.

### Issues Resolved

N/A

### Version

main

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
