### PR TITLE
Add redirect_from entries for pages that older versions still point at

### DIFF
--- a/_benchmark/anatomy-of-a-workload.md
+++ b/_benchmark/anatomy-of-a-workload.md
@@ -10,6 +10,7 @@ redirect_from:
   - /benchmark/reference/workloads/index/
   - /benchmark/workloads/
   - /benchmark/workloads/index/
+  - /benchmark/user-guide/understanding-workloads/
 ---
 
 # Anatomy of a workload

--- a/_benchmark/distributed-load.md
+++ b/_benchmark/distributed-load.md
@@ -4,6 +4,7 @@ title: Running distributed loads
 nav_order: 32
 redirect_from:
   - /benchmark/user-guide/optimizing-benchmarks/distributed-load/
+  - /benchmark/user-guide/distributed-load/
 ---
 
 # Running distributed loads

--- a/_benchmark/reference/telemetry.md
+++ b/_benchmark/reference/telemetry.md
@@ -5,6 +5,7 @@ nav_order: 45
 parent: Reference
 redirect_from:
   - /benchmark/user-guide/understanding-results/telemetry/
+  - /benchmark/user-guide/telemetry/
 ---
 
 # Telemetry devices

--- a/_data-prepper/managing-data-prepper/extensions/geoip-service.md
+++ b/_data-prepper/managing-data-prepper/extensions/geoip-service.md
@@ -4,6 +4,8 @@ title: geoip_service
 nav_order: 5
 parent: Extensions
 grand_parent: Managing OpenSearch Data Prepper
+redirect_from:
+  - /data-prepper/managing-data-prepper/extensions/geoip_service/
 ---
 
 # GeoIP service extension

--- a/_data-prepper/pipelines/configuration/processors/otel-traces.md
+++ b/_data-prepper/pipelines/configuration/processors/otel-traces.md
@@ -4,6 +4,8 @@ title: OTel trace
 parent: Processors
 grand_parent: Pipelines
 nav_order: 260
+redirect_from:
+  - /data-prepper/pipelines/configuration/processors/otel-trace-raw/
 ---
 
 # OTel trace processor

--- a/_data-prepper/pipelines/configuration/processors/service-map.md
+++ b/_data-prepper/pipelines/configuration/processors/service-map.md
@@ -4,6 +4,8 @@ title: Service map
 parent: Processors
 grand_parent: Pipelines
 nav_order: 330
+redirect_from:
+  - /data-prepper/pipelines/configuration/processors/service-map-stateful/
 ---
 
 # Service map processor

--- a/_data-prepper/pipelines/configuration/processors/write-json.md
+++ b/_data-prepper/pipelines/configuration/processors/write-json.md
@@ -4,6 +4,8 @@ title: Write JSON
 parent: Processors
 grand_parent: Pipelines
 nav_order: 440
+redirect_from:
+  - /data-prepper/pipelines/configuration/processors/write_json/
 ---
 
 # Write JSON processor

--- a/_data-prepper/pipelines/pipelines.md
+++ b/_data-prepper/pipelines/pipelines.md
@@ -6,6 +6,8 @@ nav_order: 10
 redirect_from:
   - /data-prepper/pipelines/
   - /clients/data-prepper/pipelines/
+  - /data-prepper/pipelines/configuration/processors/routes/
+  - /data-prepper/pipelines/pipelines-configuration-options/
 ---
 
 # Data Prepper pipelines

--- a/_ml-commons-plugin/agents-tools/tools/index.md
+++ b/_ml-commons-plugin/agents-tools/tools/index.md
@@ -8,6 +8,7 @@ nav_order: 20
 redirect_from: 
   - /ml-commons-plugin/agents-tools/tools/
   - /ml-commons-plugin/agents-tools/tools/cat-index-tool/
+  - /ml-commons-plugin/agents-tools/tools/dynamic-tool/
 ---
 
 # Tools

--- a/_ml-commons-plugin/api/index.md
+++ b/_ml-commons-plugin/api/index.md
@@ -6,6 +6,7 @@ has_children: true
 has_toc: false
 redirect_from:
   - /ml-commons-plugin/api/
+  - /ml-commons-plugin/api/train-predict/
 ---
 
 # ML APIs 


### PR DESCRIPTION
### Description

Eleven URLs that older documentation versions still point at return a 404 on `/latest/`, because the pages moved or were renamed on `main` without a `redirect_from` left behind. This adds the missing entries across 10 files, each pointing at the page that actually replaced the old one:

| Old URL | Now redirects to |
|---|---|
| `/benchmark/user-guide/telemetry/` | `_benchmark/reference/telemetry.md` |
| `/benchmark/user-guide/distributed-load/` | `_benchmark/distributed-load.md` |
| `/benchmark/user-guide/understanding-workloads/` | `_benchmark/anatomy-of-a-workload.md` |
| `/data-prepper/managing-data-prepper/extensions/geoip_service/` | `_data-prepper/managing-data-prepper/extensions/geoip-service.md` |
| `/data-prepper/pipelines/configuration/processors/otel-trace-raw/` | `_data-prepper/pipelines/configuration/processors/otel-traces.md` |
| `/data-prepper/pipelines/configuration/processors/service-map-stateful/` | `_data-prepper/pipelines/configuration/processors/service-map.md` |
| `/data-prepper/pipelines/configuration/processors/write_json/` | `_data-prepper/pipelines/configuration/processors/write-json.md` |
| `/data-prepper/pipelines/configuration/processors/routes/` | `_data-prepper/pipelines/pipelines.md` |
| `/data-prepper/pipelines/pipelines-configuration-options/` | `_data-prepper/pipelines/pipelines.md` |
| `/ml-commons-plugin/agents-tools/tools/dynamic-tool/` | `_ml-commons-plugin/agents-tools/tools/index.md` |
| `/ml-commons-plugin/api/train-predict/` | `_ml-commons-plugin/api/index.md` |

These are the eleven paths that the canonical links on branches 1.3-3.7 could not be resolved against, so this is the `main` side of the redirect PRs #13026-#13054. Every target was verified to be a live page, no source URL duplicates an existing `redirect_from`, and no source shadows a page that already publishes at that URL.

### Issues Resolved

N/A

### Version

`main`

### Frontend features

N/A

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).