### PR TITLE
Correct requests that had double endpoints and remove unsupported APIs

### DIFF
--- a/_api-reference/index-apis/create-index-template.md
+++ b/_api-reference/index-apis/create-index-template.md
@@ -172,7 +172,9 @@ response = client.indices.put_index_template(
 
 ### Using multiple matching templates
 
-When multiple index templates match the name of a new index or data stream, the template with the highest priority is used. For example, the following two requests create index templates with different priorities: 
+When multiple index templates match the name of a new index or data stream, the template with the highest priority is used. For example, the following two requests create index templates with different priorities.
+
+The first request creates a template with priority `0` that matches index names starting with `h`:
 
 ```json
 PUT /_index_template/template_one
@@ -189,7 +191,12 @@ PUT /_index_template/template_one
     }
   }
 }
+```
+{% include copy-curl.html %}
 
+The second request creates a template with priority `1` that matches the narrower set of index names starting with `ha`:
+
+```json
 PUT /_index_template/template_two
 {
   "index_patterns" : ["ha*"],
@@ -217,7 +224,7 @@ The following example request adds a `version` number to an index template, whic
 
 <!-- spec_insert_start
 component: example_code
-rest: PUT /_index_template/template_one
+rest: PUT /_index_template/versioned-template
 body: |
 {
   "index_patterns" : ["mac", "cheese"],
@@ -231,7 +238,7 @@ body: |
 }
 -->
 {% capture step1_rest %}
-PUT /_index_template/template_one
+PUT /_index_template/versioned-template
 {
   "index_patterns": [
     "mac",
@@ -251,7 +258,7 @@ PUT /_index_template/template_one
 
 
 response = client.indices.put_index_template(
-  name = "template_one",
+  name = "versioned-template",
   body =   {
     "index_patterns": [
       "mac",
@@ -281,7 +288,7 @@ The following example request uses the `meta` parameter to add metadata to the i
 
 <!-- spec_insert_start
 component: example_code
-rest: PUT /_index_template/template_one
+rest: PUT /_index_template/metadata-template
 body: |
 {
   "index_patterns": ["rom", "juliet"],
@@ -300,7 +307,7 @@ body: |
 }
 -->
 {% capture step1_rest %}
-PUT /_index_template/template_one
+PUT /_index_template/metadata-template
 {
   "index_patterns": [
     "rom",
@@ -325,7 +332,7 @@ PUT /_index_template/template_one
 
 
 response = client.indices.put_index_template(
-  name = "template_one",
+  name = "metadata-template",
   body =   {
     "index_patterns": [
       "rom",
@@ -359,7 +366,7 @@ Include a `data_stream` object to use an index template for data streams, as sho
 
 <!-- spec_insert_start
 component: example_code
-rest: PUT /_index_template/template_1
+rest: PUT /_index_template/logs-template
 body: |
 {
   "index_patterns": ["logs-*"],
@@ -367,7 +374,7 @@ body: |
 }
 -->
 {% capture step1_rest %}
-PUT /_index_template/template_1
+PUT /_index_template/logs-template
 {
   "index_patterns": [
     "logs-*"
@@ -380,7 +387,7 @@ PUT /_index_template/template_1
 
 
 response = client.indices.put_index_template(
-  name = "template_1",
+  name = "logs-template",
   body =   {
     "index_patterns": [
       "logs-*"
@@ -400,7 +407,9 @@ response = client.indices.put_index_template(
 
 When using multiple component templates with the `composed_of` field, the component templates are merged in the specified order. Next, all mappings, settings, and aliases from the parent index template of the component are merged. Lastly, any configuration options added to the index requests are merged.
 
-In the following example request, an index with `h*` has two merged primary shards. If the order in the request body were reversed, then the index would have one primary shard:
+In the following example, an index matching `my-index-*` has two merged primary shards. If the order in the `composed_of` array were reversed, then the index would have one primary shard.
+
+First, create a component template that sets one primary shard:
 
 ```json
 PUT /_component_template/template_with_1_shard
@@ -411,7 +420,12 @@ PUT /_component_template/template_with_1_shard
     }
   }
 }
