### PR TITLE
Warn against granting untrusted users Painless script access

### DIFF
--- a/_analyzers/token-filters/predicate-token-filter.md
+++ b/_analyzers/token-filters/predicate-token-filter.md
@@ -9,6 +9,9 @@ nav_order: 340
 
 The `predicate_token_filter` evaluates whether tokens should be kept or discarded, depending on the conditions defined in a custom script. The tokens are evaluated in the analysis predicate context. This filter supports only inline Painless scripts.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Parameters
 
 The `predicate_token_filter` has one required parameter: `script`. This parameter provides a condition that is used to evaluate whether the token should be kept. 

--- a/_api-reference/script-apis/create-stored-script.md
+++ b/_api-reference/script-apis/create-stored-script.md
@@ -11,6 +11,9 @@ nav_order: 10
 
 Creates or updates a stored script or search template in the cluster state. Stored scripts are compiled once and can be reused across multiple requests for better performance.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 For additional information about Painless scripting, see:
 
 * [k-NN Painless Scripting extensions]({{site.url}}{{site.baseurl}}/search-plugins/knn/painless-functions/).

--- a/_api-reference/script-apis/exec-script.md
+++ b/_api-reference/script-apis/exec-script.md
@@ -11,6 +11,9 @@ nav_order: 7
 
 The Execute Inline Script API allows you to run a script directly without storing it in the cluster state. The script is compiled and executed each time the API is called.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Endpoints
 
 ```json

--- a/_api-reference/script-apis/exec-stored-script.md
+++ b/_api-reference/script-apis/exec-stored-script.md
@@ -11,6 +11,9 @@ nav_order: 20
 
 Runs a stored script that was previously saved to the cluster state using the Create Stored Script API. 
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 OpenSearch provides several ways to run a script; the following sections show how to run a script by passing script information in the request body of a `GET <index>/_search` request.
 
 ## Endpoints

--- a/_api-reference/script-apis/index.md
+++ b/_api-reference/script-apis/index.md
@@ -15,6 +15,9 @@ redirect_from:
 
 The script APIs allow you to work with both stored and inline scripts in OpenSearch. The default scripting language is Painless.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Types of scripts
 
 OpenSearch supports two types of scripts:

--- a/_ingest-pipelines/accessing-data.md
+++ b/_ingest-pipelines/accessing-data.md
@@ -164,6 +164,9 @@ The following processor configuration sets the target index dynamically by appen
 
 Use the `script` processor for advanced transformations.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ### Example: Adding a field only if another is missing
 
 The following processor adds the `error_message` field with the value "none" only if the field is missing from the document:

--- a/_ingest-pipelines/complex-conditionals.md
+++ b/_ingest-pipelines/complex-conditionals.md
@@ -9,6 +9,9 @@ nav_order: 50
 
 In ingest pipelines, the `if` parameter in processors can evaluate complex conditions using Painless scripts. These conditionals help fine-tune document processing, allowing advanced logic such as type checking, regular expressions, and combining multiple criteria.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Multiple condition checks
 
 You can combine logical operators like `&&` (and), `||` (or), and `!` (not) to construct more complex conditions. The following pipeline tags documents as `spam` and drops them if they contain an `error_code` higher than `1000`:

--- a/_ingest-pipelines/conditional-execution.md
+++ b/_ingest-pipelines/conditional-execution.md
@@ -9,6 +9,9 @@ nav_order: 40
 
 In ingest pipelines, you can control whether a processor runs by using the optional `if` parameter. This allows for conditional execution of processors based on the incoming document contents. The condition is written as a Painless script and evaluated against the document context (`ctx`).
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Basic conditional execution
 
 Each processor can include an `if` clause. If the condition evaluates to `true`, the processor runs; otherwise, it's skipped.
@@ -230,5 +233,3 @@ The response demonstrates how the processors respond based on each condition:
   ]
 }
 ```
-
-