+```
+{% include copy-curl.html %}
 
+Next, create a component template that sets two primary shards:
+
+```json
 PUT /_component_template/template_with_2_shards
 {
   "template": {
@@ -420,10 +434,15 @@ PUT /_component_template/template_with_2_shards
     }
   }
 }
+```
+{% include copy-curl.html %}
 
-PUT /_index_template/template_1
+Finally, create an index template that composes both component templates in order:
+
+```json
+PUT /_index_template/composed-template
 {
-  "index_patterns": ["h*"],
+  "index_patterns": ["my-index-*"],
   "composed_of": ["template_with_1_shard", "template_with_2_shards"]
 }
 ```

--- a/_api-reference/index-apis/rollover.md
+++ b/_api-reference/index-apis/rollover.md
@@ -158,10 +158,9 @@ response = client.indices.rollover(
 
 ### Rolling over an index alias with a write index
 
-The following request creates a date-time index and sets it as the write index for `my-alias`:
+The following request creates a date-time index and sets it as the write index for `my-alias`. The index name must be URL encoded: `%3Cmy-index-%7Bnow%2Fd%7D-000001%3E` is the encoded form of `<my-index-{now/d}-000001>`, and `{now/d}` resolves to the current date:
 
 ```json
-PUT <my-index-{now/d}-000001>
 PUT %3Cmy-index-%7Bnow%2Fd%7D-000001%3E
 {
   "aliases": {

--- a/_data-prepper/pipelines/configuration/sources/opensearch-api.md
+++ b/_data-prepper/pipelines/configuration/sources/opensearch-api.md
@@ -226,7 +226,7 @@ curl -XPOST "http://localhost:9202/opensearch/_bulk" \
 {"delete":{"_index":"movies","_id":"2"}}
 '
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 <!-- vale off -->
 ### Sending data using opensearch-py

--- a/_ingest-pipelines/simulate-ingest.md
+++ b/_ingest-pipelines/simulate-ingest.md
@@ -21,7 +21,6 @@ The following requests **simulate the latest ingest pipeline created**:
 GET _ingest/pipeline/_simulate
 POST _ingest/pipeline/_simulate
 ```
-{% include copy-curl.html %}
 
 The following requests **simulate a single pipeline based on the pipeline ID**:
 
@@ -29,7 +28,6 @@ The following requests **simulate a single pipeline based on the pipeline ID**:
 GET _ingest/pipeline/{pipeline-id}/_simulate
 POST _ingest/pipeline/{pipeline-id}/_simulate
 ```
-{% include copy-curl.html %}
 
 ## Request body fields
 

--- a/_mappings/index.md
+++ b/_mappings/index.md
@@ -270,7 +270,6 @@ To get a mapping for a specific field, provide the index name and the field name
 GET _mapping/field/{fields}
 GET /{index}/_mapping/field/{fields}
 ```
-{% include copy-curl.html %}
 
 Both `<index>` and `<fields>` can be specified as either one value or a comma-separated list. For example, the following request retrieves the mapping for the `year` and `age` fields in `sample-index1`:
 

--- a/_mappings/metadata-fields/id.md
+++ b/_mappings/metadata-fields/id.md
@@ -14,14 +14,21 @@ Each document in OpenSearch has a unique `_id` field. This field is indexed, all
 If you do not provide an `_id` value, then OpenSearch automatically generates one for the document.
 {: .note}
 
-The following example request creates an index named `test-index1` and adds two documents with different `_id` values:
+The following example requests create an index named `test-index1` and add two documents with different `_id` values.
+
+The first request adds a document with an `_id` of `1`:
 
 ```json
 PUT test-index1/_doc/1
 {
   "text": "Document with ID 1"
 }
+```
+{% include copy-curl.html %}
 
+The second request adds a document with an `_id` of `2` and refreshes the index so that both documents are immediately searchable:
+
+```json
 PUT test-index1/_doc/2?refresh=true
 {
   "text": "Document with ID 2"

--- a/_mappings/metadata-fields/ignored.md
+++ b/_mappings/metadata-fields/ignored.md
@@ -36,7 +36,9 @@ GET _search
 
 #### Example indexing request with the `_ignored` field
 
-The following example request adds a new document to the `test-ignored` index with `ignore_malformed` set to `true` so that no error is thrown during indexing: 
+The following example requests add a document with a malformed value to the `test-ignored` index and then search for the documents that contain an ignored field.
+
+First, create the index with `ignore_malformed` set to `true` on the `length` field so that no error is thrown during indexing:
 
 ```json
 PUT test-ignored
@@ -53,13 +55,23 @@ PUT test-ignored
     }
   }
 }
+```
+{% include copy-curl.html %}
 
-POST test-ignored/_doc
+Next, index a document whose `length` value is not a number. The `refresh` parameter makes the document immediately searchable:
+
+```json
+POST test-ignored/_doc?refresh=true
 {
   "title": "correct text",
   "length": "not a number"
 }
+```
+{% include copy-curl.html %}
 
+Finally, search for the documents that have at least one ignored field:
+
+```json
 GET test-ignored/_search
 {
   "query": {

--- a/_mappings/metadata-fields/index-metadata.md
+++ b/_mappings/metadata-fields/index-metadata.md
@@ -11,14 +11,21 @@ redirect_from:
 
 When querying across multiple indexes, you may need to filter results based on the index into which a document was indexed. The `index` field matches documents based on their index. 
 
-The following example request creates two indexes, `products` and `customers`, and adds a document to each index:
+The following example requests create two indexes, `products` and `customers`, and add a document to each index.
+
+The first request adds a document to the `products` index:
 
 ```json
 PUT products/_doc/1
 {
   "name": "Widget X"
 }
+```
+{% include copy-curl.html %}
 
+The second request adds a document to the `customers` index:
+
+```json
 PUT customers/_doc/2
 {
   "name": "John Doe"

--- a/_ml-commons-plugin/api/controller-apis/create-controller.md
+++ b/_ml-commons-plugin/api/controller-apis/create-controller.md
@@ -25,7 +25,6 @@ To learn how to set rate limits at the model level for all users, see [Update Mo
 POST /_plugins/_ml/controllers/{model_id}
 PUT /_plugins/_ml/controllers/{model_id}
 ```
-{% include copy-curl.html %}
 
 ## Path parameters
 

--- a/_observing-your-data/ad/security.md
+++ b/_observing-your-data/ad/security.md
@@ -49,14 +49,14 @@ To use a remote index as a data source for a detector, see the setup steps in [A
 ```
 curl -XPUT -k -u 'admin:<custom-admin-password>' 'https://localhost:9200/_plugins/_security/api/internalusers/anomalyuser' -H 'Content-Type: application/json' -d '{"password":"password"}'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 2. Map the new user to the `anomaly_full_access` role:
 
 ```
 curl -XPUT -k -u 'admin:<custom-admin-password>' -H 'Content-Type: application/json' 'https://localhost:9200/_plugins/_security/api/rolesmapping/anomaly_full_access' -d '{"users" : ["anomalyuser"]}'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 3. On the remote cluster, create the same user and map `anomaly_full_access` to that role:
 
@@ -64,7 +64,7 @@ curl -XPUT -k -u 'admin:<custom-admin-password>' -H 'Content-Type: application/j
 curl -XPUT -k -u 'admin:<custom-admin-password>' 'https://localhost:9250/_plugins/_security/api/internalusers/anomalyuser' -H 'Content-Type: application/json' -d '{"password":"password"}'
 curl -XPUT -k -u 'admin:<custom-admin-password>' -H 'Content-Type: application/json' 'https://localhost:9250/_plugins/_security/api/rolesmapping/anomaly_full_access' -d '{"users" : ["anomalyuser"]}'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 ---
 

--- a/_observing-your-data/alerting/api.md
+++ b/_observing-your-data/alerting/api.md
@@ -743,63 +743,11 @@ If you run a document-level query while the index is getting reindexed, the API 
 
 ## Update monitor
 
-When updating a monitor, you can optionally include `seq_no` and `primary_term` as parameters. If these numbers do not match the existing monitor or the monitor does not exist, the Alerting plugin throws an error. OpenSearch increments the version number and the sequence number automatically (see the example response).
+When updating a monitor, you can optionally include the `if_seq_no` and `if_primary_term` query parameters, for example, `?if_seq_no=3&if_primary_term=1`. If these numbers do not match the existing monitor or the monitor does not exist, the Alerting plugin throws an error. OpenSearch increments the version number and the sequence number automatically (see the example response).
 
 #### Example request
 ```json
 PUT _plugins/_alerting/monitors/{monitor_id}
-{
-  "type": "monitor",
-  "name": "test-monitor",
-  "enabled": true,
-  "enabled_time": 1551466220455,
-  "schedule": {
-    "period": {
-      "interval": 1,
-      "unit": "MINUTES"
-    }
-  },
-  "inputs": [{
-    "search": {
-      "indices": [
-        "*"
-      ],
-      "query": {
-        "query": {
-          "match_all": {
-            "boost": 1
-          }
-        }
-      }
-    }
-  }],
-  "triggers": [{
-    "id": "StaeOmkBC25HCRGmL_y-",
-    "name": "test-trigger",
-    "severity": "1",
-    "condition": {
-      "script": {
-        "source": "return true",
-        "lang": "painless"
-      }
-    },
-    "actions": [{
-      "name": "test-action",
-      "destination_id": "RtaaOmkBC25HCRGm0fxi",
-      "subject_template": {
-        "source": "My Message Subject",
-        "lang": "mustache"
-      },
-      "message_template": {
-        "source": "This is my message body.",
-        "lang": "mustache"
-      }
-    }]
-  }],
-  "last_update_time": 1551466639295
-}
-
-PUT _plugins/_alerting/monitors/{monitor_id}?if_seq_no=3&if_primary_term=1
 {
   "type": "monitor",
   "name": "test-monitor",
@@ -1018,7 +966,6 @@ GET _plugins/_alerting/stats/{metric}
 GET _plugins/_alerting/{node-id}/stats
 GET _plugins/_alerting/{node-id}/stats/{metric}
 ```
-{% include copy-curl.html %}
 
 
 <details markdown="block">
@@ -1521,149 +1468,12 @@ POST _plugins/_alerting/monitors/{monitor-id}/_acknowledge/alerts
 
 ---
 
-## Create destination
+## Destinations
 
-Define and configure various destinations for receiving alert notifications using the following request. These destinations can be of different types, such as Slack, custom webhooks, or email, and are used to specify where and how alerts should be delivered.
+Destinations were deprecated in OpenSearch 2.0 and replaced by notification channels. The operations that created, updated, and deleted destinations were removed in the same release, and existing destinations were migrated to notification channels automatically. To configure where alerts are delivered, use the [Notifications API]({{site.url}}{{site.baseurl}}/observing-your-data/notifications/api/). The following read operations remain available for retrieving destinations that did not migrate.
+{: .warning}
 
-#### Example request
-```json
-POST _plugins/_alerting/destinations
-{
-  "name": "my-destination",
-  "type": "slack",
-  "slack": {
-    "url": "http://www.example.com"
-  }
-}
-
-POST _plugins/_alerting/destinations
-{
-  "type": "custom_webhook",
-  "name": "my-custom-destination",
-  "custom_webhook": {
-    "path": "incomingwebhooks/123456-123456-XXXXXX",
-    "header_params": {
-      "Content-Type": "application/json"
-    },
-    "scheme": "HTTPS",
-    "port": 443,
-    "query_params": {
-      "token": "R2x1UlN4ZHF8MXxxVFJpelJNVDgzdGNwXXXXXXXXX"
-    },
-    "host": "hooks.chime.aws"
-  }
-}
-
-POST _plugins/_alerting/destinations
-{
-  "type": "email",
-  "name": "my-email-destination",
-  "email": {
-    "email_account_id": "YjY7mXMBx015759_IcfW",
-    "recipients": [
-      {
-        "type": "email_group",
-        "email_group_id": "YzY-mXMBx015759_dscs"
-      },
-      {
-        "type": "email",
-        "email": "example@email.com"
-      }
-    ]
-  }
-}
-
-// The email_account_id and email_group_id will be the document IDs of the email_account and email_group you have created.
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-
-#### Example response
-```json
-{
-  "_id": "nO-yFmkB8NzS6aXjJdiI",
-  "_version" : 1,
-  "_seq_no" : 3,
-  "_primary_term" : 1,
-  "destination": {
-    "type": "slack",
-    "name": "my-destination",
-    "last_update_time": 1550863967624,
-    "slack": {
-      "url": "http://www.example.com"
-    }
-  }
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
----
-
-## Update destination
-
-When updating a destination, you can optionally include `seq_no` and `primary_term` as parameters. If these numbers do not match the existing destination or the destination doesn't exist, the Alerting plugin throws an error. OpenSearch increments the version number and the sequence number automatically (see the example response).
-
-#### Example request
-```json
-PUT _plugins/_alerting/destinations/{destination-id}
-{
-  "name": "my-updated-destination",
-  "type": "slack",
-  "slack": {
-    "url": "http://www.example.com"
-  }
-}
-
-PUT _plugins/_alerting/destinations/{destination-id}?if_seq_no=3&if_primary_term=1
-{
-  "name": "my-updated-destination",
-  "type": "slack",
-  "slack": {
-    "url": "http://www.example.com"
-  }
-}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-
-#### Example response
-```json
-{
-  "_id": "pe-1FmkB8NzS6aXjqvVY",
-  "_version" : 2,
-  "_seq_no" : 4,
-  "_primary_term" : 1,
-  "destination": {
-    "type": "slack",
-    "name": "my-updated-destination",
-    "last_update_time": 1550864289375,
-    "slack": {
-      "url": "http://www.example.com"
-    }
-  }
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
----
-
-## Get destination
+### Get destination
 
 Retrieve one destination using the following request.
 
@@ -1714,9 +1524,7 @@ GET _plugins/_alerting/destinations/{destination-id}
 
 </details>
 
----
-
-## Get destinations
+### Get destinations
 
 Retrieve all destinations using the following request.
 
@@ -1767,149 +1575,7 @@ GET _plugins/_alerting/destinations
 
 </details>
 
----
-
-## Delete destination
-
-Remove a specific destination from the alerting system using the following request.
-
-#### Example request
-```
-DELETE _plugins/_alerting/destinations/{destination-id}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-
-#### Example response
-```json
-{
-  "_index": ".opendistro-alerting-config",
-  "_type": "_doc",
-  "_id": "Zu-zFmkB8NzS6aXjLeBI",
-  "_version": 2,
-  "result": "deleted",
-  "forced_refresh": true,
-  "_shards": {
-    "total": 2,
-    "successful": 2,
-    "failed": 0
-  },
-  "_seq_no": 8,
-  "_primary_term": 1
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
----
-
-## Create email account
-
-Set up a new email account for sending alert notifications using the following request.
-
-#### Example request
-```json
-POST _plugins/_alerting/destinations/email_accounts
-{
-  "name": "example_account",
-  "email": "example@email.com",
-  "host": "smtp.email.com",
-  "port": 465,
-  "method": "ssl"
-}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-
-#### Example response
-```json
-{
-  "_id" : "email_account_id",
-  "_version" : 1,
-  "_seq_no" : 7,
-  "_primary_term" : 2,
-  "email_account" : {
-    "schema_version" : 2,
-    "name" : "example_account",
-    "email" : "example@email.com",
-    "host" : "smtp.email.com",
-    "port" : 465,
-    "method" : "ssl"
-  }
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
-## Update email account
-
-When updating an email account, you can optionally include `seq_no` and `primary_term` as parameters. If these numbers don't match the existing email account or the email account doesn't exist, the Alerting plugin throws an error. OpenSearch increments the version number and the sequence number automatically (see the example response).
-
-#### Example request
-```json
-PUT _plugins/_alerting/destinations/email_accounts/{email_account_id}
-{
-  "name": "example_account",
-  "email": "example@email.com",
-  "host": "smtp.email.com",
-  "port": 465,
-  "method": "ssl"
-}
-
-PUT _plugins/_alerting/destinations/email_accounts/{email_account_id}?if_seq_no=18&if_primary_term=2
-{
-  "name": "example_account",
-  "email": "example@email.com",
-  "host": "smtp.email.com",
-  "port": 465,
-  "method": "ssl"
-}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-
-#### Example response
-```json
-{
-  "_id" : "email_account_id",
-  "_version" : 3,
-  "_seq_no" : 19,
-  "_primary_term" : 2,
-  "email_account" : {
-    "schema_version" : 2,
-    "name" : "example_account",
-    "email" : "example@email.com",
-    "host" : "smtp.email.com",
-    "port" : 465,
-    "method" : "ssl"
-  }
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
-## Get email account
+### Get email account
 
 Retrieve the details of a specific email account configured for alerting purposes using the following request.
 
@@ -1954,46 +1620,7 @@ GET _plugins/_alerting/destinations/email_accounts/{email_account_id}
 
 </details>
 
-## Delete email account
-
-Remove an existing email account configuration from the alerting system using the following request.
-
-#### Example request
-```
-DELETE _plugins/_alerting/destinations/email_accounts/{email_account_id}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-
-#### Example response
-```json
-{
-  "_index" : ".opendistro-alerting-config",
-  "_type" : "_doc",
-  "_id" : "email_account_id",
-  "_version" : 1,
-  "result" : "deleted",
-  "forced_refresh" : true,
-  "_shards" : {
-    "total" : 2,
-    "successful" : 2,
-    "failed" : 0
-  },
-  "_seq_no" : 12,
-  "_primary_term" : 2
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
-## Search email account
+### Search email account
 
 Retrieve information about the configured email accounts used for email-based alerting using the following request.
 
@@ -2068,107 +1695,7 @@ POST _plugins/_alerting/destinations/email_accounts/_search
 
 </details>
 
----
-
-## Create email group
-
-Define a new group of email recipients for alerts using the following request.
-
-#### Example request
-```json
-POST _plugins/_alerting/destinations/email_groups
-{
-  "name": "example_email_group",
-  "emails": [{
-    "email": "example@email.com"
-  }]
-}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-
-#### Example response
-```json
-{
-  "_id" : "email_group_id",
-  "_version" : 1,
-  "_seq_no" : 9,
-  "_primary_term" : 2,
-  "email_group" : {
-    "schema_version" : 2,
-    "name" : "example_email_group",
-    "emails" : [
-      {
-        "email" : "example@email.com"
-      }
-    ]
-  }
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
-## Update email group
-
-When updating an email group, you can optionally include `seq_no` and `primary_term` as parameters. If these numbers don't match the existing email group or the email group doesn't exist, the Alerting plugin throws an error. OpenSearch increments the version number and the sequence number automatically (see the example response).
-
-#### Example request
-```json
-PUT _plugins/_alerting/destinations/email_groups/{email_group_id}
-{
-  "name": "example_email_group",
-  "emails": [{
-    "email": "example@email.com"
-  }]
-}
-
-PUT _plugins/_alerting/destinations/email_groups/{email_group_id}?if_seq_no=16&if_primary_term=2
-{
-  "name": "example_email_group",
-  "emails": [{
-    "email": "example@email.com"
-  }]
-}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-  
-#### Example response
-```json
-{
-  "_id" : "email_group_id",
-  "_version" : 4,
-  "_seq_no" : 17,
-  "_primary_term" : 2,
-  "email_group" : {
-    "schema_version" : 2,
-    "name" : "example_email_group",
-    "emails" : [
-      {
-        "email" : "example@email.com"
-      }
-    ]
-  }
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
-## Get email group
+### Get email group
 
 Retrieve the details of a specific email group destination using the following request, passing the ID of the email group you want to fetch.
 
@@ -2213,46 +1740,7 @@ GET _plugins/_alerting/destinations/email_groups/{email_group_id}
 
 </details>
 
-## Delete email group
-
-Remove an existing email group from the list of destinations for alerts using the following request.
-
-#### Example request
-```
-DELETE _plugins/_alerting/destinations/email_groups/{email_group_id}
-```
-{% include copy-curl.html %}
-
-
-<details markdown="block">
-  <summary>
-    Select to expand example response
-  </summary>
-  {: .text-delta}
-  
-#### Example response
-```json
-{
-  "_index" : ".opendistro-alerting-config",
-  "_type" : "_doc",
-  "_id" : "email_group_id",
-  "_version" : 1,
-  "result" : "deleted",
-  "forced_refresh" : true,
-  "_shards" : {
-    "total" : 2,
-    "successful" : 2,
-    "failed" : 0
-  },
-  "_seq_no" : 11,
-  "_primary_term" : 2
-}
-```
-{% include copy-curl.html %}
-
-</details>
-
-## Search email group
+### Search email group
 
 Query and retrieve information about existing email groups used for alerting purposes, enabling you to filter and sort the results based on various criteria. An example is shown in the following request.
 

--- a/_observing-your-data/forecast/security.md
+++ b/_observing-your-data/forecast/security.md
@@ -340,7 +340,7 @@ curl -XPUT -k -u 'admin:<custom-admin-password>' \
   -H 'Content-Type: application/json' \
   -d '{"password":"password"}'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 Using the following command, map the new user to the `forecast_full_access` role:
 
@@ -350,7 +350,7 @@ curl -XPUT -k -u 'admin:<custom-admin-password>' \
   -H 'Content-Type: application/json' \
   -d '{"users":["forecastuser"]}'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 In the remote cluster, create the same user and map `forecast_full_access` to that role, as shown in the following command:
 
@@ -439,7 +439,7 @@ curl -X PUT "https://localhost:9200/_cluster/settings" \
     }
   }'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 
 - Replace `127.0.0.1` with the remote node's transport layer IP if it's located on a different host.

--- a/_search-plugins/filter-search.md
+++ b/_search-plugins/filter-search.md
@@ -37,27 +37,13 @@ PUT /electronics
 2. Add documents to the `electronics` index using the following request:
 
 ```json
-PUT /electronics/_doc/1?refresh
-{
-  "brand": "BrandA",
-  "category": "Smartphone",
-  "price": 699.99,
-  "features": ["5G", "Dual Camera"]
-}
-PUT /electronics/_doc/2?refresh
-{
-  "brand": "BrandA",
-  "category": "Laptop",
-  "price": 1199.99,
-  "features": ["Touchscreen", "16GB RAM"]
-}
-PUT /electronics/_doc/3?refresh
-{
-  "brand": "BrandB",
-  "category": "Smartphone",
-  "price": 799.99,
-  "features": ["5G", "Triple Camera"]
-}
+POST /_bulk?refresh
+{ "index": { "_index": "electronics", "_id": "1" } }
+{ "brand": "BrandA", "category": "Smartphone", "price": 699.99, "features": ["5G", "Dual Camera"] }
+{ "index": { "_index": "electronics", "_id": "2" } }
+{ "brand": "BrandA", "category": "Laptop", "price": 1199.99, "features": ["Touchscreen", "16GB RAM"] }
+{ "index": { "_index": "electronics", "_id": "3" } }
+{ "brand": "BrandB", "category": "Smartphone", "price": 799.99, "features": ["5G", "Triple Camera"] }
 ```
 {% include copy-curl.html %}
 

--- a/_search-plugins/ltr/advanced-functionality.md
+++ b/_search-plugins/ltr/advanced-functionality.md
@@ -136,11 +136,18 @@ POST _ltr/_featureset/more_movie_features
 
 ## Multiple feature stores
 
-A feature store corresponds to an independent LTR system, including features, feature sets, and models backed by a single index and cache. A feature store typically represents a single search problem or application, like Wikipedia or Wiktionary. To use multiple feature stores in your OpenSearch cluster, you can create and manage them using the provided API. For example, you can create a feature set for the `wikipedia` feature store as follows:
+A feature store corresponds to an independent LTR system, including features, feature sets, and models backed by a single index and cache. A feature store typically represents a single search problem or application, like Wikipedia or Wiktionary. To use multiple feature stores in your OpenSearch cluster, you can create and manage them using the provided API.
+
+For example, first create the `wikipedia` feature store:
 
 ```json
 PUT _ltr/wikipedia
+```
+{% include copy-curl.html %}
 
+Then create a feature set in that store:
+
+```json
 POST _ltr/wikipedia/_featureset/attempt_1
 {
   "featureset": {
@@ -402,7 +409,6 @@ You can limit the information to a single node in the cluster by sending the fol
 GET /_plugins/_ltr/{nodeId}/stats
 GET /_plugins/_ltr/{nodeId}/stats/{stat}
 ```
-{% include copy-curl.html %}
 
 ## TermStat query
 Experimental

--- a/_search-plugins/search-relevance/query-sets.md
+++ b/_search-plugins/search-relevance/query-sets.md
@@ -146,7 +146,6 @@ This API retrieves available query sets.
 GET _plugins/_search_relevance/query_sets
 GET _plugins/_search_relevance/query_sets/{query_set_id}
 ```
-{% include copy-curl.html %}
 
 #### Example response
 

--- a/_search-plugins/search-relevance/search-configurations.md
+++ b/_search-plugins/search-relevance/search-configurations.md
@@ -86,7 +86,6 @@ You can retrieve or delete configurations using the following APIs.
 GET _plugins/_search_relevance/search_configurations
 GET _plugins/_search_relevance/search_configurations/{search_configuration_id}
 ```
-{% include copy-curl.html %}
 
 #### Example response
 

--- a/_security/configuration/tls.md
+++ b/_security/configuration/tls.md
@@ -287,10 +287,10 @@ Only a [superadmin]({{site.url}}{{site.baseurl}}/security/configuration/tls/#con
 
  The following command reloads TLS certificates on the transport layer using the Reload Certificates API:
 
-```json
+```bash
 curl --cacert <ca.pem> --cert <admin.pem> --key <admin.key> -XPUT https://localhost:9200/_plugins/_security/api/ssl/transport/reloadcerts
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 You should receive the following response:
 
@@ -302,10 +302,10 @@ You should receive the following response:
 
 The following command reloads TLS certificates on the HTTP layer using the Reload Certificates API:
 
-```json
+```bash
 curl --cacert <ca.pem> --cert <admin.pem> --key <admin.key> -XPUT https://localhost:9200/_plugins/_security/api/ssl/http/reloadcerts
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 You should receive the following response:
 

--- a/_tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore.md
+++ b/_tuning-your-cluster/availability-and-recovery/snapshots/snapshot-restore.md
@@ -715,7 +715,7 @@ The `.opendistro_security` index contains sensitive data, so we recommend exclud
 ```bash
 curl -k --cert ./kirk.pem --key ./kirk-key.pem -XPOST 'https://localhost:9200/_snapshot/my-repository/snapshot-3/_restore?pretty'
 ```
-{% include copy-curl.html %}
+{% include copy.html %}
 
 We strongly recommend against restoring `.opendistro_security` using an admin certificate because doing so can alter the security posture of the entire cluster. See [A word of caution]({{site.url}}{{site.baseurl}}/security-plugin/configuration/security-admin/#a-word-of-caution) for a recommended process to back up and restore your Security plugin configuration.
 {: .warning}


### PR DESCRIPTION
This PR:
- Corrects the requests that had double endpoints
- Corrects copy-curl includes to copy includes for commands (not requests)
- Deletes the APIs that are not supported but still documented
- Corrects the running example in the create template page
- Removes copy buttons from endpoint blocks

### Checklist
- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