--- a/_ingest-pipelines/processors/script.md
+++ b/_ingest-pipelines/processors/script.md
@@ -9,6 +9,9 @@ nav_order: 230
 
 The `script` processor executes inline and stored scripts that can modify or transform data in an OpenSearch document during the ingestion process. The processor uses script caching for improved performance because scripts may be recompiled per document. Refer to [Script APIs]({{site.url}}{{site.baseurl}}/api-reference/script-apis/index/) for information about working with scripts in OpenSearch. 
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 The following is the syntax for the `script` processor:
 
 ```json

--- a/_ingest-pipelines/regex-conditionals.md
+++ b/_ingest-pipelines/regex-conditionals.md
@@ -9,6 +9,9 @@ nav_order: 70
 
 Ingest pipelines support conditional logic using regular expressions (regex) with the Painless scripting language. This allows fine-grained control over which documents get processed based on the structure and contents of text fields. Regex can be used within the `if` parameter to evaluate string patterns. This is especially useful for matching IP formats, validating email addresses, identifying UUIDs, or processing logs with specific keywords.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Example: Email domain filtering
 
 The following pipeline uses regex to identify users from the `@example.com` email domain and tag those documents accordingly:

--- a/_observing-your-data/alerting/triggers.md
+++ b/_observing-your-data/alerting/triggers.md
@@ -42,6 +42,9 @@ Now you can create the trigger condition and specify the tag name. This creates 
 
 For a query-level monitor, specify a Painless script that returns `true` or `false`. Painless is the default OpenSearch scripting language and has a syntax similar to Groovy.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 Trigger condition scripts revolve around the `ctx.results[0]` variable, which corresponds to the extraction query response. For example, the script might reference `ctx.results[0].hits.total.value` or `ctx.results[0].hits.hits[i]._source.error_code`.
 
 A return value of `true` means that the trigger condition has been met and the trigger should run its actions. Test the script using the **Run** button.

--- a/_query-dsl/specialized/script-score.md
+++ b/_query-dsl/specialized/script-score.md
@@ -9,6 +9,9 @@ nav_order: 60
 
 Use a `script_score` query to customize the score calculation by using a script. For an expensive scoring function, you can use a `script_score` query to calculate the score only for the returned documents that have been filtered.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Example
 
 For example, the following request creates an index containing one document:

--- a/_query-dsl/specialized/script.md
+++ b/_query-dsl/specialized/script.md
@@ -9,6 +9,9 @@ nav_order: 58
 
 Use the `script` query to filter documents based on a custom condition written in the Painless scripting language. This query returns documents for which the script evaluates to `true`, enabling advanced filtering logic that can't be expressed using standard queries.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 The `script` query is computationally expensive and should be used sparingly. Only use it when necessary and ensure `search.allow_expensive_queries` is enabled (default is `true`). For more information, see [Expensive queries]({{site.url}}{{site.baseurl}}/query-dsl/#expensive-queries).
 {: .important }
 

--- a/_search-plugins/ltr/advanced-functionality.md
+++ b/_search-plugins/ltr/advanced-functionality.md
@@ -77,6 +77,9 @@ Additionally, derived features can accept query-time variables of type [`Number`
 Script features are a type of [derived feature](#derived-features). These features have access to the `feature_vector`, but they are implemented as native or Painless OpenSearch scripts rather than as [Lucene
 expressions](http://lucene.apache.org/core/{{site.lucene_version}}/expressions/index.html?org/apache/lucene/expressions/js/package-summary.html). 
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 To identify these features, set the `"template_language": "script_feature""`. The custom script can access the `feature_vector` through the [Java Map](https://docs.oracle.com/javase/8/docs/api/java/util/Map.html), as described in [Create a feature set]({{site.url}}{{site.baseurl}}/search-plugins/ltr/working-with-features#creating-feature-sets).
 
 Script-based features may impact the performance of your OpenSearch cluster, so it is best to avoid them if you require highly performant queries.

--- a/_search-plugins/search-pipelines/script-processor.md
+++ b/_search-plugins/search-pipelines/script-processor.md
@@ -24,6 +24,9 @@ The `script` search request processor intercepts a search request and adds an in
 - `terminate_after` 
 - `profile` 
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 For request field definitions, see [search request fields]({{site.url}}{{site.baseurl}}/api-reference/search#request-body).
 
 ## Request body fields

--- a/_security/access-control/permissions.md
+++ b/_security/access-control/permissions.md
@@ -389,6 +389,11 @@ See [Script APIs]({{site.url}}{{site.baseurl}}/api-reference/script-apis/index/)
 - `cluster:admin/script/delete`
 - `cluster:admin/script/get`
 - `cluster:admin/script/put`
+- `cluster:admin/scripts/painless/execute`
+
+The `cluster:admin/scripts/painless/execute` permission allows a user to run scripts with the Execute Inline Script API. The other permissions allow users to manage stored scripts.
+
+These permissions do not control Painless scripts embedded in other operations, such as search, update, ingest, or alerting requests. Authorization for an embedded script is based on the permission required for the enclosing operation. There is no single permission that controls every use of Painless scripting. Only grant trusted users access to operations that let them submit scripts.
 
 ### Update settings permission
 

--- a/_vector-search/vector-search-techniques/painless-functions.md
+++ b/_vector-search/vector-search-techniques/painless-functions.md
@@ -14,6 +14,9 @@ redirect_from:
 
 With Painless scripting extensions, you can use k-nearest neighbors (k-NN) distance functions directly in your Painless scripts to perform operations on `knn_vector` fields. Painless has a strict list of allowed functions and classes per context to ensure that its scripts are secure. OpenSearch adds Painless scripting extensions to a few of the distance functions used in [k-NN scoring script]({{site.url}}{{site.baseurl}}/search-plugins/knn/knn-score-script/), so you can use them to customize your k-NN workload.
 
+Only grant trusted users access to operations that create or run Painless scripts. For more information, see [Script permissions]({{site.url}}{{site.baseurl}}/security/access-control/permissions/#script-permissions).
+{: .warning }
+
 ## Get started with k-NN Painless scripting functions
 
 To use k-NN Painless scripting functions, first create an index with `knn_vector` fields, as described in [Getting started with the scoring script for vectors]({{site.url}}{{site.baseurl}}/search-plugins/knn/knn-score-script#getting-started-with-the-scoring-script-for-vectors). Once you have created the index and ingested some data, you can use Painless extensions:


### PR DESCRIPTION
### Description

Adds a security warning to documentation pages that teach users to create or execute Painless scripts. The warning advises administrators to grant script-capable operations only to trusted users and links to centralized permission guidance.

This update also expands the Security permissions reference to explain that:

- `cluster:admin/scripts/painless/execute` grants access to the Execute Inline Script API.
- `cluster:admin/script/put`, `cluster:admin/script/get`, and `cluster:admin/script/delete` manage stored scripts.
- There is no single permission governing Painless scripts embedded in other operations. Those scripts are authorized through the enclosing search, update, ingest, alerting, or other operation.

The warning is included on the primary scripting pages for script APIs, queries and scoring, ingest pipelines, alert triggers, LTR, search pipelines, token filtering, and k-NN Painless extensions. Pages that only report Painless as an available language are unchanged.

### Issues Resolved

N/A

### Version

All versions.

### Frontend features

Not applicable.

### Testing

- `git diff --check`
- Markdown code-fence structural check
- Warning coverage check across the 16 targeted pages
- Full local Jekyll build not run because the checkout does not have the required Ruby gems installed; repository CI performs render and style checks.

### Checklist

- [x] By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license and subject to the [Developers Certificate of Origin](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
